### PR TITLE
fix: filter invalid request bodies

### DIFF
--- a/integration-tests/typescript-angular/src/generated/stripe.yaml/client.service.ts
+++ b/integration-tests/typescript-angular/src/generated/stripe.yaml/client.service.ts
@@ -308,25 +308,19 @@ export class StripeApiService {
   }
 
   getAccount(
-    p: {expand?: string[]; requestBody?: EmptyObject} = {},
+    p: {expand?: string[]} = {},
   ): Observable<
     | (HttpResponse<t_account> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/account`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -537,7 +531,6 @@ export class StripeApiService {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
   ): Observable<
     | (HttpResponse<{
@@ -549,9 +542,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       created: p["created"],
       ending_before: p["endingBefore"],
@@ -559,15 +549,12 @@ export class StripeApiService {
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/accounts`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -1178,23 +1165,15 @@ export class StripeApiService {
 
   deleteAccountsAccount(p: {
     account: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_deleted_account> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
-    const body = p["requestBody"]
-
     return this.httpClient.request<any>(
       "DELETE",
       this.config.basePath + `/v1/accounts/${p["account"]}`,
       {
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -1204,25 +1183,18 @@ export class StripeApiService {
   getAccountsAccount(p: {
     account: string
     expand?: string[]
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_account> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/accounts/${p["account"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -1849,24 +1821,16 @@ export class StripeApiService {
   deleteAccountsAccountBankAccountsId(p: {
     account: string
     id: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_deleted_external_account> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
-    const body = p["requestBody"]
-
     return this.httpClient.request<any>(
       "DELETE",
       this.config.basePath +
         `/v1/accounts/${p["account"]}/bank_accounts/${p["id"]}`,
       {
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -1877,17 +1841,12 @@ export class StripeApiService {
     account: string
     expand?: string[]
     id: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_external_account> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
@@ -1895,8 +1854,6 @@ export class StripeApiService {
         `/v1/accounts/${p["account"]}/bank_accounts/${p["id"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -1968,7 +1925,6 @@ export class StripeApiService {
   getAccountsAccountCapabilities(p: {
     account: string
     expand?: string[]
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<{
         data: t_capability[]
@@ -1979,19 +1935,13 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/accounts/${p["account"]}/capabilities`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -2002,17 +1952,12 @@ export class StripeApiService {
     account: string
     capability: string
     expand?: string[]
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_capability> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
@@ -2020,8 +1965,6 @@ export class StripeApiService {
         `/v1/accounts/${p["account"]}/capabilities/${p["capability"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -2065,7 +2008,6 @@ export class StripeApiService {
     limit?: number
     object?: "bank_account" | "card" | UnknownEnumStringValue
     startingAfter?: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<{
         data: (t_bank_account | t_card)[]
@@ -2076,9 +2018,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       ending_before: p["endingBefore"],
       expand: p["expand"],
@@ -2086,15 +2025,12 @@ export class StripeApiService {
       object: p["object"],
       starting_after: p["startingAfter"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/accounts/${p["account"]}/external_accounts`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -2161,24 +2097,16 @@ export class StripeApiService {
   deleteAccountsAccountExternalAccountsId(p: {
     account: string
     id: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_deleted_external_account> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
-    const body = p["requestBody"]
-
     return this.httpClient.request<any>(
       "DELETE",
       this.config.basePath +
         `/v1/accounts/${p["account"]}/external_accounts/${p["id"]}`,
       {
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -2189,17 +2117,12 @@ export class StripeApiService {
     account: string
     expand?: string[]
     id: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_external_account> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
@@ -2207,8 +2130,6 @@ export class StripeApiService {
         `/v1/accounts/${p["account"]}/external_accounts/${p["id"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -2318,7 +2239,6 @@ export class StripeApiService {
       representative?: boolean
     }
     startingAfter?: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<{
         data: t_person[]
@@ -2329,9 +2249,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       ending_before: p["endingBefore"],
       expand: p["expand"],
@@ -2339,15 +2256,12 @@ export class StripeApiService {
       relationship: p["relationship"],
       starting_after: p["startingAfter"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/accounts/${p["account"]}/people`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -2533,24 +2447,16 @@ export class StripeApiService {
   deleteAccountsAccountPeoplePerson(p: {
     account: string
     person: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_deleted_person> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
-    const body = p["requestBody"]
-
     return this.httpClient.request<any>(
       "DELETE",
       this.config.basePath +
         `/v1/accounts/${p["account"]}/people/${p["person"]}`,
       {
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -2561,17 +2467,12 @@ export class StripeApiService {
     account: string
     expand?: string[]
     person: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_person> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
@@ -2579,8 +2480,6 @@ export class StripeApiService {
         `/v1/accounts/${p["account"]}/people/${p["person"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -2779,7 +2678,6 @@ export class StripeApiService {
       representative?: boolean
     }
     startingAfter?: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<{
         data: t_person[]
@@ -2790,9 +2688,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       ending_before: p["endingBefore"],
       expand: p["expand"],
@@ -2800,15 +2695,12 @@ export class StripeApiService {
       relationship: p["relationship"],
       starting_after: p["startingAfter"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/accounts/${p["account"]}/persons`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -2994,24 +2886,16 @@ export class StripeApiService {
   deleteAccountsAccountPersonsPerson(p: {
     account: string
     person: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_deleted_person> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
-    const body = p["requestBody"]
-
     return this.httpClient.request<any>(
       "DELETE",
       this.config.basePath +
         `/v1/accounts/${p["account"]}/persons/${p["person"]}`,
       {
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -3022,17 +2906,12 @@ export class StripeApiService {
     account: string
     expand?: string[]
     person: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_person> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
@@ -3040,8 +2919,6 @@ export class StripeApiService {
         `/v1/accounts/${p["account"]}/persons/${p["person"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -3261,7 +3138,6 @@ export class StripeApiService {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
   ): Observable<
     | (HttpResponse<{
@@ -3273,9 +3149,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       domain_name: p["domainName"],
       ending_before: p["endingBefore"],
@@ -3283,15 +3156,12 @@ export class StripeApiService {
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/apple_pay/domains`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -3327,23 +3197,15 @@ export class StripeApiService {
 
   deleteApplePayDomainsDomain(p: {
     domain: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_deleted_apple_pay_domain> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
-    const body = p["requestBody"]
-
     return this.httpClient.request<any>(
       "DELETE",
       this.config.basePath + `/v1/apple_pay/domains/${p["domain"]}`,
       {
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -3353,25 +3215,18 @@ export class StripeApiService {
   getApplePayDomainsDomain(p: {
     domain: string
     expand?: string[]
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_apple_pay_domain> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/apple_pay/domains/${p["domain"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -3393,7 +3248,6 @@ export class StripeApiService {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
   ): Observable<
     | (HttpResponse<{
@@ -3405,9 +3259,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       charge: p["charge"],
       created: p["created"],
@@ -3416,15 +3267,12 @@ export class StripeApiService {
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/application_fees`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -3435,17 +3283,12 @@ export class StripeApiService {
     expand?: string[]
     fee: string
     id: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_fee_refund> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
@@ -3453,8 +3296,6 @@ export class StripeApiService {
         `/v1/application_fees/${p["fee"]}/refunds/${p["id"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -3499,25 +3340,18 @@ export class StripeApiService {
   getApplicationFeesId(p: {
     expand?: string[]
     id: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_application_fee> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/application_fees/${p["id"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -3559,7 +3393,6 @@ export class StripeApiService {
     id: string
     limit?: number
     startingAfter?: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<{
         data: t_fee_refund[]
@@ -3570,24 +3403,18 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       ending_before: p["endingBefore"],
       expand: p["expand"],
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/application_fees/${p["id"]}/refunds`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -3634,7 +3461,6 @@ export class StripeApiService {
       user?: string
     }
     startingAfter?: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<{
         data: t_apps_secret[]
@@ -3645,9 +3471,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       ending_before: p["endingBefore"],
       expand: p["expand"],
@@ -3655,15 +3478,12 @@ export class StripeApiService {
       scope: p["scope"],
       starting_after: p["startingAfter"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/apps/secrets`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -3741,29 +3561,22 @@ export class StripeApiService {
       type: "account" | "user" | UnknownEnumStringValue
       user?: string
     }
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_apps_secret> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       expand: p["expand"],
       name: p["name"],
       scope: p["scope"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/apps/secrets/find`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -3771,25 +3584,19 @@ export class StripeApiService {
   }
 
   getBalance(
-    p: {expand?: string[]; requestBody?: EmptyObject} = {},
+    p: {expand?: string[]} = {},
   ): Observable<
     | (HttpResponse<t_balance> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/balance`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -3814,7 +3621,6 @@ export class StripeApiService {
       source?: string
       startingAfter?: string
       type?: string
-      requestBody?: EmptyObject
     } = {},
   ): Observable<
     | (HttpResponse<{
@@ -3826,9 +3632,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       created: p["created"],
       currency: p["currency"],
@@ -3840,15 +3643,12 @@ export class StripeApiService {
       starting_after: p["startingAfter"],
       type: p["type"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/balance/history`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -3858,25 +3658,18 @@ export class StripeApiService {
   getBalanceHistoryId(p: {
     expand?: string[]
     id: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_balance_transaction> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/balance/history/${p["id"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -3901,7 +3694,6 @@ export class StripeApiService {
       source?: string
       startingAfter?: string
       type?: string
-      requestBody?: EmptyObject
     } = {},
   ): Observable<
     | (HttpResponse<{
@@ -3913,9 +3705,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       created: p["created"],
       currency: p["currency"],
@@ -3927,15 +3716,12 @@ export class StripeApiService {
       starting_after: p["startingAfter"],
       type: p["type"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/balance_transactions`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -3945,25 +3731,18 @@ export class StripeApiService {
   getBalanceTransactionsId(p: {
     expand?: string[]
     id: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_balance_transaction> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/balance_transactions/${p["id"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -3978,7 +3757,6 @@ export class StripeApiService {
       limit?: number
       meter?: string
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
   ): Observable<
     | (HttpResponse<{
@@ -3990,9 +3768,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       alert_type: p["alertType"],
       ending_before: p["endingBefore"],
@@ -4001,15 +3776,12 @@ export class StripeApiService {
       meter: p["meter"],
       starting_after: p["startingAfter"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/billing/alerts`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -4056,25 +3828,18 @@ export class StripeApiService {
   getBillingAlertsId(p: {
     expand?: string[]
     id: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_billing_alert> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/billing/alerts/${p["id"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -4175,29 +3940,22 @@ export class StripeApiService {
       credit_grant?: string
       type: "applicability_scope" | "credit_grant" | UnknownEnumStringValue
     }
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_billing_credit_balance_summary> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       customer: p["customer"],
       expand: p["expand"],
       filter: p["filter"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/billing/credit_balance_summary`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -4211,7 +3969,6 @@ export class StripeApiService {
     expand?: string[]
     limit?: number
     startingAfter?: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<{
         data: t_billing_credit_balance_transaction[]
@@ -4222,9 +3979,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       credit_grant: p["creditGrant"],
       customer: p["customer"],
@@ -4233,15 +3987,12 @@ export class StripeApiService {
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/billing/credit_balance_transactions`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -4251,17 +4002,12 @@ export class StripeApiService {
   getBillingCreditBalanceTransactionsId(p: {
     expand?: string[]
     id: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_billing_credit_balance_transaction> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
@@ -4269,8 +4015,6 @@ export class StripeApiService {
         `/v1/billing/credit_balance_transactions/${p["id"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -4284,7 +4028,6 @@ export class StripeApiService {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
   ): Observable<
     | (HttpResponse<{
@@ -4296,9 +4039,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       customer: p["customer"],
       ending_before: p["endingBefore"],
@@ -4306,15 +4046,12 @@ export class StripeApiService {
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/billing/credit_grants`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -4374,25 +4111,18 @@ export class StripeApiService {
   getBillingCreditGrantsId(p: {
     expand?: string[]
     id: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_billing_credit_grant> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/billing/credit_grants/${p["id"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -4554,7 +4284,6 @@ export class StripeApiService {
       limit?: number
       startingAfter?: string
       status?: "active" | "inactive" | UnknownEnumStringValue
-      requestBody?: EmptyObject
     } = {},
   ): Observable<
     | (HttpResponse<{
@@ -4566,9 +4295,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       ending_before: p["endingBefore"],
       expand: p["expand"],
@@ -4576,15 +4302,12 @@ export class StripeApiService {
       starting_after: p["startingAfter"],
       status: p["status"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/billing/meters`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -4633,25 +4356,18 @@ export class StripeApiService {
   getBillingMetersId(p: {
     expand?: string[]
     id: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_billing_meter> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/billing/meters/${p["id"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -4723,7 +4439,6 @@ export class StripeApiService {
     startTime: number
     startingAfter?: string
     valueGroupingWindow?: "day" | "hour" | UnknownEnumStringValue
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<{
         data: t_billing_meter_event_summary[]
@@ -4734,9 +4449,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       customer: p["customer"],
       end_time: p["endTime"],
@@ -4747,15 +4459,12 @@ export class StripeApiService {
       starting_after: p["startingAfter"],
       value_grouping_window: p["valueGroupingWindow"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/billing/meters/${p["id"]}/event_summaries`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -4797,7 +4506,6 @@ export class StripeApiService {
       isDefault?: boolean
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
   ): Observable<
     | (HttpResponse<{
@@ -4809,9 +4517,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       active: p["active"],
       ending_before: p["endingBefore"],
@@ -4820,15 +4525,12 @@ export class StripeApiService {
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/billing_portal/configurations`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -4957,17 +4659,12 @@ export class StripeApiService {
   getBillingPortalConfigurationsConfiguration(p: {
     configuration: string
     expand?: string[]
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_billing_portal_configuration> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
@@ -4975,8 +4672,6 @@ export class StripeApiService {
         `/v1/billing_portal/configurations/${p["configuration"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -5252,7 +4947,6 @@ export class StripeApiService {
       paymentIntent?: string
       startingAfter?: string
       transferGroup?: string
-      requestBody?: EmptyObject
     } = {},
   ): Observable<
     | (HttpResponse<{
@@ -5264,9 +4958,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       created: p["created"],
       customer: p["customer"],
@@ -5277,15 +4968,12 @@ export class StripeApiService {
       starting_after: p["startingAfter"],
       transfer_group: p["transferGroup"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/charges`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -5390,7 +5078,6 @@ export class StripeApiService {
     limit?: number
     page?: string
     query: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<{
         data: t_charge[]
@@ -5403,24 +5090,18 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       expand: p["expand"],
       limit: p["limit"],
       page: p["page"],
       query: p["query"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/charges/search`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -5430,25 +5111,18 @@ export class StripeApiService {
   getChargesCharge(p: {
     charge: string
     expand?: string[]
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_charge> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/charges/${p["charge"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -5549,25 +5223,18 @@ export class StripeApiService {
   getChargesChargeDispute(p: {
     charge: string
     expand?: string[]
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_dispute> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/charges/${p["charge"]}/dispute`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -5766,7 +5433,6 @@ export class StripeApiService {
     expand?: string[]
     limit?: number
     startingAfter?: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<{
         data: t_refund[]
@@ -5777,24 +5443,18 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       ending_before: p["endingBefore"],
       expand: p["expand"],
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/charges/${p["charge"]}/refunds`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -5851,17 +5511,12 @@ export class StripeApiService {
     charge: string
     expand?: string[]
     refund: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_refund> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
@@ -5869,8 +5524,6 @@ export class StripeApiService {
         `/v1/charges/${p["charge"]}/refunds/${p["refund"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -5934,7 +5587,6 @@ export class StripeApiService {
       startingAfter?: string
       status?: "complete" | "expired" | "open" | UnknownEnumStringValue
       subscription?: string
-      requestBody?: EmptyObject
     } = {},
   ): Observable<
     | (HttpResponse<{
@@ -5946,9 +5598,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       created: p["created"],
       customer: p["customer"],
@@ -5962,15 +5611,12 @@ export class StripeApiService {
       status: p["status"],
       subscription: p["subscription"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/checkout/sessions`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -7034,25 +6680,18 @@ export class StripeApiService {
   getCheckoutSessionsSession(p: {
     expand?: string[]
     session: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_checkout_session> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/checkout/sessions/${p["session"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -7195,7 +6834,6 @@ export class StripeApiService {
     limit?: number
     session: string
     startingAfter?: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<{
         data: t_item[]
@@ -7206,24 +6844,18 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       ending_before: p["endingBefore"],
       expand: p["expand"],
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/checkout/sessions/${p["session"]}/line_items`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -7236,7 +6868,6 @@ export class StripeApiService {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
   ): Observable<
     | (HttpResponse<{
@@ -7248,24 +6879,18 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       ending_before: p["endingBefore"],
       expand: p["expand"],
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/climate/orders`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -7311,25 +6936,18 @@ export class StripeApiService {
   getClimateOrdersOrder(p: {
     expand?: string[]
     order: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_climate_order> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/climate/orders/${p["order"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -7405,7 +7023,6 @@ export class StripeApiService {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
   ): Observable<
     | (HttpResponse<{
@@ -7417,24 +7034,18 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       ending_before: p["endingBefore"],
       expand: p["expand"],
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/climate/products`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -7444,25 +7055,18 @@ export class StripeApiService {
   getClimateProductsProduct(p: {
     expand?: string[]
     product: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_climate_product> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/climate/products/${p["product"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -7475,7 +7079,6 @@ export class StripeApiService {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
   ): Observable<
     | (HttpResponse<{
@@ -7487,24 +7090,18 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       ending_before: p["endingBefore"],
       expand: p["expand"],
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/climate/suppliers`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -7514,25 +7111,18 @@ export class StripeApiService {
   getClimateSuppliersSupplier(p: {
     expand?: string[]
     supplier: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_climate_supplier> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/climate/suppliers/${p["supplier"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -7542,17 +7132,12 @@ export class StripeApiService {
   getConfirmationTokensConfirmationToken(p: {
     confirmationToken: string
     expand?: string[]
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_confirmation_token> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
@@ -7560,8 +7145,6 @@ export class StripeApiService {
         `/v1/confirmation_tokens/${p["confirmationToken"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -7574,7 +7157,6 @@ export class StripeApiService {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
   ): Observable<
     | (HttpResponse<{
@@ -7586,24 +7168,18 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       ending_before: p["endingBefore"],
       expand: p["expand"],
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/country_specs`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -7613,25 +7189,18 @@ export class StripeApiService {
   getCountrySpecsCountry(p: {
     country: string
     expand?: string[]
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_country_spec> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/country_specs/${p["country"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -7652,7 +7221,6 @@ export class StripeApiService {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
   ): Observable<
     | (HttpResponse<{
@@ -7664,9 +7232,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       created: p["created"],
       ending_before: p["endingBefore"],
@@ -7674,15 +7239,12 @@ export class StripeApiService {
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/coupons`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -7744,23 +7306,15 @@ export class StripeApiService {
 
   deleteCouponsCoupon(p: {
     coupon: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_deleted_coupon> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
-    const body = p["requestBody"]
-
     return this.httpClient.request<any>(
       "DELETE",
       this.config.basePath + `/v1/coupons/${p["coupon"]}`,
       {
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -7770,25 +7324,18 @@ export class StripeApiService {
   getCouponsCoupon(p: {
     coupon: string
     expand?: string[]
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_coupon> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/coupons/${p["coupon"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -7852,7 +7399,6 @@ export class StripeApiService {
       invoice?: string
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
   ): Observable<
     | (HttpResponse<{
@@ -7864,9 +7410,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       created: p["created"],
       customer: p["customer"],
@@ -7876,15 +7419,12 @@ export class StripeApiService {
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/credit_notes`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -8003,15 +7543,11 @@ export class StripeApiService {
     shippingCost?: {
       shipping_rate?: string
     }
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_credit_note> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       amount: p["amount"],
       credit_amount: p["creditAmount"],
@@ -8028,15 +7564,12 @@ export class StripeApiService {
       refunds: p["refunds"],
       shipping_cost: p["shippingCost"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/credit_notes/preview`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -8090,7 +7623,6 @@ export class StripeApiService {
       shipping_rate?: string
     }
     startingAfter?: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<{
         data: t_credit_note_line_item[]
@@ -8101,9 +7633,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       amount: p["amount"],
       credit_amount: p["creditAmount"],
@@ -8123,15 +7652,12 @@ export class StripeApiService {
       shipping_cost: p["shippingCost"],
       starting_after: p["startingAfter"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/credit_notes/preview/lines`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -8144,7 +7670,6 @@ export class StripeApiService {
     expand?: string[]
     limit?: number
     startingAfter?: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<{
         data: t_credit_note_line_item[]
@@ -8155,24 +7680,18 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       ending_before: p["endingBefore"],
       expand: p["expand"],
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/credit_notes/${p["creditNote"]}/lines`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -8182,25 +7701,18 @@ export class StripeApiService {
   getCreditNotesId(p: {
     expand?: string[]
     id: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_credit_note> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/credit_notes/${p["id"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -8344,7 +7856,6 @@ export class StripeApiService {
       limit?: number
       startingAfter?: string
       testClock?: string
-      requestBody?: EmptyObject
     } = {},
   ): Observable<
     | (HttpResponse<{
@@ -8356,9 +7867,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       created: p["created"],
       email: p["email"],
@@ -8368,15 +7876,12 @@ export class StripeApiService {
       starting_after: p["startingAfter"],
       test_clock: p["testClock"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/customers`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -8613,7 +8118,6 @@ export class StripeApiService {
     limit?: number
     page?: string
     query: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<{
         data: t_customer[]
@@ -8626,24 +8130,18 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       expand: p["expand"],
       limit: p["limit"],
       page: p["page"],
       query: p["query"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/customers/search`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -8652,23 +8150,15 @@ export class StripeApiService {
 
   deleteCustomersCustomer(p: {
     customer: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_deleted_customer> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
-    const body = p["requestBody"]
-
     return this.httpClient.request<any>(
       "DELETE",
       this.config.basePath + `/v1/customers/${p["customer"]}`,
       {
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -8678,25 +8168,18 @@ export class StripeApiService {
   getCustomersCustomer(p: {
     customer: string
     expand?: string[]
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_customer | t_deleted_customer> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/customers/${p["customer"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -8854,7 +8337,6 @@ export class StripeApiService {
     expand?: string[]
     limit?: number
     startingAfter?: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<{
         data: t_customer_balance_transaction[]
@@ -8865,16 +8347,12 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       ending_before: p["endingBefore"],
       expand: p["expand"],
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
@@ -8882,8 +8360,6 @@ export class StripeApiService {
         `/v1/customers/${p["customer"]}/balance_transactions`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -8931,17 +8407,12 @@ export class StripeApiService {
     customer: string
     expand?: string[]
     transaction: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_customer_balance_transaction> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
@@ -8949,8 +8420,6 @@ export class StripeApiService {
         `/v1/customers/${p["customer"]}/balance_transactions/${p["transaction"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -8999,7 +8468,6 @@ export class StripeApiService {
     expand?: string[]
     limit?: number
     startingAfter?: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<{
         data: t_bank_account[]
@@ -9010,24 +8478,18 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       ending_before: p["endingBefore"],
       expand: p["expand"],
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/customers/${p["customer"]}/bank_accounts`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -9134,17 +8596,12 @@ export class StripeApiService {
     customer: string
     expand?: string[]
     id: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_bank_account> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
@@ -9152,8 +8609,6 @@ export class StripeApiService {
         `/v1/customers/${p["customer"]}/bank_accounts/${p["id"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -9255,7 +8710,6 @@ export class StripeApiService {
     expand?: string[]
     limit?: number
     startingAfter?: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<{
         data: t_card[]
@@ -9266,24 +8720,18 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       ending_before: p["endingBefore"],
       expand: p["expand"],
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/customers/${p["customer"]}/cards`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -9389,25 +8837,18 @@ export class StripeApiService {
     customer: string
     expand?: string[]
     id: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_card> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/customers/${p["customer"]}/cards/${p["id"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -9475,25 +8916,18 @@ export class StripeApiService {
   getCustomersCustomerCashBalance(p: {
     customer: string
     expand?: string[]
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_cash_balance> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/customers/${p["customer"]}/cash_balance`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -9540,7 +8974,6 @@ export class StripeApiService {
     expand?: string[]
     limit?: number
     startingAfter?: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<{
         data: t_customer_cash_balance_transaction[]
@@ -9551,16 +8984,12 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       ending_before: p["endingBefore"],
       expand: p["expand"],
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
@@ -9568,8 +8997,6 @@ export class StripeApiService {
         `/v1/customers/${p["customer"]}/cash_balance_transactions`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -9580,17 +9007,12 @@ export class StripeApiService {
     customer: string
     expand?: string[]
     transaction: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_customer_cash_balance_transaction> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
@@ -9598,8 +9020,6 @@ export class StripeApiService {
         `/v1/customers/${p["customer"]}/cash_balance_transactions/${p["transaction"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -9608,23 +9028,15 @@ export class StripeApiService {
 
   deleteCustomersCustomerDiscount(p: {
     customer: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_deleted_discount> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
-    const body = p["requestBody"]
-
     return this.httpClient.request<any>(
       "DELETE",
       this.config.basePath + `/v1/customers/${p["customer"]}/discount`,
       {
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -9634,25 +9046,18 @@ export class StripeApiService {
   getCustomersCustomerDiscount(p: {
     customer: string
     expand?: string[]
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_discount> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/customers/${p["customer"]}/discount`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -9769,7 +9174,6 @@ export class StripeApiService {
       | "wechat_pay"
       | "zip"
       | UnknownEnumStringValue
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<{
         data: t_payment_method[]
@@ -9780,9 +9184,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       allow_redisplay: p["allowRedisplay"],
       ending_before: p["endingBefore"],
@@ -9791,15 +9192,12 @@ export class StripeApiService {
       starting_after: p["startingAfter"],
       type: p["type"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/customers/${p["customer"]}/payment_methods`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -9810,17 +9208,12 @@ export class StripeApiService {
     customer: string
     expand?: string[]
     paymentMethod: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_payment_method> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
@@ -9828,8 +9221,6 @@ export class StripeApiService {
         `/v1/customers/${p["customer"]}/payment_methods/${p["paymentMethod"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -9843,7 +9234,6 @@ export class StripeApiService {
     limit?: number
     object?: string
     startingAfter?: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<{
         data: (t_bank_account | t_card | t_source)[]
@@ -9854,9 +9244,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       ending_before: p["endingBefore"],
       expand: p["expand"],
@@ -9864,15 +9251,12 @@ export class StripeApiService {
       object: p["object"],
       starting_after: p["startingAfter"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/customers/${p["customer"]}/sources`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -9979,17 +9363,12 @@ export class StripeApiService {
     customer: string
     expand?: string[]
     id: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_payment_source> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
@@ -9997,8 +9376,6 @@ export class StripeApiService {
         `/v1/customers/${p["customer"]}/sources/${p["id"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -10100,7 +9477,6 @@ export class StripeApiService {
     expand?: string[]
     limit?: number
     startingAfter?: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<{
         data: t_subscription[]
@@ -10111,24 +9487,18 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       ending_before: p["endingBefore"],
       expand: p["expand"],
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/customers/${p["customer"]}/subscriptions`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -10495,17 +9865,12 @@ export class StripeApiService {
     customer: string
     expand?: string[]
     subscriptionExposedId: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_subscription> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
@@ -10513,8 +9878,6 @@ export class StripeApiService {
         `/v1/customers/${p["customer"]}/subscriptions/${p["subscriptionExposedId"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -10883,24 +10246,16 @@ export class StripeApiService {
   deleteCustomersCustomerSubscriptionsSubscriptionExposedIdDiscount(p: {
     customer: string
     subscriptionExposedId: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_deleted_discount> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
-    const body = p["requestBody"]
-
     return this.httpClient.request<any>(
       "DELETE",
       this.config.basePath +
         `/v1/customers/${p["customer"]}/subscriptions/${p["subscriptionExposedId"]}/discount`,
       {
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -10911,17 +10266,12 @@ export class StripeApiService {
     customer: string
     expand?: string[]
     subscriptionExposedId: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_discount> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
@@ -10929,8 +10279,6 @@ export class StripeApiService {
         `/v1/customers/${p["customer"]}/subscriptions/${p["subscriptionExposedId"]}/discount`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -10943,7 +10291,6 @@ export class StripeApiService {
     expand?: string[]
     limit?: number
     startingAfter?: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<{
         data: t_tax_id[]
@@ -10954,24 +10301,18 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       ending_before: p["endingBefore"],
       expand: p["expand"],
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/customers/${p["customer"]}/tax_ids`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -11121,24 +10462,16 @@ export class StripeApiService {
   deleteCustomersCustomerTaxIdsId(p: {
     customer: string
     id: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_deleted_tax_id> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
-    const body = p["requestBody"]
-
     return this.httpClient.request<any>(
       "DELETE",
       this.config.basePath +
         `/v1/customers/${p["customer"]}/tax_ids/${p["id"]}`,
       {
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -11149,17 +10482,12 @@ export class StripeApiService {
     customer: string
     expand?: string[]
     id: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_tax_id> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
@@ -11167,8 +10495,6 @@ export class StripeApiService {
         `/v1/customers/${p["customer"]}/tax_ids/${p["id"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -11191,7 +10517,6 @@ export class StripeApiService {
       limit?: number
       paymentIntent?: string
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
   ): Observable<
     | (HttpResponse<{
@@ -11203,9 +10528,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       charge: p["charge"],
       created: p["created"],
@@ -11215,15 +10537,12 @@ export class StripeApiService {
       payment_intent: p["paymentIntent"],
       starting_after: p["startingAfter"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/disputes`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -11233,25 +10552,18 @@ export class StripeApiService {
   getDisputesDispute(p: {
     dispute: string
     expand?: string[]
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_dispute> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/disputes/${p["dispute"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -11407,7 +10719,6 @@ export class StripeApiService {
     expand?: string[]
     limit?: number
     startingAfter?: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<{
         data: t_entitlements_active_entitlement[]
@@ -11418,9 +10729,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       customer: p["customer"],
       ending_before: p["endingBefore"],
@@ -11428,15 +10736,12 @@ export class StripeApiService {
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/entitlements/active_entitlements`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -11446,25 +10751,18 @@ export class StripeApiService {
   getEntitlementsActiveEntitlementsId(p: {
     expand?: string[]
     id: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_entitlements_active_entitlement> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/entitlements/active_entitlements/${p["id"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -11479,7 +10777,6 @@ export class StripeApiService {
       limit?: number
       lookupKey?: string
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
   ): Observable<
     | (HttpResponse<{
@@ -11491,9 +10788,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       archived: p["archived"],
       ending_before: p["endingBefore"],
@@ -11502,15 +10796,12 @@ export class StripeApiService {
       lookup_key: p["lookupKey"],
       starting_after: p["startingAfter"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/entitlements/features`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -11551,25 +10842,18 @@ export class StripeApiService {
   getEntitlementsFeaturesId(p: {
     expand?: string[]
     id: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_entitlements_feature> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/entitlements/features/${p["id"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -11687,7 +10971,6 @@ export class StripeApiService {
       startingAfter?: string
       type?: string
       types?: string[]
-      requestBody?: EmptyObject
     } = {},
   ): Observable<
     | (HttpResponse<{
@@ -11699,9 +10982,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       created: p["created"],
       delivery_success: p["deliverySuccess"],
@@ -11712,15 +10992,12 @@ export class StripeApiService {
       type: p["type"],
       types: p["types"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/events`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -11730,25 +11007,18 @@ export class StripeApiService {
   getEventsId(p: {
     expand?: string[]
     id: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_event> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/events/${p["id"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -11761,7 +11031,6 @@ export class StripeApiService {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
   ): Observable<
     | (HttpResponse<{
@@ -11773,24 +11042,18 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       ending_before: p["endingBefore"],
       expand: p["expand"],
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/exchange_rates`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -11800,25 +11063,18 @@ export class StripeApiService {
   getExchangeRatesRateId(p: {
     expand?: string[]
     rateId: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_exchange_rate> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/exchange_rates/${p["rateId"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -11901,7 +11157,6 @@ export class StripeApiService {
       file?: string
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
   ): Observable<
     | (HttpResponse<{
@@ -11913,9 +11168,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       created: p["created"],
       ending_before: p["endingBefore"],
@@ -11925,15 +11177,12 @@ export class StripeApiService {
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/file_links`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -11977,25 +11226,18 @@ export class StripeApiService {
   getFileLinksLink(p: {
     expand?: string[]
     link: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_file_link> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/file_links/${p["link"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -12069,7 +11311,6 @@ export class StripeApiService {
         | "terminal_reader_splashscreen"
         | UnknownEnumStringValue
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
   ): Observable<
     | (HttpResponse<{
@@ -12081,9 +11322,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       created: p["created"],
       ending_before: p["endingBefore"],
@@ -12092,15 +11330,12 @@ export class StripeApiService {
       purpose: p["purpose"],
       starting_after: p["startingAfter"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/files`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -12159,25 +11394,18 @@ export class StripeApiService {
   getFilesFile(p: {
     expand?: string[]
     file: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_file> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/files/${p["file"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -12195,7 +11423,6 @@ export class StripeApiService {
       limit?: number
       session?: string
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
   ): Observable<
     | (HttpResponse<{
@@ -12207,9 +11434,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       account_holder: p["accountHolder"],
       ending_before: p["endingBefore"],
@@ -12218,15 +11442,12 @@ export class StripeApiService {
       session: p["session"],
       starting_after: p["startingAfter"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/financial_connections/accounts`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -12236,17 +11457,12 @@ export class StripeApiService {
   getFinancialConnectionsAccountsAccount(p: {
     account: string
     expand?: string[]
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_financial_connections_account> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
@@ -12254,8 +11470,6 @@ export class StripeApiService {
         `/v1/financial_connections/accounts/${p["account"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -12297,7 +11511,6 @@ export class StripeApiService {
     limit?: number
     ownership: string
     startingAfter?: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<{
         data: t_financial_connections_account_owner[]
@@ -12308,9 +11521,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       ending_before: p["endingBefore"],
       expand: p["expand"],
@@ -12318,7 +11528,6 @@ export class StripeApiService {
       ownership: p["ownership"],
       starting_after: p["startingAfter"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
@@ -12326,8 +11535,6 @@ export class StripeApiService {
         `/v1/financial_connections/accounts/${p["account"]}/owners`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -12485,17 +11692,12 @@ export class StripeApiService {
   getFinancialConnectionsSessionsSession(p: {
     expand?: string[]
     session: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_financial_connections_session> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
@@ -12503,8 +11705,6 @@ export class StripeApiService {
         `/v1/financial_connections/sessions/${p["session"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -12528,7 +11728,6 @@ export class StripeApiService {
     transactionRefresh?: {
       after: string
     }
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<{
         data: t_financial_connections_transaction[]
@@ -12539,9 +11738,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       account: p["account"],
       ending_before: p["endingBefore"],
@@ -12551,15 +11747,12 @@ export class StripeApiService {
       transacted_at: p["transactedAt"],
       transaction_refresh: p["transactionRefresh"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/financial_connections/transactions`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -12569,17 +11762,12 @@ export class StripeApiService {
   getFinancialConnectionsTransactionsTransaction(p: {
     expand?: string[]
     transaction: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_financial_connections_transaction> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
@@ -12587,8 +11775,6 @@ export class StripeApiService {
         `/v1/financial_connections/transactions/${p["transaction"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -12607,7 +11793,6 @@ export class StripeApiService {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
   ): Observable<
     | (HttpResponse<{
@@ -12619,9 +11804,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       created: p["created"],
       ending_before: p["endingBefore"],
@@ -12629,15 +11811,12 @@ export class StripeApiService {
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/forwarding/requests`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -12693,25 +11872,18 @@ export class StripeApiService {
   getForwardingRequestsId(p: {
     expand?: string[]
     id: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_forwarding_request> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/forwarding/requests/${p["id"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -12735,7 +11907,6 @@ export class StripeApiService {
       startingAfter?: string
       type?: "document" | "id_number" | UnknownEnumStringValue
       verificationSession?: string
-      requestBody?: EmptyObject
     } = {},
   ): Observable<
     | (HttpResponse<{
@@ -12747,9 +11918,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       client_reference_id: p["clientReferenceId"],
       created: p["created"],
@@ -12760,15 +11928,12 @@ export class StripeApiService {
       type: p["type"],
       verification_session: p["verificationSession"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/identity/verification_reports`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -12778,25 +11943,18 @@ export class StripeApiService {
   getIdentityVerificationReportsReport(p: {
     expand?: string[]
     report: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_identity_verification_report> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/identity/verification_reports/${p["report"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -12825,7 +11983,6 @@ export class StripeApiService {
         | "requires_input"
         | "verified"
         | UnknownEnumStringValue
-      requestBody?: EmptyObject
     } = {},
   ): Observable<
     | (HttpResponse<{
@@ -12837,9 +11994,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       client_reference_id: p["clientReferenceId"],
       created: p["created"],
@@ -12850,15 +12004,12 @@ export class StripeApiService {
       starting_after: p["startingAfter"],
       status: p["status"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/identity/verification_sessions`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -12928,17 +12079,12 @@ export class StripeApiService {
   getIdentityVerificationSessionsSession(p: {
     expand?: string[]
     session: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_identity_verification_session> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
@@ -12946,8 +12092,6 @@ export class StripeApiService {
         `/v1/identity/verification_sessions/${p["session"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -13074,7 +12218,6 @@ export class StripeApiService {
       }
       startingAfter?: string
       status?: "canceled" | "open" | "paid" | UnknownEnumStringValue
-      requestBody?: EmptyObject
     } = {},
   ): Observable<
     | (HttpResponse<{
@@ -13086,9 +12229,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       ending_before: p["endingBefore"],
       expand: p["expand"],
@@ -13098,15 +12238,12 @@ export class StripeApiService {
       starting_after: p["startingAfter"],
       status: p["status"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/invoice_payments`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -13116,25 +12253,18 @@ export class StripeApiService {
   getInvoicePaymentsInvoicePayment(p: {
     expand?: string[]
     invoicePayment: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_invoice_payment> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/invoice_payments/${p["invoicePayment"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -13148,7 +12278,6 @@ export class StripeApiService {
       limit?: number
       startingAfter?: string
       status?: "active" | "archived" | UnknownEnumStringValue
-      requestBody?: EmptyObject
     } = {},
   ): Observable<
     | (HttpResponse<{
@@ -13160,9 +12289,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       ending_before: p["endingBefore"],
       expand: p["expand"],
@@ -13170,15 +12296,12 @@ export class StripeApiService {
       starting_after: p["startingAfter"],
       status: p["status"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/invoice_rendering_templates`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -13189,28 +12312,21 @@ export class StripeApiService {
     expand?: string[]
     template: string
     version?: number
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_invoice_rendering_template> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       expand: p["expand"],
       version: p["version"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/invoice_rendering_templates/${p["template"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -13290,7 +12406,6 @@ export class StripeApiService {
       limit?: number
       pending?: boolean
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
   ): Observable<
     | (HttpResponse<{
@@ -13302,9 +12417,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       created: p["created"],
       customer: p["customer"],
@@ -13315,15 +12427,12 @@ export class StripeApiService {
       pending: p["pending"],
       starting_after: p["startingAfter"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/invoiceitems`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -13406,23 +12515,15 @@ export class StripeApiService {
 
   deleteInvoiceitemsInvoiceitem(p: {
     invoiceitem: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_deleted_invoiceitem> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
-    const body = p["requestBody"]
-
     return this.httpClient.request<any>(
       "DELETE",
       this.config.basePath + `/v1/invoiceitems/${p["invoiceitem"]}`,
       {
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -13432,25 +12533,18 @@ export class StripeApiService {
   getInvoiceitemsInvoiceitem(p: {
     expand?: string[]
     invoiceitem: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_invoiceitem> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/invoiceitems/${p["invoiceitem"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -13563,7 +12657,6 @@ export class StripeApiService {
         | "void"
         | UnknownEnumStringValue
       subscription?: string
-      requestBody?: EmptyObject
     } = {},
   ): Observable<
     | (HttpResponse<{
@@ -13575,9 +12668,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       collection_method: p["collectionMethod"],
       created: p["created"],
@@ -13590,15 +12680,12 @@ export class StripeApiService {
       status: p["status"],
       subscription: p["subscription"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/invoices`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -14389,7 +13476,6 @@ export class StripeApiService {
     limit?: number
     page?: string
     query: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<{
         data: t_invoice[]
@@ -14402,24 +13488,18 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       expand: p["expand"],
       limit: p["limit"],
       page: p["page"],
       query: p["query"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/invoices/search`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -14428,23 +13508,15 @@ export class StripeApiService {
 
   deleteInvoicesInvoice(p: {
     invoice: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_deleted_invoice> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
-    const body = p["requestBody"]
-
     return this.httpClient.request<any>(
       "DELETE",
       this.config.basePath + `/v1/invoices/${p["invoice"]}`,
       {
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -14454,25 +13526,18 @@ export class StripeApiService {
   getInvoicesInvoice(p: {
     expand?: string[]
     invoice: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_invoice> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/invoices/${p["invoice"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -14997,7 +14062,6 @@ export class StripeApiService {
     invoice: string
     limit?: number
     startingAfter?: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<{
         data: t_line_item[]
@@ -15008,24 +14072,18 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       ending_before: p["endingBefore"],
       expand: p["expand"],
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/invoices/${p["invoice"]}/lines`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -15476,7 +14534,6 @@ export class StripeApiService {
         | "pending"
         | "reversed"
         | UnknownEnumStringValue
-      requestBody?: EmptyObject
     } = {},
   ): Observable<
     | (HttpResponse<{
@@ -15488,9 +14545,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       card: p["card"],
       cardholder: p["cardholder"],
@@ -15501,15 +14555,12 @@ export class StripeApiService {
       starting_after: p["startingAfter"],
       status: p["status"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/issuing/authorizations`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -15519,25 +14570,18 @@ export class StripeApiService {
   getIssuingAuthorizationsAuthorization(p: {
     authorization: string
     expand?: string[]
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_issuing_authorization> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/issuing/authorizations/${p["authorization"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -15664,7 +14708,6 @@ export class StripeApiService {
       startingAfter?: string
       status?: "active" | "blocked" | "inactive" | UnknownEnumStringValue
       type?: "company" | "individual" | UnknownEnumStringValue
-      requestBody?: EmptyObject
     } = {},
   ): Observable<
     | (HttpResponse<{
@@ -15676,9 +14719,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       created: p["created"],
       email: p["email"],
@@ -15690,15 +14730,12 @@ export class StripeApiService {
       status: p["status"],
       type: p["type"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/issuing/cardholders`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -16695,25 +15732,18 @@ export class StripeApiService {
   getIssuingCardholdersCardholder(p: {
     cardholder: string
     expand?: string[]
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_issuing_cardholder> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/issuing/cardholders/${p["cardholder"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -17727,7 +16757,6 @@ export class StripeApiService {
       startingAfter?: string
       status?: "active" | "canceled" | "inactive" | UnknownEnumStringValue
       type?: "physical" | "virtual" | UnknownEnumStringValue
-      requestBody?: EmptyObject
     } = {},
   ): Observable<
     | (HttpResponse<{
@@ -17739,9 +16768,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       cardholder: p["cardholder"],
       created: p["created"],
@@ -17756,15 +16782,12 @@ export class StripeApiService {
       status: p["status"],
       type: p["type"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/issuing/cards`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -18754,25 +17777,18 @@ export class StripeApiService {
   getIssuingCardsCard(p: {
     card: string
     expand?: string[]
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_issuing_card> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/issuing/cards/${p["card"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -19774,7 +18790,6 @@ export class StripeApiService {
         | "won"
         | UnknownEnumStringValue
       transaction?: string
-      requestBody?: EmptyObject
     } = {},
   ): Observable<
     | (HttpResponse<{
@@ -19786,9 +18801,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       created: p["created"],
       ending_before: p["endingBefore"],
@@ -19798,15 +18810,12 @@ export class StripeApiService {
       status: p["status"],
       transaction: p["transaction"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/issuing/disputes`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -19967,25 +18976,18 @@ export class StripeApiService {
   getIssuingDisputesDispute(p: {
     dispute: string
     expand?: string[]
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_issuing_dispute> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/issuing/disputes/${p["dispute"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -20191,7 +19193,6 @@ export class StripeApiService {
         | "rejected"
         | "review"
         | UnknownEnumStringValue
-      requestBody?: EmptyObject
     } = {},
   ): Observable<
     | (HttpResponse<{
@@ -20203,9 +19204,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       ending_before: p["endingBefore"],
       expand: p["expand"],
@@ -20215,15 +19213,12 @@ export class StripeApiService {
       starting_after: p["startingAfter"],
       status: p["status"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/issuing/personalization_designs`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -20276,17 +19271,12 @@ export class StripeApiService {
   getIssuingPersonalizationDesignsPersonalizationDesign(p: {
     expand?: string[]
     personalizationDesign: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_issuing_personalization_design> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
@@ -20294,8 +19284,6 @@ export class StripeApiService {
         `/v1/issuing/personalization_designs/${p["personalizationDesign"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -20358,7 +19346,6 @@ export class StripeApiService {
       startingAfter?: string
       status?: "active" | "inactive" | "review" | UnknownEnumStringValue
       type?: "custom" | "standard" | UnknownEnumStringValue
-      requestBody?: EmptyObject
     } = {},
   ): Observable<
     | (HttpResponse<{
@@ -20370,9 +19357,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       ending_before: p["endingBefore"],
       expand: p["expand"],
@@ -20381,15 +19365,12 @@ export class StripeApiService {
       status: p["status"],
       type: p["type"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/issuing/physical_bundles`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -20399,17 +19380,12 @@ export class StripeApiService {
   getIssuingPhysicalBundlesPhysicalBundle(p: {
     expand?: string[]
     physicalBundle: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_issuing_physical_bundle> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
@@ -20417,8 +19393,6 @@ export class StripeApiService {
         `/v1/issuing/physical_bundles/${p["physicalBundle"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -20428,25 +19402,18 @@ export class StripeApiService {
   getIssuingSettlementsSettlement(p: {
     expand?: string[]
     settlement: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_issuing_settlement> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/issuing/settlements/${p["settlement"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -20503,7 +19470,6 @@ export class StripeApiService {
       | "requested"
       | "suspended"
       | UnknownEnumStringValue
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<{
         data: t_issuing_token[]
@@ -20514,9 +19480,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       card: p["card"],
       created: p["created"],
@@ -20526,15 +19489,12 @@ export class StripeApiService {
       starting_after: p["startingAfter"],
       status: p["status"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/issuing/tokens`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -20544,25 +19504,18 @@ export class StripeApiService {
   getIssuingTokensToken(p: {
     expand?: string[]
     token: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_issuing_token> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/issuing/tokens/${p["token"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -20614,7 +19567,6 @@ export class StripeApiService {
       limit?: number
       startingAfter?: string
       type?: "capture" | "refund" | UnknownEnumStringValue
-      requestBody?: EmptyObject
     } = {},
   ): Observable<
     | (HttpResponse<{
@@ -20626,9 +19578,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       card: p["card"],
       cardholder: p["cardholder"],
@@ -20639,15 +19588,12 @@ export class StripeApiService {
       starting_after: p["startingAfter"],
       type: p["type"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/issuing/transactions`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -20657,25 +19603,18 @@ export class StripeApiService {
   getIssuingTransactionsTransaction(p: {
     expand?: string[]
     transaction: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_issuing_transaction> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/issuing/transactions/${p["transaction"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -20774,25 +19713,18 @@ export class StripeApiService {
   getLinkAccountSessionsSession(p: {
     expand?: string[]
     session: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_financial_connections_session> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/link_account_sessions/${p["session"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -20810,7 +19742,6 @@ export class StripeApiService {
       limit?: number
       session?: string
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
   ): Observable<
     | (HttpResponse<{
@@ -20822,9 +19753,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       account_holder: p["accountHolder"],
       ending_before: p["endingBefore"],
@@ -20833,15 +19761,12 @@ export class StripeApiService {
       session: p["session"],
       starting_after: p["startingAfter"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/linked_accounts`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -20851,25 +19776,18 @@ export class StripeApiService {
   getLinkedAccountsAccount(p: {
     account: string
     expand?: string[]
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_financial_connections_account> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/linked_accounts/${p["account"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -20910,7 +19828,6 @@ export class StripeApiService {
     limit?: number
     ownership: string
     startingAfter?: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<{
         data: t_financial_connections_account_owner[]
@@ -20921,9 +19838,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       ending_before: p["endingBefore"],
       expand: p["expand"],
@@ -20931,15 +19845,12 @@ export class StripeApiService {
       ownership: p["ownership"],
       starting_after: p["startingAfter"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/linked_accounts/${p["account"]}/owners`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -20982,25 +19893,18 @@ export class StripeApiService {
   getMandatesMandate(p: {
     expand?: string[]
     mandate: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_mandate> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/mandates/${p["mandate"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -21022,7 +19926,6 @@ export class StripeApiService {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
   ): Observable<
     | (HttpResponse<{
@@ -21034,9 +19937,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       created: p["created"],
       customer: p["customer"],
@@ -21045,15 +19945,12 @@ export class StripeApiService {
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/payment_intents`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -22192,7 +21089,6 @@ export class StripeApiService {
     limit?: number
     page?: string
     query: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<{
         data: t_payment_intent[]
@@ -22205,24 +21101,18 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       expand: p["expand"],
       limit: p["limit"],
       page: p["page"],
       query: p["query"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/payment_intents/search`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -22233,28 +21123,21 @@ export class StripeApiService {
     clientSecret?: string
     expand?: string[]
     intent: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_payment_intent> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       client_secret: p["clientSecret"],
       expand: p["expand"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/payment_intents/${p["intent"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -24670,7 +23553,6 @@ export class StripeApiService {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
   ): Observable<
     | (HttpResponse<{
@@ -24682,9 +23564,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       active: p["active"],
       ending_before: p["endingBefore"],
@@ -24692,15 +23571,12 @@ export class StripeApiService {
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/payment_links`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -25228,25 +24104,18 @@ export class StripeApiService {
   getPaymentLinksPaymentLink(p: {
     expand?: string[]
     paymentLink: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_payment_link> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/payment_links/${p["paymentLink"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -25763,7 +24632,6 @@ export class StripeApiService {
     limit?: number
     paymentLink: string
     startingAfter?: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<{
         data: t_item[]
@@ -25774,24 +24642,18 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       ending_before: p["endingBefore"],
       expand: p["expand"],
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/payment_links/${p["paymentLink"]}/line_items`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -25805,7 +24667,6 @@ export class StripeApiService {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
   ): Observable<
     | (HttpResponse<{
@@ -25817,9 +24678,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       application: p["application"],
       ending_before: p["endingBefore"],
@@ -25827,15 +24685,12 @@ export class StripeApiService {
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/payment_method_configurations`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -26135,17 +24990,12 @@ export class StripeApiService {
   getPaymentMethodConfigurationsConfiguration(p: {
     configuration: string
     expand?: string[]
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_payment_method_configuration> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
@@ -26153,8 +25003,6 @@ export class StripeApiService {
         `/v1/payment_method_configurations/${p["configuration"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -26459,7 +25307,6 @@ export class StripeApiService {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
   ): Observable<
     | (HttpResponse<{
@@ -26471,9 +25318,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       domain_name: p["domainName"],
       enabled: p["enabled"],
@@ -26482,15 +25326,12 @@ export class StripeApiService {
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/payment_method_domains`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -26528,17 +25369,12 @@ export class StripeApiService {
   getPaymentMethodDomainsPaymentMethodDomain(p: {
     expand?: string[]
     paymentMethodDomain: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_payment_method_domain> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
@@ -26546,8 +25382,6 @@ export class StripeApiService {
         `/v1/payment_method_domains/${p["paymentMethodDomain"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -26668,7 +25502,6 @@ export class StripeApiService {
         | "wechat_pay"
         | "zip"
         | UnknownEnumStringValue
-      requestBody?: EmptyObject
     } = {},
   ): Observable<
     | (HttpResponse<{
@@ -26680,9 +25513,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       customer: p["customer"],
       ending_before: p["endingBefore"],
@@ -26691,15 +25521,12 @@ export class StripeApiService {
       starting_after: p["startingAfter"],
       type: p["type"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/payment_methods`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -27034,25 +25861,18 @@ export class StripeApiService {
   getPaymentMethodsPaymentMethod(p: {
     expand?: string[]
     paymentMethod: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_payment_method> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/payment_methods/${p["paymentMethod"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -27211,7 +26031,6 @@ export class StripeApiService {
       limit?: number
       startingAfter?: string
       status?: string
-      requestBody?: EmptyObject
     } = {},
   ): Observable<
     | (HttpResponse<{
@@ -27223,9 +26042,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       arrival_date: p["arrivalDate"],
       created: p["created"],
@@ -27236,15 +26052,12 @@ export class StripeApiService {
       starting_after: p["startingAfter"],
       status: p["status"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/payouts`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -27290,25 +26103,18 @@ export class StripeApiService {
   getPayoutsPayout(p: {
     expand?: string[]
     payout: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_payout> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/payouts/${p["payout"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -27421,7 +26227,6 @@ export class StripeApiService {
       limit?: number
       product?: string
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
   ): Observable<
     | (HttpResponse<{
@@ -27433,9 +26238,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       active: p["active"],
       created: p["created"],
@@ -27445,15 +26247,12 @@ export class StripeApiService {
       product: p["product"],
       starting_after: p["startingAfter"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/plans`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -27531,23 +26330,15 @@ export class StripeApiService {
 
   deletePlansPlan(p: {
     plan: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_deleted_plan> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
-    const body = p["requestBody"]
-
     return this.httpClient.request<any>(
       "DELETE",
       this.config.basePath + `/v1/plans/${p["plan"]}`,
       {
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -27557,25 +26348,18 @@ export class StripeApiService {
   getPlansPlan(p: {
     expand?: string[]
     plan: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_plan> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/plans/${p["plan"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -27643,7 +26427,6 @@ export class StripeApiService {
       }
       startingAfter?: string
       type?: "one_time" | "recurring" | UnknownEnumStringValue
-      requestBody?: EmptyObject
     } = {},
   ): Observable<
     | (HttpResponse<{
@@ -27655,9 +26438,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       active: p["active"],
       created: p["created"],
@@ -27671,15 +26451,12 @@ export class StripeApiService {
       starting_after: p["startingAfter"],
       type: p["type"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/prices`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -27795,7 +26572,6 @@ export class StripeApiService {
     limit?: number
     page?: string
     query: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<{
         data: t_price[]
@@ -27808,24 +26584,18 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       expand: p["expand"],
       limit: p["limit"],
       page: p["page"],
       query: p["query"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/prices/search`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -27835,25 +26605,18 @@ export class StripeApiService {
   getPricesPrice(p: {
     expand?: string[]
     price: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_price> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/prices/${p["price"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -27949,7 +26712,6 @@ export class StripeApiService {
       shippable?: boolean
       startingAfter?: string
       url?: string
-      requestBody?: EmptyObject
     } = {},
   ): Observable<
     | (HttpResponse<{
@@ -27961,9 +26723,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       active: p["active"],
       created: p["created"],
@@ -27975,15 +26734,12 @@ export class StripeApiService {
       starting_after: p["startingAfter"],
       url: p["url"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/products`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -28092,7 +26848,6 @@ export class StripeApiService {
     limit?: number
     page?: string
     query: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<{
         data: t_product[]
@@ -28105,24 +26860,18 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       expand: p["expand"],
       limit: p["limit"],
       page: p["page"],
       query: p["query"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/products/search`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -28131,23 +26880,15 @@ export class StripeApiService {
 
   deleteProductsId(p: {
     id: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_deleted_product> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
-    const body = p["requestBody"]
-
     return this.httpClient.request<any>(
       "DELETE",
       this.config.basePath + `/v1/products/${p["id"]}`,
       {
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -28157,25 +26898,18 @@ export class StripeApiService {
   getProductsId(p: {
     expand?: string[]
     id: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_product> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/products/${p["id"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -28246,7 +26980,6 @@ export class StripeApiService {
     limit?: number
     product: string
     startingAfter?: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<{
         data: t_product_feature[]
@@ -28257,24 +26990,18 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       ending_before: p["endingBefore"],
       expand: p["expand"],
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/products/${p["product"]}/features`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -28312,23 +27039,15 @@ export class StripeApiService {
   deleteProductsProductFeaturesId(p: {
     id: string
     product: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_deleted_product_feature> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
-    const body = p["requestBody"]
-
     return this.httpClient.request<any>(
       "DELETE",
       this.config.basePath + `/v1/products/${p["product"]}/features/${p["id"]}`,
       {
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -28339,25 +27058,18 @@ export class StripeApiService {
     expand?: string[]
     id: string
     product: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_product_feature> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/products/${p["product"]}/features/${p["id"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -28382,7 +27094,6 @@ export class StripeApiService {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
   ): Observable<
     | (HttpResponse<{
@@ -28394,9 +27105,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       active: p["active"],
       code: p["code"],
@@ -28408,15 +27116,12 @@ export class StripeApiService {
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/promotion_codes`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -28473,25 +27178,18 @@ export class StripeApiService {
   getPromotionCodesPromotionCode(p: {
     expand?: string[]
     promotionCode: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_promotion_code> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/promotion_codes/${p["promotionCode"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -28555,7 +27253,6 @@ export class StripeApiService {
         | "open"
         | UnknownEnumStringValue
       testClock?: string
-      requestBody?: EmptyObject
     } = {},
   ): Observable<
     | (HttpResponse<{
@@ -28567,9 +27264,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       customer: p["customer"],
       ending_before: p["endingBefore"],
@@ -28579,15 +27273,12 @@ export class StripeApiService {
       status: p["status"],
       test_clock: p["testClock"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/quotes`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -28724,25 +27415,18 @@ export class StripeApiService {
   getQuotesQuote(p: {
     expand?: string[]
     quote: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_quote> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/quotes/${p["quote"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -28923,7 +27607,6 @@ export class StripeApiService {
     limit?: number
     quote: string
     startingAfter?: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<{
         data: t_item[]
@@ -28934,16 +27617,12 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       ending_before: p["endingBefore"],
       expand: p["expand"],
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
@@ -28951,8 +27630,6 @@ export class StripeApiService {
         `/v1/quotes/${p["quote"]}/computed_upfront_line_items`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -28993,7 +27670,6 @@ export class StripeApiService {
     limit?: number
     quote: string
     startingAfter?: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<{
         data: t_item[]
@@ -29004,24 +27680,18 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       ending_before: p["endingBefore"],
       expand: p["expand"],
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/quotes/${p["quote"]}/line_items`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -29032,7 +27702,6 @@ export class StripeApiService {
     p: {
       expand?: string[]
       quote: string
-      requestBody?: EmptyObject
     },
     basePath:
       | Server<"getQuotesQuotePdf_StripeApiService">
@@ -29042,19 +27711,13 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       basePath + `/v1/quotes/${p["quote"]}/pdf`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -29077,7 +27740,6 @@ export class StripeApiService {
       limit?: number
       paymentIntent?: string
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
   ): Observable<
     | (HttpResponse<{
@@ -29089,9 +27751,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       charge: p["charge"],
       created: p["created"],
@@ -29101,15 +27760,12 @@ export class StripeApiService {
       payment_intent: p["paymentIntent"],
       starting_after: p["startingAfter"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/radar/early_fraud_warnings`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -29119,17 +27775,12 @@ export class StripeApiService {
   getRadarEarlyFraudWarningsEarlyFraudWarning(p: {
     earlyFraudWarning: string
     expand?: string[]
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_radar_early_fraud_warning> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
@@ -29137,8 +27788,6 @@ export class StripeApiService {
         `/v1/radar/early_fraud_warnings/${p["earlyFraudWarning"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -29160,7 +27809,6 @@ export class StripeApiService {
     startingAfter?: string
     value?: string
     valueList: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<{
         data: t_radar_value_list_item[]
@@ -29171,9 +27819,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       created: p["created"],
       ending_before: p["endingBefore"],
@@ -29183,15 +27828,12 @@ export class StripeApiService {
       value: p["value"],
       value_list: p["valueList"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/radar/value_list_items`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -29228,23 +27870,15 @@ export class StripeApiService {
 
   deleteRadarValueListItemsItem(p: {
     item: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_deleted_radar_value_list_item> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
-    const body = p["requestBody"]
-
     return this.httpClient.request<any>(
       "DELETE",
       this.config.basePath + `/v1/radar/value_list_items/${p["item"]}`,
       {
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -29254,25 +27888,18 @@ export class StripeApiService {
   getRadarValueListItemsItem(p: {
     expand?: string[]
     item: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_radar_value_list_item> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/radar/value_list_items/${p["item"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -29295,7 +27922,6 @@ export class StripeApiService {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
   ): Observable<
     | (HttpResponse<{
@@ -29307,9 +27933,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       alias: p["alias"],
       contains: p["contains"],
@@ -29319,15 +27942,12 @@ export class StripeApiService {
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/radar/value_lists`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -29379,23 +27999,15 @@ export class StripeApiService {
 
   deleteRadarValueListsValueList(p: {
     valueList: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_deleted_radar_value_list> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
-    const body = p["requestBody"]
-
     return this.httpClient.request<any>(
       "DELETE",
       this.config.basePath + `/v1/radar/value_lists/${p["valueList"]}`,
       {
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -29405,25 +28017,18 @@ export class StripeApiService {
   getRadarValueListsValueList(p: {
     expand?: string[]
     valueList: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_radar_value_list> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/radar/value_lists/${p["valueList"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -29478,7 +28083,6 @@ export class StripeApiService {
       limit?: number
       paymentIntent?: string
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
   ): Observable<
     | (HttpResponse<{
@@ -29490,9 +28094,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       charge: p["charge"],
       created: p["created"],
@@ -29502,15 +28103,12 @@ export class StripeApiService {
       payment_intent: p["paymentIntent"],
       starting_after: p["startingAfter"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/refunds`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -29568,25 +28166,18 @@ export class StripeApiService {
   getRefundsRefund(p: {
     expand?: string[]
     refund: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_refund> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/refunds/${p["refund"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -29667,7 +28258,6 @@ export class StripeApiService {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
   ): Observable<
     | (HttpResponse<{
@@ -29679,9 +28269,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       created: p["created"],
       ending_before: p["endingBefore"],
@@ -29689,15 +28276,12 @@ export class StripeApiService {
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/reporting/report_runs`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -30381,34 +28965,25 @@ export class StripeApiService {
   getReportingReportRunsReportRun(p: {
     expand?: string[]
     reportRun: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_reporting_report_run> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/reporting/report_runs/${p["reportRun"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
     )
   }
 
-  getReportingReportTypes(
-    p: {expand?: string[]; requestBody?: EmptyObject} = {},
-  ): Observable<
+  getReportingReportTypes(p: {expand?: string[]} = {}): Observable<
     | (HttpResponse<{
         data: t_reporting_report_type[]
         has_more: boolean
@@ -30418,19 +28993,13 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/reporting/report_types`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -30440,25 +29009,18 @@ export class StripeApiService {
   getReportingReportTypesReportType(p: {
     expand?: string[]
     reportType: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_reporting_report_type> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/reporting/report_types/${p["reportType"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -30479,7 +29041,6 @@ export class StripeApiService {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
   ): Observable<
     | (HttpResponse<{
@@ -30491,9 +29052,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       created: p["created"],
       ending_before: p["endingBefore"],
@@ -30501,15 +29059,12 @@ export class StripeApiService {
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/reviews`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -30519,25 +29074,18 @@ export class StripeApiService {
   getReviewsReview(p: {
     expand?: string[]
     review: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_review> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/reviews/${p["review"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -30585,7 +29133,6 @@ export class StripeApiService {
     limit?: number
     setupIntent: string
     startingAfter?: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<{
         data: t_setup_attempt[]
@@ -30596,9 +29143,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       created: p["created"],
       ending_before: p["endingBefore"],
@@ -30607,15 +29151,12 @@ export class StripeApiService {
       setup_intent: p["setupIntent"],
       starting_after: p["startingAfter"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/setup_attempts`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -30639,7 +29180,6 @@ export class StripeApiService {
       limit?: number
       paymentMethod?: string
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
   ): Observable<
     | (HttpResponse<{
@@ -30651,9 +29191,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       attach_to_self: p["attachToSelf"],
       created: p["created"],
@@ -30664,15 +29201,12 @@ export class StripeApiService {
       payment_method: p["paymentMethod"],
       starting_after: p["startingAfter"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/setup_intents`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -31269,28 +29803,21 @@ export class StripeApiService {
     clientSecret?: string
     expand?: string[]
     intent: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_setup_intent> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       client_secret: p["clientSecret"],
       expand: p["expand"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/setup_intents/${p["intent"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -32497,7 +31024,6 @@ export class StripeApiService {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
   ): Observable<
     | (HttpResponse<{
@@ -32509,9 +31035,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       active: p["active"],
       created: p["created"],
@@ -32521,15 +31044,12 @@ export class StripeApiService {
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/shipping_rates`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -32614,25 +31134,18 @@ export class StripeApiService {
   getShippingRatesShippingRateToken(p: {
     expand?: string[]
     shippingRateToken: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_shipping_rate> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/shipping_rates/${p["shippingRateToken"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -32727,7 +31240,6 @@ export class StripeApiService {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
   ): Observable<
     | (HttpResponse<{
@@ -32739,24 +31251,18 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       ending_before: p["endingBefore"],
       expand: p["expand"],
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/sigma/scheduled_query_runs`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -32766,17 +31272,12 @@ export class StripeApiService {
   getSigmaScheduledQueryRunsScheduledQueryRun(p: {
     expand?: string[]
     scheduledQueryRun: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_scheduled_query_run> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
@@ -32784,8 +31285,6 @@ export class StripeApiService {
         `/v1/sigma/scheduled_query_runs/${p["scheduledQueryRun"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -32929,28 +31428,21 @@ export class StripeApiService {
     clientSecret?: string
     expand?: string[]
     source: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_source> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       client_secret: p["clientSecret"],
       expand: p["expand"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/sources/${p["source"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -33073,17 +31565,12 @@ export class StripeApiService {
     expand?: string[]
     mandateNotification: string
     source: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_source_mandate_notification> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
@@ -33091,8 +31578,6 @@ export class StripeApiService {
         `/v1/sources/${p["source"]}/mandate_notifications/${p["mandateNotification"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -33105,7 +31590,6 @@ export class StripeApiService {
     limit?: number
     source: string
     startingAfter?: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<{
         data: t_source_transaction[]
@@ -33116,24 +31600,18 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       ending_before: p["endingBefore"],
       expand: p["expand"],
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/sources/${p["source"]}/source_transactions`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -33144,17 +31622,12 @@ export class StripeApiService {
     expand?: string[]
     source: string
     sourceTransaction: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_source_transaction> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
@@ -33162,8 +31635,6 @@ export class StripeApiService {
         `/v1/sources/${p["source"]}/source_transactions/${p["sourceTransaction"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -33204,7 +31675,6 @@ export class StripeApiService {
     limit?: number
     startingAfter?: string
     subscription: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<{
         data: t_subscription_item[]
@@ -33215,9 +31685,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       ending_before: p["endingBefore"],
       expand: p["expand"],
@@ -33225,15 +31692,12 @@ export class StripeApiService {
       starting_after: p["startingAfter"],
       subscription: p["subscription"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/subscription_items`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -33350,25 +31814,18 @@ export class StripeApiService {
   getSubscriptionItemsItem(p: {
     expand?: string[]
     item: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_subscription_item> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/subscription_items/${p["item"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -33493,7 +31950,6 @@ export class StripeApiService {
         | number
       scheduled?: boolean
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
   ): Observable<
     | (HttpResponse<{
@@ -33505,9 +31961,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       canceled_at: p["canceledAt"],
       completed_at: p["completedAt"],
@@ -33520,15 +31973,12 @@ export class StripeApiService {
       scheduled: p["scheduled"],
       starting_after: p["startingAfter"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/subscription_schedules`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -33752,25 +32202,18 @@ export class StripeApiService {
   getSubscriptionSchedulesSchedule(p: {
     expand?: string[]
     schedule: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_subscription_schedule> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/subscription_schedules/${p["schedule"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -34100,7 +32543,6 @@ export class StripeApiService {
         | "unpaid"
         | UnknownEnumStringValue
       testClock?: string
-      requestBody?: EmptyObject
     } = {},
   ): Observable<
     | (HttpResponse<{
@@ -34112,9 +32554,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       automatic_tax: p["automaticTax"],
       collection_method: p["collectionMethod"],
@@ -34130,15 +32569,12 @@ export class StripeApiService {
       status: p["status"],
       test_clock: p["testClock"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/subscriptions`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -34487,7 +32923,6 @@ export class StripeApiService {
     limit?: number
     page?: string
     query: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<{
         data: t_subscription[]
@@ -34500,24 +32935,18 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       expand: p["expand"],
       limit: p["limit"],
       page: p["page"],
       query: p["query"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/subscriptions/search`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -34570,25 +32999,18 @@ export class StripeApiService {
   getSubscriptionsSubscriptionExposedId(p: {
     expand?: string[]
     subscriptionExposedId: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_subscription> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/subscriptions/${p["subscriptionExposedId"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -34956,24 +33378,16 @@ export class StripeApiService {
 
   deleteSubscriptionsSubscriptionExposedIdDiscount(p: {
     subscriptionExposedId: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_deleted_discount> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
-    const body = p["requestBody"]
-
     return this.httpClient.request<any>(
       "DELETE",
       this.config.basePath +
         `/v1/subscriptions/${p["subscriptionExposedId"]}/discount`,
       {
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -35235,25 +33649,18 @@ export class StripeApiService {
   getTaxCalculationsCalculation(p: {
     calculation: string
     expand?: string[]
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_tax_calculation> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/tax/calculations/${p["calculation"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -35266,7 +33673,6 @@ export class StripeApiService {
     expand?: string[]
     limit?: number
     startingAfter?: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<{
         data: t_tax_calculation_line_item[]
@@ -35277,16 +33683,12 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       ending_before: p["endingBefore"],
       expand: p["expand"],
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
@@ -35294,8 +33696,6 @@ export class StripeApiService {
         `/v1/tax/calculations/${p["calculation"]}/line_items`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -35314,7 +33714,6 @@ export class StripeApiService {
         | "expired"
         | "scheduled"
         | UnknownEnumStringValue
-      requestBody?: EmptyObject
     } = {},
   ): Observable<
     | (HttpResponse<{
@@ -35326,9 +33725,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       ending_before: p["endingBefore"],
       expand: p["expand"],
@@ -35336,15 +33732,12 @@ export class StripeApiService {
       starting_after: p["startingAfter"],
       status: p["status"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/tax/registrations`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -36009,25 +34402,18 @@ export class StripeApiService {
   getTaxRegistrationsId(p: {
     expand?: string[]
     id: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_tax_registration> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/tax/registrations/${p["id"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -36064,25 +34450,19 @@ export class StripeApiService {
   }
 
   getTaxSettings(
-    p: {expand?: string[]; requestBody?: EmptyObject} = {},
+    p: {expand?: string[]} = {},
   ): Observable<
     | (HttpResponse<t_tax_settings> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/tax/settings`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -36217,25 +34597,18 @@ export class StripeApiService {
   getTaxTransactionsTransaction(p: {
     expand?: string[]
     transaction: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_tax_transaction> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/tax/transactions/${p["transaction"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -36248,7 +34621,6 @@ export class StripeApiService {
     limit?: number
     startingAfter?: string
     transaction: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<{
         data: t_tax_transaction_line_item[]
@@ -36259,16 +34631,12 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       ending_before: p["endingBefore"],
       expand: p["expand"],
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
@@ -36276,8 +34644,6 @@ export class StripeApiService {
         `/v1/tax/transactions/${p["transaction"]}/line_items`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -36290,7 +34656,6 @@ export class StripeApiService {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
   ): Observable<
     | (HttpResponse<{
@@ -36302,24 +34667,18 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       ending_before: p["endingBefore"],
       expand: p["expand"],
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/tax_codes`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -36329,25 +34688,18 @@ export class StripeApiService {
   getTaxCodesId(p: {
     expand?: string[]
     id: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_tax_code> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/tax_codes/${p["id"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -36370,7 +34722,6 @@ export class StripeApiService {
           | UnknownEnumStringValue
       }
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
   ): Observable<
     | (HttpResponse<{
@@ -36382,9 +34733,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       ending_before: p["endingBefore"],
       expand: p["expand"],
@@ -36392,15 +34740,12 @@ export class StripeApiService {
       owner: p["owner"],
       starting_after: p["startingAfter"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/tax_ids`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -36558,23 +34903,15 @@ export class StripeApiService {
 
   deleteTaxIdsId(p: {
     id: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_deleted_tax_id> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
-    const body = p["requestBody"]
-
     return this.httpClient.request<any>(
       "DELETE",
       this.config.basePath + `/v1/tax_ids/${p["id"]}`,
       {
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -36584,25 +34921,18 @@ export class StripeApiService {
   getTaxIdsId(p: {
     expand?: string[]
     id: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_tax_id> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/tax_ids/${p["id"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -36625,7 +34955,6 @@ export class StripeApiService {
       inclusive?: boolean
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
   ): Observable<
     | (HttpResponse<{
@@ -36637,9 +34966,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       active: p["active"],
       created: p["created"],
@@ -36649,15 +34975,12 @@ export class StripeApiService {
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/tax_rates`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -36720,25 +35043,18 @@ export class StripeApiService {
   getTaxRatesTaxRate(p: {
     expand?: string[]
     taxRate: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_tax_rate> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/tax_rates/${p["taxRate"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -36807,7 +35123,6 @@ export class StripeApiService {
       isAccountDefault?: boolean
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
   ): Observable<
     | (HttpResponse<{
@@ -36819,9 +35134,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       ending_before: p["endingBefore"],
       expand: p["expand"],
@@ -36829,15 +35141,12 @@ export class StripeApiService {
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/terminal/configurations`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -37006,24 +35315,16 @@ export class StripeApiService {
 
   deleteTerminalConfigurationsConfiguration(p: {
     configuration: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_deleted_terminal_configuration> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
-    const body = p["requestBody"]
-
     return this.httpClient.request<any>(
       "DELETE",
       this.config.basePath +
         `/v1/terminal/configurations/${p["configuration"]}`,
       {
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -37033,7 +35334,6 @@ export class StripeApiService {
   getTerminalConfigurationsConfiguration(p: {
     configuration: string
     expand?: string[]
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<
         t_terminal_configuration | t_deleted_terminal_configuration
@@ -37041,11 +35341,7 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
@@ -37053,8 +35349,6 @@ export class StripeApiService {
         `/v1/terminal/configurations/${p["configuration"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -37270,7 +35564,6 @@ export class StripeApiService {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
   ): Observable<
     | (HttpResponse<{
@@ -37282,24 +35575,18 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       ending_before: p["endingBefore"],
       expand: p["expand"],
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/terminal/locations`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -37350,23 +35637,15 @@ export class StripeApiService {
 
   deleteTerminalLocationsLocation(p: {
     location: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_deleted_terminal_location> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
-    const body = p["requestBody"]
-
     return this.httpClient.request<any>(
       "DELETE",
       this.config.basePath + `/v1/terminal/locations/${p["location"]}`,
       {
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -37376,7 +35655,6 @@ export class StripeApiService {
   getTerminalLocationsLocation(p: {
     expand?: string[]
     location: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_terminal_location | t_deleted_terminal_location> & {
         status: 200
@@ -37384,19 +35662,13 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/terminal/locations/${p["location"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -37468,7 +35740,6 @@ export class StripeApiService {
       serialNumber?: string
       startingAfter?: string
       status?: "offline" | "online" | UnknownEnumStringValue
-      requestBody?: EmptyObject
     } = {},
   ): Observable<
     | (HttpResponse<{
@@ -37480,9 +35751,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       device_type: p["deviceType"],
       ending_before: p["endingBefore"],
@@ -37493,15 +35761,12 @@ export class StripeApiService {
       starting_after: p["startingAfter"],
       status: p["status"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/terminal/readers`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -37545,23 +35810,15 @@ export class StripeApiService {
 
   deleteTerminalReadersReader(p: {
     reader: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_deleted_terminal_reader> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
-    const body = p["requestBody"]
-
     return this.httpClient.request<any>(
       "DELETE",
       this.config.basePath + `/v1/terminal/readers/${p["reader"]}`,
       {
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -37571,7 +35828,6 @@ export class StripeApiService {
   getTerminalReadersReader(p: {
     expand?: string[]
     reader: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_terminal_reader | t_deleted_terminal_reader> & {
         status: 200
@@ -37579,19 +35835,13 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/terminal/readers/${p["reader"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -40376,7 +38626,6 @@ export class StripeApiService {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
   ): Observable<
     | (HttpResponse<{
@@ -40388,24 +38637,18 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       ending_before: p["endingBefore"],
       expand: p["expand"],
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/test_helpers/test_clocks`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -40442,23 +38685,15 @@ export class StripeApiService {
 
   deleteTestHelpersTestClocksTestClock(p: {
     testClock: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_deleted_test_helpers_test_clock> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
-    const body = p["requestBody"]
-
     return this.httpClient.request<any>(
       "DELETE",
       this.config.basePath + `/v1/test_helpers/test_clocks/${p["testClock"]}`,
       {
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -40468,25 +38703,18 @@ export class StripeApiService {
   getTestHelpersTestClocksTestClock(p: {
     expand?: string[]
     testClock: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_test_helpers_test_clock> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/test_helpers/test_clocks/${p["testClock"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -41392,25 +39620,18 @@ export class StripeApiService {
   getTokensToken(p: {
     expand?: string[]
     token: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_token> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/tokens/${p["token"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -41445,7 +39666,6 @@ export class StripeApiService {
         | "pending"
         | "succeeded"
         | UnknownEnumStringValue
-      requestBody?: EmptyObject
     } = {},
   ): Observable<
     | (HttpResponse<{
@@ -41457,9 +39677,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       amount: p["amount"],
       created: p["created"],
@@ -41469,15 +39686,12 @@ export class StripeApiService {
       starting_after: p["startingAfter"],
       status: p["status"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/topups`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -41525,25 +39739,18 @@ export class StripeApiService {
   getTopupsTopup(p: {
     expand?: string[]
     topup: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_topup> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/topups/${p["topup"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -41627,7 +39834,6 @@ export class StripeApiService {
       limit?: number
       startingAfter?: string
       transferGroup?: string
-      requestBody?: EmptyObject
     } = {},
   ): Observable<
     | (HttpResponse<{
@@ -41639,9 +39845,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       created: p["created"],
       destination: p["destination"],
@@ -41651,15 +39854,12 @@ export class StripeApiService {
       starting_after: p["startingAfter"],
       transfer_group: p["transferGroup"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/transfers`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -41708,7 +39908,6 @@ export class StripeApiService {
     id: string
     limit?: number
     startingAfter?: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<{
         data: t_transfer_reversal[]
@@ -41719,24 +39918,18 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       ending_before: p["endingBefore"],
       expand: p["expand"],
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/transfers/${p["id"]}/reversals`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -41782,25 +39975,18 @@ export class StripeApiService {
   getTransfersTransfer(p: {
     expand?: string[]
     transfer: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_transfer> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/transfers/${p["transfer"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -41845,17 +40031,12 @@ export class StripeApiService {
     expand?: string[]
     id: string
     transfer: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_transfer_reversal> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
@@ -41863,8 +40044,6 @@ export class StripeApiService {
         `/v1/transfers/${p["transfer"]}/reversals/${p["id"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -41914,7 +40093,6 @@ export class StripeApiService {
     receivedCredit?: string
     startingAfter?: string
     status?: "canceled" | "posted" | "processing" | UnknownEnumStringValue
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<{
         data: t_treasury_credit_reversal[]
@@ -41925,9 +40103,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       ending_before: p["endingBefore"],
       expand: p["expand"],
@@ -41937,15 +40112,12 @@ export class StripeApiService {
       starting_after: p["startingAfter"],
       status: p["status"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/treasury/credit_reversals`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -41985,17 +40157,12 @@ export class StripeApiService {
   getTreasuryCreditReversalsCreditReversal(p: {
     creditReversal: string
     expand?: string[]
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_treasury_credit_reversal> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
@@ -42003,8 +40170,6 @@ export class StripeApiService {
         `/v1/treasury/credit_reversals/${p["creditReversal"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -42020,7 +40185,6 @@ export class StripeApiService {
     resolution?: "lost" | "won" | UnknownEnumStringValue
     startingAfter?: string
     status?: "canceled" | "completed" | "processing" | UnknownEnumStringValue
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<{
         data: t_treasury_debit_reversal[]
@@ -42031,9 +40195,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       ending_before: p["endingBefore"],
       expand: p["expand"],
@@ -42044,15 +40205,12 @@ export class StripeApiService {
       starting_after: p["startingAfter"],
       status: p["status"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/treasury/debit_reversals`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -42092,17 +40250,12 @@ export class StripeApiService {
   getTreasuryDebitReversalsDebitReversal(p: {
     debitReversal: string
     expand?: string[]
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_treasury_debit_reversal> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
@@ -42110,8 +40263,6 @@ export class StripeApiService {
         `/v1/treasury/debit_reversals/${p["debitReversal"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -42133,7 +40284,6 @@ export class StripeApiService {
       limit?: number
       startingAfter?: string
       status?: "closed" | "open" | UnknownEnumStringValue
-      requestBody?: EmptyObject
     } = {},
   ): Observable<
     | (HttpResponse<{
@@ -42145,9 +40295,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       created: p["created"],
       ending_before: p["endingBefore"],
@@ -42156,15 +40303,12 @@ export class StripeApiService {
       starting_after: p["startingAfter"],
       status: p["status"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/treasury/financial_accounts`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -42246,17 +40390,12 @@ export class StripeApiService {
   getTreasuryFinancialAccountsFinancialAccount(p: {
     expand?: string[]
     financialAccount: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_treasury_financial_account> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
@@ -42264,8 +40403,6 @@ export class StripeApiService {
         `/v1/treasury/financial_accounts/${p["financialAccount"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -42386,17 +40523,12 @@ export class StripeApiService {
   getTreasuryFinancialAccountsFinancialAccountFeatures(p: {
     expand?: string[]
     financialAccount: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_treasury_financial_account_features> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
@@ -42404,8 +40536,6 @@ export class StripeApiService {
         `/v1/treasury/financial_accounts/${p["financialAccount"]}/features`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -42487,7 +40617,6 @@ export class StripeApiService {
       | "processing"
       | "succeeded"
       | UnknownEnumStringValue
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<{
         data: t_treasury_inbound_transfer[]
@@ -42498,9 +40627,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       ending_before: p["endingBefore"],
       expand: p["expand"],
@@ -42509,15 +40635,12 @@ export class StripeApiService {
       starting_after: p["startingAfter"],
       status: p["status"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/treasury/inbound_transfers`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -42562,25 +40685,18 @@ export class StripeApiService {
   getTreasuryInboundTransfersId(p: {
     expand?: string[]
     id: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_treasury_inbound_transfer> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/treasury/inbound_transfers/${p["id"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -42637,7 +40753,6 @@ export class StripeApiService {
       | "processing"
       | "returned"
       | UnknownEnumStringValue
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<{
         data: t_treasury_outbound_payment[]
@@ -42648,9 +40763,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       created: p["created"],
       customer: p["customer"],
@@ -42661,15 +40773,12 @@ export class StripeApiService {
       starting_after: p["startingAfter"],
       status: p["status"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/treasury/outbound_payments`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -42760,25 +40869,18 @@ export class StripeApiService {
   getTreasuryOutboundPaymentsId(p: {
     expand?: string[]
     id: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_treasury_outbound_payment> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/treasury/outbound_payments/${p["id"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -42825,7 +40927,6 @@ export class StripeApiService {
       | "processing"
       | "returned"
       | UnknownEnumStringValue
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<{
         data: t_treasury_outbound_transfer[]
@@ -42836,9 +40937,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       ending_before: p["endingBefore"],
       expand: p["expand"],
@@ -42847,15 +40945,12 @@ export class StripeApiService {
       starting_after: p["startingAfter"],
       status: p["status"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/treasury/outbound_transfers`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -42912,17 +41007,12 @@ export class StripeApiService {
   getTreasuryOutboundTransfersOutboundTransfer(p: {
     expand?: string[]
     outboundTransfer: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_treasury_outbound_transfer> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
@@ -42930,8 +41020,6 @@ export class StripeApiService {
         `/v1/treasury/outbound_transfers/${p["outboundTransfer"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -42982,7 +41070,6 @@ export class StripeApiService {
     }
     startingAfter?: string
     status?: "failed" | "succeeded" | UnknownEnumStringValue
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<{
         data: t_treasury_received_credit[]
@@ -42993,9 +41080,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       ending_before: p["endingBefore"],
       expand: p["expand"],
@@ -43005,15 +41089,12 @@ export class StripeApiService {
       starting_after: p["startingAfter"],
       status: p["status"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/treasury/received_credits`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -43023,25 +41104,18 @@ export class StripeApiService {
   getTreasuryReceivedCreditsId(p: {
     expand?: string[]
     id: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_treasury_received_credit> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/treasury/received_credits/${p["id"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -43055,7 +41129,6 @@ export class StripeApiService {
     limit?: number
     startingAfter?: string
     status?: "failed" | "succeeded" | UnknownEnumStringValue
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<{
         data: t_treasury_received_debit[]
@@ -43066,9 +41139,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       ending_before: p["endingBefore"],
       expand: p["expand"],
@@ -43077,15 +41147,12 @@ export class StripeApiService {
       starting_after: p["startingAfter"],
       status: p["status"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/treasury/received_debits`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -43095,25 +41162,18 @@ export class StripeApiService {
   getTreasuryReceivedDebitsId(p: {
     expand?: string[]
     id: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_treasury_received_debit> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/treasury/received_debits/${p["id"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -43144,7 +41204,6 @@ export class StripeApiService {
     orderBy?: "created" | "effective_at" | UnknownEnumStringValue
     startingAfter?: string
     transaction?: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<{
         data: t_treasury_transaction_entry[]
@@ -43155,9 +41214,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       created: p["created"],
       effective_at: p["effectiveAt"],
@@ -43169,15 +41225,12 @@ export class StripeApiService {
       starting_after: p["startingAfter"],
       transaction: p["transaction"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/treasury/transaction_entries`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -43187,25 +41240,18 @@ export class StripeApiService {
   getTreasuryTransactionEntriesId(p: {
     expand?: string[]
     id: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_treasury_transaction_entry> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/treasury/transaction_entries/${p["id"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -43238,7 +41284,6 @@ export class StripeApiService {
           }
         | number
     }
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<{
         data: t_treasury_transaction[]
@@ -43249,9 +41294,6 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       created: p["created"],
       ending_before: p["endingBefore"],
@@ -43263,15 +41305,12 @@ export class StripeApiService {
       status: p["status"],
       status_transitions: p["statusTransitions"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/treasury/transactions`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -43281,25 +41320,18 @@ export class StripeApiService {
   getTreasuryTransactionsId(p: {
     expand?: string[]
     id: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_treasury_transaction> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/treasury/transactions/${p["id"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -43312,7 +41344,6 @@ export class StripeApiService {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
   ): Observable<
     | (HttpResponse<{
@@ -43324,24 +41355,18 @@ export class StripeApiService {
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({
       ending_before: p["endingBefore"],
       expand: p["expand"],
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/webhook_endpoints`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -43746,23 +41771,15 @@ export class StripeApiService {
 
   deleteWebhookEndpointsWebhookEndpoint(p: {
     webhookEndpoint: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_deleted_webhook_endpoint> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
-    const body = p["requestBody"]
-
     return this.httpClient.request<any>(
       "DELETE",
       this.config.basePath + `/v1/webhook_endpoints/${p["webhookEndpoint"]}`,
       {
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },
@@ -43772,25 +41789,18 @@ export class StripeApiService {
   getWebhookEndpointsWebhookEndpoint(p: {
     expand?: string[]
     webhookEndpoint: string
-    requestBody?: EmptyObject
   }): Observable<
     | (HttpResponse<t_webhook_endpoint> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/x-www-form-urlencoded",
-    })
     const params = this._queryParams({expand: p["expand"]})
-    const body = p["requestBody"]
 
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/v1/webhook_endpoints/${p["webhookEndpoint"]}`,
       {
         params,
-        headers,
-        body,
         observe: "response",
         reportProgress: false,
       },

--- a/integration-tests/typescript-axios/src/generated/stripe.yaml/client.ts
+++ b/integration-tests/typescript-axios/src/generated/stripe.yaml/client.ts
@@ -239,23 +239,17 @@ export class StripeApi extends AbstractAxiosClient {
   async getAccount(
     p: {
       expand?: string[]
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_account>> {
     const url = `/v1/account`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -542,7 +536,6 @@ export class StripeApi extends AbstractAxiosClient {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -555,10 +548,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/accounts`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       created: p["created"],
       ending_before: p["endingBefore"],
@@ -566,12 +556,10 @@ export class StripeApi extends AbstractAxiosClient {
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -1458,22 +1446,16 @@ export class StripeApi extends AbstractAxiosClient {
   async deleteAccountsAccount(
     p: {
       account: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_deleted_account>> {
     const url = `/v1/accounts/${p["account"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
-    const body = JSON.stringify(p.requestBody)
+    const headers = this._headers({}, opts.headers)
 
     return this._request({
       url: url,
       method: "DELETE",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -1484,23 +1466,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       account: string
       expand?: string[]
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_account>> {
     const url = `/v1/accounts/${p["account"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -2394,22 +2370,16 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       account: string
       id: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_deleted_external_account>> {
     const url = `/v1/accounts/${p["account"]}/bank_accounts/${p["id"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
-    const body = JSON.stringify(p.requestBody)
+    const headers = this._headers({}, opts.headers)
 
     return this._request({
       url: url,
       method: "DELETE",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -2421,23 +2391,17 @@ export class StripeApi extends AbstractAxiosClient {
       account: string
       expand?: string[]
       id: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_external_account>> {
     const url = `/v1/accounts/${p["account"]}/bank_accounts/${p["id"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -2511,7 +2475,6 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       account: string
       expand?: string[]
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -2524,17 +2487,12 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/accounts/${p["account"]}/capabilities`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -2546,23 +2504,17 @@ export class StripeApi extends AbstractAxiosClient {
       account: string
       capability: string
       expand?: string[]
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_capability>> {
     const url = `/v1/accounts/${p["account"]}/capabilities/${p["capability"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -2606,7 +2558,6 @@ export class StripeApi extends AbstractAxiosClient {
       limit?: number
       object?: "bank_account" | "card" | UnknownEnumStringValue
       startingAfter?: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -2619,10 +2570,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/accounts/${p["account"]}/external_accounts`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
@@ -2630,12 +2578,10 @@ export class StripeApi extends AbstractAxiosClient {
       object: p["object"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -2714,22 +2660,16 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       account: string
       id: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_deleted_external_account>> {
     const url = `/v1/accounts/${p["account"]}/external_accounts/${p["id"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
-    const body = JSON.stringify(p.requestBody)
+    const headers = this._headers({}, opts.headers)
 
     return this._request({
       url: url,
       method: "DELETE",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -2741,23 +2681,17 @@ export class StripeApi extends AbstractAxiosClient {
       account: string
       expand?: string[]
       id: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_external_account>> {
     const url = `/v1/accounts/${p["account"]}/external_accounts/${p["id"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -2869,7 +2803,6 @@ export class StripeApi extends AbstractAxiosClient {
         representative?: boolean | undefined
       }
       startingAfter?: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -2882,10 +2815,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/accounts/${p["account"]}/people`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
@@ -2893,12 +2823,10 @@ export class StripeApi extends AbstractAxiosClient {
       relationship: p["relationship"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -3135,22 +3063,16 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       account: string
       person: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_deleted_person>> {
     const url = `/v1/accounts/${p["account"]}/people/${p["person"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
-    const body = JSON.stringify(p.requestBody)
+    const headers = this._headers({}, opts.headers)
 
     return this._request({
       url: url,
       method: "DELETE",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -3162,23 +3084,17 @@ export class StripeApi extends AbstractAxiosClient {
       account: string
       expand?: string[]
       person: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_person>> {
     const url = `/v1/accounts/${p["account"]}/people/${p["person"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -3427,7 +3343,6 @@ export class StripeApi extends AbstractAxiosClient {
         representative?: boolean | undefined
       }
       startingAfter?: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -3440,10 +3355,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/accounts/${p["account"]}/persons`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
@@ -3451,12 +3363,10 @@ export class StripeApi extends AbstractAxiosClient {
       relationship: p["relationship"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -3693,22 +3603,16 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       account: string
       person: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_deleted_person>> {
     const url = `/v1/accounts/${p["account"]}/persons/${p["person"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
-    const body = JSON.stringify(p.requestBody)
+    const headers = this._headers({}, opts.headers)
 
     return this._request({
       url: url,
       method: "DELETE",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -3720,23 +3624,17 @@ export class StripeApi extends AbstractAxiosClient {
       account: string
       expand?: string[]
       person: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_person>> {
     const url = `/v1/accounts/${p["account"]}/persons/${p["person"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -4005,7 +3903,6 @@ export class StripeApi extends AbstractAxiosClient {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -4018,10 +3915,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/apple_pay/domains`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       domain_name: p["domainName"],
       ending_before: p["endingBefore"],
@@ -4029,12 +3923,10 @@ export class StripeApi extends AbstractAxiosClient {
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -4071,22 +3963,16 @@ export class StripeApi extends AbstractAxiosClient {
   async deleteApplePayDomainsDomain(
     p: {
       domain: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_deleted_apple_pay_domain>> {
     const url = `/v1/apple_pay/domains/${p["domain"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
-    const body = JSON.stringify(p.requestBody)
+    const headers = this._headers({}, opts.headers)
 
     return this._request({
       url: url,
       method: "DELETE",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -4097,23 +3983,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       domain: string
       expand?: string[]
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_apple_pay_domain>> {
     const url = `/v1/apple_pay/domains/${p["domain"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -4135,7 +4015,6 @@ export class StripeApi extends AbstractAxiosClient {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -4148,10 +4027,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/application_fees`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       charge: p["charge"],
       created: p["created"],
@@ -4160,12 +4036,10 @@ export class StripeApi extends AbstractAxiosClient {
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -4177,23 +4051,17 @@ export class StripeApi extends AbstractAxiosClient {
       expand?: string[]
       fee: string
       id: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_fee_refund>> {
     const url = `/v1/application_fees/${p["fee"]}/refunds/${p["id"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -4241,23 +4109,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       expand?: string[]
       id: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_application_fee>> {
     const url = `/v1/application_fees/${p["id"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -4300,7 +4162,6 @@ export class StripeApi extends AbstractAxiosClient {
       id: string
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -4313,22 +4174,17 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/application_fees/${p["id"]}/refunds`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -4378,7 +4234,6 @@ export class StripeApi extends AbstractAxiosClient {
         user?: string | undefined
       }
       startingAfter?: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -4391,10 +4246,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/apps/secrets`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
@@ -4402,12 +4254,10 @@ export class StripeApi extends AbstractAxiosClient {
       scope: p["scope"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -4486,27 +4336,21 @@ export class StripeApi extends AbstractAxiosClient {
         type: "account" | "user" | UnknownEnumStringValue
         user?: string | undefined
       }
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_apps_secret>> {
     const url = `/v1/apps/secrets/find`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       expand: p["expand"],
       name: p["name"],
       scope: p["scope"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -4516,23 +4360,17 @@ export class StripeApi extends AbstractAxiosClient {
   async getBalance(
     p: {
       expand?: string[]
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_balance>> {
     const url = `/v1/balance`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -4557,7 +4395,6 @@ export class StripeApi extends AbstractAxiosClient {
       source?: string
       startingAfter?: string
       type?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -4570,10 +4407,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/balance/history`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       created: p["created"],
       currency: p["currency"],
@@ -4585,12 +4419,10 @@ export class StripeApi extends AbstractAxiosClient {
       starting_after: p["startingAfter"],
       type: p["type"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -4601,23 +4433,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       expand?: string[]
       id: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_balance_transaction>> {
     const url = `/v1/balance/history/${p["id"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -4642,7 +4468,6 @@ export class StripeApi extends AbstractAxiosClient {
       source?: string
       startingAfter?: string
       type?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -4655,10 +4480,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/balance_transactions`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       created: p["created"],
       currency: p["currency"],
@@ -4670,12 +4492,10 @@ export class StripeApi extends AbstractAxiosClient {
       starting_after: p["startingAfter"],
       type: p["type"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -4686,23 +4506,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       expand?: string[]
       id: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_balance_transaction>> {
     const url = `/v1/balance_transactions/${p["id"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -4717,7 +4531,6 @@ export class StripeApi extends AbstractAxiosClient {
       limit?: number
       meter?: string
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -4730,10 +4543,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/billing/alerts`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       alert_type: p["alertType"],
       ending_before: p["endingBefore"],
@@ -4742,12 +4552,10 @@ export class StripeApi extends AbstractAxiosClient {
       meter: p["meter"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -4799,23 +4607,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       expand?: string[]
       id: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_billing_alert>> {
     const url = `/v1/billing/alerts/${p["id"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -4921,27 +4723,21 @@ export class StripeApi extends AbstractAxiosClient {
         credit_grant?: string | undefined
         type: "applicability_scope" | "credit_grant" | UnknownEnumStringValue
       }
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_billing_credit_balance_summary>> {
     const url = `/v1/billing/credit_balance_summary`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       customer: p["customer"],
       expand: p["expand"],
       filter: p["filter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -4956,7 +4752,6 @@ export class StripeApi extends AbstractAxiosClient {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -4969,10 +4764,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/billing/credit_balance_transactions`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       credit_grant: p["creditGrant"],
       customer: p["customer"],
@@ -4981,12 +4773,10 @@ export class StripeApi extends AbstractAxiosClient {
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -4997,23 +4787,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       expand?: string[]
       id: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_billing_credit_balance_transaction>> {
     const url = `/v1/billing/credit_balance_transactions/${p["id"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -5027,7 +4811,6 @@ export class StripeApi extends AbstractAxiosClient {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -5040,10 +4823,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/billing/credit_grants`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       customer: p["customer"],
       ending_before: p["endingBefore"],
@@ -5051,12 +4831,10 @@ export class StripeApi extends AbstractAxiosClient {
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -5123,23 +4901,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       expand?: string[]
       id: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_billing_credit_grant>> {
     const url = `/v1/billing/credit_grants/${p["id"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -5305,7 +5077,6 @@ export class StripeApi extends AbstractAxiosClient {
       limit?: number
       startingAfter?: string
       status?: "active" | "inactive" | UnknownEnumStringValue
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -5318,10 +5089,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/billing/meters`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
@@ -5329,12 +5097,10 @@ export class StripeApi extends AbstractAxiosClient {
       starting_after: p["startingAfter"],
       status: p["status"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -5390,23 +5156,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       expand?: string[]
       id: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_billing_meter>> {
     const url = `/v1/billing/meters/${p["id"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -5479,7 +5239,6 @@ export class StripeApi extends AbstractAxiosClient {
       startTime: number
       startingAfter?: string
       valueGroupingWindow?: "day" | "hour" | UnknownEnumStringValue
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -5492,10 +5251,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/billing/meters/${p["id"]}/event_summaries`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       customer: p["customer"],
       end_time: p["endTime"],
@@ -5506,12 +5262,10 @@ export class StripeApi extends AbstractAxiosClient {
       starting_after: p["startingAfter"],
       value_grouping_window: p["valueGroupingWindow"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -5553,7 +5307,6 @@ export class StripeApi extends AbstractAxiosClient {
       isDefault?: boolean
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -5566,10 +5319,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/billing_portal/configurations`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       active: p["active"],
       ending_before: p["endingBefore"],
@@ -5578,12 +5328,10 @@ export class StripeApi extends AbstractAxiosClient {
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -5752,23 +5500,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       configuration: string
       expand?: string[]
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_billing_portal_configuration>> {
     const url = `/v1/billing_portal/configurations/${p["configuration"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -6118,7 +5860,6 @@ export class StripeApi extends AbstractAxiosClient {
       paymentIntent?: string
       startingAfter?: string
       transferGroup?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -6131,10 +5872,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/charges`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       created: p["created"],
       customer: p["customer"],
@@ -6145,12 +5883,10 @@ export class StripeApi extends AbstractAxiosClient {
       starting_after: p["startingAfter"],
       transfer_group: p["transferGroup"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -6271,7 +6007,6 @@ export class StripeApi extends AbstractAxiosClient {
       limit?: number
       page?: string
       query: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -6286,22 +6021,17 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/charges/search`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       expand: p["expand"],
       limit: p["limit"],
       page: p["page"],
       query: p["query"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -6312,23 +6042,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       charge: string
       expand?: string[]
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_charge>> {
     const url = `/v1/charges/${p["charge"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -6439,23 +6163,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       charge: string
       expand?: string[]
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_dispute>> {
     const url = `/v1/charges/${p["charge"]}/dispute`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -6774,7 +6492,6 @@ export class StripeApi extends AbstractAxiosClient {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -6787,22 +6504,17 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/charges/${p["charge"]}/refunds`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -6866,23 +6578,17 @@ export class StripeApi extends AbstractAxiosClient {
       charge: string
       expand?: string[]
       refund: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_refund>> {
     const url = `/v1/charges/${p["charge"]}/refunds/${p["refund"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -6948,7 +6654,6 @@ export class StripeApi extends AbstractAxiosClient {
       startingAfter?: string
       status?: "complete" | "expired" | "open" | UnknownEnumStringValue
       subscription?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -6961,10 +6666,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/checkout/sessions`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       created: p["created"],
       customer: p["customer"],
@@ -6978,12 +6680,10 @@ export class StripeApi extends AbstractAxiosClient {
       status: p["status"],
       subscription: p["subscription"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -8416,23 +8116,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       expand?: string[]
       session: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_checkout_session>> {
     const url = `/v1/checkout/sessions/${p["session"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -8608,7 +8302,6 @@ export class StripeApi extends AbstractAxiosClient {
       limit?: number
       session: string
       startingAfter?: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -8621,22 +8314,17 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/checkout/sessions/${p["session"]}/line_items`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -8649,7 +8337,6 @@ export class StripeApi extends AbstractAxiosClient {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -8662,22 +8349,17 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/climate/orders`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -8728,23 +8410,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       expand?: string[]
       order: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_climate_order>> {
     const url = `/v1/climate/orders/${p["order"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -8825,7 +8501,6 @@ export class StripeApi extends AbstractAxiosClient {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -8838,22 +8513,17 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/climate/products`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -8864,23 +8534,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       expand?: string[]
       product: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_climate_product>> {
     const url = `/v1/climate/products/${p["product"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -8893,7 +8557,6 @@ export class StripeApi extends AbstractAxiosClient {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -8906,22 +8569,17 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/climate/suppliers`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -8932,23 +8590,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       expand?: string[]
       supplier: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_climate_supplier>> {
     const url = `/v1/climate/suppliers/${p["supplier"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -8959,23 +8611,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       confirmationToken: string
       expand?: string[]
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_confirmation_token>> {
     const url = `/v1/confirmation_tokens/${p["confirmationToken"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -8988,7 +8634,6 @@ export class StripeApi extends AbstractAxiosClient {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -9001,22 +8646,17 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/country_specs`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -9027,23 +8667,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       country: string
       expand?: string[]
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_country_spec>> {
     const url = `/v1/country_specs/${p["country"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -9064,7 +8698,6 @@ export class StripeApi extends AbstractAxiosClient {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -9077,10 +8710,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/coupons`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       created: p["created"],
       ending_before: p["endingBefore"],
@@ -9088,12 +8718,10 @@ export class StripeApi extends AbstractAxiosClient {
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -9163,22 +8791,16 @@ export class StripeApi extends AbstractAxiosClient {
   async deleteCouponsCoupon(
     p: {
       coupon: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_deleted_coupon>> {
     const url = `/v1/coupons/${p["coupon"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
-    const body = JSON.stringify(p.requestBody)
+    const headers = this._headers({}, opts.headers)
 
     return this._request({
       url: url,
       method: "DELETE",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -9189,23 +8811,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       coupon: string
       expand?: string[]
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_coupon>> {
     const url = `/v1/coupons/${p["coupon"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -9274,7 +8890,6 @@ export class StripeApi extends AbstractAxiosClient {
       invoice?: string
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -9287,10 +8902,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/credit_notes`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       created: p["created"],
       customer: p["customer"],
@@ -9300,12 +8912,10 @@ export class StripeApi extends AbstractAxiosClient {
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -9447,16 +9057,12 @@ export class StripeApi extends AbstractAxiosClient {
       shippingCost?: {
         shipping_rate?: string | undefined
       }
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_credit_note>> {
     const url = `/v1/credit_notes/preview`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       amount: p["amount"],
       credit_amount: p["creditAmount"],
@@ -9473,12 +9079,10 @@ export class StripeApi extends AbstractAxiosClient {
       refunds: p["refunds"],
       shipping_cost: p["shippingCost"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -9536,7 +9140,6 @@ export class StripeApi extends AbstractAxiosClient {
         shipping_rate?: string | undefined
       }
       startingAfter?: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -9549,10 +9152,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/credit_notes/preview/lines`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       amount: p["amount"],
       credit_amount: p["creditAmount"],
@@ -9572,12 +9172,10 @@ export class StripeApi extends AbstractAxiosClient {
       shipping_cost: p["shippingCost"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -9591,7 +9189,6 @@ export class StripeApi extends AbstractAxiosClient {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -9604,22 +9201,17 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/credit_notes/${p["creditNote"]}/lines`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -9630,23 +9222,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       expand?: string[]
       id: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_credit_note>> {
     const url = `/v1/credit_notes/${p["id"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -9802,7 +9388,6 @@ export class StripeApi extends AbstractAxiosClient {
       limit?: number
       startingAfter?: string
       testClock?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -9815,10 +9400,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/customers`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       created: p["created"],
       email: p["email"],
@@ -9828,12 +9410,10 @@ export class StripeApi extends AbstractAxiosClient {
       starting_after: p["startingAfter"],
       test_clock: p["testClock"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -10101,7 +9681,6 @@ export class StripeApi extends AbstractAxiosClient {
       limit?: number
       page?: string
       query: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -10116,22 +9695,17 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/customers/search`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       expand: p["expand"],
       limit: p["limit"],
       page: p["page"],
       query: p["query"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -10141,22 +9715,16 @@ export class StripeApi extends AbstractAxiosClient {
   async deleteCustomersCustomer(
     p: {
       customer: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_deleted_customer>> {
     const url = `/v1/customers/${p["customer"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
-    const body = JSON.stringify(p.requestBody)
+    const headers = this._headers({}, opts.headers)
 
     return this._request({
       url: url,
       method: "DELETE",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -10167,23 +9735,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       customer: string
       expand?: string[]
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_customer | t_deleted_customer>> {
     const url = `/v1/customers/${p["customer"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -10378,7 +9940,6 @@ export class StripeApi extends AbstractAxiosClient {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -10391,22 +9952,17 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/customers/${p["customer"]}/balance_transactions`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -10457,23 +10013,17 @@ export class StripeApi extends AbstractAxiosClient {
       customer: string
       expand?: string[]
       transaction: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_customer_balance_transaction>> {
     const url = `/v1/customers/${p["customer"]}/balance_transactions/${p["transaction"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -10525,7 +10075,6 @@ export class StripeApi extends AbstractAxiosClient {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -10538,22 +10087,17 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/customers/${p["customer"]}/bank_accounts`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -10667,23 +10211,17 @@ export class StripeApi extends AbstractAxiosClient {
       customer: string
       expand?: string[]
       id: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_bank_account>> {
     const url = `/v1/customers/${p["customer"]}/bank_accounts/${p["id"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -10793,7 +10331,6 @@ export class StripeApi extends AbstractAxiosClient {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -10806,22 +10343,17 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/customers/${p["customer"]}/cards`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -10935,23 +10467,17 @@ export class StripeApi extends AbstractAxiosClient {
       customer: string
       expand?: string[]
       id: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_card>> {
     const url = `/v1/customers/${p["customer"]}/cards/${p["id"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -11029,23 +10555,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       customer: string
       expand?: string[]
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_cash_balance>> {
     const url = `/v1/customers/${p["customer"]}/cash_balance`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -11098,7 +10618,6 @@ export class StripeApi extends AbstractAxiosClient {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -11111,22 +10630,17 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/customers/${p["customer"]}/cash_balance_transactions`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -11138,23 +10652,17 @@ export class StripeApi extends AbstractAxiosClient {
       customer: string
       expand?: string[]
       transaction: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_customer_cash_balance_transaction>> {
     const url = `/v1/customers/${p["customer"]}/cash_balance_transactions/${p["transaction"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -11164,22 +10672,16 @@ export class StripeApi extends AbstractAxiosClient {
   async deleteCustomersCustomerDiscount(
     p: {
       customer: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_deleted_discount>> {
     const url = `/v1/customers/${p["customer"]}/discount`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
-    const body = JSON.stringify(p.requestBody)
+    const headers = this._headers({}, opts.headers)
 
     return this._request({
       url: url,
       method: "DELETE",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -11190,23 +10692,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       customer: string
       expand?: string[]
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_discount>> {
     const url = `/v1/customers/${p["customer"]}/discount`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -11327,7 +10823,6 @@ export class StripeApi extends AbstractAxiosClient {
         | "wechat_pay"
         | "zip"
         | UnknownEnumStringValue
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -11340,10 +10835,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/customers/${p["customer"]}/payment_methods`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       allow_redisplay: p["allowRedisplay"],
       ending_before: p["endingBefore"],
@@ -11352,12 +10844,10 @@ export class StripeApi extends AbstractAxiosClient {
       starting_after: p["startingAfter"],
       type: p["type"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -11369,23 +10859,17 @@ export class StripeApi extends AbstractAxiosClient {
       customer: string
       expand?: string[]
       paymentMethod: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_payment_method>> {
     const url = `/v1/customers/${p["customer"]}/payment_methods/${p["paymentMethod"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -11400,7 +10884,6 @@ export class StripeApi extends AbstractAxiosClient {
       limit?: number
       object?: string
       startingAfter?: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -11413,10 +10896,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/customers/${p["customer"]}/sources`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
@@ -11424,12 +10904,10 @@ export class StripeApi extends AbstractAxiosClient {
       object: p["object"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -11543,23 +11021,17 @@ export class StripeApi extends AbstractAxiosClient {
       customer: string
       expand?: string[]
       id: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_payment_source>> {
     const url = `/v1/customers/${p["customer"]}/sources/${p["id"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -11669,7 +11141,6 @@ export class StripeApi extends AbstractAxiosClient {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -11682,22 +11153,17 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/customers/${p["customer"]}/subscriptions`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -12198,23 +11664,17 @@ export class StripeApi extends AbstractAxiosClient {
       customer: string
       expand?: string[]
       subscriptionExposedId: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_subscription>> {
     const url = `/v1/customers/${p["customer"]}/subscriptions/${p["subscriptionExposedId"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -12729,22 +12189,16 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       customer: string
       subscriptionExposedId: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_deleted_discount>> {
     const url = `/v1/customers/${p["customer"]}/subscriptions/${p["subscriptionExposedId"]}/discount`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
-    const body = JSON.stringify(p.requestBody)
+    const headers = this._headers({}, opts.headers)
 
     return this._request({
       url: url,
       method: "DELETE",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -12756,23 +12210,17 @@ export class StripeApi extends AbstractAxiosClient {
       customer: string
       expand?: string[]
       subscriptionExposedId: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_discount>> {
     const url = `/v1/customers/${p["customer"]}/subscriptions/${p["subscriptionExposedId"]}/discount`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -12786,7 +12234,6 @@ export class StripeApi extends AbstractAxiosClient {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -12799,22 +12246,17 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/customers/${p["customer"]}/tax_ids`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -12965,22 +12407,16 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       customer: string
       id: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_deleted_tax_id>> {
     const url = `/v1/customers/${p["customer"]}/tax_ids/${p["id"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
-    const body = JSON.stringify(p.requestBody)
+    const headers = this._headers({}, opts.headers)
 
     return this._request({
       url: url,
       method: "DELETE",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -12992,23 +12428,17 @@ export class StripeApi extends AbstractAxiosClient {
       customer: string
       expand?: string[]
       id: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_tax_id>> {
     const url = `/v1/customers/${p["customer"]}/tax_ids/${p["id"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -13031,7 +12461,6 @@ export class StripeApi extends AbstractAxiosClient {
       limit?: number
       paymentIntent?: string
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -13044,10 +12473,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/disputes`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       charge: p["charge"],
       created: p["created"],
@@ -13057,12 +12483,10 @@ export class StripeApi extends AbstractAxiosClient {
       payment_intent: p["paymentIntent"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -13073,23 +12497,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       dispute: string
       expand?: string[]
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_dispute>> {
     const url = `/v1/disputes/${p["dispute"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -13359,7 +12777,6 @@ export class StripeApi extends AbstractAxiosClient {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -13372,10 +12789,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/entitlements/active_entitlements`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       customer: p["customer"],
       ending_before: p["endingBefore"],
@@ -13383,12 +12797,10 @@ export class StripeApi extends AbstractAxiosClient {
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -13399,23 +12811,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       expand?: string[]
       id: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_entitlements_active_entitlement>> {
     const url = `/v1/entitlements/active_entitlements/${p["id"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -13430,7 +12836,6 @@ export class StripeApi extends AbstractAxiosClient {
       limit?: number
       lookupKey?: string
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -13443,10 +12848,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/entitlements/features`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       archived: p["archived"],
       ending_before: p["endingBefore"],
@@ -13455,12 +12857,10 @@ export class StripeApi extends AbstractAxiosClient {
       lookup_key: p["lookupKey"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -13504,23 +12904,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       expand?: string[]
       id: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_entitlements_feature>> {
     const url = `/v1/entitlements/features/${p["id"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -13639,7 +13033,6 @@ export class StripeApi extends AbstractAxiosClient {
       startingAfter?: string
       type?: string
       types?: string[]
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -13652,10 +13045,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/events`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       created: p["created"],
       delivery_success: p["deliverySuccess"],
@@ -13666,12 +13056,10 @@ export class StripeApi extends AbstractAxiosClient {
       type: p["type"],
       types: p["types"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -13682,23 +13070,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       expand?: string[]
       id: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_event>> {
     const url = `/v1/events/${p["id"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -13711,7 +13093,6 @@ export class StripeApi extends AbstractAxiosClient {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -13724,22 +13105,17 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/exchange_rates`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -13750,23 +13126,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       expand?: string[]
       rateId: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_exchange_rate>> {
     const url = `/v1/exchange_rates/${p["rateId"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -13851,7 +13221,6 @@ export class StripeApi extends AbstractAxiosClient {
       file?: string
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -13864,10 +13233,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/file_links`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       created: p["created"],
       ending_before: p["endingBefore"],
@@ -13877,12 +13243,10 @@ export class StripeApi extends AbstractAxiosClient {
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -13930,23 +13294,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       expand?: string[]
       link: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_file_link>> {
     const url = `/v1/file_links/${p["link"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -14023,7 +13381,6 @@ export class StripeApi extends AbstractAxiosClient {
         | "terminal_reader_splashscreen"
         | UnknownEnumStringValue
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -14036,10 +13393,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/files`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       created: p["created"],
       ending_before: p["endingBefore"],
@@ -14048,12 +13402,10 @@ export class StripeApi extends AbstractAxiosClient {
       purpose: p["purpose"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -14123,23 +13475,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       expand?: string[]
       file: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_file>> {
     const url = `/v1/files/${p["file"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -14157,7 +13503,6 @@ export class StripeApi extends AbstractAxiosClient {
       limit?: number
       session?: string
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -14170,10 +13515,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/financial_connections/accounts`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       account_holder: p["accountHolder"],
       ending_before: p["endingBefore"],
@@ -14182,12 +13524,10 @@ export class StripeApi extends AbstractAxiosClient {
       session: p["session"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -14198,23 +13538,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       account: string
       expand?: string[]
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_financial_connections_account>> {
     const url = `/v1/financial_connections/accounts/${p["account"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -14256,7 +13590,6 @@ export class StripeApi extends AbstractAxiosClient {
       limit?: number
       ownership: string
       startingAfter?: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -14269,10 +13602,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/financial_connections/accounts/${p["account"]}/owners`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
@@ -14280,12 +13610,10 @@ export class StripeApi extends AbstractAxiosClient {
       ownership: p["ownership"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -14447,23 +13775,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       expand?: string[]
       session: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_financial_connections_session>> {
     const url = `/v1/financial_connections/sessions/${p["session"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -14488,7 +13810,6 @@ export class StripeApi extends AbstractAxiosClient {
       transactionRefresh?: {
         after: string
       }
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -14501,10 +13822,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/financial_connections/transactions`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       account: p["account"],
       ending_before: p["endingBefore"],
@@ -14514,12 +13832,10 @@ export class StripeApi extends AbstractAxiosClient {
       transacted_at: p["transactedAt"],
       transaction_refresh: p["transactionRefresh"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -14530,23 +13846,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       expand?: string[]
       transaction: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_financial_connections_transaction>> {
     const url = `/v1/financial_connections/transactions/${p["transaction"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -14565,7 +13875,6 @@ export class StripeApi extends AbstractAxiosClient {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -14578,10 +13887,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/forwarding/requests`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       created: p["created"],
       ending_before: p["endingBefore"],
@@ -14589,12 +13895,10 @@ export class StripeApi extends AbstractAxiosClient {
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -14657,23 +13961,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       expand?: string[]
       id: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_forwarding_request>> {
     const url = `/v1/forwarding/requests/${p["id"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -14697,7 +13995,6 @@ export class StripeApi extends AbstractAxiosClient {
       startingAfter?: string
       type?: "document" | "id_number" | UnknownEnumStringValue
       verificationSession?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -14710,10 +14007,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/identity/verification_reports`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       client_reference_id: p["clientReferenceId"],
       created: p["created"],
@@ -14724,12 +14018,10 @@ export class StripeApi extends AbstractAxiosClient {
       type: p["type"],
       verification_session: p["verificationSession"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -14740,23 +14032,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       expand?: string[]
       report: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_identity_verification_report>> {
     const url = `/v1/identity/verification_reports/${p["report"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -14785,7 +14071,6 @@ export class StripeApi extends AbstractAxiosClient {
         | "requires_input"
         | "verified"
         | UnknownEnumStringValue
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -14798,10 +14083,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/identity/verification_sessions`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       client_reference_id: p["clientReferenceId"],
       created: p["created"],
@@ -14812,12 +14094,10 @@ export class StripeApi extends AbstractAxiosClient {
       starting_after: p["startingAfter"],
       status: p["status"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -14899,23 +14179,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       expand?: string[]
       session: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_identity_verification_session>> {
     const url = `/v1/identity/verification_sessions/${p["session"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -15050,7 +14324,6 @@ export class StripeApi extends AbstractAxiosClient {
       }
       startingAfter?: string
       status?: "canceled" | "open" | "paid" | UnknownEnumStringValue
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -15063,10 +14336,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/invoice_payments`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
@@ -15076,12 +14346,10 @@ export class StripeApi extends AbstractAxiosClient {
       starting_after: p["startingAfter"],
       status: p["status"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -15092,23 +14360,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       expand?: string[]
       invoicePayment: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_invoice_payment>> {
     const url = `/v1/invoice_payments/${p["invoicePayment"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -15122,7 +14384,6 @@ export class StripeApi extends AbstractAxiosClient {
       limit?: number
       startingAfter?: string
       status?: "active" | "archived" | UnknownEnumStringValue
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -15135,10 +14396,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/invoice_rendering_templates`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
@@ -15146,12 +14404,10 @@ export class StripeApi extends AbstractAxiosClient {
       starting_after: p["startingAfter"],
       status: p["status"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -15163,23 +14419,17 @@ export class StripeApi extends AbstractAxiosClient {
       expand?: string[]
       template: string
       version?: number
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_invoice_rendering_template>> {
     const url = `/v1/invoice_rendering_templates/${p["template"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"], version: p["version"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -15257,7 +14507,6 @@ export class StripeApi extends AbstractAxiosClient {
       limit?: number
       pending?: boolean
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -15270,10 +14519,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/invoiceitems`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       created: p["created"],
       customer: p["customer"],
@@ -15284,12 +14530,10 @@ export class StripeApi extends AbstractAxiosClient {
       pending: p["pending"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -15386,22 +14630,16 @@ export class StripeApi extends AbstractAxiosClient {
   async deleteInvoiceitemsInvoiceitem(
     p: {
       invoiceitem: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_deleted_invoiceitem>> {
     const url = `/v1/invoiceitems/${p["invoiceitem"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
-    const body = JSON.stringify(p.requestBody)
+    const headers = this._headers({}, opts.headers)
 
     return this._request({
       url: url,
       method: "DELETE",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -15412,23 +14650,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       expand?: string[]
       invoiceitem: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_invoiceitem>> {
     const url = `/v1/invoiceitems/${p["invoiceitem"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -15554,7 +14786,6 @@ export class StripeApi extends AbstractAxiosClient {
         | "void"
         | UnknownEnumStringValue
       subscription?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -15567,10 +14798,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/invoices`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       collection_method: p["collectionMethod"],
       created: p["created"],
@@ -15583,12 +14811,10 @@ export class StripeApi extends AbstractAxiosClient {
       status: p["status"],
       subscription: p["subscription"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -16640,7 +15866,6 @@ export class StripeApi extends AbstractAxiosClient {
       limit?: number
       page?: string
       query: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -16655,22 +15880,17 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/invoices/search`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       expand: p["expand"],
       limit: p["limit"],
       page: p["page"],
       query: p["query"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -16680,22 +15900,16 @@ export class StripeApi extends AbstractAxiosClient {
   async deleteInvoicesInvoice(
     p: {
       invoice: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_deleted_invoice>> {
     const url = `/v1/invoices/${p["invoice"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
-    const body = JSON.stringify(p.requestBody)
+    const headers = this._headers({}, opts.headers)
 
     return this._request({
       url: url,
       method: "DELETE",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -16706,23 +15920,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       expand?: string[]
       invoice: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_invoice>> {
     const url = `/v1/invoices/${p["invoice"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -17407,7 +16615,6 @@ export class StripeApi extends AbstractAxiosClient {
       invoice: string
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -17420,22 +16627,17 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/invoices/${p["invoice"]}/lines`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -17953,7 +17155,6 @@ export class StripeApi extends AbstractAxiosClient {
         | "pending"
         | "reversed"
         | UnknownEnumStringValue
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -17966,10 +17167,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/issuing/authorizations`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       card: p["card"],
       cardholder: p["cardholder"],
@@ -17980,12 +17178,10 @@ export class StripeApi extends AbstractAxiosClient {
       starting_after: p["startingAfter"],
       status: p["status"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -17996,23 +17192,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       authorization: string
       expand?: string[]
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_issuing_authorization>> {
     const url = `/v1/issuing/authorizations/${p["authorization"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -18146,7 +17336,6 @@ export class StripeApi extends AbstractAxiosClient {
       startingAfter?: string
       status?: "active" | "blocked" | "inactive" | UnknownEnumStringValue
       type?: "company" | "individual" | UnknownEnumStringValue
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -18159,10 +17348,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/issuing/cardholders`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       created: p["created"],
       email: p["email"],
@@ -18174,12 +17360,10 @@ export class StripeApi extends AbstractAxiosClient {
       status: p["status"],
       type: p["type"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -19200,23 +18384,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       cardholder: string
       expand?: string[]
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_issuing_cardholder>> {
     const url = `/v1/issuing/cardholders/${p["cardholder"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -20255,7 +19433,6 @@ export class StripeApi extends AbstractAxiosClient {
       startingAfter?: string
       status?: "active" | "canceled" | "inactive" | UnknownEnumStringValue
       type?: "physical" | "virtual" | UnknownEnumStringValue
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -20268,10 +19445,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/issuing/cards`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       cardholder: p["cardholder"],
       created: p["created"],
@@ -20286,12 +19460,10 @@ export class StripeApi extends AbstractAxiosClient {
       status: p["status"],
       type: p["type"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -21303,23 +20475,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       card: string
       expand?: string[]
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_issuing_card>> {
     const url = `/v1/issuing/cards/${p["card"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -22350,7 +21516,6 @@ export class StripeApi extends AbstractAxiosClient {
         | "won"
         | UnknownEnumStringValue
       transaction?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -22363,10 +21528,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/issuing/disputes`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       created: p["created"],
       ending_before: p["endingBefore"],
@@ -22376,12 +21538,10 @@ export class StripeApi extends AbstractAxiosClient {
       status: p["status"],
       transaction: p["transaction"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -22654,23 +21814,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       dispute: string
       expand?: string[]
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_issuing_dispute>> {
     const url = `/v1/issuing/disputes/${p["dispute"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -22991,7 +22145,6 @@ export class StripeApi extends AbstractAxiosClient {
         | "rejected"
         | "review"
         | UnknownEnumStringValue
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -23004,10 +22157,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/issuing/personalization_designs`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
@@ -23017,12 +22167,10 @@ export class StripeApi extends AbstractAxiosClient {
       starting_after: p["startingAfter"],
       status: p["status"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -23082,23 +22230,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       expand?: string[]
       personalizationDesign: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_issuing_personalization_design>> {
     const url = `/v1/issuing/personalization_designs/${p["personalizationDesign"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -23175,7 +22317,6 @@ export class StripeApi extends AbstractAxiosClient {
       startingAfter?: string
       status?: "active" | "inactive" | "review" | UnknownEnumStringValue
       type?: "custom" | "standard" | UnknownEnumStringValue
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -23188,10 +22329,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/issuing/physical_bundles`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
@@ -23200,12 +22338,10 @@ export class StripeApi extends AbstractAxiosClient {
       status: p["status"],
       type: p["type"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -23216,23 +22352,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       expand?: string[]
       physicalBundle: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_issuing_physical_bundle>> {
     const url = `/v1/issuing/physical_bundles/${p["physicalBundle"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -23243,23 +22373,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       expand?: string[]
       settlement: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_issuing_settlement>> {
     const url = `/v1/issuing/settlements/${p["settlement"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -23319,7 +22443,6 @@ export class StripeApi extends AbstractAxiosClient {
         | "requested"
         | "suspended"
         | UnknownEnumStringValue
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -23332,10 +22455,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/issuing/tokens`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       card: p["card"],
       created: p["created"],
@@ -23345,12 +22465,10 @@ export class StripeApi extends AbstractAxiosClient {
       starting_after: p["startingAfter"],
       status: p["status"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -23361,23 +22479,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       expand?: string[]
       token: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_issuing_token>> {
     const url = `/v1/issuing/tokens/${p["token"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -23429,7 +22541,6 @@ export class StripeApi extends AbstractAxiosClient {
       limit?: number
       startingAfter?: string
       type?: "capture" | "refund" | UnknownEnumStringValue
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -23442,10 +22553,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/issuing/transactions`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       card: p["card"],
       cardholder: p["cardholder"],
@@ -23456,12 +22564,10 @@ export class StripeApi extends AbstractAxiosClient {
       starting_after: p["startingAfter"],
       type: p["type"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -23472,23 +22578,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       expand?: string[]
       transaction: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_issuing_transaction>> {
     const url = `/v1/issuing/transactions/${p["transaction"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -23597,23 +22697,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       expand?: string[]
       session: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_financial_connections_session>> {
     const url = `/v1/link_account_sessions/${p["session"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -23631,7 +22725,6 @@ export class StripeApi extends AbstractAxiosClient {
       limit?: number
       session?: string
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -23644,10 +22737,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/linked_accounts`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       account_holder: p["accountHolder"],
       ending_before: p["endingBefore"],
@@ -23656,12 +22746,10 @@ export class StripeApi extends AbstractAxiosClient {
       session: p["session"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -23672,23 +22760,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       account: string
       expand?: string[]
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_financial_connections_account>> {
     const url = `/v1/linked_accounts/${p["account"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -23730,7 +22812,6 @@ export class StripeApi extends AbstractAxiosClient {
       limit?: number
       ownership: string
       startingAfter?: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -23743,10 +22824,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/linked_accounts/${p["account"]}/owners`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
@@ -23754,12 +22832,10 @@ export class StripeApi extends AbstractAxiosClient {
       ownership: p["ownership"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -23803,23 +22879,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       expand?: string[]
       mandate: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_mandate>> {
     const url = `/v1/mandates/${p["mandate"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -23841,7 +22911,6 @@ export class StripeApi extends AbstractAxiosClient {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -23854,10 +22923,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/payment_intents`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       created: p["created"],
       customer: p["customer"],
@@ -23866,12 +22932,10 @@ export class StripeApi extends AbstractAxiosClient {
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -25501,7 +24565,6 @@ export class StripeApi extends AbstractAxiosClient {
       limit?: number
       page?: string
       query: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -25516,22 +24579,17 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/payment_intents/search`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       expand: p["expand"],
       limit: p["limit"],
       page: p["page"],
       query: p["query"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -25543,26 +24601,20 @@ export class StripeApi extends AbstractAxiosClient {
       clientSecret?: string
       expand?: string[]
       intent: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_payment_intent>> {
     const url = `/v1/payment_intents/${p["intent"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       client_secret: p["clientSecret"],
       expand: p["expand"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -28939,7 +27991,6 @@ export class StripeApi extends AbstractAxiosClient {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -28952,10 +28003,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/payment_links`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       active: p["active"],
       ending_before: p["endingBefore"],
@@ -28963,12 +28011,10 @@ export class StripeApi extends AbstractAxiosClient {
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -29603,23 +28649,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       expand?: string[]
       paymentLink: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_payment_link>> {
     const url = `/v1/payment_links/${p["paymentLink"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -30242,7 +29282,6 @@ export class StripeApi extends AbstractAxiosClient {
       limit?: number
       paymentLink: string
       startingAfter?: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -30255,22 +29294,17 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/payment_links/${p["paymentLink"]}/line_items`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -30284,7 +29318,6 @@ export class StripeApi extends AbstractAxiosClient {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -30297,10 +29330,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/payment_method_configurations`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       application: p["application"],
       ending_before: p["endingBefore"],
@@ -30308,12 +29338,10 @@ export class StripeApi extends AbstractAxiosClient {
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -30924,23 +29952,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       configuration: string
       expand?: string[]
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_payment_method_configuration>> {
     const url = `/v1/payment_method_configurations/${p["configuration"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -31556,7 +30578,6 @@ export class StripeApi extends AbstractAxiosClient {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -31569,10 +30590,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/payment_method_domains`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       domain_name: p["domainName"],
       enabled: p["enabled"],
@@ -31581,12 +30599,10 @@ export class StripeApi extends AbstractAxiosClient {
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -31625,23 +30641,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       expand?: string[]
       paymentMethodDomain: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_payment_method_domain>> {
     const url = `/v1/payment_method_domains/${p["paymentMethodDomain"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -31760,7 +30770,6 @@ export class StripeApi extends AbstractAxiosClient {
         | "wechat_pay"
         | "zip"
         | UnknownEnumStringValue
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -31773,10 +30782,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/payment_methods`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       customer: p["customer"],
       ending_before: p["endingBefore"],
@@ -31785,12 +30791,10 @@ export class StripeApi extends AbstractAxiosClient {
       starting_after: p["startingAfter"],
       type: p["type"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -32182,23 +31186,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       expand?: string[]
       paymentMethod: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_payment_method>> {
     const url = `/v1/payment_methods/${p["paymentMethod"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -32376,7 +31374,6 @@ export class StripeApi extends AbstractAxiosClient {
       limit?: number
       startingAfter?: string
       status?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -32389,10 +31386,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/payouts`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       arrival_date: p["arrivalDate"],
       created: p["created"],
@@ -32403,12 +31397,10 @@ export class StripeApi extends AbstractAxiosClient {
       starting_after: p["startingAfter"],
       status: p["status"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -32459,23 +31451,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       expand?: string[]
       payout: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_payout>> {
     const url = `/v1/payouts/${p["payout"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -32593,7 +31579,6 @@ export class StripeApi extends AbstractAxiosClient {
       limit?: number
       product?: string
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -32606,10 +31591,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/plans`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       active: p["active"],
       created: p["created"],
@@ -32619,12 +31601,10 @@ export class StripeApi extends AbstractAxiosClient {
       product: p["product"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -32721,22 +31701,16 @@ export class StripeApi extends AbstractAxiosClient {
   async deletePlansPlan(
     p: {
       plan: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_deleted_plan>> {
     const url = `/v1/plans/${p["plan"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
-    const body = JSON.stringify(p.requestBody)
+    const headers = this._headers({}, opts.headers)
 
     return this._request({
       url: url,
       method: "DELETE",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -32747,23 +31721,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       expand?: string[]
       plan: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_plan>> {
     const url = `/v1/plans/${p["plan"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -32838,7 +31806,6 @@ export class StripeApi extends AbstractAxiosClient {
       }
       startingAfter?: string
       type?: "one_time" | "recurring" | UnknownEnumStringValue
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -32851,10 +31818,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/prices`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       active: p["active"],
       created: p["created"],
@@ -32868,12 +31832,10 @@ export class StripeApi extends AbstractAxiosClient {
       starting_after: p["startingAfter"],
       type: p["type"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -33022,7 +31984,6 @@ export class StripeApi extends AbstractAxiosClient {
       limit?: number
       page?: string
       query: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -33037,22 +31998,17 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/prices/search`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       expand: p["expand"],
       limit: p["limit"],
       page: p["page"],
       query: p["query"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -33063,23 +32019,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       expand?: string[]
       price: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_price>> {
     const url = `/v1/prices/${p["price"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -33186,7 +32136,6 @@ export class StripeApi extends AbstractAxiosClient {
       shippable?: boolean
       startingAfter?: string
       url?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -33199,10 +32148,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/products`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       active: p["active"],
       created: p["created"],
@@ -33214,12 +32160,10 @@ export class StripeApi extends AbstractAxiosClient {
       starting_after: p["startingAfter"],
       url: p["url"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -33360,7 +32304,6 @@ export class StripeApi extends AbstractAxiosClient {
       limit?: number
       page?: string
       query: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -33375,22 +32318,17 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/products/search`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       expand: p["expand"],
       limit: p["limit"],
       page: p["page"],
       query: p["query"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -33400,22 +32338,16 @@ export class StripeApi extends AbstractAxiosClient {
   async deleteProductsId(
     p: {
       id: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_deleted_product>> {
     const url = `/v1/products/${p["id"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
-    const body = JSON.stringify(p.requestBody)
+    const headers = this._headers({}, opts.headers)
 
     return this._request({
       url: url,
       method: "DELETE",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -33426,23 +32358,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       expand?: string[]
       id: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_product>> {
     const url = `/v1/products/${p["id"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -33523,7 +32449,6 @@ export class StripeApi extends AbstractAxiosClient {
       limit?: number
       product: string
       startingAfter?: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -33536,22 +32461,17 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/products/${p["product"]}/features`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -33590,22 +32510,16 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       id: string
       product: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_deleted_product_feature>> {
     const url = `/v1/products/${p["product"]}/features/${p["id"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
-    const body = JSON.stringify(p.requestBody)
+    const headers = this._headers({}, opts.headers)
 
     return this._request({
       url: url,
       method: "DELETE",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -33617,23 +32531,17 @@ export class StripeApi extends AbstractAxiosClient {
       expand?: string[]
       id: string
       product: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_product_feature>> {
     const url = `/v1/products/${p["product"]}/features/${p["id"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -33658,7 +32566,6 @@ export class StripeApi extends AbstractAxiosClient {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -33671,10 +32578,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/promotion_codes`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       active: p["active"],
       code: p["code"],
@@ -33686,12 +32590,10 @@ export class StripeApi extends AbstractAxiosClient {
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -33755,23 +32657,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       expand?: string[]
       promotionCode: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_promotion_code>> {
     const url = `/v1/promotion_codes/${p["promotionCode"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -33842,7 +32738,6 @@ export class StripeApi extends AbstractAxiosClient {
         | "open"
         | UnknownEnumStringValue
       testClock?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -33855,10 +32750,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/quotes`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       customer: p["customer"],
       ending_before: p["endingBefore"],
@@ -33868,12 +32760,10 @@ export class StripeApi extends AbstractAxiosClient {
       status: p["status"],
       test_clock: p["testClock"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -34048,23 +32938,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       expand?: string[]
       quote: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_quote>> {
     const url = `/v1/quotes/${p["quote"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -34286,7 +33170,6 @@ export class StripeApi extends AbstractAxiosClient {
       limit?: number
       quote: string
       startingAfter?: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -34299,22 +33182,17 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/quotes/${p["quote"]}/computed_upfront_line_items`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -34356,7 +33234,6 @@ export class StripeApi extends AbstractAxiosClient {
       limit?: number
       quote: string
       startingAfter?: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -34369,22 +33246,17 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/quotes/${p["quote"]}/line_items`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -34395,7 +33267,6 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       expand?: string[]
       quote: string
-      requestBody?: EmptyObject
     },
     basePath:
       | Server<"getQuotesQuotePdf_StripeApi">
@@ -34404,17 +33275,12 @@ export class StripeApi extends AbstractAxiosClient {
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<string>> {
     const url = `/v1/quotes/${p["quote"]}/pdf`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       baseURL: basePath,
       ...(timeout ? {timeout} : {}),
       ...opts,
@@ -34438,7 +33304,6 @@ export class StripeApi extends AbstractAxiosClient {
       limit?: number
       paymentIntent?: string
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -34451,10 +33316,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/radar/early_fraud_warnings`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       charge: p["charge"],
       created: p["created"],
@@ -34464,12 +33326,10 @@ export class StripeApi extends AbstractAxiosClient {
       payment_intent: p["paymentIntent"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -34480,23 +33340,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       earlyFraudWarning: string
       expand?: string[]
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_radar_early_fraud_warning>> {
     const url = `/v1/radar/early_fraud_warnings/${p["earlyFraudWarning"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -34519,7 +33373,6 @@ export class StripeApi extends AbstractAxiosClient {
       startingAfter?: string
       value?: string
       valueList: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -34532,10 +33385,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/radar/value_list_items`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       created: p["created"],
       ending_before: p["endingBefore"],
@@ -34545,12 +33395,10 @@ export class StripeApi extends AbstractAxiosClient {
       value: p["value"],
       value_list: p["valueList"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -34588,22 +33436,16 @@ export class StripeApi extends AbstractAxiosClient {
   async deleteRadarValueListItemsItem(
     p: {
       item: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_deleted_radar_value_list_item>> {
     const url = `/v1/radar/value_list_items/${p["item"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
-    const body = JSON.stringify(p.requestBody)
+    const headers = this._headers({}, opts.headers)
 
     return this._request({
       url: url,
       method: "DELETE",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -34614,23 +33456,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       expand?: string[]
       item: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_radar_value_list_item>> {
     const url = `/v1/radar/value_list_items/${p["item"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -34653,7 +33489,6 @@ export class StripeApi extends AbstractAxiosClient {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -34666,10 +33501,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/radar/value_lists`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       alias: p["alias"],
       contains: p["contains"],
@@ -34679,12 +33511,10 @@ export class StripeApi extends AbstractAxiosClient {
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -34742,22 +33572,16 @@ export class StripeApi extends AbstractAxiosClient {
   async deleteRadarValueListsValueList(
     p: {
       valueList: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_deleted_radar_value_list>> {
     const url = `/v1/radar/value_lists/${p["valueList"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
-    const body = JSON.stringify(p.requestBody)
+    const headers = this._headers({}, opts.headers)
 
     return this._request({
       url: url,
       method: "DELETE",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -34768,23 +33592,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       expand?: string[]
       valueList: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_radar_value_list>> {
     const url = `/v1/radar/value_lists/${p["valueList"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -34841,7 +33659,6 @@ export class StripeApi extends AbstractAxiosClient {
       limit?: number
       paymentIntent?: string
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -34854,10 +33671,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/refunds`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       charge: p["charge"],
       created: p["created"],
@@ -34867,12 +33681,10 @@ export class StripeApi extends AbstractAxiosClient {
       payment_intent: p["paymentIntent"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -34935,23 +33747,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       expand?: string[]
       refund: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_refund>> {
     const url = `/v1/refunds/${p["refund"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -35035,7 +33841,6 @@ export class StripeApi extends AbstractAxiosClient {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -35048,10 +33853,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/reporting/report_runs`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       created: p["created"],
       ending_before: p["endingBefore"],
@@ -35059,12 +33861,10 @@ export class StripeApi extends AbstractAxiosClient {
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -35757,23 +34557,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       expand?: string[]
       reportRun: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_reporting_report_run>> {
     const url = `/v1/reporting/report_runs/${p["reportRun"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -35783,7 +34577,6 @@ export class StripeApi extends AbstractAxiosClient {
   async getReportingReportTypes(
     p: {
       expand?: string[]
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -35796,17 +34589,12 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/reporting/report_types`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -35817,23 +34605,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       expand?: string[]
       reportType: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_reporting_report_type>> {
     const url = `/v1/reporting/report_types/${p["reportType"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -35854,7 +34636,6 @@ export class StripeApi extends AbstractAxiosClient {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -35867,10 +34648,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/reviews`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       created: p["created"],
       ending_before: p["endingBefore"],
@@ -35878,12 +34656,10 @@ export class StripeApi extends AbstractAxiosClient {
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -35894,23 +34670,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       expand?: string[]
       review: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_review>> {
     const url = `/v1/reviews/${p["review"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -35959,7 +34729,6 @@ export class StripeApi extends AbstractAxiosClient {
       limit?: number
       setupIntent: string
       startingAfter?: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -35972,10 +34741,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/setup_attempts`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       created: p["created"],
       ending_before: p["endingBefore"],
@@ -35984,12 +34750,10 @@ export class StripeApi extends AbstractAxiosClient {
       setup_intent: p["setupIntent"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -36013,7 +34777,6 @@ export class StripeApi extends AbstractAxiosClient {
       limit?: number
       paymentMethod?: string
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -36026,10 +34789,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/setup_intents`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       attach_to_self: p["attachToSelf"],
       created: p["created"],
@@ -36040,12 +34800,10 @@ export class StripeApi extends AbstractAxiosClient {
       payment_method: p["paymentMethod"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -36815,26 +35573,20 @@ export class StripeApi extends AbstractAxiosClient {
       clientSecret?: string
       expand?: string[]
       intent: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_setup_intent>> {
     const url = `/v1/setup_intents/${p["intent"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       client_secret: p["clientSecret"],
       expand: p["expand"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -38381,7 +37133,6 @@ export class StripeApi extends AbstractAxiosClient {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -38394,10 +37145,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/shipping_rates`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       active: p["active"],
       created: p["created"],
@@ -38407,12 +37155,10 @@ export class StripeApi extends AbstractAxiosClient {
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -38511,23 +37257,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       expand?: string[]
       shippingRateToken: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_shipping_rate>> {
     const url = `/v1/shipping_rates/${p["shippingRateToken"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -38630,7 +37370,6 @@ export class StripeApi extends AbstractAxiosClient {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -38643,22 +37382,17 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/sigma/scheduled_query_runs`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -38669,23 +37403,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       expand?: string[]
       scheduledQueryRun: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_scheduled_query_run>> {
     const url = `/v1/sigma/scheduled_query_runs/${p["scheduledQueryRun"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -38864,26 +37592,20 @@ export class StripeApi extends AbstractAxiosClient {
       clientSecret?: string
       expand?: string[]
       source: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_source>> {
     const url = `/v1/sources/${p["source"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       client_secret: p["clientSecret"],
       expand: p["expand"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -39039,23 +37761,17 @@ export class StripeApi extends AbstractAxiosClient {
       expand?: string[]
       mandateNotification: string
       source: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_source_mandate_notification>> {
     const url = `/v1/sources/${p["source"]}/mandate_notifications/${p["mandateNotification"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -39069,7 +37785,6 @@ export class StripeApi extends AbstractAxiosClient {
       limit?: number
       source: string
       startingAfter?: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -39082,22 +37797,17 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/sources/${p["source"]}/source_transactions`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -39109,23 +37819,17 @@ export class StripeApi extends AbstractAxiosClient {
       expand?: string[]
       source: string
       sourceTransaction: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_source_transaction>> {
     const url = `/v1/sources/${p["source"]}/source_transactions/${p["sourceTransaction"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -39167,7 +37871,6 @@ export class StripeApi extends AbstractAxiosClient {
       limit?: number
       startingAfter?: string
       subscription: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -39180,10 +37883,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/subscription_items`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
@@ -39191,12 +37891,10 @@ export class StripeApi extends AbstractAxiosClient {
       starting_after: p["startingAfter"],
       subscription: p["subscription"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -39341,23 +38039,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       expand?: string[]
       item: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_subscription_item>> {
     const url = `/v1/subscription_items/${p["item"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -39507,7 +38199,6 @@ export class StripeApi extends AbstractAxiosClient {
         | number
       scheduled?: boolean
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -39520,10 +38211,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/subscription_schedules`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       canceled_at: p["canceledAt"],
       completed_at: p["completedAt"],
@@ -39536,12 +38224,10 @@ export class StripeApi extends AbstractAxiosClient {
       scheduled: p["scheduled"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -39839,23 +38525,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       expand?: string[]
       schedule: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_subscription_schedule>> {
     const url = `/v1/subscription_schedules/${p["schedule"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -40259,7 +38939,6 @@ export class StripeApi extends AbstractAxiosClient {
         | "unpaid"
         | UnknownEnumStringValue
       testClock?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -40272,10 +38951,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/subscriptions`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       automatic_tax: p["automaticTax"],
       collection_method: p["collectionMethod"],
@@ -40291,12 +38967,10 @@ export class StripeApi extends AbstractAxiosClient {
       status: p["status"],
       test_clock: p["testClock"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -40784,7 +39458,6 @@ export class StripeApi extends AbstractAxiosClient {
       limit?: number
       page?: string
       query: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -40799,22 +39472,17 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/subscriptions/search`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       expand: p["expand"],
       limit: p["limit"],
       page: p["page"],
       query: p["query"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -40873,23 +39541,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       expand?: string[]
       subscriptionExposedId: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_subscription>> {
     const url = `/v1/subscriptions/${p["subscriptionExposedId"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -41404,22 +40066,16 @@ export class StripeApi extends AbstractAxiosClient {
   async deleteSubscriptionsSubscriptionExposedIdDiscount(
     p: {
       subscriptionExposedId: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_deleted_discount>> {
     const url = `/v1/subscriptions/${p["subscriptionExposedId"]}/discount`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
-    const body = JSON.stringify(p.requestBody)
+    const headers = this._headers({}, opts.headers)
 
     return this._request({
       url: url,
       method: "DELETE",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -41710,23 +40366,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       calculation: string
       expand?: string[]
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_tax_calculation>> {
     const url = `/v1/tax/calculations/${p["calculation"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -41740,7 +40390,6 @@ export class StripeApi extends AbstractAxiosClient {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -41753,22 +40402,17 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/tax/calculations/${p["calculation"]}/line_items`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -41787,7 +40431,6 @@ export class StripeApi extends AbstractAxiosClient {
         | "expired"
         | "scheduled"
         | UnknownEnumStringValue
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -41800,10 +40443,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/tax/registrations`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
@@ -41811,12 +40451,10 @@ export class StripeApi extends AbstractAxiosClient {
       starting_after: p["startingAfter"],
       status: p["status"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -42742,23 +41380,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       expand?: string[]
       id: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_tax_registration>> {
     const url = `/v1/tax/registrations/${p["id"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -42797,23 +41429,17 @@ export class StripeApi extends AbstractAxiosClient {
   async getTaxSettings(
     p: {
       expand?: string[]
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_tax_settings>> {
     const url = `/v1/tax/settings`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -42964,23 +41590,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       expand?: string[]
       transaction: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_tax_transaction>> {
     const url = `/v1/tax/transactions/${p["transaction"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -42994,7 +41614,6 @@ export class StripeApi extends AbstractAxiosClient {
       limit?: number
       startingAfter?: string
       transaction: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -43007,22 +41626,17 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/tax/transactions/${p["transaction"]}/line_items`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -43035,7 +41649,6 @@ export class StripeApi extends AbstractAxiosClient {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -43048,22 +41661,17 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/tax_codes`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -43074,23 +41682,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       expand?: string[]
       id: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_tax_code>> {
     const url = `/v1/tax_codes/${p["id"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -43113,7 +41715,6 @@ export class StripeApi extends AbstractAxiosClient {
           | UnknownEnumStringValue
       }
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -43126,10 +41727,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/tax_ids`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
@@ -43137,12 +41735,10 @@ export class StripeApi extends AbstractAxiosClient {
       owner: p["owner"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -43303,22 +41899,16 @@ export class StripeApi extends AbstractAxiosClient {
   async deleteTaxIdsId(
     p: {
       id: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_deleted_tax_id>> {
     const url = `/v1/tax_ids/${p["id"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
-    const body = JSON.stringify(p.requestBody)
+    const headers = this._headers({}, opts.headers)
 
     return this._request({
       url: url,
       method: "DELETE",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -43329,23 +41919,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       expand?: string[]
       id: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_tax_id>> {
     const url = `/v1/tax_ids/${p["id"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -43368,7 +41952,6 @@ export class StripeApi extends AbstractAxiosClient {
       inclusive?: boolean
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -43381,10 +41964,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/tax_rates`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       active: p["active"],
       created: p["created"],
@@ -43394,12 +41974,10 @@ export class StripeApi extends AbstractAxiosClient {
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -43468,23 +42046,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       expand?: string[]
       taxRate: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_tax_rate>> {
     const url = `/v1/tax_rates/${p["taxRate"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -43559,7 +42131,6 @@ export class StripeApi extends AbstractAxiosClient {
       isAccountDefault?: boolean
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -43572,10 +42143,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/terminal/configurations`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
@@ -43583,12 +42151,10 @@ export class StripeApi extends AbstractAxiosClient {
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -43811,22 +42377,16 @@ export class StripeApi extends AbstractAxiosClient {
   async deleteTerminalConfigurationsConfiguration(
     p: {
       configuration: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_deleted_terminal_configuration>> {
     const url = `/v1/terminal/configurations/${p["configuration"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
-    const body = JSON.stringify(p.requestBody)
+    const headers = this._headers({}, opts.headers)
 
     return this._request({
       url: url,
       method: "DELETE",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -43837,7 +42397,6 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       configuration: string
       expand?: string[]
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -43845,17 +42404,12 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<t_terminal_configuration | t_deleted_terminal_configuration>
   > {
     const url = `/v1/terminal/configurations/${p["configuration"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -44133,7 +42687,6 @@ export class StripeApi extends AbstractAxiosClient {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -44146,22 +42699,17 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/terminal/locations`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -44216,22 +42764,16 @@ export class StripeApi extends AbstractAxiosClient {
   async deleteTerminalLocationsLocation(
     p: {
       location: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_deleted_terminal_location>> {
     const url = `/v1/terminal/locations/${p["location"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
-    const body = JSON.stringify(p.requestBody)
+    const headers = this._headers({}, opts.headers)
 
     return this._request({
       url: url,
       method: "DELETE",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -44242,23 +42784,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       expand?: string[]
       location: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_terminal_location | t_deleted_terminal_location>> {
     const url = `/v1/terminal/locations/${p["location"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -44335,7 +42871,6 @@ export class StripeApi extends AbstractAxiosClient {
       serialNumber?: string
       startingAfter?: string
       status?: "offline" | "online" | UnknownEnumStringValue
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -44348,10 +42883,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/terminal/readers`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       device_type: p["deviceType"],
       ending_before: p["endingBefore"],
@@ -44362,12 +42894,10 @@ export class StripeApi extends AbstractAxiosClient {
       starting_after: p["startingAfter"],
       status: p["status"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -44415,22 +42945,16 @@ export class StripeApi extends AbstractAxiosClient {
   async deleteTerminalReadersReader(
     p: {
       reader: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_deleted_terminal_reader>> {
     const url = `/v1/terminal/readers/${p["reader"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
-    const body = JSON.stringify(p.requestBody)
+    const headers = this._headers({}, opts.headers)
 
     return this._request({
       url: url,
       method: "DELETE",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -44441,23 +42965,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       expand?: string[]
       reader: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_terminal_reader | t_deleted_terminal_reader>> {
     const url = `/v1/terminal/readers/${p["reader"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -47525,7 +46043,6 @@ export class StripeApi extends AbstractAxiosClient {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -47538,22 +46055,17 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/test_helpers/test_clocks`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -47591,22 +46103,16 @@ export class StripeApi extends AbstractAxiosClient {
   async deleteTestHelpersTestClocksTestClock(
     p: {
       testClock: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_deleted_test_helpers_test_clock>> {
     const url = `/v1/test_helpers/test_clocks/${p["testClock"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
-    const body = JSON.stringify(p.requestBody)
+    const headers = this._headers({}, opts.headers)
 
     return this._request({
       url: url,
       method: "DELETE",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -47617,23 +46123,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       expand?: string[]
       testClock: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_test_helpers_test_clock>> {
     const url = `/v1/test_helpers/test_clocks/${p["testClock"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -48693,23 +47193,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       expand?: string[]
       token: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_token>> {
     const url = `/v1/tokens/${p["token"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -48744,7 +47238,6 @@ export class StripeApi extends AbstractAxiosClient {
         | "pending"
         | "succeeded"
         | UnknownEnumStringValue
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -48757,10 +47250,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/topups`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       amount: p["amount"],
       created: p["created"],
@@ -48770,12 +47260,10 @@ export class StripeApi extends AbstractAxiosClient {
       starting_after: p["startingAfter"],
       status: p["status"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -48827,23 +47315,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       expand?: string[]
       topup: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_topup>> {
     const url = `/v1/topups/${p["topup"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -48930,7 +47412,6 @@ export class StripeApi extends AbstractAxiosClient {
       limit?: number
       startingAfter?: string
       transferGroup?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -48943,10 +47424,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/transfers`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       created: p["created"],
       destination: p["destination"],
@@ -48956,12 +47434,10 @@ export class StripeApi extends AbstractAxiosClient {
       starting_after: p["startingAfter"],
       transfer_group: p["transferGroup"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -49015,7 +47491,6 @@ export class StripeApi extends AbstractAxiosClient {
       id: string
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -49028,22 +47503,17 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/transfers/${p["id"]}/reversals`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -49093,23 +47563,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       expand?: string[]
       transfer: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_transfer>> {
     const url = `/v1/transfers/${p["transfer"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -49158,23 +47622,17 @@ export class StripeApi extends AbstractAxiosClient {
       expand?: string[]
       id: string
       transfer: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_transfer_reversal>> {
     const url = `/v1/transfers/${p["transfer"]}/reversals/${p["id"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -49227,7 +47685,6 @@ export class StripeApi extends AbstractAxiosClient {
       receivedCredit?: string
       startingAfter?: string
       status?: "canceled" | "posted" | "processing" | UnknownEnumStringValue
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -49240,10 +47697,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/treasury/credit_reversals`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
@@ -49253,12 +47707,10 @@ export class StripeApi extends AbstractAxiosClient {
       starting_after: p["startingAfter"],
       status: p["status"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -49301,23 +47753,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       creditReversal: string
       expand?: string[]
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_treasury_credit_reversal>> {
     const url = `/v1/treasury/credit_reversals/${p["creditReversal"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -49334,7 +47780,6 @@ export class StripeApi extends AbstractAxiosClient {
       resolution?: "lost" | "won" | UnknownEnumStringValue
       startingAfter?: string
       status?: "canceled" | "completed" | "processing" | UnknownEnumStringValue
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -49347,10 +47792,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/treasury/debit_reversals`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
@@ -49361,12 +47803,10 @@ export class StripeApi extends AbstractAxiosClient {
       starting_after: p["startingAfter"],
       status: p["status"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -49409,23 +47849,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       debitReversal: string
       expand?: string[]
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_treasury_debit_reversal>> {
     const url = `/v1/treasury/debit_reversals/${p["debitReversal"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -49447,7 +47881,6 @@ export class StripeApi extends AbstractAxiosClient {
       limit?: number
       startingAfter?: string
       status?: "closed" | "open" | UnknownEnumStringValue
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -49460,10 +47893,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/treasury/financial_accounts`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       created: p["created"],
       ending_before: p["endingBefore"],
@@ -49472,12 +47902,10 @@ export class StripeApi extends AbstractAxiosClient {
       starting_after: p["startingAfter"],
       status: p["status"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -49596,23 +48024,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       expand?: string[]
       financialAccount: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_treasury_financial_account>> {
     const url = `/v1/treasury/financial_accounts/${p["financialAccount"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -49778,23 +48200,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       expand?: string[]
       financialAccount: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_treasury_financial_account_features>> {
     const url = `/v1/treasury/financial_accounts/${p["financialAccount"]}/features`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -49902,7 +48318,6 @@ export class StripeApi extends AbstractAxiosClient {
         | "processing"
         | "succeeded"
         | UnknownEnumStringValue
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -49915,10 +48330,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/treasury/inbound_transfers`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
@@ -49927,12 +48339,10 @@ export class StripeApi extends AbstractAxiosClient {
       starting_after: p["startingAfter"],
       status: p["status"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -49980,23 +48390,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       expand?: string[]
       id: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_treasury_inbound_transfer>> {
     const url = `/v1/treasury/inbound_transfers/${p["id"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -50053,7 +48457,6 @@ export class StripeApi extends AbstractAxiosClient {
         | "processing"
         | "returned"
         | UnknownEnumStringValue
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -50066,10 +48469,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/treasury/outbound_payments`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       created: p["created"],
       customer: p["customer"],
@@ -50080,12 +48480,10 @@ export class StripeApi extends AbstractAxiosClient {
       starting_after: p["startingAfter"],
       status: p["status"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -50207,23 +48605,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       expand?: string[]
       id: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_treasury_outbound_payment>> {
     const url = `/v1/treasury/outbound_payments/${p["id"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -50271,7 +48663,6 @@ export class StripeApi extends AbstractAxiosClient {
         | "processing"
         | "returned"
         | UnknownEnumStringValue
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -50284,10 +48675,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/treasury/outbound_transfers`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
@@ -50296,12 +48684,10 @@ export class StripeApi extends AbstractAxiosClient {
       starting_after: p["startingAfter"],
       status: p["status"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -50374,23 +48760,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       expand?: string[]
       outboundTransfer: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_treasury_outbound_transfer>> {
     const url = `/v1/treasury/outbound_transfers/${p["outboundTransfer"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -50441,7 +48821,6 @@ export class StripeApi extends AbstractAxiosClient {
       }
       startingAfter?: string
       status?: "failed" | "succeeded" | UnknownEnumStringValue
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -50454,10 +48833,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/treasury/received_credits`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
@@ -50467,12 +48843,10 @@ export class StripeApi extends AbstractAxiosClient {
       starting_after: p["startingAfter"],
       status: p["status"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -50483,23 +48857,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       expand?: string[]
       id: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_treasury_received_credit>> {
     const url = `/v1/treasury/received_credits/${p["id"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -50514,7 +48882,6 @@ export class StripeApi extends AbstractAxiosClient {
       limit?: number
       startingAfter?: string
       status?: "failed" | "succeeded" | UnknownEnumStringValue
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -50527,10 +48894,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/treasury/received_debits`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
@@ -50539,12 +48903,10 @@ export class StripeApi extends AbstractAxiosClient {
       starting_after: p["startingAfter"],
       status: p["status"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -50555,23 +48917,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       expand?: string[]
       id: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_treasury_received_debit>> {
     const url = `/v1/treasury/received_debits/${p["id"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -50603,7 +48959,6 @@ export class StripeApi extends AbstractAxiosClient {
       orderBy?: "created" | "effective_at" | UnknownEnumStringValue
       startingAfter?: string
       transaction?: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -50616,10 +48971,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/treasury/transaction_entries`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       created: p["created"],
       effective_at: p["effectiveAt"],
@@ -50631,12 +48983,10 @@ export class StripeApi extends AbstractAxiosClient {
       starting_after: p["startingAfter"],
       transaction: p["transaction"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -50647,23 +48997,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       expand?: string[]
       id: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_treasury_transaction_entry>> {
     const url = `/v1/treasury/transaction_entries/${p["id"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -50700,7 +49044,6 @@ export class StripeApi extends AbstractAxiosClient {
             )
           | undefined
       }
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -50713,10 +49056,7 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/treasury/transactions`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       created: p["created"],
       ending_before: p["endingBefore"],
@@ -50728,12 +49068,10 @@ export class StripeApi extends AbstractAxiosClient {
       status: p["status"],
       status_transitions: p["statusTransitions"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -50744,23 +49082,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       expand?: string[]
       id: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_treasury_transaction>> {
     const url = `/v1/treasury/transactions/${p["id"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -50773,7 +49105,6 @@ export class StripeApi extends AbstractAxiosClient {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -50786,22 +49117,17 @@ export class StripeApi extends AbstractAxiosClient {
     }>
   > {
     const url = `/v1/webhook_endpoints`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -51213,22 +49539,16 @@ export class StripeApi extends AbstractAxiosClient {
   async deleteWebhookEndpointsWebhookEndpoint(
     p: {
       webhookEndpoint: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_deleted_webhook_endpoint>> {
     const url = `/v1/webhook_endpoints/${p["webhookEndpoint"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
-    const body = JSON.stringify(p.requestBody)
+    const headers = this._headers({}, opts.headers)
 
     return this._request({
       url: url,
       method: "DELETE",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
@@ -51239,23 +49559,17 @@ export class StripeApi extends AbstractAxiosClient {
     p: {
       expand?: string[]
       webhookEndpoint: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<t_webhook_endpoint>> {
     const url = `/v1/webhook_endpoints/${p["webhookEndpoint"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
-      data: body,
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,

--- a/integration-tests/typescript-express/src/generated/stripe.yaml/generated.ts
+++ b/integration-tests/typescript-express/src/generated/stripe.yaml/generated.ts
@@ -4,732 +4,451 @@
 
 import {
   t_DeleteAccountsAccountBankAccountsIdParamSchema,
-  t_DeleteAccountsAccountBankAccountsIdRequestBodySchema,
   t_DeleteAccountsAccountExternalAccountsIdParamSchema,
-  t_DeleteAccountsAccountExternalAccountsIdRequestBodySchema,
   t_DeleteAccountsAccountParamSchema,
   t_DeleteAccountsAccountPeoplePersonParamSchema,
-  t_DeleteAccountsAccountPeoplePersonRequestBodySchema,
   t_DeleteAccountsAccountPersonsPersonParamSchema,
-  t_DeleteAccountsAccountPersonsPersonRequestBodySchema,
-  t_DeleteAccountsAccountRequestBodySchema,
   t_DeleteApplePayDomainsDomainParamSchema,
-  t_DeleteApplePayDomainsDomainRequestBodySchema,
   t_DeleteCouponsCouponParamSchema,
-  t_DeleteCouponsCouponRequestBodySchema,
   t_DeleteCustomersCustomerBankAccountsIdParamSchema,
   t_DeleteCustomersCustomerBankAccountsIdRequestBodySchema,
   t_DeleteCustomersCustomerCardsIdParamSchema,
   t_DeleteCustomersCustomerCardsIdRequestBodySchema,
   t_DeleteCustomersCustomerDiscountParamSchema,
-  t_DeleteCustomersCustomerDiscountRequestBodySchema,
   t_DeleteCustomersCustomerParamSchema,
-  t_DeleteCustomersCustomerRequestBodySchema,
   t_DeleteCustomersCustomerSourcesIdParamSchema,
   t_DeleteCustomersCustomerSourcesIdRequestBodySchema,
   t_DeleteCustomersCustomerSubscriptionsSubscriptionExposedIdDiscountParamSchema,
-  t_DeleteCustomersCustomerSubscriptionsSubscriptionExposedIdDiscountRequestBodySchema,
   t_DeleteCustomersCustomerSubscriptionsSubscriptionExposedIdParamSchema,
   t_DeleteCustomersCustomerSubscriptionsSubscriptionExposedIdRequestBodySchema,
   t_DeleteCustomersCustomerTaxIdsIdParamSchema,
-  t_DeleteCustomersCustomerTaxIdsIdRequestBodySchema,
   t_DeleteEphemeralKeysKeyParamSchema,
   t_DeleteEphemeralKeysKeyRequestBodySchema,
   t_DeleteInvoiceitemsInvoiceitemParamSchema,
-  t_DeleteInvoiceitemsInvoiceitemRequestBodySchema,
   t_DeleteInvoicesInvoiceParamSchema,
-  t_DeleteInvoicesInvoiceRequestBodySchema,
   t_DeletePlansPlanParamSchema,
-  t_DeletePlansPlanRequestBodySchema,
   t_DeleteProductsIdParamSchema,
-  t_DeleteProductsIdRequestBodySchema,
   t_DeleteProductsProductFeaturesIdParamSchema,
-  t_DeleteProductsProductFeaturesIdRequestBodySchema,
   t_DeleteRadarValueListItemsItemParamSchema,
-  t_DeleteRadarValueListItemsItemRequestBodySchema,
   t_DeleteRadarValueListsValueListParamSchema,
-  t_DeleteRadarValueListsValueListRequestBodySchema,
   t_DeleteSubscriptionItemsItemParamSchema,
   t_DeleteSubscriptionItemsItemRequestBodySchema,
   t_DeleteSubscriptionsSubscriptionExposedIdDiscountParamSchema,
-  t_DeleteSubscriptionsSubscriptionExposedIdDiscountRequestBodySchema,
   t_DeleteSubscriptionsSubscriptionExposedIdParamSchema,
   t_DeleteSubscriptionsSubscriptionExposedIdRequestBodySchema,
   t_DeleteTaxIdsIdParamSchema,
-  t_DeleteTaxIdsIdRequestBodySchema,
   t_DeleteTerminalConfigurationsConfigurationParamSchema,
-  t_DeleteTerminalConfigurationsConfigurationRequestBodySchema,
   t_DeleteTerminalLocationsLocationParamSchema,
-  t_DeleteTerminalLocationsLocationRequestBodySchema,
   t_DeleteTerminalReadersReaderParamSchema,
-  t_DeleteTerminalReadersReaderRequestBodySchema,
   t_DeleteTestHelpersTestClocksTestClockParamSchema,
-  t_DeleteTestHelpersTestClocksTestClockRequestBodySchema,
   t_DeleteWebhookEndpointsWebhookEndpointParamSchema,
-  t_DeleteWebhookEndpointsWebhookEndpointRequestBodySchema,
   t_GetAccountQuerySchema,
-  t_GetAccountRequestBodySchema,
   t_GetAccountsAccountBankAccountsIdParamSchema,
   t_GetAccountsAccountBankAccountsIdQuerySchema,
-  t_GetAccountsAccountBankAccountsIdRequestBodySchema,
   t_GetAccountsAccountCapabilitiesCapabilityParamSchema,
   t_GetAccountsAccountCapabilitiesCapabilityQuerySchema,
-  t_GetAccountsAccountCapabilitiesCapabilityRequestBodySchema,
   t_GetAccountsAccountCapabilitiesParamSchema,
   t_GetAccountsAccountCapabilitiesQuerySchema,
-  t_GetAccountsAccountCapabilitiesRequestBodySchema,
   t_GetAccountsAccountExternalAccountsIdParamSchema,
   t_GetAccountsAccountExternalAccountsIdQuerySchema,
-  t_GetAccountsAccountExternalAccountsIdRequestBodySchema,
   t_GetAccountsAccountExternalAccountsParamSchema,
   t_GetAccountsAccountExternalAccountsQuerySchema,
-  t_GetAccountsAccountExternalAccountsRequestBodySchema,
   t_GetAccountsAccountParamSchema,
   t_GetAccountsAccountPeopleParamSchema,
   t_GetAccountsAccountPeoplePersonParamSchema,
   t_GetAccountsAccountPeoplePersonQuerySchema,
-  t_GetAccountsAccountPeoplePersonRequestBodySchema,
   t_GetAccountsAccountPeopleQuerySchema,
-  t_GetAccountsAccountPeopleRequestBodySchema,
   t_GetAccountsAccountPersonsParamSchema,
   t_GetAccountsAccountPersonsPersonParamSchema,
   t_GetAccountsAccountPersonsPersonQuerySchema,
-  t_GetAccountsAccountPersonsPersonRequestBodySchema,
   t_GetAccountsAccountPersonsQuerySchema,
-  t_GetAccountsAccountPersonsRequestBodySchema,
   t_GetAccountsAccountQuerySchema,
-  t_GetAccountsAccountRequestBodySchema,
   t_GetAccountsQuerySchema,
-  t_GetAccountsRequestBodySchema,
   t_GetApplePayDomainsDomainParamSchema,
   t_GetApplePayDomainsDomainQuerySchema,
-  t_GetApplePayDomainsDomainRequestBodySchema,
   t_GetApplePayDomainsQuerySchema,
-  t_GetApplePayDomainsRequestBodySchema,
   t_GetApplicationFeesFeeRefundsIdParamSchema,
   t_GetApplicationFeesFeeRefundsIdQuerySchema,
-  t_GetApplicationFeesFeeRefundsIdRequestBodySchema,
   t_GetApplicationFeesIdParamSchema,
   t_GetApplicationFeesIdQuerySchema,
   t_GetApplicationFeesIdRefundsParamSchema,
   t_GetApplicationFeesIdRefundsQuerySchema,
-  t_GetApplicationFeesIdRefundsRequestBodySchema,
-  t_GetApplicationFeesIdRequestBodySchema,
   t_GetApplicationFeesQuerySchema,
-  t_GetApplicationFeesRequestBodySchema,
   t_GetAppsSecretsFindQuerySchema,
-  t_GetAppsSecretsFindRequestBodySchema,
   t_GetAppsSecretsQuerySchema,
-  t_GetAppsSecretsRequestBodySchema,
   t_GetBalanceHistoryIdParamSchema,
   t_GetBalanceHistoryIdQuerySchema,
-  t_GetBalanceHistoryIdRequestBodySchema,
   t_GetBalanceHistoryQuerySchema,
-  t_GetBalanceHistoryRequestBodySchema,
   t_GetBalanceQuerySchema,
-  t_GetBalanceRequestBodySchema,
   t_GetBalanceTransactionsIdParamSchema,
   t_GetBalanceTransactionsIdQuerySchema,
-  t_GetBalanceTransactionsIdRequestBodySchema,
   t_GetBalanceTransactionsQuerySchema,
-  t_GetBalanceTransactionsRequestBodySchema,
   t_GetBillingAlertsIdParamSchema,
   t_GetBillingAlertsIdQuerySchema,
-  t_GetBillingAlertsIdRequestBodySchema,
   t_GetBillingAlertsQuerySchema,
-  t_GetBillingAlertsRequestBodySchema,
   t_GetBillingCreditBalanceSummaryQuerySchema,
-  t_GetBillingCreditBalanceSummaryRequestBodySchema,
   t_GetBillingCreditBalanceTransactionsIdParamSchema,
   t_GetBillingCreditBalanceTransactionsIdQuerySchema,
-  t_GetBillingCreditBalanceTransactionsIdRequestBodySchema,
   t_GetBillingCreditBalanceTransactionsQuerySchema,
-  t_GetBillingCreditBalanceTransactionsRequestBodySchema,
   t_GetBillingCreditGrantsIdParamSchema,
   t_GetBillingCreditGrantsIdQuerySchema,
-  t_GetBillingCreditGrantsIdRequestBodySchema,
   t_GetBillingCreditGrantsQuerySchema,
-  t_GetBillingCreditGrantsRequestBodySchema,
   t_GetBillingMetersIdEventSummariesParamSchema,
   t_GetBillingMetersIdEventSummariesQuerySchema,
-  t_GetBillingMetersIdEventSummariesRequestBodySchema,
   t_GetBillingMetersIdParamSchema,
   t_GetBillingMetersIdQuerySchema,
-  t_GetBillingMetersIdRequestBodySchema,
   t_GetBillingMetersQuerySchema,
-  t_GetBillingMetersRequestBodySchema,
   t_GetBillingPortalConfigurationsConfigurationParamSchema,
   t_GetBillingPortalConfigurationsConfigurationQuerySchema,
-  t_GetBillingPortalConfigurationsConfigurationRequestBodySchema,
   t_GetBillingPortalConfigurationsQuerySchema,
-  t_GetBillingPortalConfigurationsRequestBodySchema,
   t_GetChargesChargeDisputeParamSchema,
   t_GetChargesChargeDisputeQuerySchema,
-  t_GetChargesChargeDisputeRequestBodySchema,
   t_GetChargesChargeParamSchema,
   t_GetChargesChargeQuerySchema,
   t_GetChargesChargeRefundsParamSchema,
   t_GetChargesChargeRefundsQuerySchema,
   t_GetChargesChargeRefundsRefundParamSchema,
   t_GetChargesChargeRefundsRefundQuerySchema,
-  t_GetChargesChargeRefundsRefundRequestBodySchema,
-  t_GetChargesChargeRefundsRequestBodySchema,
-  t_GetChargesChargeRequestBodySchema,
   t_GetChargesQuerySchema,
-  t_GetChargesRequestBodySchema,
   t_GetChargesSearchQuerySchema,
-  t_GetChargesSearchRequestBodySchema,
   t_GetCheckoutSessionsQuerySchema,
-  t_GetCheckoutSessionsRequestBodySchema,
   t_GetCheckoutSessionsSessionLineItemsParamSchema,
   t_GetCheckoutSessionsSessionLineItemsQuerySchema,
-  t_GetCheckoutSessionsSessionLineItemsRequestBodySchema,
   t_GetCheckoutSessionsSessionParamSchema,
   t_GetCheckoutSessionsSessionQuerySchema,
-  t_GetCheckoutSessionsSessionRequestBodySchema,
   t_GetClimateOrdersOrderParamSchema,
   t_GetClimateOrdersOrderQuerySchema,
-  t_GetClimateOrdersOrderRequestBodySchema,
   t_GetClimateOrdersQuerySchema,
-  t_GetClimateOrdersRequestBodySchema,
   t_GetClimateProductsProductParamSchema,
   t_GetClimateProductsProductQuerySchema,
-  t_GetClimateProductsProductRequestBodySchema,
   t_GetClimateProductsQuerySchema,
-  t_GetClimateProductsRequestBodySchema,
   t_GetClimateSuppliersQuerySchema,
-  t_GetClimateSuppliersRequestBodySchema,
   t_GetClimateSuppliersSupplierParamSchema,
   t_GetClimateSuppliersSupplierQuerySchema,
-  t_GetClimateSuppliersSupplierRequestBodySchema,
   t_GetConfirmationTokensConfirmationTokenParamSchema,
   t_GetConfirmationTokensConfirmationTokenQuerySchema,
-  t_GetConfirmationTokensConfirmationTokenRequestBodySchema,
   t_GetCountrySpecsCountryParamSchema,
   t_GetCountrySpecsCountryQuerySchema,
-  t_GetCountrySpecsCountryRequestBodySchema,
   t_GetCountrySpecsQuerySchema,
-  t_GetCountrySpecsRequestBodySchema,
   t_GetCouponsCouponParamSchema,
   t_GetCouponsCouponQuerySchema,
-  t_GetCouponsCouponRequestBodySchema,
   t_GetCouponsQuerySchema,
-  t_GetCouponsRequestBodySchema,
   t_GetCreditNotesCreditNoteLinesParamSchema,
   t_GetCreditNotesCreditNoteLinesQuerySchema,
-  t_GetCreditNotesCreditNoteLinesRequestBodySchema,
   t_GetCreditNotesIdParamSchema,
   t_GetCreditNotesIdQuerySchema,
-  t_GetCreditNotesIdRequestBodySchema,
   t_GetCreditNotesPreviewLinesQuerySchema,
-  t_GetCreditNotesPreviewLinesRequestBodySchema,
   t_GetCreditNotesPreviewQuerySchema,
-  t_GetCreditNotesPreviewRequestBodySchema,
   t_GetCreditNotesQuerySchema,
-  t_GetCreditNotesRequestBodySchema,
   t_GetCustomersCustomerBalanceTransactionsParamSchema,
   t_GetCustomersCustomerBalanceTransactionsQuerySchema,
-  t_GetCustomersCustomerBalanceTransactionsRequestBodySchema,
   t_GetCustomersCustomerBalanceTransactionsTransactionParamSchema,
   t_GetCustomersCustomerBalanceTransactionsTransactionQuerySchema,
-  t_GetCustomersCustomerBalanceTransactionsTransactionRequestBodySchema,
   t_GetCustomersCustomerBankAccountsIdParamSchema,
   t_GetCustomersCustomerBankAccountsIdQuerySchema,
-  t_GetCustomersCustomerBankAccountsIdRequestBodySchema,
   t_GetCustomersCustomerBankAccountsParamSchema,
   t_GetCustomersCustomerBankAccountsQuerySchema,
-  t_GetCustomersCustomerBankAccountsRequestBodySchema,
   t_GetCustomersCustomerCardsIdParamSchema,
   t_GetCustomersCustomerCardsIdQuerySchema,
-  t_GetCustomersCustomerCardsIdRequestBodySchema,
   t_GetCustomersCustomerCardsParamSchema,
   t_GetCustomersCustomerCardsQuerySchema,
-  t_GetCustomersCustomerCardsRequestBodySchema,
   t_GetCustomersCustomerCashBalanceParamSchema,
   t_GetCustomersCustomerCashBalanceQuerySchema,
-  t_GetCustomersCustomerCashBalanceRequestBodySchema,
   t_GetCustomersCustomerCashBalanceTransactionsParamSchema,
   t_GetCustomersCustomerCashBalanceTransactionsQuerySchema,
-  t_GetCustomersCustomerCashBalanceTransactionsRequestBodySchema,
   t_GetCustomersCustomerCashBalanceTransactionsTransactionParamSchema,
   t_GetCustomersCustomerCashBalanceTransactionsTransactionQuerySchema,
-  t_GetCustomersCustomerCashBalanceTransactionsTransactionRequestBodySchema,
   t_GetCustomersCustomerDiscountParamSchema,
   t_GetCustomersCustomerDiscountQuerySchema,
-  t_GetCustomersCustomerDiscountRequestBodySchema,
   t_GetCustomersCustomerParamSchema,
   t_GetCustomersCustomerPaymentMethodsParamSchema,
   t_GetCustomersCustomerPaymentMethodsPaymentMethodParamSchema,
   t_GetCustomersCustomerPaymentMethodsPaymentMethodQuerySchema,
-  t_GetCustomersCustomerPaymentMethodsPaymentMethodRequestBodySchema,
   t_GetCustomersCustomerPaymentMethodsQuerySchema,
-  t_GetCustomersCustomerPaymentMethodsRequestBodySchema,
   t_GetCustomersCustomerQuerySchema,
-  t_GetCustomersCustomerRequestBodySchema,
   t_GetCustomersCustomerSourcesIdParamSchema,
   t_GetCustomersCustomerSourcesIdQuerySchema,
-  t_GetCustomersCustomerSourcesIdRequestBodySchema,
   t_GetCustomersCustomerSourcesParamSchema,
   t_GetCustomersCustomerSourcesQuerySchema,
-  t_GetCustomersCustomerSourcesRequestBodySchema,
   t_GetCustomersCustomerSubscriptionsParamSchema,
   t_GetCustomersCustomerSubscriptionsQuerySchema,
-  t_GetCustomersCustomerSubscriptionsRequestBodySchema,
   t_GetCustomersCustomerSubscriptionsSubscriptionExposedIdDiscountParamSchema,
   t_GetCustomersCustomerSubscriptionsSubscriptionExposedIdDiscountQuerySchema,
-  t_GetCustomersCustomerSubscriptionsSubscriptionExposedIdDiscountRequestBodySchema,
   t_GetCustomersCustomerSubscriptionsSubscriptionExposedIdParamSchema,
   t_GetCustomersCustomerSubscriptionsSubscriptionExposedIdQuerySchema,
-  t_GetCustomersCustomerSubscriptionsSubscriptionExposedIdRequestBodySchema,
   t_GetCustomersCustomerTaxIdsIdParamSchema,
   t_GetCustomersCustomerTaxIdsIdQuerySchema,
-  t_GetCustomersCustomerTaxIdsIdRequestBodySchema,
   t_GetCustomersCustomerTaxIdsParamSchema,
   t_GetCustomersCustomerTaxIdsQuerySchema,
-  t_GetCustomersCustomerTaxIdsRequestBodySchema,
   t_GetCustomersQuerySchema,
-  t_GetCustomersRequestBodySchema,
   t_GetCustomersSearchQuerySchema,
-  t_GetCustomersSearchRequestBodySchema,
   t_GetDisputesDisputeParamSchema,
   t_GetDisputesDisputeQuerySchema,
-  t_GetDisputesDisputeRequestBodySchema,
   t_GetDisputesQuerySchema,
-  t_GetDisputesRequestBodySchema,
   t_GetEntitlementsActiveEntitlementsIdParamSchema,
   t_GetEntitlementsActiveEntitlementsIdQuerySchema,
-  t_GetEntitlementsActiveEntitlementsIdRequestBodySchema,
   t_GetEntitlementsActiveEntitlementsQuerySchema,
-  t_GetEntitlementsActiveEntitlementsRequestBodySchema,
   t_GetEntitlementsFeaturesIdParamSchema,
   t_GetEntitlementsFeaturesIdQuerySchema,
-  t_GetEntitlementsFeaturesIdRequestBodySchema,
   t_GetEntitlementsFeaturesQuerySchema,
-  t_GetEntitlementsFeaturesRequestBodySchema,
   t_GetEventsIdParamSchema,
   t_GetEventsIdQuerySchema,
-  t_GetEventsIdRequestBodySchema,
   t_GetEventsQuerySchema,
-  t_GetEventsRequestBodySchema,
   t_GetExchangeRatesQuerySchema,
   t_GetExchangeRatesRateIdParamSchema,
   t_GetExchangeRatesRateIdQuerySchema,
-  t_GetExchangeRatesRateIdRequestBodySchema,
-  t_GetExchangeRatesRequestBodySchema,
   t_GetFileLinksLinkParamSchema,
   t_GetFileLinksLinkQuerySchema,
-  t_GetFileLinksLinkRequestBodySchema,
   t_GetFileLinksQuerySchema,
-  t_GetFileLinksRequestBodySchema,
   t_GetFilesFileParamSchema,
   t_GetFilesFileQuerySchema,
-  t_GetFilesFileRequestBodySchema,
   t_GetFilesQuerySchema,
-  t_GetFilesRequestBodySchema,
   t_GetFinancialConnectionsAccountsAccountOwnersParamSchema,
   t_GetFinancialConnectionsAccountsAccountOwnersQuerySchema,
-  t_GetFinancialConnectionsAccountsAccountOwnersRequestBodySchema,
   t_GetFinancialConnectionsAccountsAccountParamSchema,
   t_GetFinancialConnectionsAccountsAccountQuerySchema,
-  t_GetFinancialConnectionsAccountsAccountRequestBodySchema,
   t_GetFinancialConnectionsAccountsQuerySchema,
-  t_GetFinancialConnectionsAccountsRequestBodySchema,
   t_GetFinancialConnectionsSessionsSessionParamSchema,
   t_GetFinancialConnectionsSessionsSessionQuerySchema,
-  t_GetFinancialConnectionsSessionsSessionRequestBodySchema,
   t_GetFinancialConnectionsTransactionsQuerySchema,
-  t_GetFinancialConnectionsTransactionsRequestBodySchema,
   t_GetFinancialConnectionsTransactionsTransactionParamSchema,
   t_GetFinancialConnectionsTransactionsTransactionQuerySchema,
-  t_GetFinancialConnectionsTransactionsTransactionRequestBodySchema,
   t_GetForwardingRequestsIdParamSchema,
   t_GetForwardingRequestsIdQuerySchema,
-  t_GetForwardingRequestsIdRequestBodySchema,
   t_GetForwardingRequestsQuerySchema,
-  t_GetForwardingRequestsRequestBodySchema,
   t_GetIdentityVerificationReportsQuerySchema,
   t_GetIdentityVerificationReportsReportParamSchema,
   t_GetIdentityVerificationReportsReportQuerySchema,
-  t_GetIdentityVerificationReportsReportRequestBodySchema,
-  t_GetIdentityVerificationReportsRequestBodySchema,
   t_GetIdentityVerificationSessionsQuerySchema,
-  t_GetIdentityVerificationSessionsRequestBodySchema,
   t_GetIdentityVerificationSessionsSessionParamSchema,
   t_GetIdentityVerificationSessionsSessionQuerySchema,
-  t_GetIdentityVerificationSessionsSessionRequestBodySchema,
   t_GetInvoicePaymentsInvoicePaymentParamSchema,
   t_GetInvoicePaymentsInvoicePaymentQuerySchema,
-  t_GetInvoicePaymentsInvoicePaymentRequestBodySchema,
   t_GetInvoicePaymentsQuerySchema,
-  t_GetInvoicePaymentsRequestBodySchema,
   t_GetInvoiceRenderingTemplatesQuerySchema,
-  t_GetInvoiceRenderingTemplatesRequestBodySchema,
   t_GetInvoiceRenderingTemplatesTemplateParamSchema,
   t_GetInvoiceRenderingTemplatesTemplateQuerySchema,
-  t_GetInvoiceRenderingTemplatesTemplateRequestBodySchema,
   t_GetInvoiceitemsInvoiceitemParamSchema,
   t_GetInvoiceitemsInvoiceitemQuerySchema,
-  t_GetInvoiceitemsInvoiceitemRequestBodySchema,
   t_GetInvoiceitemsQuerySchema,
-  t_GetInvoiceitemsRequestBodySchema,
   t_GetInvoicesInvoiceLinesParamSchema,
   t_GetInvoicesInvoiceLinesQuerySchema,
-  t_GetInvoicesInvoiceLinesRequestBodySchema,
   t_GetInvoicesInvoiceParamSchema,
   t_GetInvoicesInvoiceQuerySchema,
-  t_GetInvoicesInvoiceRequestBodySchema,
   t_GetInvoicesQuerySchema,
-  t_GetInvoicesRequestBodySchema,
   t_GetInvoicesSearchQuerySchema,
-  t_GetInvoicesSearchRequestBodySchema,
   t_GetIssuingAuthorizationsAuthorizationParamSchema,
   t_GetIssuingAuthorizationsAuthorizationQuerySchema,
-  t_GetIssuingAuthorizationsAuthorizationRequestBodySchema,
   t_GetIssuingAuthorizationsQuerySchema,
-  t_GetIssuingAuthorizationsRequestBodySchema,
   t_GetIssuingCardholdersCardholderParamSchema,
   t_GetIssuingCardholdersCardholderQuerySchema,
-  t_GetIssuingCardholdersCardholderRequestBodySchema,
   t_GetIssuingCardholdersQuerySchema,
-  t_GetIssuingCardholdersRequestBodySchema,
   t_GetIssuingCardsCardParamSchema,
   t_GetIssuingCardsCardQuerySchema,
-  t_GetIssuingCardsCardRequestBodySchema,
   t_GetIssuingCardsQuerySchema,
-  t_GetIssuingCardsRequestBodySchema,
   t_GetIssuingDisputesDisputeParamSchema,
   t_GetIssuingDisputesDisputeQuerySchema,
-  t_GetIssuingDisputesDisputeRequestBodySchema,
   t_GetIssuingDisputesQuerySchema,
-  t_GetIssuingDisputesRequestBodySchema,
   t_GetIssuingPersonalizationDesignsPersonalizationDesignParamSchema,
   t_GetIssuingPersonalizationDesignsPersonalizationDesignQuerySchema,
-  t_GetIssuingPersonalizationDesignsPersonalizationDesignRequestBodySchema,
   t_GetIssuingPersonalizationDesignsQuerySchema,
-  t_GetIssuingPersonalizationDesignsRequestBodySchema,
   t_GetIssuingPhysicalBundlesPhysicalBundleParamSchema,
   t_GetIssuingPhysicalBundlesPhysicalBundleQuerySchema,
-  t_GetIssuingPhysicalBundlesPhysicalBundleRequestBodySchema,
   t_GetIssuingPhysicalBundlesQuerySchema,
-  t_GetIssuingPhysicalBundlesRequestBodySchema,
   t_GetIssuingSettlementsSettlementParamSchema,
   t_GetIssuingSettlementsSettlementQuerySchema,
-  t_GetIssuingSettlementsSettlementRequestBodySchema,
   t_GetIssuingTokensQuerySchema,
-  t_GetIssuingTokensRequestBodySchema,
   t_GetIssuingTokensTokenParamSchema,
   t_GetIssuingTokensTokenQuerySchema,
-  t_GetIssuingTokensTokenRequestBodySchema,
   t_GetIssuingTransactionsQuerySchema,
-  t_GetIssuingTransactionsRequestBodySchema,
   t_GetIssuingTransactionsTransactionParamSchema,
   t_GetIssuingTransactionsTransactionQuerySchema,
-  t_GetIssuingTransactionsTransactionRequestBodySchema,
   t_GetLinkAccountSessionsSessionParamSchema,
   t_GetLinkAccountSessionsSessionQuerySchema,
-  t_GetLinkAccountSessionsSessionRequestBodySchema,
   t_GetLinkedAccountsAccountOwnersParamSchema,
   t_GetLinkedAccountsAccountOwnersQuerySchema,
-  t_GetLinkedAccountsAccountOwnersRequestBodySchema,
   t_GetLinkedAccountsAccountParamSchema,
   t_GetLinkedAccountsAccountQuerySchema,
-  t_GetLinkedAccountsAccountRequestBodySchema,
   t_GetLinkedAccountsQuerySchema,
-  t_GetLinkedAccountsRequestBodySchema,
   t_GetMandatesMandateParamSchema,
   t_GetMandatesMandateQuerySchema,
-  t_GetMandatesMandateRequestBodySchema,
   t_GetPaymentIntentsIntentParamSchema,
   t_GetPaymentIntentsIntentQuerySchema,
-  t_GetPaymentIntentsIntentRequestBodySchema,
   t_GetPaymentIntentsQuerySchema,
-  t_GetPaymentIntentsRequestBodySchema,
   t_GetPaymentIntentsSearchQuerySchema,
-  t_GetPaymentIntentsSearchRequestBodySchema,
   t_GetPaymentLinksPaymentLinkLineItemsParamSchema,
   t_GetPaymentLinksPaymentLinkLineItemsQuerySchema,
-  t_GetPaymentLinksPaymentLinkLineItemsRequestBodySchema,
   t_GetPaymentLinksPaymentLinkParamSchema,
   t_GetPaymentLinksPaymentLinkQuerySchema,
-  t_GetPaymentLinksPaymentLinkRequestBodySchema,
   t_GetPaymentLinksQuerySchema,
-  t_GetPaymentLinksRequestBodySchema,
   t_GetPaymentMethodConfigurationsConfigurationParamSchema,
   t_GetPaymentMethodConfigurationsConfigurationQuerySchema,
-  t_GetPaymentMethodConfigurationsConfigurationRequestBodySchema,
   t_GetPaymentMethodConfigurationsQuerySchema,
-  t_GetPaymentMethodConfigurationsRequestBodySchema,
   t_GetPaymentMethodDomainsPaymentMethodDomainParamSchema,
   t_GetPaymentMethodDomainsPaymentMethodDomainQuerySchema,
-  t_GetPaymentMethodDomainsPaymentMethodDomainRequestBodySchema,
   t_GetPaymentMethodDomainsQuerySchema,
-  t_GetPaymentMethodDomainsRequestBodySchema,
   t_GetPaymentMethodsPaymentMethodParamSchema,
   t_GetPaymentMethodsPaymentMethodQuerySchema,
-  t_GetPaymentMethodsPaymentMethodRequestBodySchema,
   t_GetPaymentMethodsQuerySchema,
-  t_GetPaymentMethodsRequestBodySchema,
   t_GetPayoutsPayoutParamSchema,
   t_GetPayoutsPayoutQuerySchema,
-  t_GetPayoutsPayoutRequestBodySchema,
   t_GetPayoutsQuerySchema,
-  t_GetPayoutsRequestBodySchema,
   t_GetPlansPlanParamSchema,
   t_GetPlansPlanQuerySchema,
-  t_GetPlansPlanRequestBodySchema,
   t_GetPlansQuerySchema,
-  t_GetPlansRequestBodySchema,
   t_GetPricesPriceParamSchema,
   t_GetPricesPriceQuerySchema,
-  t_GetPricesPriceRequestBodySchema,
   t_GetPricesQuerySchema,
-  t_GetPricesRequestBodySchema,
   t_GetPricesSearchQuerySchema,
-  t_GetPricesSearchRequestBodySchema,
   t_GetProductsIdParamSchema,
   t_GetProductsIdQuerySchema,
-  t_GetProductsIdRequestBodySchema,
   t_GetProductsProductFeaturesIdParamSchema,
   t_GetProductsProductFeaturesIdQuerySchema,
-  t_GetProductsProductFeaturesIdRequestBodySchema,
   t_GetProductsProductFeaturesParamSchema,
   t_GetProductsProductFeaturesQuerySchema,
-  t_GetProductsProductFeaturesRequestBodySchema,
   t_GetProductsQuerySchema,
-  t_GetProductsRequestBodySchema,
   t_GetProductsSearchQuerySchema,
-  t_GetProductsSearchRequestBodySchema,
   t_GetPromotionCodesPromotionCodeParamSchema,
   t_GetPromotionCodesPromotionCodeQuerySchema,
-  t_GetPromotionCodesPromotionCodeRequestBodySchema,
   t_GetPromotionCodesQuerySchema,
-  t_GetPromotionCodesRequestBodySchema,
   t_GetQuotesQuerySchema,
   t_GetQuotesQuoteComputedUpfrontLineItemsParamSchema,
   t_GetQuotesQuoteComputedUpfrontLineItemsQuerySchema,
-  t_GetQuotesQuoteComputedUpfrontLineItemsRequestBodySchema,
   t_GetQuotesQuoteLineItemsParamSchema,
   t_GetQuotesQuoteLineItemsQuerySchema,
-  t_GetQuotesQuoteLineItemsRequestBodySchema,
   t_GetQuotesQuoteParamSchema,
   t_GetQuotesQuotePdfParamSchema,
   t_GetQuotesQuotePdfQuerySchema,
-  t_GetQuotesQuotePdfRequestBodySchema,
   t_GetQuotesQuoteQuerySchema,
-  t_GetQuotesQuoteRequestBodySchema,
-  t_GetQuotesRequestBodySchema,
   t_GetRadarEarlyFraudWarningsEarlyFraudWarningParamSchema,
   t_GetRadarEarlyFraudWarningsEarlyFraudWarningQuerySchema,
-  t_GetRadarEarlyFraudWarningsEarlyFraudWarningRequestBodySchema,
   t_GetRadarEarlyFraudWarningsQuerySchema,
-  t_GetRadarEarlyFraudWarningsRequestBodySchema,
   t_GetRadarValueListItemsItemParamSchema,
   t_GetRadarValueListItemsItemQuerySchema,
-  t_GetRadarValueListItemsItemRequestBodySchema,
   t_GetRadarValueListItemsQuerySchema,
-  t_GetRadarValueListItemsRequestBodySchema,
   t_GetRadarValueListsQuerySchema,
-  t_GetRadarValueListsRequestBodySchema,
   t_GetRadarValueListsValueListParamSchema,
   t_GetRadarValueListsValueListQuerySchema,
-  t_GetRadarValueListsValueListRequestBodySchema,
   t_GetRefundsQuerySchema,
   t_GetRefundsRefundParamSchema,
   t_GetRefundsRefundQuerySchema,
-  t_GetRefundsRefundRequestBodySchema,
-  t_GetRefundsRequestBodySchema,
   t_GetReportingReportRunsQuerySchema,
   t_GetReportingReportRunsReportRunParamSchema,
   t_GetReportingReportRunsReportRunQuerySchema,
-  t_GetReportingReportRunsReportRunRequestBodySchema,
-  t_GetReportingReportRunsRequestBodySchema,
   t_GetReportingReportTypesQuerySchema,
   t_GetReportingReportTypesReportTypeParamSchema,
   t_GetReportingReportTypesReportTypeQuerySchema,
-  t_GetReportingReportTypesReportTypeRequestBodySchema,
-  t_GetReportingReportTypesRequestBodySchema,
   t_GetReviewsQuerySchema,
-  t_GetReviewsRequestBodySchema,
   t_GetReviewsReviewParamSchema,
   t_GetReviewsReviewQuerySchema,
-  t_GetReviewsReviewRequestBodySchema,
   t_GetSetupAttemptsQuerySchema,
-  t_GetSetupAttemptsRequestBodySchema,
   t_GetSetupIntentsIntentParamSchema,
   t_GetSetupIntentsIntentQuerySchema,
-  t_GetSetupIntentsIntentRequestBodySchema,
   t_GetSetupIntentsQuerySchema,
-  t_GetSetupIntentsRequestBodySchema,
   t_GetShippingRatesQuerySchema,
-  t_GetShippingRatesRequestBodySchema,
   t_GetShippingRatesShippingRateTokenParamSchema,
   t_GetShippingRatesShippingRateTokenQuerySchema,
-  t_GetShippingRatesShippingRateTokenRequestBodySchema,
   t_GetSigmaScheduledQueryRunsQuerySchema,
-  t_GetSigmaScheduledQueryRunsRequestBodySchema,
   t_GetSigmaScheduledQueryRunsScheduledQueryRunParamSchema,
   t_GetSigmaScheduledQueryRunsScheduledQueryRunQuerySchema,
-  t_GetSigmaScheduledQueryRunsScheduledQueryRunRequestBodySchema,
   t_GetSourcesSourceMandateNotificationsMandateNotificationParamSchema,
   t_GetSourcesSourceMandateNotificationsMandateNotificationQuerySchema,
-  t_GetSourcesSourceMandateNotificationsMandateNotificationRequestBodySchema,
   t_GetSourcesSourceParamSchema,
   t_GetSourcesSourceQuerySchema,
-  t_GetSourcesSourceRequestBodySchema,
   t_GetSourcesSourceSourceTransactionsParamSchema,
   t_GetSourcesSourceSourceTransactionsQuerySchema,
-  t_GetSourcesSourceSourceTransactionsRequestBodySchema,
   t_GetSourcesSourceSourceTransactionsSourceTransactionParamSchema,
   t_GetSourcesSourceSourceTransactionsSourceTransactionQuerySchema,
-  t_GetSourcesSourceSourceTransactionsSourceTransactionRequestBodySchema,
   t_GetSubscriptionItemsItemParamSchema,
   t_GetSubscriptionItemsItemQuerySchema,
-  t_GetSubscriptionItemsItemRequestBodySchema,
   t_GetSubscriptionItemsQuerySchema,
-  t_GetSubscriptionItemsRequestBodySchema,
   t_GetSubscriptionSchedulesQuerySchema,
-  t_GetSubscriptionSchedulesRequestBodySchema,
   t_GetSubscriptionSchedulesScheduleParamSchema,
   t_GetSubscriptionSchedulesScheduleQuerySchema,
-  t_GetSubscriptionSchedulesScheduleRequestBodySchema,
   t_GetSubscriptionsQuerySchema,
-  t_GetSubscriptionsRequestBodySchema,
   t_GetSubscriptionsSearchQuerySchema,
-  t_GetSubscriptionsSearchRequestBodySchema,
   t_GetSubscriptionsSubscriptionExposedIdParamSchema,
   t_GetSubscriptionsSubscriptionExposedIdQuerySchema,
-  t_GetSubscriptionsSubscriptionExposedIdRequestBodySchema,
   t_GetTaxCalculationsCalculationLineItemsParamSchema,
   t_GetTaxCalculationsCalculationLineItemsQuerySchema,
-  t_GetTaxCalculationsCalculationLineItemsRequestBodySchema,
   t_GetTaxCalculationsCalculationParamSchema,
   t_GetTaxCalculationsCalculationQuerySchema,
-  t_GetTaxCalculationsCalculationRequestBodySchema,
   t_GetTaxCodesIdParamSchema,
   t_GetTaxCodesIdQuerySchema,
-  t_GetTaxCodesIdRequestBodySchema,
   t_GetTaxCodesQuerySchema,
-  t_GetTaxCodesRequestBodySchema,
   t_GetTaxIdsIdParamSchema,
   t_GetTaxIdsIdQuerySchema,
-  t_GetTaxIdsIdRequestBodySchema,
   t_GetTaxIdsQuerySchema,
-  t_GetTaxIdsRequestBodySchema,
   t_GetTaxRatesQuerySchema,
-  t_GetTaxRatesRequestBodySchema,
   t_GetTaxRatesTaxRateParamSchema,
   t_GetTaxRatesTaxRateQuerySchema,
-  t_GetTaxRatesTaxRateRequestBodySchema,
   t_GetTaxRegistrationsIdParamSchema,
   t_GetTaxRegistrationsIdQuerySchema,
-  t_GetTaxRegistrationsIdRequestBodySchema,
   t_GetTaxRegistrationsQuerySchema,
-  t_GetTaxRegistrationsRequestBodySchema,
   t_GetTaxSettingsQuerySchema,
-  t_GetTaxSettingsRequestBodySchema,
   t_GetTaxTransactionsTransactionLineItemsParamSchema,
   t_GetTaxTransactionsTransactionLineItemsQuerySchema,
-  t_GetTaxTransactionsTransactionLineItemsRequestBodySchema,
   t_GetTaxTransactionsTransactionParamSchema,
   t_GetTaxTransactionsTransactionQuerySchema,
-  t_GetTaxTransactionsTransactionRequestBodySchema,
   t_GetTerminalConfigurationsConfigurationParamSchema,
   t_GetTerminalConfigurationsConfigurationQuerySchema,
-  t_GetTerminalConfigurationsConfigurationRequestBodySchema,
   t_GetTerminalConfigurationsQuerySchema,
-  t_GetTerminalConfigurationsRequestBodySchema,
   t_GetTerminalLocationsLocationParamSchema,
   t_GetTerminalLocationsLocationQuerySchema,
-  t_GetTerminalLocationsLocationRequestBodySchema,
   t_GetTerminalLocationsQuerySchema,
-  t_GetTerminalLocationsRequestBodySchema,
   t_GetTerminalReadersQuerySchema,
   t_GetTerminalReadersReaderParamSchema,
   t_GetTerminalReadersReaderQuerySchema,
-  t_GetTerminalReadersReaderRequestBodySchema,
-  t_GetTerminalReadersRequestBodySchema,
   t_GetTestHelpersTestClocksQuerySchema,
-  t_GetTestHelpersTestClocksRequestBodySchema,
   t_GetTestHelpersTestClocksTestClockParamSchema,
   t_GetTestHelpersTestClocksTestClockQuerySchema,
-  t_GetTestHelpersTestClocksTestClockRequestBodySchema,
   t_GetTokensTokenParamSchema,
   t_GetTokensTokenQuerySchema,
-  t_GetTokensTokenRequestBodySchema,
   t_GetTopupsQuerySchema,
-  t_GetTopupsRequestBodySchema,
   t_GetTopupsTopupParamSchema,
   t_GetTopupsTopupQuerySchema,
-  t_GetTopupsTopupRequestBodySchema,
   t_GetTransfersIdReversalsParamSchema,
   t_GetTransfersIdReversalsQuerySchema,
-  t_GetTransfersIdReversalsRequestBodySchema,
   t_GetTransfersQuerySchema,
-  t_GetTransfersRequestBodySchema,
   t_GetTransfersTransferParamSchema,
   t_GetTransfersTransferQuerySchema,
-  t_GetTransfersTransferRequestBodySchema,
   t_GetTransfersTransferReversalsIdParamSchema,
   t_GetTransfersTransferReversalsIdQuerySchema,
-  t_GetTransfersTransferReversalsIdRequestBodySchema,
   t_GetTreasuryCreditReversalsCreditReversalParamSchema,
   t_GetTreasuryCreditReversalsCreditReversalQuerySchema,
-  t_GetTreasuryCreditReversalsCreditReversalRequestBodySchema,
   t_GetTreasuryCreditReversalsQuerySchema,
-  t_GetTreasuryCreditReversalsRequestBodySchema,
   t_GetTreasuryDebitReversalsDebitReversalParamSchema,
   t_GetTreasuryDebitReversalsDebitReversalQuerySchema,
-  t_GetTreasuryDebitReversalsDebitReversalRequestBodySchema,
   t_GetTreasuryDebitReversalsQuerySchema,
-  t_GetTreasuryDebitReversalsRequestBodySchema,
   t_GetTreasuryFinancialAccountsFinancialAccountFeaturesParamSchema,
   t_GetTreasuryFinancialAccountsFinancialAccountFeaturesQuerySchema,
-  t_GetTreasuryFinancialAccountsFinancialAccountFeaturesRequestBodySchema,
   t_GetTreasuryFinancialAccountsFinancialAccountParamSchema,
   t_GetTreasuryFinancialAccountsFinancialAccountQuerySchema,
-  t_GetTreasuryFinancialAccountsFinancialAccountRequestBodySchema,
   t_GetTreasuryFinancialAccountsQuerySchema,
-  t_GetTreasuryFinancialAccountsRequestBodySchema,
   t_GetTreasuryInboundTransfersIdParamSchema,
   t_GetTreasuryInboundTransfersIdQuerySchema,
-  t_GetTreasuryInboundTransfersIdRequestBodySchema,
   t_GetTreasuryInboundTransfersQuerySchema,
-  t_GetTreasuryInboundTransfersRequestBodySchema,
   t_GetTreasuryOutboundPaymentsIdParamSchema,
   t_GetTreasuryOutboundPaymentsIdQuerySchema,
-  t_GetTreasuryOutboundPaymentsIdRequestBodySchema,
   t_GetTreasuryOutboundPaymentsQuerySchema,
-  t_GetTreasuryOutboundPaymentsRequestBodySchema,
   t_GetTreasuryOutboundTransfersOutboundTransferParamSchema,
   t_GetTreasuryOutboundTransfersOutboundTransferQuerySchema,
-  t_GetTreasuryOutboundTransfersOutboundTransferRequestBodySchema,
   t_GetTreasuryOutboundTransfersQuerySchema,
-  t_GetTreasuryOutboundTransfersRequestBodySchema,
   t_GetTreasuryReceivedCreditsIdParamSchema,
   t_GetTreasuryReceivedCreditsIdQuerySchema,
-  t_GetTreasuryReceivedCreditsIdRequestBodySchema,
   t_GetTreasuryReceivedCreditsQuerySchema,
-  t_GetTreasuryReceivedCreditsRequestBodySchema,
   t_GetTreasuryReceivedDebitsIdParamSchema,
   t_GetTreasuryReceivedDebitsIdQuerySchema,
-  t_GetTreasuryReceivedDebitsIdRequestBodySchema,
   t_GetTreasuryReceivedDebitsQuerySchema,
-  t_GetTreasuryReceivedDebitsRequestBodySchema,
   t_GetTreasuryTransactionEntriesIdParamSchema,
   t_GetTreasuryTransactionEntriesIdQuerySchema,
-  t_GetTreasuryTransactionEntriesIdRequestBodySchema,
   t_GetTreasuryTransactionEntriesQuerySchema,
-  t_GetTreasuryTransactionEntriesRequestBodySchema,
   t_GetTreasuryTransactionsIdParamSchema,
   t_GetTreasuryTransactionsIdQuerySchema,
-  t_GetTreasuryTransactionsIdRequestBodySchema,
   t_GetTreasuryTransactionsQuerySchema,
-  t_GetTreasuryTransactionsRequestBodySchema,
   t_GetWebhookEndpointsQuerySchema,
-  t_GetWebhookEndpointsRequestBodySchema,
   t_GetWebhookEndpointsWebhookEndpointParamSchema,
   t_GetWebhookEndpointsWebhookEndpointQuerySchema,
-  t_GetWebhookEndpointsWebhookEndpointRequestBodySchema,
   t_PostAccountLinksRequestBodySchema,
   t_PostAccountSessionsRequestBodySchema,
   t_PostAccountsAccountBankAccountsIdParamSchema,
@@ -1553,12 +1272,7 @@ export type GetAccountResponder = {
 } & ExpressRuntimeResponder
 
 export type GetAccount = (
-  params: Params<
-    void,
-    t_GetAccountQuerySchema,
-    t_GetAccountRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetAccountQuerySchema, void, void>,
   respond: GetAccountResponder,
   req: Request,
   res: Response,
@@ -1602,12 +1316,7 @@ export type GetAccountsResponder = {
 } & ExpressRuntimeResponder
 
 export type GetAccounts = (
-  params: Params<
-    void,
-    t_GetAccountsQuerySchema,
-    t_GetAccountsRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetAccountsQuerySchema, void, void>,
   respond: GetAccountsResponder,
   req: Request,
   res: Response,
@@ -1633,12 +1342,7 @@ export type DeleteAccountsAccountResponder = {
 } & ExpressRuntimeResponder
 
 export type DeleteAccountsAccount = (
-  params: Params<
-    t_DeleteAccountsAccountParamSchema,
-    void,
-    t_DeleteAccountsAccountRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<t_DeleteAccountsAccountParamSchema, void, void, void>,
   respond: DeleteAccountsAccountResponder,
   req: Request,
   res: Response,
@@ -1654,7 +1358,7 @@ export type GetAccountsAccount = (
   params: Params<
     t_GetAccountsAccountParamSchema,
     t_GetAccountsAccountQuerySchema,
-    t_GetAccountsAccountRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetAccountsAccountResponder,
@@ -1708,7 +1412,7 @@ export type DeleteAccountsAccountBankAccountsId = (
   params: Params<
     t_DeleteAccountsAccountBankAccountsIdParamSchema,
     void,
-    t_DeleteAccountsAccountBankAccountsIdRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: DeleteAccountsAccountBankAccountsIdResponder,
@@ -1726,7 +1430,7 @@ export type GetAccountsAccountBankAccountsId = (
   params: Params<
     t_GetAccountsAccountBankAccountsIdParamSchema,
     t_GetAccountsAccountBankAccountsIdQuerySchema,
-    t_GetAccountsAccountBankAccountsIdRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetAccountsAccountBankAccountsIdResponder,
@@ -1767,7 +1471,7 @@ export type GetAccountsAccountCapabilities = (
   params: Params<
     t_GetAccountsAccountCapabilitiesParamSchema,
     t_GetAccountsAccountCapabilitiesQuerySchema,
-    t_GetAccountsAccountCapabilitiesRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetAccountsAccountCapabilitiesResponder,
@@ -1785,7 +1489,7 @@ export type GetAccountsAccountCapabilitiesCapability = (
   params: Params<
     t_GetAccountsAccountCapabilitiesCapabilityParamSchema,
     t_GetAccountsAccountCapabilitiesCapabilityQuerySchema,
-    t_GetAccountsAccountCapabilitiesCapabilityRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetAccountsAccountCapabilitiesCapabilityResponder,
@@ -1826,7 +1530,7 @@ export type GetAccountsAccountExternalAccounts = (
   params: Params<
     t_GetAccountsAccountExternalAccountsParamSchema,
     t_GetAccountsAccountExternalAccountsQuerySchema,
-    t_GetAccountsAccountExternalAccountsRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetAccountsAccountExternalAccountsResponder,
@@ -1862,7 +1566,7 @@ export type DeleteAccountsAccountExternalAccountsId = (
   params: Params<
     t_DeleteAccountsAccountExternalAccountsIdParamSchema,
     void,
-    t_DeleteAccountsAccountExternalAccountsIdRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: DeleteAccountsAccountExternalAccountsIdResponder,
@@ -1880,7 +1584,7 @@ export type GetAccountsAccountExternalAccountsId = (
   params: Params<
     t_GetAccountsAccountExternalAccountsIdParamSchema,
     t_GetAccountsAccountExternalAccountsIdQuerySchema,
-    t_GetAccountsAccountExternalAccountsIdRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetAccountsAccountExternalAccountsIdResponder,
@@ -1939,7 +1643,7 @@ export type GetAccountsAccountPeople = (
   params: Params<
     t_GetAccountsAccountPeopleParamSchema,
     t_GetAccountsAccountPeopleQuerySchema,
-    t_GetAccountsAccountPeopleRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetAccountsAccountPeopleResponder,
@@ -1975,7 +1679,7 @@ export type DeleteAccountsAccountPeoplePerson = (
   params: Params<
     t_DeleteAccountsAccountPeoplePersonParamSchema,
     void,
-    t_DeleteAccountsAccountPeoplePersonRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: DeleteAccountsAccountPeoplePersonResponder,
@@ -1993,7 +1697,7 @@ export type GetAccountsAccountPeoplePerson = (
   params: Params<
     t_GetAccountsAccountPeoplePersonParamSchema,
     t_GetAccountsAccountPeoplePersonQuerySchema,
-    t_GetAccountsAccountPeoplePersonRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetAccountsAccountPeoplePersonResponder,
@@ -2034,7 +1738,7 @@ export type GetAccountsAccountPersons = (
   params: Params<
     t_GetAccountsAccountPersonsParamSchema,
     t_GetAccountsAccountPersonsQuerySchema,
-    t_GetAccountsAccountPersonsRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetAccountsAccountPersonsResponder,
@@ -2070,7 +1774,7 @@ export type DeleteAccountsAccountPersonsPerson = (
   params: Params<
     t_DeleteAccountsAccountPersonsPersonParamSchema,
     void,
-    t_DeleteAccountsAccountPersonsPersonRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: DeleteAccountsAccountPersonsPersonResponder,
@@ -2088,7 +1792,7 @@ export type GetAccountsAccountPersonsPerson = (
   params: Params<
     t_GetAccountsAccountPersonsPersonParamSchema,
     t_GetAccountsAccountPersonsPersonQuerySchema,
-    t_GetAccountsAccountPersonsPersonRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetAccountsAccountPersonsPersonResponder,
@@ -2144,12 +1848,7 @@ export type GetApplePayDomainsResponder = {
 } & ExpressRuntimeResponder
 
 export type GetApplePayDomains = (
-  params: Params<
-    void,
-    t_GetApplePayDomainsQuerySchema,
-    t_GetApplePayDomainsRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetApplePayDomainsQuerySchema, void, void>,
   respond: GetApplePayDomainsResponder,
   req: Request,
   res: Response,
@@ -2175,12 +1874,7 @@ export type DeleteApplePayDomainsDomainResponder = {
 } & ExpressRuntimeResponder
 
 export type DeleteApplePayDomainsDomain = (
-  params: Params<
-    t_DeleteApplePayDomainsDomainParamSchema,
-    void,
-    t_DeleteApplePayDomainsDomainRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<t_DeleteApplePayDomainsDomainParamSchema, void, void, void>,
   respond: DeleteApplePayDomainsDomainResponder,
   req: Request,
   res: Response,
@@ -2196,7 +1890,7 @@ export type GetApplePayDomainsDomain = (
   params: Params<
     t_GetApplePayDomainsDomainParamSchema,
     t_GetApplePayDomainsDomainQuerySchema,
-    t_GetApplePayDomainsDomainRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetApplePayDomainsDomainResponder,
@@ -2216,12 +1910,7 @@ export type GetApplicationFeesResponder = {
 } & ExpressRuntimeResponder
 
 export type GetApplicationFees = (
-  params: Params<
-    void,
-    t_GetApplicationFeesQuerySchema,
-    t_GetApplicationFeesRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetApplicationFeesQuerySchema, void, void>,
   respond: GetApplicationFeesResponder,
   req: Request,
   res: Response,
@@ -2237,7 +1926,7 @@ export type GetApplicationFeesFeeRefundsId = (
   params: Params<
     t_GetApplicationFeesFeeRefundsIdParamSchema,
     t_GetApplicationFeesFeeRefundsIdQuerySchema,
-    t_GetApplicationFeesFeeRefundsIdRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetApplicationFeesFeeRefundsIdResponder,
@@ -2273,7 +1962,7 @@ export type GetApplicationFeesId = (
   params: Params<
     t_GetApplicationFeesIdParamSchema,
     t_GetApplicationFeesIdQuerySchema,
-    t_GetApplicationFeesIdRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetApplicationFeesIdResponder,
@@ -2314,7 +2003,7 @@ export type GetApplicationFeesIdRefunds = (
   params: Params<
     t_GetApplicationFeesIdRefundsParamSchema,
     t_GetApplicationFeesIdRefundsQuerySchema,
-    t_GetApplicationFeesIdRefundsRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetApplicationFeesIdRefundsResponder,
@@ -2352,12 +2041,7 @@ export type GetAppsSecretsResponder = {
 } & ExpressRuntimeResponder
 
 export type GetAppsSecrets = (
-  params: Params<
-    void,
-    t_GetAppsSecretsQuerySchema,
-    t_GetAppsSecretsRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetAppsSecretsQuerySchema, void, void>,
   respond: GetAppsSecretsResponder,
   req: Request,
   res: Response,
@@ -2396,12 +2080,7 @@ export type GetAppsSecretsFindResponder = {
 } & ExpressRuntimeResponder
 
 export type GetAppsSecretsFind = (
-  params: Params<
-    void,
-    t_GetAppsSecretsFindQuerySchema,
-    t_GetAppsSecretsFindRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetAppsSecretsFindQuerySchema, void, void>,
   respond: GetAppsSecretsFindResponder,
   req: Request,
   res: Response,
@@ -2414,12 +2093,7 @@ export type GetBalanceResponder = {
 } & ExpressRuntimeResponder
 
 export type GetBalance = (
-  params: Params<
-    void,
-    t_GetBalanceQuerySchema,
-    t_GetBalanceRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetBalanceQuerySchema, void, void>,
   respond: GetBalanceResponder,
   req: Request,
   res: Response,
@@ -2437,12 +2111,7 @@ export type GetBalanceHistoryResponder = {
 } & ExpressRuntimeResponder
 
 export type GetBalanceHistory = (
-  params: Params<
-    void,
-    t_GetBalanceHistoryQuerySchema,
-    t_GetBalanceHistoryRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetBalanceHistoryQuerySchema, void, void>,
   respond: GetBalanceHistoryResponder,
   req: Request,
   res: Response,
@@ -2458,7 +2127,7 @@ export type GetBalanceHistoryId = (
   params: Params<
     t_GetBalanceHistoryIdParamSchema,
     t_GetBalanceHistoryIdQuerySchema,
-    t_GetBalanceHistoryIdRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetBalanceHistoryIdResponder,
@@ -2478,12 +2147,7 @@ export type GetBalanceTransactionsResponder = {
 } & ExpressRuntimeResponder
 
 export type GetBalanceTransactions = (
-  params: Params<
-    void,
-    t_GetBalanceTransactionsQuerySchema,
-    t_GetBalanceTransactionsRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetBalanceTransactionsQuerySchema, void, void>,
   respond: GetBalanceTransactionsResponder,
   req: Request,
   res: Response,
@@ -2499,7 +2163,7 @@ export type GetBalanceTransactionsId = (
   params: Params<
     t_GetBalanceTransactionsIdParamSchema,
     t_GetBalanceTransactionsIdQuerySchema,
-    t_GetBalanceTransactionsIdRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetBalanceTransactionsIdResponder,
@@ -2519,12 +2183,7 @@ export type GetBillingAlertsResponder = {
 } & ExpressRuntimeResponder
 
 export type GetBillingAlerts = (
-  params: Params<
-    void,
-    t_GetBillingAlertsQuerySchema,
-    t_GetBillingAlertsRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetBillingAlertsQuerySchema, void, void>,
   respond: GetBillingAlertsResponder,
   req: Request,
   res: Response,
@@ -2553,7 +2212,7 @@ export type GetBillingAlertsId = (
   params: Params<
     t_GetBillingAlertsIdParamSchema,
     t_GetBillingAlertsIdQuerySchema,
-    t_GetBillingAlertsIdRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetBillingAlertsIdResponder,
@@ -2622,12 +2281,7 @@ export type GetBillingCreditBalanceSummaryResponder = {
 } & ExpressRuntimeResponder
 
 export type GetBillingCreditBalanceSummary = (
-  params: Params<
-    void,
-    t_GetBillingCreditBalanceSummaryQuerySchema,
-    t_GetBillingCreditBalanceSummaryRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetBillingCreditBalanceSummaryQuerySchema, void, void>,
   respond: GetBillingCreditBalanceSummaryResponder,
   req: Request,
   res: Response,
@@ -2648,7 +2302,7 @@ export type GetBillingCreditBalanceTransactions = (
   params: Params<
     void,
     t_GetBillingCreditBalanceTransactionsQuerySchema,
-    t_GetBillingCreditBalanceTransactionsRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetBillingCreditBalanceTransactionsResponder,
@@ -2666,7 +2320,7 @@ export type GetBillingCreditBalanceTransactionsId = (
   params: Params<
     t_GetBillingCreditBalanceTransactionsIdParamSchema,
     t_GetBillingCreditBalanceTransactionsIdQuerySchema,
-    t_GetBillingCreditBalanceTransactionsIdRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetBillingCreditBalanceTransactionsIdResponder,
@@ -2686,12 +2340,7 @@ export type GetBillingCreditGrantsResponder = {
 } & ExpressRuntimeResponder
 
 export type GetBillingCreditGrants = (
-  params: Params<
-    void,
-    t_GetBillingCreditGrantsQuerySchema,
-    t_GetBillingCreditGrantsRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetBillingCreditGrantsQuerySchema, void, void>,
   respond: GetBillingCreditGrantsResponder,
   req: Request,
   res: Response,
@@ -2720,7 +2369,7 @@ export type GetBillingCreditGrantsId = (
   params: Params<
     t_GetBillingCreditGrantsIdParamSchema,
     t_GetBillingCreditGrantsIdQuerySchema,
-    t_GetBillingCreditGrantsIdRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetBillingCreditGrantsIdResponder,
@@ -2825,12 +2474,7 @@ export type GetBillingMetersResponder = {
 } & ExpressRuntimeResponder
 
 export type GetBillingMeters = (
-  params: Params<
-    void,
-    t_GetBillingMetersQuerySchema,
-    t_GetBillingMetersRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetBillingMetersQuerySchema, void, void>,
   respond: GetBillingMetersResponder,
   req: Request,
   res: Response,
@@ -2859,7 +2503,7 @@ export type GetBillingMetersId = (
   params: Params<
     t_GetBillingMetersIdParamSchema,
     t_GetBillingMetersIdQuerySchema,
-    t_GetBillingMetersIdRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetBillingMetersIdResponder,
@@ -2918,7 +2562,7 @@ export type GetBillingMetersIdEventSummaries = (
   params: Params<
     t_GetBillingMetersIdEventSummariesParamSchema,
     t_GetBillingMetersIdEventSummariesQuerySchema,
-    t_GetBillingMetersIdEventSummariesRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetBillingMetersIdEventSummariesResponder,
@@ -2956,12 +2600,7 @@ export type GetBillingPortalConfigurationsResponder = {
 } & ExpressRuntimeResponder
 
 export type GetBillingPortalConfigurations = (
-  params: Params<
-    void,
-    t_GetBillingPortalConfigurationsQuerySchema,
-    t_GetBillingPortalConfigurationsRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetBillingPortalConfigurationsQuerySchema, void, void>,
   respond: GetBillingPortalConfigurationsResponder,
   req: Request,
   res: Response,
@@ -2995,7 +2634,7 @@ export type GetBillingPortalConfigurationsConfiguration = (
   params: Params<
     t_GetBillingPortalConfigurationsConfigurationParamSchema,
     t_GetBillingPortalConfigurationsConfigurationQuerySchema,
-    t_GetBillingPortalConfigurationsConfigurationRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetBillingPortalConfigurationsConfigurationResponder,
@@ -3051,12 +2690,7 @@ export type GetChargesResponder = {
 } & ExpressRuntimeResponder
 
 export type GetCharges = (
-  params: Params<
-    void,
-    t_GetChargesQuerySchema,
-    t_GetChargesRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetChargesQuerySchema, void, void>,
   respond: GetChargesResponder,
   req: Request,
   res: Response,
@@ -3089,12 +2723,7 @@ export type GetChargesSearchResponder = {
 } & ExpressRuntimeResponder
 
 export type GetChargesSearch = (
-  params: Params<
-    void,
-    t_GetChargesSearchQuerySchema,
-    t_GetChargesSearchRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetChargesSearchQuerySchema, void, void>,
   respond: GetChargesSearchResponder,
   req: Request,
   res: Response,
@@ -3110,7 +2739,7 @@ export type GetChargesCharge = (
   params: Params<
     t_GetChargesChargeParamSchema,
     t_GetChargesChargeQuerySchema,
-    t_GetChargesChargeRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetChargesChargeResponder,
@@ -3164,7 +2793,7 @@ export type GetChargesChargeDispute = (
   params: Params<
     t_GetChargesChargeDisputeParamSchema,
     t_GetChargesChargeDisputeQuerySchema,
-    t_GetChargesChargeDisputeRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetChargesChargeDisputeResponder,
@@ -3241,7 +2870,7 @@ export type GetChargesChargeRefunds = (
   params: Params<
     t_GetChargesChargeRefundsParamSchema,
     t_GetChargesChargeRefundsQuerySchema,
-    t_GetChargesChargeRefundsRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetChargesChargeRefundsResponder,
@@ -3277,7 +2906,7 @@ export type GetChargesChargeRefundsRefund = (
   params: Params<
     t_GetChargesChargeRefundsRefundParamSchema,
     t_GetChargesChargeRefundsRefundQuerySchema,
-    t_GetChargesChargeRefundsRefundRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetChargesChargeRefundsRefundResponder,
@@ -3315,12 +2944,7 @@ export type GetCheckoutSessionsResponder = {
 } & ExpressRuntimeResponder
 
 export type GetCheckoutSessions = (
-  params: Params<
-    void,
-    t_GetCheckoutSessionsQuerySchema,
-    t_GetCheckoutSessionsRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetCheckoutSessionsQuerySchema, void, void>,
   respond: GetCheckoutSessionsResponder,
   req: Request,
   res: Response,
@@ -3354,7 +2978,7 @@ export type GetCheckoutSessionsSession = (
   params: Params<
     t_GetCheckoutSessionsSessionParamSchema,
     t_GetCheckoutSessionsSessionQuerySchema,
-    t_GetCheckoutSessionsSessionRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetCheckoutSessionsSessionResponder,
@@ -3413,7 +3037,7 @@ export type GetCheckoutSessionsSessionLineItems = (
   params: Params<
     t_GetCheckoutSessionsSessionLineItemsParamSchema,
     t_GetCheckoutSessionsSessionLineItemsQuerySchema,
-    t_GetCheckoutSessionsSessionLineItemsRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetCheckoutSessionsSessionLineItemsResponder,
@@ -3433,12 +3057,7 @@ export type GetClimateOrdersResponder = {
 } & ExpressRuntimeResponder
 
 export type GetClimateOrders = (
-  params: Params<
-    void,
-    t_GetClimateOrdersQuerySchema,
-    t_GetClimateOrdersRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetClimateOrdersQuerySchema, void, void>,
   respond: GetClimateOrdersResponder,
   req: Request,
   res: Response,
@@ -3467,7 +3086,7 @@ export type GetClimateOrdersOrder = (
   params: Params<
     t_GetClimateOrdersOrderParamSchema,
     t_GetClimateOrdersOrderQuerySchema,
-    t_GetClimateOrdersOrderRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetClimateOrdersOrderResponder,
@@ -3523,12 +3142,7 @@ export type GetClimateProductsResponder = {
 } & ExpressRuntimeResponder
 
 export type GetClimateProducts = (
-  params: Params<
-    void,
-    t_GetClimateProductsQuerySchema,
-    t_GetClimateProductsRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetClimateProductsQuerySchema, void, void>,
   respond: GetClimateProductsResponder,
   req: Request,
   res: Response,
@@ -3544,7 +3158,7 @@ export type GetClimateProductsProduct = (
   params: Params<
     t_GetClimateProductsProductParamSchema,
     t_GetClimateProductsProductQuerySchema,
-    t_GetClimateProductsProductRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetClimateProductsProductResponder,
@@ -3564,12 +3178,7 @@ export type GetClimateSuppliersResponder = {
 } & ExpressRuntimeResponder
 
 export type GetClimateSuppliers = (
-  params: Params<
-    void,
-    t_GetClimateSuppliersQuerySchema,
-    t_GetClimateSuppliersRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetClimateSuppliersQuerySchema, void, void>,
   respond: GetClimateSuppliersResponder,
   req: Request,
   res: Response,
@@ -3585,7 +3194,7 @@ export type GetClimateSuppliersSupplier = (
   params: Params<
     t_GetClimateSuppliersSupplierParamSchema,
     t_GetClimateSuppliersSupplierQuerySchema,
-    t_GetClimateSuppliersSupplierRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetClimateSuppliersSupplierResponder,
@@ -3603,7 +3212,7 @@ export type GetConfirmationTokensConfirmationToken = (
   params: Params<
     t_GetConfirmationTokensConfirmationTokenParamSchema,
     t_GetConfirmationTokensConfirmationTokenQuerySchema,
-    t_GetConfirmationTokensConfirmationTokenRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetConfirmationTokensConfirmationTokenResponder,
@@ -3623,12 +3232,7 @@ export type GetCountrySpecsResponder = {
 } & ExpressRuntimeResponder
 
 export type GetCountrySpecs = (
-  params: Params<
-    void,
-    t_GetCountrySpecsQuerySchema,
-    t_GetCountrySpecsRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetCountrySpecsQuerySchema, void, void>,
   respond: GetCountrySpecsResponder,
   req: Request,
   res: Response,
@@ -3644,7 +3248,7 @@ export type GetCountrySpecsCountry = (
   params: Params<
     t_GetCountrySpecsCountryParamSchema,
     t_GetCountrySpecsCountryQuerySchema,
-    t_GetCountrySpecsCountryRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetCountrySpecsCountryResponder,
@@ -3664,12 +3268,7 @@ export type GetCouponsResponder = {
 } & ExpressRuntimeResponder
 
 export type GetCoupons = (
-  params: Params<
-    void,
-    t_GetCouponsQuerySchema,
-    t_GetCouponsRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetCouponsQuerySchema, void, void>,
   respond: GetCouponsResponder,
   req: Request,
   res: Response,
@@ -3695,12 +3294,7 @@ export type DeleteCouponsCouponResponder = {
 } & ExpressRuntimeResponder
 
 export type DeleteCouponsCoupon = (
-  params: Params<
-    t_DeleteCouponsCouponParamSchema,
-    void,
-    t_DeleteCouponsCouponRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<t_DeleteCouponsCouponParamSchema, void, void, void>,
   respond: DeleteCouponsCouponResponder,
   req: Request,
   res: Response,
@@ -3716,7 +3310,7 @@ export type GetCouponsCoupon = (
   params: Params<
     t_GetCouponsCouponParamSchema,
     t_GetCouponsCouponQuerySchema,
-    t_GetCouponsCouponRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetCouponsCouponResponder,
@@ -3754,12 +3348,7 @@ export type GetCreditNotesResponder = {
 } & ExpressRuntimeResponder
 
 export type GetCreditNotes = (
-  params: Params<
-    void,
-    t_GetCreditNotesQuerySchema,
-    t_GetCreditNotesRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetCreditNotesQuerySchema, void, void>,
   respond: GetCreditNotesResponder,
   req: Request,
   res: Response,
@@ -3785,12 +3374,7 @@ export type GetCreditNotesPreviewResponder = {
 } & ExpressRuntimeResponder
 
 export type GetCreditNotesPreview = (
-  params: Params<
-    void,
-    t_GetCreditNotesPreviewQuerySchema,
-    t_GetCreditNotesPreviewRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetCreditNotesPreviewQuerySchema, void, void>,
   respond: GetCreditNotesPreviewResponder,
   req: Request,
   res: Response,
@@ -3808,12 +3392,7 @@ export type GetCreditNotesPreviewLinesResponder = {
 } & ExpressRuntimeResponder
 
 export type GetCreditNotesPreviewLines = (
-  params: Params<
-    void,
-    t_GetCreditNotesPreviewLinesQuerySchema,
-    t_GetCreditNotesPreviewLinesRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetCreditNotesPreviewLinesQuerySchema, void, void>,
   respond: GetCreditNotesPreviewLinesResponder,
   req: Request,
   res: Response,
@@ -3834,7 +3413,7 @@ export type GetCreditNotesCreditNoteLines = (
   params: Params<
     t_GetCreditNotesCreditNoteLinesParamSchema,
     t_GetCreditNotesCreditNoteLinesQuerySchema,
-    t_GetCreditNotesCreditNoteLinesRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetCreditNotesCreditNoteLinesResponder,
@@ -3852,7 +3431,7 @@ export type GetCreditNotesId = (
   params: Params<
     t_GetCreditNotesIdParamSchema,
     t_GetCreditNotesIdQuerySchema,
-    t_GetCreditNotesIdRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetCreditNotesIdResponder,
@@ -3921,12 +3500,7 @@ export type GetCustomersResponder = {
 } & ExpressRuntimeResponder
 
 export type GetCustomers = (
-  params: Params<
-    void,
-    t_GetCustomersQuerySchema,
-    t_GetCustomersRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetCustomersQuerySchema, void, void>,
   respond: GetCustomersResponder,
   req: Request,
   res: Response,
@@ -3964,12 +3538,7 @@ export type GetCustomersSearchResponder = {
 } & ExpressRuntimeResponder
 
 export type GetCustomersSearch = (
-  params: Params<
-    void,
-    t_GetCustomersSearchQuerySchema,
-    t_GetCustomersSearchRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetCustomersSearchQuerySchema, void, void>,
   respond: GetCustomersSearchResponder,
   req: Request,
   res: Response,
@@ -3982,12 +3551,7 @@ export type DeleteCustomersCustomerResponder = {
 } & ExpressRuntimeResponder
 
 export type DeleteCustomersCustomer = (
-  params: Params<
-    t_DeleteCustomersCustomerParamSchema,
-    void,
-    t_DeleteCustomersCustomerRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<t_DeleteCustomersCustomerParamSchema, void, void, void>,
   respond: DeleteCustomersCustomerResponder,
   req: Request,
   res: Response,
@@ -4003,7 +3567,7 @@ export type GetCustomersCustomer = (
   params: Params<
     t_GetCustomersCustomerParamSchema,
     t_GetCustomersCustomerQuerySchema,
-    t_GetCustomersCustomerRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetCustomersCustomerResponder,
@@ -4044,7 +3608,7 @@ export type GetCustomersCustomerBalanceTransactions = (
   params: Params<
     t_GetCustomersCustomerBalanceTransactionsParamSchema,
     t_GetCustomersCustomerBalanceTransactionsQuerySchema,
-    t_GetCustomersCustomerBalanceTransactionsRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetCustomersCustomerBalanceTransactionsResponder,
@@ -4080,8 +3644,7 @@ export type GetCustomersCustomerBalanceTransactionsTransaction = (
   params: Params<
     t_GetCustomersCustomerBalanceTransactionsTransactionParamSchema,
     t_GetCustomersCustomerBalanceTransactionsTransactionQuerySchema,
-    | t_GetCustomersCustomerBalanceTransactionsTransactionRequestBodySchema
-    | undefined,
+    void,
     void
   >,
   respond: GetCustomersCustomerBalanceTransactionsTransactionResponder,
@@ -4123,7 +3686,7 @@ export type GetCustomersCustomerBankAccounts = (
   params: Params<
     t_GetCustomersCustomerBankAccountsParamSchema,
     t_GetCustomersCustomerBankAccountsQuerySchema,
-    t_GetCustomersCustomerBankAccountsRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetCustomersCustomerBankAccountsResponder,
@@ -4177,7 +3740,7 @@ export type GetCustomersCustomerBankAccountsId = (
   params: Params<
     t_GetCustomersCustomerBankAccountsIdParamSchema,
     t_GetCustomersCustomerBankAccountsIdQuerySchema,
-    t_GetCustomersCustomerBankAccountsIdRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetCustomersCustomerBankAccountsIdResponder,
@@ -4236,7 +3799,7 @@ export type GetCustomersCustomerCards = (
   params: Params<
     t_GetCustomersCustomerCardsParamSchema,
     t_GetCustomersCustomerCardsQuerySchema,
-    t_GetCustomersCustomerCardsRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetCustomersCustomerCardsResponder,
@@ -4290,7 +3853,7 @@ export type GetCustomersCustomerCardsId = (
   params: Params<
     t_GetCustomersCustomerCardsIdParamSchema,
     t_GetCustomersCustomerCardsIdQuerySchema,
-    t_GetCustomersCustomerCardsIdRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetCustomersCustomerCardsIdResponder,
@@ -4326,7 +3889,7 @@ export type GetCustomersCustomerCashBalance = (
   params: Params<
     t_GetCustomersCustomerCashBalanceParamSchema,
     t_GetCustomersCustomerCashBalanceQuerySchema,
-    t_GetCustomersCustomerCashBalanceRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetCustomersCustomerCashBalanceResponder,
@@ -4367,7 +3930,7 @@ export type GetCustomersCustomerCashBalanceTransactions = (
   params: Params<
     t_GetCustomersCustomerCashBalanceTransactionsParamSchema,
     t_GetCustomersCustomerCashBalanceTransactionsQuerySchema,
-    t_GetCustomersCustomerCashBalanceTransactionsRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetCustomersCustomerCashBalanceTransactionsResponder,
@@ -4385,8 +3948,7 @@ export type GetCustomersCustomerCashBalanceTransactionsTransaction = (
   params: Params<
     t_GetCustomersCustomerCashBalanceTransactionsTransactionParamSchema,
     t_GetCustomersCustomerCashBalanceTransactionsTransactionQuerySchema,
-    | t_GetCustomersCustomerCashBalanceTransactionsTransactionRequestBodySchema
-    | undefined,
+    void,
     void
   >,
   respond: GetCustomersCustomerCashBalanceTransactionsTransactionResponder,
@@ -4404,7 +3966,7 @@ export type DeleteCustomersCustomerDiscount = (
   params: Params<
     t_DeleteCustomersCustomerDiscountParamSchema,
     void,
-    t_DeleteCustomersCustomerDiscountRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: DeleteCustomersCustomerDiscountResponder,
@@ -4422,7 +3984,7 @@ export type GetCustomersCustomerDiscount = (
   params: Params<
     t_GetCustomersCustomerDiscountParamSchema,
     t_GetCustomersCustomerDiscountQuerySchema,
-    t_GetCustomersCustomerDiscountRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetCustomersCustomerDiscountResponder,
@@ -4463,7 +4025,7 @@ export type GetCustomersCustomerPaymentMethods = (
   params: Params<
     t_GetCustomersCustomerPaymentMethodsParamSchema,
     t_GetCustomersCustomerPaymentMethodsQuerySchema,
-    t_GetCustomersCustomerPaymentMethodsRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetCustomersCustomerPaymentMethodsResponder,
@@ -4481,8 +4043,7 @@ export type GetCustomersCustomerPaymentMethodsPaymentMethod = (
   params: Params<
     t_GetCustomersCustomerPaymentMethodsPaymentMethodParamSchema,
     t_GetCustomersCustomerPaymentMethodsPaymentMethodQuerySchema,
-    | t_GetCustomersCustomerPaymentMethodsPaymentMethodRequestBodySchema
-    | undefined,
+    void,
     void
   >,
   respond: GetCustomersCustomerPaymentMethodsPaymentMethodResponder,
@@ -4505,7 +4066,7 @@ export type GetCustomersCustomerSources = (
   params: Params<
     t_GetCustomersCustomerSourcesParamSchema,
     t_GetCustomersCustomerSourcesQuerySchema,
-    t_GetCustomersCustomerSourcesRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetCustomersCustomerSourcesResponder,
@@ -4559,7 +4120,7 @@ export type GetCustomersCustomerSourcesId = (
   params: Params<
     t_GetCustomersCustomerSourcesIdParamSchema,
     t_GetCustomersCustomerSourcesIdQuerySchema,
-    t_GetCustomersCustomerSourcesIdRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetCustomersCustomerSourcesIdResponder,
@@ -4618,7 +4179,7 @@ export type GetCustomersCustomerSubscriptions = (
   params: Params<
     t_GetCustomersCustomerSubscriptionsParamSchema,
     t_GetCustomersCustomerSubscriptionsQuerySchema,
-    t_GetCustomersCustomerSubscriptionsRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetCustomersCustomerSubscriptionsResponder,
@@ -4674,8 +4235,7 @@ export type GetCustomersCustomerSubscriptionsSubscriptionExposedId = (
   params: Params<
     t_GetCustomersCustomerSubscriptionsSubscriptionExposedIdParamSchema,
     t_GetCustomersCustomerSubscriptionsSubscriptionExposedIdQuerySchema,
-    | t_GetCustomersCustomerSubscriptionsSubscriptionExposedIdRequestBodySchema
-    | undefined,
+    void,
     void
   >,
   respond: GetCustomersCustomerSubscriptionsSubscriptionExposedIdResponder,
@@ -4714,8 +4274,7 @@ export type DeleteCustomersCustomerSubscriptionsSubscriptionExposedIdDiscount =
     params: Params<
       t_DeleteCustomersCustomerSubscriptionsSubscriptionExposedIdDiscountParamSchema,
       void,
-      | t_DeleteCustomersCustomerSubscriptionsSubscriptionExposedIdDiscountRequestBodySchema
-      | undefined,
+      void,
       void
     >,
     respond: DeleteCustomersCustomerSubscriptionsSubscriptionExposedIdDiscountResponder,
@@ -4734,8 +4293,7 @@ export type GetCustomersCustomerSubscriptionsSubscriptionExposedIdDiscount = (
   params: Params<
     t_GetCustomersCustomerSubscriptionsSubscriptionExposedIdDiscountParamSchema,
     t_GetCustomersCustomerSubscriptionsSubscriptionExposedIdDiscountQuerySchema,
-    | t_GetCustomersCustomerSubscriptionsSubscriptionExposedIdDiscountRequestBodySchema
-    | undefined,
+    void,
     void
   >,
   respond: GetCustomersCustomerSubscriptionsSubscriptionExposedIdDiscountResponder,
@@ -4758,7 +4316,7 @@ export type GetCustomersCustomerTaxIds = (
   params: Params<
     t_GetCustomersCustomerTaxIdsParamSchema,
     t_GetCustomersCustomerTaxIdsQuerySchema,
-    t_GetCustomersCustomerTaxIdsRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetCustomersCustomerTaxIdsResponder,
@@ -4794,7 +4352,7 @@ export type DeleteCustomersCustomerTaxIdsId = (
   params: Params<
     t_DeleteCustomersCustomerTaxIdsIdParamSchema,
     void,
-    t_DeleteCustomersCustomerTaxIdsIdRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: DeleteCustomersCustomerTaxIdsIdResponder,
@@ -4812,7 +4370,7 @@ export type GetCustomersCustomerTaxIdsId = (
   params: Params<
     t_GetCustomersCustomerTaxIdsIdParamSchema,
     t_GetCustomersCustomerTaxIdsIdQuerySchema,
-    t_GetCustomersCustomerTaxIdsIdRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetCustomersCustomerTaxIdsIdResponder,
@@ -4832,12 +4390,7 @@ export type GetDisputesResponder = {
 } & ExpressRuntimeResponder
 
 export type GetDisputes = (
-  params: Params<
-    void,
-    t_GetDisputesQuerySchema,
-    t_GetDisputesRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetDisputesQuerySchema, void, void>,
   respond: GetDisputesResponder,
   req: Request,
   res: Response,
@@ -4853,7 +4406,7 @@ export type GetDisputesDispute = (
   params: Params<
     t_GetDisputesDisputeParamSchema,
     t_GetDisputesDisputeQuerySchema,
-    t_GetDisputesDisputeRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetDisputesDisputeResponder,
@@ -4912,7 +4465,7 @@ export type GetEntitlementsActiveEntitlements = (
   params: Params<
     void,
     t_GetEntitlementsActiveEntitlementsQuerySchema,
-    t_GetEntitlementsActiveEntitlementsRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetEntitlementsActiveEntitlementsResponder,
@@ -4930,7 +4483,7 @@ export type GetEntitlementsActiveEntitlementsId = (
   params: Params<
     t_GetEntitlementsActiveEntitlementsIdParamSchema,
     t_GetEntitlementsActiveEntitlementsIdQuerySchema,
-    t_GetEntitlementsActiveEntitlementsIdRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetEntitlementsActiveEntitlementsIdResponder,
@@ -4950,12 +4503,7 @@ export type GetEntitlementsFeaturesResponder = {
 } & ExpressRuntimeResponder
 
 export type GetEntitlementsFeatures = (
-  params: Params<
-    void,
-    t_GetEntitlementsFeaturesQuerySchema,
-    t_GetEntitlementsFeaturesRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetEntitlementsFeaturesQuerySchema, void, void>,
   respond: GetEntitlementsFeaturesResponder,
   req: Request,
   res: Response,
@@ -4984,7 +4532,7 @@ export type GetEntitlementsFeaturesId = (
   params: Params<
     t_GetEntitlementsFeaturesIdParamSchema,
     t_GetEntitlementsFeaturesIdQuerySchema,
-    t_GetEntitlementsFeaturesIdRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetEntitlementsFeaturesIdResponder,
@@ -5058,12 +4606,7 @@ export type GetEventsResponder = {
 } & ExpressRuntimeResponder
 
 export type GetEvents = (
-  params: Params<
-    void,
-    t_GetEventsQuerySchema,
-    t_GetEventsRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetEventsQuerySchema, void, void>,
   respond: GetEventsResponder,
   req: Request,
   res: Response,
@@ -5079,7 +4622,7 @@ export type GetEventsId = (
   params: Params<
     t_GetEventsIdParamSchema,
     t_GetEventsIdQuerySchema,
-    t_GetEventsIdRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetEventsIdResponder,
@@ -5099,12 +4642,7 @@ export type GetExchangeRatesResponder = {
 } & ExpressRuntimeResponder
 
 export type GetExchangeRates = (
-  params: Params<
-    void,
-    t_GetExchangeRatesQuerySchema,
-    t_GetExchangeRatesRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetExchangeRatesQuerySchema, void, void>,
   respond: GetExchangeRatesResponder,
   req: Request,
   res: Response,
@@ -5120,7 +4658,7 @@ export type GetExchangeRatesRateId = (
   params: Params<
     t_GetExchangeRatesRateIdParamSchema,
     t_GetExchangeRatesRateIdQuerySchema,
-    t_GetExchangeRatesRateIdRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetExchangeRatesRateIdResponder,
@@ -5158,12 +4696,7 @@ export type GetFileLinksResponder = {
 } & ExpressRuntimeResponder
 
 export type GetFileLinks = (
-  params: Params<
-    void,
-    t_GetFileLinksQuerySchema,
-    t_GetFileLinksRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetFileLinksQuerySchema, void, void>,
   respond: GetFileLinksResponder,
   req: Request,
   res: Response,
@@ -5192,7 +4725,7 @@ export type GetFileLinksLink = (
   params: Params<
     t_GetFileLinksLinkParamSchema,
     t_GetFileLinksLinkQuerySchema,
-    t_GetFileLinksLinkRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetFileLinksLinkResponder,
@@ -5230,12 +4763,7 @@ export type GetFilesResponder = {
 } & ExpressRuntimeResponder
 
 export type GetFiles = (
-  params: Params<
-    void,
-    t_GetFilesQuerySchema,
-    t_GetFilesRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetFilesQuerySchema, void, void>,
   respond: GetFilesResponder,
   req: Request,
   res: Response,
@@ -5264,7 +4792,7 @@ export type GetFilesFile = (
   params: Params<
     t_GetFilesFileParamSchema,
     t_GetFilesFileQuerySchema,
-    t_GetFilesFileRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetFilesFileResponder,
@@ -5287,7 +4815,7 @@ export type GetFinancialConnectionsAccounts = (
   params: Params<
     void,
     t_GetFinancialConnectionsAccountsQuerySchema,
-    t_GetFinancialConnectionsAccountsRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetFinancialConnectionsAccountsResponder,
@@ -5305,7 +4833,7 @@ export type GetFinancialConnectionsAccountsAccount = (
   params: Params<
     t_GetFinancialConnectionsAccountsAccountParamSchema,
     t_GetFinancialConnectionsAccountsAccountQuerySchema,
-    t_GetFinancialConnectionsAccountsAccountRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetFinancialConnectionsAccountsAccountResponder,
@@ -5347,7 +4875,7 @@ export type GetFinancialConnectionsAccountsAccountOwners = (
   params: Params<
     t_GetFinancialConnectionsAccountsAccountOwnersParamSchema,
     t_GetFinancialConnectionsAccountsAccountOwnersQuerySchema,
-    t_GetFinancialConnectionsAccountsAccountOwnersRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetFinancialConnectionsAccountsAccountOwnersResponder,
@@ -5437,7 +4965,7 @@ export type GetFinancialConnectionsSessionsSession = (
   params: Params<
     t_GetFinancialConnectionsSessionsSessionParamSchema,
     t_GetFinancialConnectionsSessionsSessionQuerySchema,
-    t_GetFinancialConnectionsSessionsSessionRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetFinancialConnectionsSessionsSessionResponder,
@@ -5460,7 +4988,7 @@ export type GetFinancialConnectionsTransactions = (
   params: Params<
     void,
     t_GetFinancialConnectionsTransactionsQuerySchema,
-    t_GetFinancialConnectionsTransactionsRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetFinancialConnectionsTransactionsResponder,
@@ -5478,8 +5006,7 @@ export type GetFinancialConnectionsTransactionsTransaction = (
   params: Params<
     t_GetFinancialConnectionsTransactionsTransactionParamSchema,
     t_GetFinancialConnectionsTransactionsTransactionQuerySchema,
-    | t_GetFinancialConnectionsTransactionsTransactionRequestBodySchema
-    | undefined,
+    void,
     void
   >,
   respond: GetFinancialConnectionsTransactionsTransactionResponder,
@@ -5499,12 +5026,7 @@ export type GetForwardingRequestsResponder = {
 } & ExpressRuntimeResponder
 
 export type GetForwardingRequests = (
-  params: Params<
-    void,
-    t_GetForwardingRequestsQuerySchema,
-    t_GetForwardingRequestsRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetForwardingRequestsQuerySchema, void, void>,
   respond: GetForwardingRequestsResponder,
   req: Request,
   res: Response,
@@ -5533,7 +5055,7 @@ export type GetForwardingRequestsId = (
   params: Params<
     t_GetForwardingRequestsIdParamSchema,
     t_GetForwardingRequestsIdQuerySchema,
-    t_GetForwardingRequestsIdRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetForwardingRequestsIdResponder,
@@ -5553,12 +5075,7 @@ export type GetIdentityVerificationReportsResponder = {
 } & ExpressRuntimeResponder
 
 export type GetIdentityVerificationReports = (
-  params: Params<
-    void,
-    t_GetIdentityVerificationReportsQuerySchema,
-    t_GetIdentityVerificationReportsRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetIdentityVerificationReportsQuerySchema, void, void>,
   respond: GetIdentityVerificationReportsResponder,
   req: Request,
   res: Response,
@@ -5574,7 +5091,7 @@ export type GetIdentityVerificationReportsReport = (
   params: Params<
     t_GetIdentityVerificationReportsReportParamSchema,
     t_GetIdentityVerificationReportsReportQuerySchema,
-    t_GetIdentityVerificationReportsReportRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetIdentityVerificationReportsReportResponder,
@@ -5597,7 +5114,7 @@ export type GetIdentityVerificationSessions = (
   params: Params<
     void,
     t_GetIdentityVerificationSessionsQuerySchema,
-    t_GetIdentityVerificationSessionsRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetIdentityVerificationSessionsResponder,
@@ -5633,7 +5150,7 @@ export type GetIdentityVerificationSessionsSession = (
   params: Params<
     t_GetIdentityVerificationSessionsSessionParamSchema,
     t_GetIdentityVerificationSessionsSessionQuerySchema,
-    t_GetIdentityVerificationSessionsSessionRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetIdentityVerificationSessionsSessionResponder,
@@ -5709,12 +5226,7 @@ export type GetInvoicePaymentsResponder = {
 } & ExpressRuntimeResponder
 
 export type GetInvoicePayments = (
-  params: Params<
-    void,
-    t_GetInvoicePaymentsQuerySchema,
-    t_GetInvoicePaymentsRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetInvoicePaymentsQuerySchema, void, void>,
   respond: GetInvoicePaymentsResponder,
   req: Request,
   res: Response,
@@ -5730,7 +5242,7 @@ export type GetInvoicePaymentsInvoicePayment = (
   params: Params<
     t_GetInvoicePaymentsInvoicePaymentParamSchema,
     t_GetInvoicePaymentsInvoicePaymentQuerySchema,
-    t_GetInvoicePaymentsInvoicePaymentRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetInvoicePaymentsInvoicePaymentResponder,
@@ -5750,12 +5262,7 @@ export type GetInvoiceRenderingTemplatesResponder = {
 } & ExpressRuntimeResponder
 
 export type GetInvoiceRenderingTemplates = (
-  params: Params<
-    void,
-    t_GetInvoiceRenderingTemplatesQuerySchema,
-    t_GetInvoiceRenderingTemplatesRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetInvoiceRenderingTemplatesQuerySchema, void, void>,
   respond: GetInvoiceRenderingTemplatesResponder,
   req: Request,
   res: Response,
@@ -5771,7 +5278,7 @@ export type GetInvoiceRenderingTemplatesTemplate = (
   params: Params<
     t_GetInvoiceRenderingTemplatesTemplateParamSchema,
     t_GetInvoiceRenderingTemplatesTemplateQuerySchema,
-    t_GetInvoiceRenderingTemplatesTemplateRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetInvoiceRenderingTemplatesTemplateResponder,
@@ -5828,12 +5335,7 @@ export type GetInvoiceitemsResponder = {
 } & ExpressRuntimeResponder
 
 export type GetInvoiceitems = (
-  params: Params<
-    void,
-    t_GetInvoiceitemsQuerySchema,
-    t_GetInvoiceitemsRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetInvoiceitemsQuerySchema, void, void>,
   respond: GetInvoiceitemsResponder,
   req: Request,
   res: Response,
@@ -5859,12 +5361,7 @@ export type DeleteInvoiceitemsInvoiceitemResponder = {
 } & ExpressRuntimeResponder
 
 export type DeleteInvoiceitemsInvoiceitem = (
-  params: Params<
-    t_DeleteInvoiceitemsInvoiceitemParamSchema,
-    void,
-    t_DeleteInvoiceitemsInvoiceitemRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<t_DeleteInvoiceitemsInvoiceitemParamSchema, void, void, void>,
   respond: DeleteInvoiceitemsInvoiceitemResponder,
   req: Request,
   res: Response,
@@ -5880,7 +5377,7 @@ export type GetInvoiceitemsInvoiceitem = (
   params: Params<
     t_GetInvoiceitemsInvoiceitemParamSchema,
     t_GetInvoiceitemsInvoiceitemQuerySchema,
-    t_GetInvoiceitemsInvoiceitemRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetInvoiceitemsInvoiceitemResponder,
@@ -5918,12 +5415,7 @@ export type GetInvoicesResponder = {
 } & ExpressRuntimeResponder
 
 export type GetInvoices = (
-  params: Params<
-    void,
-    t_GetInvoicesQuerySchema,
-    t_GetInvoicesRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetInvoicesQuerySchema, void, void>,
   respond: GetInvoicesResponder,
   req: Request,
   res: Response,
@@ -5974,12 +5466,7 @@ export type GetInvoicesSearchResponder = {
 } & ExpressRuntimeResponder
 
 export type GetInvoicesSearch = (
-  params: Params<
-    void,
-    t_GetInvoicesSearchQuerySchema,
-    t_GetInvoicesSearchRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetInvoicesSearchQuerySchema, void, void>,
   respond: GetInvoicesSearchResponder,
   req: Request,
   res: Response,
@@ -5992,12 +5479,7 @@ export type DeleteInvoicesInvoiceResponder = {
 } & ExpressRuntimeResponder
 
 export type DeleteInvoicesInvoice = (
-  params: Params<
-    t_DeleteInvoicesInvoiceParamSchema,
-    void,
-    t_DeleteInvoicesInvoiceRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<t_DeleteInvoicesInvoiceParamSchema, void, void, void>,
   respond: DeleteInvoicesInvoiceResponder,
   req: Request,
   res: Response,
@@ -6013,7 +5495,7 @@ export type GetInvoicesInvoice = (
   params: Params<
     t_GetInvoicesInvoiceParamSchema,
     t_GetInvoicesInvoiceQuerySchema,
-    t_GetInvoicesInvoiceRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetInvoicesInvoiceResponder,
@@ -6108,7 +5590,7 @@ export type GetInvoicesInvoiceLines = (
   params: Params<
     t_GetInvoicesInvoiceLinesParamSchema,
     t_GetInvoicesInvoiceLinesQuerySchema,
-    t_GetInvoicesInvoiceLinesRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetInvoicesInvoiceLinesResponder,
@@ -6254,12 +5736,7 @@ export type GetIssuingAuthorizationsResponder = {
 } & ExpressRuntimeResponder
 
 export type GetIssuingAuthorizations = (
-  params: Params<
-    void,
-    t_GetIssuingAuthorizationsQuerySchema,
-    t_GetIssuingAuthorizationsRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetIssuingAuthorizationsQuerySchema, void, void>,
   respond: GetIssuingAuthorizationsResponder,
   req: Request,
   res: Response,
@@ -6275,7 +5752,7 @@ export type GetIssuingAuthorizationsAuthorization = (
   params: Params<
     t_GetIssuingAuthorizationsAuthorizationParamSchema,
     t_GetIssuingAuthorizationsAuthorizationQuerySchema,
-    t_GetIssuingAuthorizationsAuthorizationRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetIssuingAuthorizationsAuthorizationResponder,
@@ -6351,12 +5828,7 @@ export type GetIssuingCardholdersResponder = {
 } & ExpressRuntimeResponder
 
 export type GetIssuingCardholders = (
-  params: Params<
-    void,
-    t_GetIssuingCardholdersQuerySchema,
-    t_GetIssuingCardholdersRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetIssuingCardholdersQuerySchema, void, void>,
   respond: GetIssuingCardholdersResponder,
   req: Request,
   res: Response,
@@ -6385,7 +5857,7 @@ export type GetIssuingCardholdersCardholder = (
   params: Params<
     t_GetIssuingCardholdersCardholderParamSchema,
     t_GetIssuingCardholdersCardholderQuerySchema,
-    t_GetIssuingCardholdersCardholderRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetIssuingCardholdersCardholderResponder,
@@ -6423,12 +5895,7 @@ export type GetIssuingCardsResponder = {
 } & ExpressRuntimeResponder
 
 export type GetIssuingCards = (
-  params: Params<
-    void,
-    t_GetIssuingCardsQuerySchema,
-    t_GetIssuingCardsRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetIssuingCardsQuerySchema, void, void>,
   respond: GetIssuingCardsResponder,
   req: Request,
   res: Response,
@@ -6457,7 +5924,7 @@ export type GetIssuingCardsCard = (
   params: Params<
     t_GetIssuingCardsCardParamSchema,
     t_GetIssuingCardsCardQuerySchema,
-    t_GetIssuingCardsCardRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetIssuingCardsCardResponder,
@@ -6495,12 +5962,7 @@ export type GetIssuingDisputesResponder = {
 } & ExpressRuntimeResponder
 
 export type GetIssuingDisputes = (
-  params: Params<
-    void,
-    t_GetIssuingDisputesQuerySchema,
-    t_GetIssuingDisputesRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetIssuingDisputesQuerySchema, void, void>,
   respond: GetIssuingDisputesResponder,
   req: Request,
   res: Response,
@@ -6534,7 +5996,7 @@ export type GetIssuingDisputesDispute = (
   params: Params<
     t_GetIssuingDisputesDisputeParamSchema,
     t_GetIssuingDisputesDisputeQuerySchema,
-    t_GetIssuingDisputesDisputeRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetIssuingDisputesDisputeResponder,
@@ -6593,7 +6055,7 @@ export type GetIssuingPersonalizationDesigns = (
   params: Params<
     void,
     t_GetIssuingPersonalizationDesignsQuerySchema,
-    t_GetIssuingPersonalizationDesignsRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetIssuingPersonalizationDesignsResponder,
@@ -6629,8 +6091,7 @@ export type GetIssuingPersonalizationDesignsPersonalizationDesign = (
   params: Params<
     t_GetIssuingPersonalizationDesignsPersonalizationDesignParamSchema,
     t_GetIssuingPersonalizationDesignsPersonalizationDesignQuerySchema,
-    | t_GetIssuingPersonalizationDesignsPersonalizationDesignRequestBodySchema
-    | undefined,
+    void,
     void
   >,
   respond: GetIssuingPersonalizationDesignsPersonalizationDesignResponder,
@@ -6669,12 +6130,7 @@ export type GetIssuingPhysicalBundlesResponder = {
 } & ExpressRuntimeResponder
 
 export type GetIssuingPhysicalBundles = (
-  params: Params<
-    void,
-    t_GetIssuingPhysicalBundlesQuerySchema,
-    t_GetIssuingPhysicalBundlesRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetIssuingPhysicalBundlesQuerySchema, void, void>,
   respond: GetIssuingPhysicalBundlesResponder,
   req: Request,
   res: Response,
@@ -6690,7 +6146,7 @@ export type GetIssuingPhysicalBundlesPhysicalBundle = (
   params: Params<
     t_GetIssuingPhysicalBundlesPhysicalBundleParamSchema,
     t_GetIssuingPhysicalBundlesPhysicalBundleQuerySchema,
-    t_GetIssuingPhysicalBundlesPhysicalBundleRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetIssuingPhysicalBundlesPhysicalBundleResponder,
@@ -6708,7 +6164,7 @@ export type GetIssuingSettlementsSettlement = (
   params: Params<
     t_GetIssuingSettlementsSettlementParamSchema,
     t_GetIssuingSettlementsSettlementQuerySchema,
-    t_GetIssuingSettlementsSettlementRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetIssuingSettlementsSettlementResponder,
@@ -6746,12 +6202,7 @@ export type GetIssuingTokensResponder = {
 } & ExpressRuntimeResponder
 
 export type GetIssuingTokens = (
-  params: Params<
-    void,
-    t_GetIssuingTokensQuerySchema,
-    t_GetIssuingTokensRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetIssuingTokensQuerySchema, void, void>,
   respond: GetIssuingTokensResponder,
   req: Request,
   res: Response,
@@ -6767,7 +6218,7 @@ export type GetIssuingTokensToken = (
   params: Params<
     t_GetIssuingTokensTokenParamSchema,
     t_GetIssuingTokensTokenQuerySchema,
-    t_GetIssuingTokensTokenRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetIssuingTokensTokenResponder,
@@ -6805,12 +6256,7 @@ export type GetIssuingTransactionsResponder = {
 } & ExpressRuntimeResponder
 
 export type GetIssuingTransactions = (
-  params: Params<
-    void,
-    t_GetIssuingTransactionsQuerySchema,
-    t_GetIssuingTransactionsRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetIssuingTransactionsQuerySchema, void, void>,
   respond: GetIssuingTransactionsResponder,
   req: Request,
   res: Response,
@@ -6826,7 +6272,7 @@ export type GetIssuingTransactionsTransaction = (
   params: Params<
     t_GetIssuingTransactionsTransactionParamSchema,
     t_GetIssuingTransactionsTransactionQuerySchema,
-    t_GetIssuingTransactionsTransactionRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetIssuingTransactionsTransactionResponder,
@@ -6875,7 +6321,7 @@ export type GetLinkAccountSessionsSession = (
   params: Params<
     t_GetLinkAccountSessionsSessionParamSchema,
     t_GetLinkAccountSessionsSessionQuerySchema,
-    t_GetLinkAccountSessionsSessionRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetLinkAccountSessionsSessionResponder,
@@ -6895,12 +6341,7 @@ export type GetLinkedAccountsResponder = {
 } & ExpressRuntimeResponder
 
 export type GetLinkedAccounts = (
-  params: Params<
-    void,
-    t_GetLinkedAccountsQuerySchema,
-    t_GetLinkedAccountsRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetLinkedAccountsQuerySchema, void, void>,
   respond: GetLinkedAccountsResponder,
   req: Request,
   res: Response,
@@ -6916,7 +6357,7 @@ export type GetLinkedAccountsAccount = (
   params: Params<
     t_GetLinkedAccountsAccountParamSchema,
     t_GetLinkedAccountsAccountQuerySchema,
-    t_GetLinkedAccountsAccountRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetLinkedAccountsAccountResponder,
@@ -6957,7 +6398,7 @@ export type GetLinkedAccountsAccountOwners = (
   params: Params<
     t_GetLinkedAccountsAccountOwnersParamSchema,
     t_GetLinkedAccountsAccountOwnersQuerySchema,
-    t_GetLinkedAccountsAccountOwnersRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetLinkedAccountsAccountOwnersResponder,
@@ -6993,7 +6434,7 @@ export type GetMandatesMandate = (
   params: Params<
     t_GetMandatesMandateParamSchema,
     t_GetMandatesMandateQuerySchema,
-    t_GetMandatesMandateRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetMandatesMandateResponder,
@@ -7013,12 +6454,7 @@ export type GetPaymentIntentsResponder = {
 } & ExpressRuntimeResponder
 
 export type GetPaymentIntents = (
-  params: Params<
-    void,
-    t_GetPaymentIntentsQuerySchema,
-    t_GetPaymentIntentsRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetPaymentIntentsQuerySchema, void, void>,
   respond: GetPaymentIntentsResponder,
   req: Request,
   res: Response,
@@ -7051,12 +6487,7 @@ export type GetPaymentIntentsSearchResponder = {
 } & ExpressRuntimeResponder
 
 export type GetPaymentIntentsSearch = (
-  params: Params<
-    void,
-    t_GetPaymentIntentsSearchQuerySchema,
-    t_GetPaymentIntentsSearchRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetPaymentIntentsSearchQuerySchema, void, void>,
   respond: GetPaymentIntentsSearchResponder,
   req: Request,
   res: Response,
@@ -7072,7 +6503,7 @@ export type GetPaymentIntentsIntent = (
   params: Params<
     t_GetPaymentIntentsIntentParamSchema,
     t_GetPaymentIntentsIntentQuerySchema,
-    t_GetPaymentIntentsIntentRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetPaymentIntentsIntentResponder,
@@ -7218,12 +6649,7 @@ export type GetPaymentLinksResponder = {
 } & ExpressRuntimeResponder
 
 export type GetPaymentLinks = (
-  params: Params<
-    void,
-    t_GetPaymentLinksQuerySchema,
-    t_GetPaymentLinksRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetPaymentLinksQuerySchema, void, void>,
   respond: GetPaymentLinksResponder,
   req: Request,
   res: Response,
@@ -7252,7 +6678,7 @@ export type GetPaymentLinksPaymentLink = (
   params: Params<
     t_GetPaymentLinksPaymentLinkParamSchema,
     t_GetPaymentLinksPaymentLinkQuerySchema,
-    t_GetPaymentLinksPaymentLinkRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetPaymentLinksPaymentLinkResponder,
@@ -7293,7 +6719,7 @@ export type GetPaymentLinksPaymentLinkLineItems = (
   params: Params<
     t_GetPaymentLinksPaymentLinkLineItemsParamSchema,
     t_GetPaymentLinksPaymentLinkLineItemsQuerySchema,
-    t_GetPaymentLinksPaymentLinkLineItemsRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetPaymentLinksPaymentLinkLineItemsResponder,
@@ -7313,12 +6739,7 @@ export type GetPaymentMethodConfigurationsResponder = {
 } & ExpressRuntimeResponder
 
 export type GetPaymentMethodConfigurations = (
-  params: Params<
-    void,
-    t_GetPaymentMethodConfigurationsQuerySchema,
-    t_GetPaymentMethodConfigurationsRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetPaymentMethodConfigurationsQuerySchema, void, void>,
   respond: GetPaymentMethodConfigurationsResponder,
   req: Request,
   res: Response,
@@ -7352,7 +6773,7 @@ export type GetPaymentMethodConfigurationsConfiguration = (
   params: Params<
     t_GetPaymentMethodConfigurationsConfigurationParamSchema,
     t_GetPaymentMethodConfigurationsConfigurationQuerySchema,
-    t_GetPaymentMethodConfigurationsConfigurationRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetPaymentMethodConfigurationsConfigurationResponder,
@@ -7390,12 +6811,7 @@ export type GetPaymentMethodDomainsResponder = {
 } & ExpressRuntimeResponder
 
 export type GetPaymentMethodDomains = (
-  params: Params<
-    void,
-    t_GetPaymentMethodDomainsQuerySchema,
-    t_GetPaymentMethodDomainsRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetPaymentMethodDomainsQuerySchema, void, void>,
   respond: GetPaymentMethodDomainsResponder,
   req: Request,
   res: Response,
@@ -7424,7 +6840,7 @@ export type GetPaymentMethodDomainsPaymentMethodDomain = (
   params: Params<
     t_GetPaymentMethodDomainsPaymentMethodDomainParamSchema,
     t_GetPaymentMethodDomainsPaymentMethodDomainQuerySchema,
-    t_GetPaymentMethodDomainsPaymentMethodDomainRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetPaymentMethodDomainsPaymentMethodDomainResponder,
@@ -7481,12 +6897,7 @@ export type GetPaymentMethodsResponder = {
 } & ExpressRuntimeResponder
 
 export type GetPaymentMethods = (
-  params: Params<
-    void,
-    t_GetPaymentMethodsQuerySchema,
-    t_GetPaymentMethodsRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetPaymentMethodsQuerySchema, void, void>,
   respond: GetPaymentMethodsResponder,
   req: Request,
   res: Response,
@@ -7520,7 +6931,7 @@ export type GetPaymentMethodsPaymentMethod = (
   params: Params<
     t_GetPaymentMethodsPaymentMethodParamSchema,
     t_GetPaymentMethodsPaymentMethodQuerySchema,
-    t_GetPaymentMethodsPaymentMethodRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetPaymentMethodsPaymentMethodResponder,
@@ -7594,12 +7005,7 @@ export type GetPayoutsResponder = {
 } & ExpressRuntimeResponder
 
 export type GetPayouts = (
-  params: Params<
-    void,
-    t_GetPayoutsQuerySchema,
-    t_GetPayoutsRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetPayoutsQuerySchema, void, void>,
   respond: GetPayoutsResponder,
   req: Request,
   res: Response,
@@ -7628,7 +7034,7 @@ export type GetPayoutsPayout = (
   params: Params<
     t_GetPayoutsPayoutParamSchema,
     t_GetPayoutsPayoutQuerySchema,
-    t_GetPayoutsPayoutRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetPayoutsPayoutResponder,
@@ -7702,12 +7108,7 @@ export type GetPlansResponder = {
 } & ExpressRuntimeResponder
 
 export type GetPlans = (
-  params: Params<
-    void,
-    t_GetPlansQuerySchema,
-    t_GetPlansRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetPlansQuerySchema, void, void>,
   respond: GetPlansResponder,
   req: Request,
   res: Response,
@@ -7733,12 +7134,7 @@ export type DeletePlansPlanResponder = {
 } & ExpressRuntimeResponder
 
 export type DeletePlansPlan = (
-  params: Params<
-    t_DeletePlansPlanParamSchema,
-    void,
-    t_DeletePlansPlanRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<t_DeletePlansPlanParamSchema, void, void, void>,
   respond: DeletePlansPlanResponder,
   req: Request,
   res: Response,
@@ -7754,7 +7150,7 @@ export type GetPlansPlan = (
   params: Params<
     t_GetPlansPlanParamSchema,
     t_GetPlansPlanQuerySchema,
-    t_GetPlansPlanRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetPlansPlanResponder,
@@ -7792,12 +7188,7 @@ export type GetPricesResponder = {
 } & ExpressRuntimeResponder
 
 export type GetPrices = (
-  params: Params<
-    void,
-    t_GetPricesQuerySchema,
-    t_GetPricesRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetPricesQuerySchema, void, void>,
   respond: GetPricesResponder,
   req: Request,
   res: Response,
@@ -7830,12 +7221,7 @@ export type GetPricesSearchResponder = {
 } & ExpressRuntimeResponder
 
 export type GetPricesSearch = (
-  params: Params<
-    void,
-    t_GetPricesSearchQuerySchema,
-    t_GetPricesSearchRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetPricesSearchQuerySchema, void, void>,
   respond: GetPricesSearchResponder,
   req: Request,
   res: Response,
@@ -7851,7 +7237,7 @@ export type GetPricesPrice = (
   params: Params<
     t_GetPricesPriceParamSchema,
     t_GetPricesPriceQuerySchema,
-    t_GetPricesPriceRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetPricesPriceResponder,
@@ -7889,12 +7275,7 @@ export type GetProductsResponder = {
 } & ExpressRuntimeResponder
 
 export type GetProducts = (
-  params: Params<
-    void,
-    t_GetProductsQuerySchema,
-    t_GetProductsRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetProductsQuerySchema, void, void>,
   respond: GetProductsResponder,
   req: Request,
   res: Response,
@@ -7927,12 +7308,7 @@ export type GetProductsSearchResponder = {
 } & ExpressRuntimeResponder
 
 export type GetProductsSearch = (
-  params: Params<
-    void,
-    t_GetProductsSearchQuerySchema,
-    t_GetProductsSearchRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetProductsSearchQuerySchema, void, void>,
   respond: GetProductsSearchResponder,
   req: Request,
   res: Response,
@@ -7945,12 +7321,7 @@ export type DeleteProductsIdResponder = {
 } & ExpressRuntimeResponder
 
 export type DeleteProductsId = (
-  params: Params<
-    t_DeleteProductsIdParamSchema,
-    void,
-    t_DeleteProductsIdRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<t_DeleteProductsIdParamSchema, void, void, void>,
   respond: DeleteProductsIdResponder,
   req: Request,
   res: Response,
@@ -7966,7 +7337,7 @@ export type GetProductsId = (
   params: Params<
     t_GetProductsIdParamSchema,
     t_GetProductsIdQuerySchema,
-    t_GetProductsIdRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetProductsIdResponder,
@@ -8007,7 +7378,7 @@ export type GetProductsProductFeatures = (
   params: Params<
     t_GetProductsProductFeaturesParamSchema,
     t_GetProductsProductFeaturesQuerySchema,
-    t_GetProductsProductFeaturesRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetProductsProductFeaturesResponder,
@@ -8043,7 +7414,7 @@ export type DeleteProductsProductFeaturesId = (
   params: Params<
     t_DeleteProductsProductFeaturesIdParamSchema,
     void,
-    t_DeleteProductsProductFeaturesIdRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: DeleteProductsProductFeaturesIdResponder,
@@ -8061,7 +7432,7 @@ export type GetProductsProductFeaturesId = (
   params: Params<
     t_GetProductsProductFeaturesIdParamSchema,
     t_GetProductsProductFeaturesIdQuerySchema,
-    t_GetProductsProductFeaturesIdRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetProductsProductFeaturesIdResponder,
@@ -8081,12 +7452,7 @@ export type GetPromotionCodesResponder = {
 } & ExpressRuntimeResponder
 
 export type GetPromotionCodes = (
-  params: Params<
-    void,
-    t_GetPromotionCodesQuerySchema,
-    t_GetPromotionCodesRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetPromotionCodesQuerySchema, void, void>,
   respond: GetPromotionCodesResponder,
   req: Request,
   res: Response,
@@ -8115,7 +7481,7 @@ export type GetPromotionCodesPromotionCode = (
   params: Params<
     t_GetPromotionCodesPromotionCodeParamSchema,
     t_GetPromotionCodesPromotionCodeQuerySchema,
-    t_GetPromotionCodesPromotionCodeRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetPromotionCodesPromotionCodeResponder,
@@ -8153,12 +7519,7 @@ export type GetQuotesResponder = {
 } & ExpressRuntimeResponder
 
 export type GetQuotes = (
-  params: Params<
-    void,
-    t_GetQuotesQuerySchema,
-    t_GetQuotesRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetQuotesQuerySchema, void, void>,
   respond: GetQuotesResponder,
   req: Request,
   res: Response,
@@ -8187,7 +7548,7 @@ export type GetQuotesQuote = (
   params: Params<
     t_GetQuotesQuoteParamSchema,
     t_GetQuotesQuoteQuerySchema,
-    t_GetQuotesQuoteRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetQuotesQuoteResponder,
@@ -8264,7 +7625,7 @@ export type GetQuotesQuoteComputedUpfrontLineItems = (
   params: Params<
     t_GetQuotesQuoteComputedUpfrontLineItemsParamSchema,
     t_GetQuotesQuoteComputedUpfrontLineItemsQuerySchema,
-    t_GetQuotesQuoteComputedUpfrontLineItemsRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetQuotesQuoteComputedUpfrontLineItemsResponder,
@@ -8305,7 +7666,7 @@ export type GetQuotesQuoteLineItems = (
   params: Params<
     t_GetQuotesQuoteLineItemsParamSchema,
     t_GetQuotesQuoteLineItemsQuerySchema,
-    t_GetQuotesQuoteLineItemsRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetQuotesQuoteLineItemsResponder,
@@ -8323,7 +7684,7 @@ export type GetQuotesQuotePdf = (
   params: Params<
     t_GetQuotesQuotePdfParamSchema,
     t_GetQuotesQuotePdfQuerySchema,
-    t_GetQuotesQuotePdfRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetQuotesQuotePdfResponder,
@@ -8343,12 +7704,7 @@ export type GetRadarEarlyFraudWarningsResponder = {
 } & ExpressRuntimeResponder
 
 export type GetRadarEarlyFraudWarnings = (
-  params: Params<
-    void,
-    t_GetRadarEarlyFraudWarningsQuerySchema,
-    t_GetRadarEarlyFraudWarningsRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetRadarEarlyFraudWarningsQuerySchema, void, void>,
   respond: GetRadarEarlyFraudWarningsResponder,
   req: Request,
   res: Response,
@@ -8364,7 +7720,7 @@ export type GetRadarEarlyFraudWarningsEarlyFraudWarning = (
   params: Params<
     t_GetRadarEarlyFraudWarningsEarlyFraudWarningParamSchema,
     t_GetRadarEarlyFraudWarningsEarlyFraudWarningQuerySchema,
-    t_GetRadarEarlyFraudWarningsEarlyFraudWarningRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetRadarEarlyFraudWarningsEarlyFraudWarningResponder,
@@ -8384,12 +7740,7 @@ export type GetRadarValueListItemsResponder = {
 } & ExpressRuntimeResponder
 
 export type GetRadarValueListItems = (
-  params: Params<
-    void,
-    t_GetRadarValueListItemsQuerySchema,
-    t_GetRadarValueListItemsRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetRadarValueListItemsQuerySchema, void, void>,
   respond: GetRadarValueListItemsResponder,
   req: Request,
   res: Response,
@@ -8415,12 +7766,7 @@ export type DeleteRadarValueListItemsItemResponder = {
 } & ExpressRuntimeResponder
 
 export type DeleteRadarValueListItemsItem = (
-  params: Params<
-    t_DeleteRadarValueListItemsItemParamSchema,
-    void,
-    t_DeleteRadarValueListItemsItemRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<t_DeleteRadarValueListItemsItemParamSchema, void, void, void>,
   respond: DeleteRadarValueListItemsItemResponder,
   req: Request,
   res: Response,
@@ -8436,7 +7782,7 @@ export type GetRadarValueListItemsItem = (
   params: Params<
     t_GetRadarValueListItemsItemParamSchema,
     t_GetRadarValueListItemsItemQuerySchema,
-    t_GetRadarValueListItemsItemRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetRadarValueListItemsItemResponder,
@@ -8456,12 +7802,7 @@ export type GetRadarValueListsResponder = {
 } & ExpressRuntimeResponder
 
 export type GetRadarValueLists = (
-  params: Params<
-    void,
-    t_GetRadarValueListsQuerySchema,
-    t_GetRadarValueListsRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetRadarValueListsQuerySchema, void, void>,
   respond: GetRadarValueListsResponder,
   req: Request,
   res: Response,
@@ -8487,12 +7828,7 @@ export type DeleteRadarValueListsValueListResponder = {
 } & ExpressRuntimeResponder
 
 export type DeleteRadarValueListsValueList = (
-  params: Params<
-    t_DeleteRadarValueListsValueListParamSchema,
-    void,
-    t_DeleteRadarValueListsValueListRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<t_DeleteRadarValueListsValueListParamSchema, void, void, void>,
   respond: DeleteRadarValueListsValueListResponder,
   req: Request,
   res: Response,
@@ -8508,7 +7844,7 @@ export type GetRadarValueListsValueList = (
   params: Params<
     t_GetRadarValueListsValueListParamSchema,
     t_GetRadarValueListsValueListQuerySchema,
-    t_GetRadarValueListsValueListRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetRadarValueListsValueListResponder,
@@ -8546,12 +7882,7 @@ export type GetRefundsResponder = {
 } & ExpressRuntimeResponder
 
 export type GetRefunds = (
-  params: Params<
-    void,
-    t_GetRefundsQuerySchema,
-    t_GetRefundsRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetRefundsQuerySchema, void, void>,
   respond: GetRefundsResponder,
   req: Request,
   res: Response,
@@ -8580,7 +7911,7 @@ export type GetRefundsRefund = (
   params: Params<
     t_GetRefundsRefundParamSchema,
     t_GetRefundsRefundQuerySchema,
-    t_GetRefundsRefundRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetRefundsRefundResponder,
@@ -8636,12 +7967,7 @@ export type GetReportingReportRunsResponder = {
 } & ExpressRuntimeResponder
 
 export type GetReportingReportRuns = (
-  params: Params<
-    void,
-    t_GetReportingReportRunsQuerySchema,
-    t_GetReportingReportRunsRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetReportingReportRunsQuerySchema, void, void>,
   respond: GetReportingReportRunsResponder,
   req: Request,
   res: Response,
@@ -8670,7 +7996,7 @@ export type GetReportingReportRunsReportRun = (
   params: Params<
     t_GetReportingReportRunsReportRunParamSchema,
     t_GetReportingReportRunsReportRunQuerySchema,
-    t_GetReportingReportRunsReportRunRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetReportingReportRunsReportRunResponder,
@@ -8690,12 +8016,7 @@ export type GetReportingReportTypesResponder = {
 } & ExpressRuntimeResponder
 
 export type GetReportingReportTypes = (
-  params: Params<
-    void,
-    t_GetReportingReportTypesQuerySchema,
-    t_GetReportingReportTypesRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetReportingReportTypesQuerySchema, void, void>,
   respond: GetReportingReportTypesResponder,
   req: Request,
   res: Response,
@@ -8711,7 +8032,7 @@ export type GetReportingReportTypesReportType = (
   params: Params<
     t_GetReportingReportTypesReportTypeParamSchema,
     t_GetReportingReportTypesReportTypeQuerySchema,
-    t_GetReportingReportTypesReportTypeRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetReportingReportTypesReportTypeResponder,
@@ -8731,12 +8052,7 @@ export type GetReviewsResponder = {
 } & ExpressRuntimeResponder
 
 export type GetReviews = (
-  params: Params<
-    void,
-    t_GetReviewsQuerySchema,
-    t_GetReviewsRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetReviewsQuerySchema, void, void>,
   respond: GetReviewsResponder,
   req: Request,
   res: Response,
@@ -8752,7 +8068,7 @@ export type GetReviewsReview = (
   params: Params<
     t_GetReviewsReviewParamSchema,
     t_GetReviewsReviewQuerySchema,
-    t_GetReviewsReviewRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetReviewsReviewResponder,
@@ -8790,12 +8106,7 @@ export type GetSetupAttemptsResponder = {
 } & ExpressRuntimeResponder
 
 export type GetSetupAttempts = (
-  params: Params<
-    void,
-    t_GetSetupAttemptsQuerySchema,
-    t_GetSetupAttemptsRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetSetupAttemptsQuerySchema, void, void>,
   respond: GetSetupAttemptsResponder,
   req: Request,
   res: Response,
@@ -8813,12 +8124,7 @@ export type GetSetupIntentsResponder = {
 } & ExpressRuntimeResponder
 
 export type GetSetupIntents = (
-  params: Params<
-    void,
-    t_GetSetupIntentsQuerySchema,
-    t_GetSetupIntentsRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetSetupIntentsQuerySchema, void, void>,
   respond: GetSetupIntentsResponder,
   req: Request,
   res: Response,
@@ -8852,7 +8158,7 @@ export type GetSetupIntentsIntent = (
   params: Params<
     t_GetSetupIntentsIntentParamSchema,
     t_GetSetupIntentsIntentQuerySchema,
-    t_GetSetupIntentsIntentRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetSetupIntentsIntentResponder,
@@ -8944,12 +8250,7 @@ export type GetShippingRatesResponder = {
 } & ExpressRuntimeResponder
 
 export type GetShippingRates = (
-  params: Params<
-    void,
-    t_GetShippingRatesQuerySchema,
-    t_GetShippingRatesRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetShippingRatesQuerySchema, void, void>,
   respond: GetShippingRatesResponder,
   req: Request,
   res: Response,
@@ -8978,7 +8279,7 @@ export type GetShippingRatesShippingRateToken = (
   params: Params<
     t_GetShippingRatesShippingRateTokenParamSchema,
     t_GetShippingRatesShippingRateTokenQuerySchema,
-    t_GetShippingRatesShippingRateTokenRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetShippingRatesShippingRateTokenResponder,
@@ -9034,12 +8335,7 @@ export type GetSigmaScheduledQueryRunsResponder = {
 } & ExpressRuntimeResponder
 
 export type GetSigmaScheduledQueryRuns = (
-  params: Params<
-    void,
-    t_GetSigmaScheduledQueryRunsQuerySchema,
-    t_GetSigmaScheduledQueryRunsRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetSigmaScheduledQueryRunsQuerySchema, void, void>,
   respond: GetSigmaScheduledQueryRunsResponder,
   req: Request,
   res: Response,
@@ -9055,7 +8351,7 @@ export type GetSigmaScheduledQueryRunsScheduledQueryRun = (
   params: Params<
     t_GetSigmaScheduledQueryRunsScheduledQueryRunParamSchema,
     t_GetSigmaScheduledQueryRunsScheduledQueryRunQuerySchema,
-    t_GetSigmaScheduledQueryRunsScheduledQueryRunRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetSigmaScheduledQueryRunsScheduledQueryRunResponder,
@@ -9086,7 +8382,7 @@ export type GetSourcesSource = (
   params: Params<
     t_GetSourcesSourceParamSchema,
     t_GetSourcesSourceQuerySchema,
-    t_GetSourcesSourceRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetSourcesSourceResponder,
@@ -9122,8 +8418,7 @@ export type GetSourcesSourceMandateNotificationsMandateNotification = (
   params: Params<
     t_GetSourcesSourceMandateNotificationsMandateNotificationParamSchema,
     t_GetSourcesSourceMandateNotificationsMandateNotificationQuerySchema,
-    | t_GetSourcesSourceMandateNotificationsMandateNotificationRequestBodySchema
-    | undefined,
+    void,
     void
   >,
   respond: GetSourcesSourceMandateNotificationsMandateNotificationResponder,
@@ -9146,7 +8441,7 @@ export type GetSourcesSourceSourceTransactions = (
   params: Params<
     t_GetSourcesSourceSourceTransactionsParamSchema,
     t_GetSourcesSourceSourceTransactionsQuerySchema,
-    t_GetSourcesSourceSourceTransactionsRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetSourcesSourceSourceTransactionsResponder,
@@ -9164,8 +8459,7 @@ export type GetSourcesSourceSourceTransactionsSourceTransaction = (
   params: Params<
     t_GetSourcesSourceSourceTransactionsSourceTransactionParamSchema,
     t_GetSourcesSourceSourceTransactionsSourceTransactionQuerySchema,
-    | t_GetSourcesSourceSourceTransactionsSourceTransactionRequestBodySchema
-    | undefined,
+    void,
     void
   >,
   respond: GetSourcesSourceSourceTransactionsSourceTransactionResponder,
@@ -9203,12 +8497,7 @@ export type GetSubscriptionItemsResponder = {
 } & ExpressRuntimeResponder
 
 export type GetSubscriptionItems = (
-  params: Params<
-    void,
-    t_GetSubscriptionItemsQuerySchema,
-    t_GetSubscriptionItemsRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetSubscriptionItemsQuerySchema, void, void>,
   respond: GetSubscriptionItemsResponder,
   req: Request,
   res: Response,
@@ -9255,7 +8544,7 @@ export type GetSubscriptionItemsItem = (
   params: Params<
     t_GetSubscriptionItemsItemParamSchema,
     t_GetSubscriptionItemsItemQuerySchema,
-    t_GetSubscriptionItemsItemRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetSubscriptionItemsItemResponder,
@@ -9293,12 +8582,7 @@ export type GetSubscriptionSchedulesResponder = {
 } & ExpressRuntimeResponder
 
 export type GetSubscriptionSchedules = (
-  params: Params<
-    void,
-    t_GetSubscriptionSchedulesQuerySchema,
-    t_GetSubscriptionSchedulesRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetSubscriptionSchedulesQuerySchema, void, void>,
   respond: GetSubscriptionSchedulesResponder,
   req: Request,
   res: Response,
@@ -9332,7 +8616,7 @@ export type GetSubscriptionSchedulesSchedule = (
   params: Params<
     t_GetSubscriptionSchedulesScheduleParamSchema,
     t_GetSubscriptionSchedulesScheduleQuerySchema,
-    t_GetSubscriptionSchedulesScheduleRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetSubscriptionSchedulesScheduleResponder,
@@ -9406,12 +8690,7 @@ export type GetSubscriptionsResponder = {
 } & ExpressRuntimeResponder
 
 export type GetSubscriptions = (
-  params: Params<
-    void,
-    t_GetSubscriptionsQuerySchema,
-    t_GetSubscriptionsRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetSubscriptionsQuerySchema, void, void>,
   respond: GetSubscriptionsResponder,
   req: Request,
   res: Response,
@@ -9444,12 +8723,7 @@ export type GetSubscriptionsSearchResponder = {
 } & ExpressRuntimeResponder
 
 export type GetSubscriptionsSearch = (
-  params: Params<
-    void,
-    t_GetSubscriptionsSearchQuerySchema,
-    t_GetSubscriptionsSearchRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetSubscriptionsSearchQuerySchema, void, void>,
   respond: GetSubscriptionsSearchResponder,
   req: Request,
   res: Response,
@@ -9483,7 +8757,7 @@ export type GetSubscriptionsSubscriptionExposedId = (
   params: Params<
     t_GetSubscriptionsSubscriptionExposedIdParamSchema,
     t_GetSubscriptionsSubscriptionExposedIdQuerySchema,
-    t_GetSubscriptionsSubscriptionExposedIdRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetSubscriptionsSubscriptionExposedIdResponder,
@@ -9519,8 +8793,7 @@ export type DeleteSubscriptionsSubscriptionExposedIdDiscount = (
   params: Params<
     t_DeleteSubscriptionsSubscriptionExposedIdDiscountParamSchema,
     void,
-    | t_DeleteSubscriptionsSubscriptionExposedIdDiscountRequestBodySchema
-    | undefined,
+    void,
     void
   >,
   respond: DeleteSubscriptionsSubscriptionExposedIdDiscountResponder,
@@ -9587,7 +8860,7 @@ export type GetTaxCalculationsCalculation = (
   params: Params<
     t_GetTaxCalculationsCalculationParamSchema,
     t_GetTaxCalculationsCalculationQuerySchema,
-    t_GetTaxCalculationsCalculationRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetTaxCalculationsCalculationResponder,
@@ -9610,7 +8883,7 @@ export type GetTaxCalculationsCalculationLineItems = (
   params: Params<
     t_GetTaxCalculationsCalculationLineItemsParamSchema,
     t_GetTaxCalculationsCalculationLineItemsQuerySchema,
-    t_GetTaxCalculationsCalculationLineItemsRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetTaxCalculationsCalculationLineItemsResponder,
@@ -9630,12 +8903,7 @@ export type GetTaxRegistrationsResponder = {
 } & ExpressRuntimeResponder
 
 export type GetTaxRegistrations = (
-  params: Params<
-    void,
-    t_GetTaxRegistrationsQuerySchema,
-    t_GetTaxRegistrationsRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetTaxRegistrationsQuerySchema, void, void>,
   respond: GetTaxRegistrationsResponder,
   req: Request,
   res: Response,
@@ -9664,7 +8932,7 @@ export type GetTaxRegistrationsId = (
   params: Params<
     t_GetTaxRegistrationsIdParamSchema,
     t_GetTaxRegistrationsIdQuerySchema,
-    t_GetTaxRegistrationsIdRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetTaxRegistrationsIdResponder,
@@ -9697,12 +8965,7 @@ export type GetTaxSettingsResponder = {
 } & ExpressRuntimeResponder
 
 export type GetTaxSettings = (
-  params: Params<
-    void,
-    t_GetTaxSettingsQuerySchema,
-    t_GetTaxSettingsRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetTaxSettingsQuerySchema, void, void>,
   respond: GetTaxSettingsResponder,
   req: Request,
   res: Response,
@@ -9772,7 +9035,7 @@ export type GetTaxTransactionsTransaction = (
   params: Params<
     t_GetTaxTransactionsTransactionParamSchema,
     t_GetTaxTransactionsTransactionQuerySchema,
-    t_GetTaxTransactionsTransactionRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetTaxTransactionsTransactionResponder,
@@ -9795,7 +9058,7 @@ export type GetTaxTransactionsTransactionLineItems = (
   params: Params<
     t_GetTaxTransactionsTransactionLineItemsParamSchema,
     t_GetTaxTransactionsTransactionLineItemsQuerySchema,
-    t_GetTaxTransactionsTransactionLineItemsRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetTaxTransactionsTransactionLineItemsResponder,
@@ -9815,12 +9078,7 @@ export type GetTaxCodesResponder = {
 } & ExpressRuntimeResponder
 
 export type GetTaxCodes = (
-  params: Params<
-    void,
-    t_GetTaxCodesQuerySchema,
-    t_GetTaxCodesRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetTaxCodesQuerySchema, void, void>,
   respond: GetTaxCodesResponder,
   req: Request,
   res: Response,
@@ -9836,7 +9094,7 @@ export type GetTaxCodesId = (
   params: Params<
     t_GetTaxCodesIdParamSchema,
     t_GetTaxCodesIdQuerySchema,
-    t_GetTaxCodesIdRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetTaxCodesIdResponder,
@@ -9856,12 +9114,7 @@ export type GetTaxIdsResponder = {
 } & ExpressRuntimeResponder
 
 export type GetTaxIds = (
-  params: Params<
-    void,
-    t_GetTaxIdsQuerySchema,
-    t_GetTaxIdsRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetTaxIdsQuerySchema, void, void>,
   respond: GetTaxIdsResponder,
   req: Request,
   res: Response,
@@ -9887,12 +9140,7 @@ export type DeleteTaxIdsIdResponder = {
 } & ExpressRuntimeResponder
 
 export type DeleteTaxIdsId = (
-  params: Params<
-    t_DeleteTaxIdsIdParamSchema,
-    void,
-    t_DeleteTaxIdsIdRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<t_DeleteTaxIdsIdParamSchema, void, void, void>,
   respond: DeleteTaxIdsIdResponder,
   req: Request,
   res: Response,
@@ -9908,7 +9156,7 @@ export type GetTaxIdsId = (
   params: Params<
     t_GetTaxIdsIdParamSchema,
     t_GetTaxIdsIdQuerySchema,
-    t_GetTaxIdsIdRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetTaxIdsIdResponder,
@@ -9928,12 +9176,7 @@ export type GetTaxRatesResponder = {
 } & ExpressRuntimeResponder
 
 export type GetTaxRates = (
-  params: Params<
-    void,
-    t_GetTaxRatesQuerySchema,
-    t_GetTaxRatesRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetTaxRatesQuerySchema, void, void>,
   respond: GetTaxRatesResponder,
   req: Request,
   res: Response,
@@ -9962,7 +9205,7 @@ export type GetTaxRatesTaxRate = (
   params: Params<
     t_GetTaxRatesTaxRateParamSchema,
     t_GetTaxRatesTaxRateQuerySchema,
-    t_GetTaxRatesTaxRateRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetTaxRatesTaxRateResponder,
@@ -10000,12 +9243,7 @@ export type GetTerminalConfigurationsResponder = {
 } & ExpressRuntimeResponder
 
 export type GetTerminalConfigurations = (
-  params: Params<
-    void,
-    t_GetTerminalConfigurationsQuerySchema,
-    t_GetTerminalConfigurationsRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetTerminalConfigurationsQuerySchema, void, void>,
   respond: GetTerminalConfigurationsResponder,
   req: Request,
   res: Response,
@@ -10039,7 +9277,7 @@ export type DeleteTerminalConfigurationsConfiguration = (
   params: Params<
     t_DeleteTerminalConfigurationsConfigurationParamSchema,
     void,
-    t_DeleteTerminalConfigurationsConfigurationRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: DeleteTerminalConfigurationsConfigurationResponder,
@@ -10059,7 +9297,7 @@ export type GetTerminalConfigurationsConfiguration = (
   params: Params<
     t_GetTerminalConfigurationsConfigurationParamSchema,
     t_GetTerminalConfigurationsConfigurationQuerySchema,
-    t_GetTerminalConfigurationsConfigurationRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetTerminalConfigurationsConfigurationResponder,
@@ -10117,12 +9355,7 @@ export type GetTerminalLocationsResponder = {
 } & ExpressRuntimeResponder
 
 export type GetTerminalLocations = (
-  params: Params<
-    void,
-    t_GetTerminalLocationsQuerySchema,
-    t_GetTerminalLocationsRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetTerminalLocationsQuerySchema, void, void>,
   respond: GetTerminalLocationsResponder,
   req: Request,
   res: Response,
@@ -10151,7 +9384,7 @@ export type DeleteTerminalLocationsLocation = (
   params: Params<
     t_DeleteTerminalLocationsLocationParamSchema,
     void,
-    t_DeleteTerminalLocationsLocationRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: DeleteTerminalLocationsLocationResponder,
@@ -10171,7 +9404,7 @@ export type GetTerminalLocationsLocation = (
   params: Params<
     t_GetTerminalLocationsLocationParamSchema,
     t_GetTerminalLocationsLocationQuerySchema,
-    t_GetTerminalLocationsLocationRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetTerminalLocationsLocationResponder,
@@ -10211,12 +9444,7 @@ export type GetTerminalReadersResponder = {
 } & ExpressRuntimeResponder
 
 export type GetTerminalReaders = (
-  params: Params<
-    void,
-    t_GetTerminalReadersQuerySchema,
-    t_GetTerminalReadersRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetTerminalReadersQuerySchema, void, void>,
   respond: GetTerminalReadersResponder,
   req: Request,
   res: Response,
@@ -10242,12 +9470,7 @@ export type DeleteTerminalReadersReaderResponder = {
 } & ExpressRuntimeResponder
 
 export type DeleteTerminalReadersReader = (
-  params: Params<
-    t_DeleteTerminalReadersReaderParamSchema,
-    void,
-    t_DeleteTerminalReadersReaderRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<t_DeleteTerminalReadersReaderParamSchema, void, void, void>,
   respond: DeleteTerminalReadersReaderResponder,
   req: Request,
   res: Response,
@@ -10265,7 +9488,7 @@ export type GetTerminalReadersReader = (
   params: Params<
     t_GetTerminalReadersReaderParamSchema,
     t_GetTerminalReadersReaderQuerySchema,
-    t_GetTerminalReadersReaderRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetTerminalReadersReaderResponder,
@@ -10945,12 +10168,7 @@ export type GetTestHelpersTestClocksResponder = {
 } & ExpressRuntimeResponder
 
 export type GetTestHelpersTestClocks = (
-  params: Params<
-    void,
-    t_GetTestHelpersTestClocksQuerySchema,
-    t_GetTestHelpersTestClocksRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetTestHelpersTestClocksQuerySchema, void, void>,
   respond: GetTestHelpersTestClocksResponder,
   req: Request,
   res: Response,
@@ -10984,7 +10202,7 @@ export type DeleteTestHelpersTestClocksTestClock = (
   params: Params<
     t_DeleteTestHelpersTestClocksTestClockParamSchema,
     void,
-    t_DeleteTestHelpersTestClocksTestClockRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: DeleteTestHelpersTestClocksTestClockResponder,
@@ -11002,7 +10220,7 @@ export type GetTestHelpersTestClocksTestClock = (
   params: Params<
     t_GetTestHelpersTestClocksTestClockParamSchema,
     t_GetTestHelpersTestClocksTestClockQuerySchema,
-    t_GetTestHelpersTestClocksTestClockRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetTestHelpersTestClocksTestClockResponder,
@@ -11298,7 +10516,7 @@ export type GetTokensToken = (
   params: Params<
     t_GetTokensTokenParamSchema,
     t_GetTokensTokenQuerySchema,
-    t_GetTokensTokenRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetTokensTokenResponder,
@@ -11318,12 +10536,7 @@ export type GetTopupsResponder = {
 } & ExpressRuntimeResponder
 
 export type GetTopups = (
-  params: Params<
-    void,
-    t_GetTopupsQuerySchema,
-    t_GetTopupsRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetTopupsQuerySchema, void, void>,
   respond: GetTopupsResponder,
   req: Request,
   res: Response,
@@ -11352,7 +10565,7 @@ export type GetTopupsTopup = (
   params: Params<
     t_GetTopupsTopupParamSchema,
     t_GetTopupsTopupQuerySchema,
-    t_GetTopupsTopupRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetTopupsTopupResponder,
@@ -11408,12 +10621,7 @@ export type GetTransfersResponder = {
 } & ExpressRuntimeResponder
 
 export type GetTransfers = (
-  params: Params<
-    void,
-    t_GetTransfersQuerySchema,
-    t_GetTransfersRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetTransfersQuerySchema, void, void>,
   respond: GetTransfersResponder,
   req: Request,
   res: Response,
@@ -11447,7 +10655,7 @@ export type GetTransfersIdReversals = (
   params: Params<
     t_GetTransfersIdReversalsParamSchema,
     t_GetTransfersIdReversalsQuerySchema,
-    t_GetTransfersIdReversalsRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetTransfersIdReversalsResponder,
@@ -11483,7 +10691,7 @@ export type GetTransfersTransfer = (
   params: Params<
     t_GetTransfersTransferParamSchema,
     t_GetTransfersTransferQuerySchema,
-    t_GetTransfersTransferRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetTransfersTransferResponder,
@@ -11519,7 +10727,7 @@ export type GetTransfersTransferReversalsId = (
   params: Params<
     t_GetTransfersTransferReversalsIdParamSchema,
     t_GetTransfersTransferReversalsIdQuerySchema,
-    t_GetTransfersTransferReversalsIdRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetTransfersTransferReversalsIdResponder,
@@ -11557,12 +10765,7 @@ export type GetTreasuryCreditReversalsResponder = {
 } & ExpressRuntimeResponder
 
 export type GetTreasuryCreditReversals = (
-  params: Params<
-    void,
-    t_GetTreasuryCreditReversalsQuerySchema,
-    t_GetTreasuryCreditReversalsRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetTreasuryCreditReversalsQuerySchema, void, void>,
   respond: GetTreasuryCreditReversalsResponder,
   req: Request,
   res: Response,
@@ -11596,7 +10799,7 @@ export type GetTreasuryCreditReversalsCreditReversal = (
   params: Params<
     t_GetTreasuryCreditReversalsCreditReversalParamSchema,
     t_GetTreasuryCreditReversalsCreditReversalQuerySchema,
-    t_GetTreasuryCreditReversalsCreditReversalRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetTreasuryCreditReversalsCreditReversalResponder,
@@ -11616,12 +10819,7 @@ export type GetTreasuryDebitReversalsResponder = {
 } & ExpressRuntimeResponder
 
 export type GetTreasuryDebitReversals = (
-  params: Params<
-    void,
-    t_GetTreasuryDebitReversalsQuerySchema,
-    t_GetTreasuryDebitReversalsRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetTreasuryDebitReversalsQuerySchema, void, void>,
   respond: GetTreasuryDebitReversalsResponder,
   req: Request,
   res: Response,
@@ -11655,7 +10853,7 @@ export type GetTreasuryDebitReversalsDebitReversal = (
   params: Params<
     t_GetTreasuryDebitReversalsDebitReversalParamSchema,
     t_GetTreasuryDebitReversalsDebitReversalQuerySchema,
-    t_GetTreasuryDebitReversalsDebitReversalRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetTreasuryDebitReversalsDebitReversalResponder,
@@ -11675,12 +10873,7 @@ export type GetTreasuryFinancialAccountsResponder = {
 } & ExpressRuntimeResponder
 
 export type GetTreasuryFinancialAccounts = (
-  params: Params<
-    void,
-    t_GetTreasuryFinancialAccountsQuerySchema,
-    t_GetTreasuryFinancialAccountsRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetTreasuryFinancialAccountsQuerySchema, void, void>,
   respond: GetTreasuryFinancialAccountsResponder,
   req: Request,
   res: Response,
@@ -11714,7 +10907,7 @@ export type GetTreasuryFinancialAccountsFinancialAccount = (
   params: Params<
     t_GetTreasuryFinancialAccountsFinancialAccountParamSchema,
     t_GetTreasuryFinancialAccountsFinancialAccountQuerySchema,
-    t_GetTreasuryFinancialAccountsFinancialAccountRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetTreasuryFinancialAccountsFinancialAccountResponder,
@@ -11770,8 +10963,7 @@ export type GetTreasuryFinancialAccountsFinancialAccountFeatures = (
   params: Params<
     t_GetTreasuryFinancialAccountsFinancialAccountFeaturesParamSchema,
     t_GetTreasuryFinancialAccountsFinancialAccountFeaturesQuerySchema,
-    | t_GetTreasuryFinancialAccountsFinancialAccountFeaturesRequestBodySchema
-    | undefined,
+    void,
     void
   >,
   respond: GetTreasuryFinancialAccountsFinancialAccountFeaturesResponder,
@@ -11810,12 +11002,7 @@ export type GetTreasuryInboundTransfersResponder = {
 } & ExpressRuntimeResponder
 
 export type GetTreasuryInboundTransfers = (
-  params: Params<
-    void,
-    t_GetTreasuryInboundTransfersQuerySchema,
-    t_GetTreasuryInboundTransfersRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetTreasuryInboundTransfersQuerySchema, void, void>,
   respond: GetTreasuryInboundTransfersResponder,
   req: Request,
   res: Response,
@@ -11849,7 +11036,7 @@ export type GetTreasuryInboundTransfersId = (
   params: Params<
     t_GetTreasuryInboundTransfersIdParamSchema,
     t_GetTreasuryInboundTransfersIdQuerySchema,
-    t_GetTreasuryInboundTransfersIdRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetTreasuryInboundTransfersIdResponder,
@@ -11888,12 +11075,7 @@ export type GetTreasuryOutboundPaymentsResponder = {
 } & ExpressRuntimeResponder
 
 export type GetTreasuryOutboundPayments = (
-  params: Params<
-    void,
-    t_GetTreasuryOutboundPaymentsQuerySchema,
-    t_GetTreasuryOutboundPaymentsRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetTreasuryOutboundPaymentsQuerySchema, void, void>,
   respond: GetTreasuryOutboundPaymentsResponder,
   req: Request,
   res: Response,
@@ -11927,7 +11109,7 @@ export type GetTreasuryOutboundPaymentsId = (
   params: Params<
     t_GetTreasuryOutboundPaymentsIdParamSchema,
     t_GetTreasuryOutboundPaymentsIdQuerySchema,
-    t_GetTreasuryOutboundPaymentsIdRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetTreasuryOutboundPaymentsIdResponder,
@@ -11965,12 +11147,7 @@ export type GetTreasuryOutboundTransfersResponder = {
 } & ExpressRuntimeResponder
 
 export type GetTreasuryOutboundTransfers = (
-  params: Params<
-    void,
-    t_GetTreasuryOutboundTransfersQuerySchema,
-    t_GetTreasuryOutboundTransfersRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetTreasuryOutboundTransfersQuerySchema, void, void>,
   respond: GetTreasuryOutboundTransfersResponder,
   req: Request,
   res: Response,
@@ -12004,7 +11181,7 @@ export type GetTreasuryOutboundTransfersOutboundTransfer = (
   params: Params<
     t_GetTreasuryOutboundTransfersOutboundTransferParamSchema,
     t_GetTreasuryOutboundTransfersOutboundTransferQuerySchema,
-    t_GetTreasuryOutboundTransfersOutboundTransferRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetTreasuryOutboundTransfersOutboundTransferResponder,
@@ -12043,12 +11220,7 @@ export type GetTreasuryReceivedCreditsResponder = {
 } & ExpressRuntimeResponder
 
 export type GetTreasuryReceivedCredits = (
-  params: Params<
-    void,
-    t_GetTreasuryReceivedCreditsQuerySchema,
-    t_GetTreasuryReceivedCreditsRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetTreasuryReceivedCreditsQuerySchema, void, void>,
   respond: GetTreasuryReceivedCreditsResponder,
   req: Request,
   res: Response,
@@ -12064,7 +11236,7 @@ export type GetTreasuryReceivedCreditsId = (
   params: Params<
     t_GetTreasuryReceivedCreditsIdParamSchema,
     t_GetTreasuryReceivedCreditsIdQuerySchema,
-    t_GetTreasuryReceivedCreditsIdRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetTreasuryReceivedCreditsIdResponder,
@@ -12084,12 +11256,7 @@ export type GetTreasuryReceivedDebitsResponder = {
 } & ExpressRuntimeResponder
 
 export type GetTreasuryReceivedDebits = (
-  params: Params<
-    void,
-    t_GetTreasuryReceivedDebitsQuerySchema,
-    t_GetTreasuryReceivedDebitsRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetTreasuryReceivedDebitsQuerySchema, void, void>,
   respond: GetTreasuryReceivedDebitsResponder,
   req: Request,
   res: Response,
@@ -12105,7 +11272,7 @@ export type GetTreasuryReceivedDebitsId = (
   params: Params<
     t_GetTreasuryReceivedDebitsIdParamSchema,
     t_GetTreasuryReceivedDebitsIdQuerySchema,
-    t_GetTreasuryReceivedDebitsIdRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetTreasuryReceivedDebitsIdResponder,
@@ -12125,12 +11292,7 @@ export type GetTreasuryTransactionEntriesResponder = {
 } & ExpressRuntimeResponder
 
 export type GetTreasuryTransactionEntries = (
-  params: Params<
-    void,
-    t_GetTreasuryTransactionEntriesQuerySchema,
-    t_GetTreasuryTransactionEntriesRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetTreasuryTransactionEntriesQuerySchema, void, void>,
   respond: GetTreasuryTransactionEntriesResponder,
   req: Request,
   res: Response,
@@ -12146,7 +11308,7 @@ export type GetTreasuryTransactionEntriesId = (
   params: Params<
     t_GetTreasuryTransactionEntriesIdParamSchema,
     t_GetTreasuryTransactionEntriesIdQuerySchema,
-    t_GetTreasuryTransactionEntriesIdRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetTreasuryTransactionEntriesIdResponder,
@@ -12166,12 +11328,7 @@ export type GetTreasuryTransactionsResponder = {
 } & ExpressRuntimeResponder
 
 export type GetTreasuryTransactions = (
-  params: Params<
-    void,
-    t_GetTreasuryTransactionsQuerySchema,
-    t_GetTreasuryTransactionsRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetTreasuryTransactionsQuerySchema, void, void>,
   respond: GetTreasuryTransactionsResponder,
   req: Request,
   res: Response,
@@ -12187,7 +11344,7 @@ export type GetTreasuryTransactionsId = (
   params: Params<
     t_GetTreasuryTransactionsIdParamSchema,
     t_GetTreasuryTransactionsIdQuerySchema,
-    t_GetTreasuryTransactionsIdRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetTreasuryTransactionsIdResponder,
@@ -12207,12 +11364,7 @@ export type GetWebhookEndpointsResponder = {
 } & ExpressRuntimeResponder
 
 export type GetWebhookEndpoints = (
-  params: Params<
-    void,
-    t_GetWebhookEndpointsQuerySchema,
-    t_GetWebhookEndpointsRequestBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetWebhookEndpointsQuerySchema, void, void>,
   respond: GetWebhookEndpointsResponder,
   req: Request,
   res: Response,
@@ -12241,7 +11393,7 @@ export type DeleteWebhookEndpointsWebhookEndpoint = (
   params: Params<
     t_DeleteWebhookEndpointsWebhookEndpointParamSchema,
     void,
-    t_DeleteWebhookEndpointsWebhookEndpointRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: DeleteWebhookEndpointsWebhookEndpointResponder,
@@ -12259,7 +11411,7 @@ export type GetWebhookEndpointsWebhookEndpoint = (
   params: Params<
     t_GetWebhookEndpointsWebhookEndpointParamSchema,
     t_GetWebhookEndpointsWebhookEndpointQuerySchema,
-    t_GetWebhookEndpointsWebhookEndpointRequestBodySchema | undefined,
+    void,
     void
   >,
   respond: GetWebhookEndpointsWebhookEndpointResponder,
@@ -12871,8 +12023,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getAccountRequestBodySchema = z.object({}).optional()
-
   const getAccountResponseBodyValidator = responseValidationFactory(
     [["200", s_account]],
     s_error,
@@ -12890,11 +12040,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getAccountRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -13286,8 +12432,6 @@ export function createRouter(implementation: Implementation): Router {
     starting_after: z.string().optional(),
   })
 
-  const getAccountsRequestBodySchema = z.object({}).optional()
-
   const getAccountsResponseBodyValidator = responseValidationFactory(
     [
       [
@@ -13315,11 +12459,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getAccountsRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -14092,8 +13232,6 @@ export function createRouter(implementation: Implementation): Router {
     account: z.string().max(5000),
   })
 
-  const deleteAccountsAccountRequestBodySchema = z.object({}).optional()
-
   const deleteAccountsAccountResponseBodyValidator = responseValidationFactory(
     [["200", s_deleted_account]],
     s_error,
@@ -14111,11 +13249,7 @@ export function createRouter(implementation: Implementation): Router {
             RequestInputType.RouteParam,
           ),
           query: undefined,
-          body: parseRequestInput(
-            deleteAccountsAccountRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -14173,8 +13307,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getAccountsAccountRequestBodySchema = z.object({}).optional()
-
   const getAccountsAccountResponseBodyValidator = responseValidationFactory(
     [["200", s_account]],
     s_error,
@@ -14196,11 +13328,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getAccountsAccountRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -15043,10 +14171,6 @@ export function createRouter(implementation: Implementation): Router {
     id: z.string(),
   })
 
-  const deleteAccountsAccountBankAccountsIdRequestBodySchema = z
-    .object({})
-    .optional()
-
   const deleteAccountsAccountBankAccountsIdResponseBodyValidator =
     responseValidationFactory([["200", s_deleted_external_account]], s_error)
 
@@ -15062,11 +14186,7 @@ export function createRouter(implementation: Implementation): Router {
             RequestInputType.RouteParam,
           ),
           query: undefined,
-          body: parseRequestInput(
-            deleteAccountsAccountBankAccountsIdRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -15130,10 +14250,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getAccountsAccountBankAccountsIdRequestBodySchema = z
-    .object({})
-    .optional()
-
   const getAccountsAccountBankAccountsIdResponseBodyValidator =
     responseValidationFactory([["200", s_external_account]], s_error)
 
@@ -15153,11 +14269,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getAccountsAccountBankAccountsIdRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -15318,10 +14430,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getAccountsAccountCapabilitiesRequestBodySchema = z
-    .object({})
-    .optional()
-
   const getAccountsAccountCapabilitiesResponseBodyValidator =
     responseValidationFactory(
       [
@@ -15354,11 +14462,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getAccountsAccountCapabilitiesRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -15424,10 +14528,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getAccountsAccountCapabilitiesCapabilityRequestBodySchema = z
-    .object({})
-    .optional()
-
   const getAccountsAccountCapabilitiesCapabilityResponseBodyValidator =
     responseValidationFactory([["200", s_capability]], s_error)
 
@@ -15447,11 +14547,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getAccountsAccountCapabilitiesCapabilityRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -15611,10 +14707,6 @@ export function createRouter(implementation: Implementation): Router {
     starting_after: z.string().optional(),
   })
 
-  const getAccountsAccountExternalAccountsRequestBodySchema = z
-    .object({})
-    .optional()
-
   const getAccountsAccountExternalAccountsResponseBodyValidator =
     responseValidationFactory(
       [
@@ -15649,11 +14741,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getAccountsAccountExternalAccountsRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -15819,10 +14907,6 @@ export function createRouter(implementation: Implementation): Router {
     id: z.string(),
   })
 
-  const deleteAccountsAccountExternalAccountsIdRequestBodySchema = z
-    .object({})
-    .optional()
-
   const deleteAccountsAccountExternalAccountsIdResponseBodyValidator =
     responseValidationFactory([["200", s_deleted_external_account]], s_error)
 
@@ -15838,11 +14922,7 @@ export function createRouter(implementation: Implementation): Router {
             RequestInputType.RouteParam,
           ),
           query: undefined,
-          body: parseRequestInput(
-            deleteAccountsAccountExternalAccountsIdRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -15912,10 +14992,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getAccountsAccountExternalAccountsIdRequestBodySchema = z
-    .object({})
-    .optional()
-
   const getAccountsAccountExternalAccountsIdResponseBodyValidator =
     responseValidationFactory([["200", s_external_account]], s_error)
 
@@ -15935,11 +15011,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getAccountsAccountExternalAccountsIdRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -16202,8 +15274,6 @@ export function createRouter(implementation: Implementation): Router {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getAccountsAccountPeopleRequestBodySchema = z.object({}).optional()
-
   const getAccountsAccountPeopleResponseBodyValidator =
     responseValidationFactory(
       [
@@ -16236,11 +15306,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getAccountsAccountPeopleRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -16567,10 +15633,6 @@ export function createRouter(implementation: Implementation): Router {
     person: z.string().max(5000),
   })
 
-  const deleteAccountsAccountPeoplePersonRequestBodySchema = z
-    .object({})
-    .optional()
-
   const deleteAccountsAccountPeoplePersonResponseBodyValidator =
     responseValidationFactory([["200", s_deleted_person]], s_error)
 
@@ -16586,11 +15648,7 @@ export function createRouter(implementation: Implementation): Router {
             RequestInputType.RouteParam,
           ),
           query: undefined,
-          body: parseRequestInput(
-            deleteAccountsAccountPeoplePersonRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -16654,10 +15712,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getAccountsAccountPeoplePersonRequestBodySchema = z
-    .object({})
-    .optional()
-
   const getAccountsAccountPeoplePersonResponseBodyValidator =
     responseValidationFactory([["200", s_person]], s_error)
 
@@ -16677,11 +15731,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getAccountsAccountPeoplePersonRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -17029,8 +16079,6 @@ export function createRouter(implementation: Implementation): Router {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getAccountsAccountPersonsRequestBodySchema = z.object({}).optional()
-
   const getAccountsAccountPersonsResponseBodyValidator =
     responseValidationFactory(
       [
@@ -17063,11 +16111,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getAccountsAccountPersonsRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -17396,10 +16440,6 @@ export function createRouter(implementation: Implementation): Router {
     person: z.string().max(5000),
   })
 
-  const deleteAccountsAccountPersonsPersonRequestBodySchema = z
-    .object({})
-    .optional()
-
   const deleteAccountsAccountPersonsPersonResponseBodyValidator =
     responseValidationFactory([["200", s_deleted_person]], s_error)
 
@@ -17415,11 +16455,7 @@ export function createRouter(implementation: Implementation): Router {
             RequestInputType.RouteParam,
           ),
           query: undefined,
-          body: parseRequestInput(
-            deleteAccountsAccountPersonsPersonRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -17483,10 +16519,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getAccountsAccountPersonsPersonRequestBodySchema = z
-    .object({})
-    .optional()
-
   const getAccountsAccountPersonsPersonResponseBodyValidator =
     responseValidationFactory([["200", s_person]], s_error)
 
@@ -17506,11 +16538,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getAccountsAccountPersonsPersonRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -17918,8 +16946,6 @@ export function createRouter(implementation: Implementation): Router {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getApplePayDomainsRequestBodySchema = z.object({}).optional()
-
   const getApplePayDomainsResponseBodyValidator = responseValidationFactory(
     [
       [
@@ -17947,11 +16973,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getApplePayDomainsRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -18072,8 +17094,6 @@ export function createRouter(implementation: Implementation): Router {
     domain: z.string().max(5000),
   })
 
-  const deleteApplePayDomainsDomainRequestBodySchema = z.object({}).optional()
-
   const deleteApplePayDomainsDomainResponseBodyValidator =
     responseValidationFactory([["200", s_deleted_apple_pay_domain]], s_error)
 
@@ -18089,11 +17109,7 @@ export function createRouter(implementation: Implementation): Router {
             RequestInputType.RouteParam,
           ),
           query: undefined,
-          body: parseRequestInput(
-            deleteApplePayDomainsDomainRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -18153,8 +17169,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getApplePayDomainsDomainRequestBodySchema = z.object({}).optional()
-
   const getApplePayDomainsDomainResponseBodyValidator =
     responseValidationFactory([["200", s_apple_pay_domain]], s_error)
 
@@ -18174,11 +17188,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getApplePayDomainsDomainRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -18247,8 +17257,6 @@ export function createRouter(implementation: Implementation): Router {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getApplicationFeesRequestBodySchema = z.object({}).optional()
-
   const getApplicationFeesResponseBodyValidator = responseValidationFactory(
     [
       [
@@ -18276,11 +17284,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getApplicationFeesRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -18344,10 +17348,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getApplicationFeesFeeRefundsIdRequestBodySchema = z
-    .object({})
-    .optional()
-
   const getApplicationFeesFeeRefundsIdResponseBodyValidator =
     responseValidationFactory([["200", s_fee_refund]], s_error)
 
@@ -18367,11 +17367,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getApplicationFeesFeeRefundsIdRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -18507,8 +17503,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getApplicationFeesIdRequestBodySchema = z.object({}).optional()
-
   const getApplicationFeesIdResponseBodyValidator = responseValidationFactory(
     [["200", s_application_fee]],
     s_error,
@@ -18530,11 +17524,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getApplicationFeesIdRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -18673,8 +17663,6 @@ export function createRouter(implementation: Implementation): Router {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getApplicationFeesIdRefundsRequestBodySchema = z.object({}).optional()
-
   const getApplicationFeesIdRefundsResponseBodyValidator =
     responseValidationFactory(
       [
@@ -18707,11 +17695,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getApplicationFeesIdRefundsRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -18857,8 +17841,6 @@ export function createRouter(implementation: Implementation): Router {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getAppsSecretsRequestBodySchema = z.object({}).optional()
-
   const getAppsSecretsResponseBodyValidator = responseValidationFactory(
     [
       [
@@ -18886,11 +17868,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getAppsSecretsRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -19098,8 +18076,6 @@ export function createRouter(implementation: Implementation): Router {
     }),
   })
 
-  const getAppsSecretsFindRequestBodySchema = z.object({}).optional()
-
   const getAppsSecretsFindResponseBodyValidator = responseValidationFactory(
     [["200", s_apps_secret]],
     s_error,
@@ -19117,11 +18093,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getAppsSecretsFindRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -19175,8 +18147,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getBalanceRequestBodySchema = z.object({}).optional()
-
   const getBalanceResponseBodyValidator = responseValidationFactory(
     [["200", s_balance]],
     s_error,
@@ -19194,11 +18164,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getBalanceRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -19270,8 +18236,6 @@ export function createRouter(implementation: Implementation): Router {
     type: z.string().max(5000).optional(),
   })
 
-  const getBalanceHistoryRequestBodySchema = z.object({}).optional()
-
   const getBalanceHistoryResponseBodyValidator = responseValidationFactory(
     [
       [
@@ -19302,11 +18266,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getBalanceHistoryRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -19367,8 +18327,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getBalanceHistoryIdRequestBodySchema = z.object({}).optional()
-
   const getBalanceHistoryIdResponseBodyValidator = responseValidationFactory(
     [["200", s_balance_transaction]],
     s_error,
@@ -19390,11 +18348,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getBalanceHistoryIdRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -19466,8 +18420,6 @@ export function createRouter(implementation: Implementation): Router {
     type: z.string().max(5000).optional(),
   })
 
-  const getBalanceTransactionsRequestBodySchema = z.object({}).optional()
-
   const getBalanceTransactionsResponseBodyValidator = responseValidationFactory(
     [
       [
@@ -19498,11 +18450,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getBalanceTransactionsRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -19565,8 +18513,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getBalanceTransactionsIdRequestBodySchema = z.object({}).optional()
-
   const getBalanceTransactionsIdResponseBodyValidator =
     responseValidationFactory([["200", s_balance_transaction]], s_error)
 
@@ -19586,11 +18532,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getBalanceTransactionsIdRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -19649,8 +18591,6 @@ export function createRouter(implementation: Implementation): Router {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getBillingAlertsRequestBodySchema = z.object({}).optional()
-
   const getBillingAlertsResponseBodyValidator = responseValidationFactory(
     [
       [
@@ -19678,11 +18618,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getBillingAlertsRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -19826,8 +18762,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getBillingAlertsIdRequestBodySchema = z.object({}).optional()
-
   const getBillingAlertsIdResponseBodyValidator = responseValidationFactory(
     [["200", s_billing_alert]],
     s_error,
@@ -19849,11 +18783,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getBillingAlertsIdRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -20140,10 +19070,6 @@ export function createRouter(implementation: Implementation): Router {
     }),
   })
 
-  const getBillingCreditBalanceSummaryRequestBodySchema = z
-    .object({})
-    .optional()
-
   const getBillingCreditBalanceSummaryResponseBodyValidator =
     responseValidationFactory(
       [["200", s_billing_credit_balance_summary]],
@@ -20162,11 +19088,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getBillingCreditBalanceSummaryRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -20229,10 +19151,6 @@ export function createRouter(implementation: Implementation): Router {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getBillingCreditBalanceTransactionsRequestBodySchema = z
-    .object({})
-    .optional()
-
   const getBillingCreditBalanceTransactionsResponseBodyValidator =
     responseValidationFactory(
       [
@@ -20264,11 +19182,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getBillingCreditBalanceTransactionsRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -20336,10 +19250,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getBillingCreditBalanceTransactionsIdRequestBodySchema = z
-    .object({})
-    .optional()
-
   const getBillingCreditBalanceTransactionsIdResponseBodyValidator =
     responseValidationFactory(
       [["200", s_billing_credit_balance_transaction]],
@@ -20362,11 +19272,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getBillingCreditBalanceTransactionsIdRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -20437,8 +19343,6 @@ export function createRouter(implementation: Implementation): Router {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getBillingCreditGrantsRequestBodySchema = z.object({}).optional()
-
   const getBillingCreditGrantsResponseBodyValidator = responseValidationFactory(
     [
       [
@@ -20469,11 +19373,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getBillingCreditGrantsRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -20619,8 +19519,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getBillingCreditGrantsIdRequestBodySchema = z.object({}).optional()
-
   const getBillingCreditGrantsIdResponseBodyValidator =
     responseValidationFactory([["200", s_billing_credit_grant]], s_error)
 
@@ -20640,11 +19538,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getBillingCreditGrantsIdRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -21070,8 +19964,6 @@ export function createRouter(implementation: Implementation): Router {
     status: z.enum(["active", "inactive"]).optional(),
   })
 
-  const getBillingMetersRequestBodySchema = z.object({}).optional()
-
   const getBillingMetersResponseBodyValidator = responseValidationFactory(
     [
       [
@@ -21099,11 +19991,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getBillingMetersRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -21240,8 +20128,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getBillingMetersIdRequestBodySchema = z.object({}).optional()
-
   const getBillingMetersIdResponseBodyValidator = responseValidationFactory(
     [["200", s_billing_meter]],
     s_error,
@@ -21263,11 +20149,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getBillingMetersIdRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -21481,10 +20363,6 @@ export function createRouter(implementation: Implementation): Router {
     value_grouping_window: z.enum(["day", "hour"]).optional(),
   })
 
-  const getBillingMetersIdEventSummariesRequestBodySchema = z
-    .object({})
-    .optional()
-
   const getBillingMetersIdEventSummariesResponseBodyValidator =
     responseValidationFactory(
       [
@@ -21520,11 +20398,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getBillingMetersIdEventSummariesRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -21664,10 +20538,6 @@ export function createRouter(implementation: Implementation): Router {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getBillingPortalConfigurationsRequestBodySchema = z
-    .object({})
-    .optional()
-
   const getBillingPortalConfigurationsResponseBodyValidator =
     responseValidationFactory(
       [
@@ -21699,11 +20569,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getBillingPortalConfigurationsRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -21941,10 +20807,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getBillingPortalConfigurationsConfigurationRequestBodySchema = z
-    .object({})
-    .optional()
-
   const getBillingPortalConfigurationsConfigurationResponseBodyValidator =
     responseValidationFactory(
       [["200", s_billing_portal_configuration]],
@@ -21967,11 +20829,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getBillingPortalConfigurationsConfigurationRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -22433,8 +21291,6 @@ export function createRouter(implementation: Implementation): Router {
     transfer_group: z.string().max(5000).optional(),
   })
 
-  const getChargesRequestBodySchema = z.object({}).optional()
-
   const getChargesResponseBodyValidator = responseValidationFactory(
     [
       [
@@ -22462,11 +21318,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getChargesRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -22664,8 +21516,6 @@ export function createRouter(implementation: Implementation): Router {
     query: z.string().max(5000),
   })
 
-  const getChargesSearchRequestBodySchema = z.object({}).optional()
-
   const getChargesSearchResponseBodyValidator = responseValidationFactory(
     [
       [
@@ -22695,11 +21545,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getChargesSearchRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -22762,8 +21608,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getChargesChargeRequestBodySchema = z.object({}).optional()
-
   const getChargesChargeResponseBodyValidator = responseValidationFactory(
     [["200", s_charge]],
     s_error,
@@ -22785,11 +21629,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getChargesChargeRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -23029,8 +21869,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getChargesChargeDisputeRequestBodySchema = z.object({}).optional()
-
   const getChargesChargeDisputeResponseBodyValidator =
     responseValidationFactory([["200", s_dispute]], s_error)
 
@@ -23050,11 +21888,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getChargesChargeDisputeRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -23485,8 +22319,6 @@ export function createRouter(implementation: Implementation): Router {
     starting_after: z.string().optional(),
   })
 
-  const getChargesChargeRefundsRequestBodySchema = z.object({}).optional()
-
   const getChargesChargeRefundsResponseBodyValidator =
     responseValidationFactory(
       [
@@ -23519,11 +22351,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getChargesChargeRefundsRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -23673,8 +22501,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getChargesChargeRefundsRefundRequestBodySchema = z.object({}).optional()
-
   const getChargesChargeRefundsRefundResponseBodyValidator =
     responseValidationFactory([["200", s_refund]], s_error)
 
@@ -23694,11 +22520,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getChargesChargeRefundsRefundRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -23852,8 +22674,6 @@ export function createRouter(implementation: Implementation): Router {
     subscription: z.string().max(5000).optional(),
   })
 
-  const getCheckoutSessionsRequestBodySchema = z.object({}).optional()
-
   const getCheckoutSessionsResponseBodyValidator = responseValidationFactory(
     [
       [
@@ -23881,11 +22701,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getCheckoutSessionsRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -25120,8 +23936,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getCheckoutSessionsSessionRequestBodySchema = z.object({}).optional()
-
   const getCheckoutSessionsSessionResponseBodyValidator =
     responseValidationFactory([["200", s_checkout_session]], s_error)
 
@@ -25141,11 +23955,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getCheckoutSessionsSessionRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -25444,10 +24254,6 @@ export function createRouter(implementation: Implementation): Router {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getCheckoutSessionsSessionLineItemsRequestBodySchema = z
-    .object({})
-    .optional()
-
   const getCheckoutSessionsSessionLineItemsResponseBodyValidator =
     responseValidationFactory(
       [
@@ -25480,11 +24286,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getCheckoutSessionsSessionLineItemsRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -25551,8 +24353,6 @@ export function createRouter(implementation: Implementation): Router {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getClimateOrdersRequestBodySchema = z.object({}).optional()
-
   const getClimateOrdersResponseBodyValidator = responseValidationFactory(
     [
       [
@@ -25580,11 +24380,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getClimateOrdersRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -25719,8 +24515,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getClimateOrdersOrderRequestBodySchema = z.object({}).optional()
-
   const getClimateOrdersOrderResponseBodyValidator = responseValidationFactory(
     [["200", s_climate_order]],
     s_error,
@@ -25742,11 +24536,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getClimateOrdersOrderRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -25962,8 +24752,6 @@ export function createRouter(implementation: Implementation): Router {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getClimateProductsRequestBodySchema = z.object({}).optional()
-
   const getClimateProductsResponseBodyValidator = responseValidationFactory(
     [
       [
@@ -25991,11 +24779,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getClimateProductsRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -26058,8 +24842,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getClimateProductsProductRequestBodySchema = z.object({}).optional()
-
   const getClimateProductsProductResponseBodyValidator =
     responseValidationFactory([["200", s_climate_product]], s_error)
 
@@ -26079,11 +24861,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getClimateProductsProductRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -26140,8 +24918,6 @@ export function createRouter(implementation: Implementation): Router {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getClimateSuppliersRequestBodySchema = z.object({}).optional()
-
   const getClimateSuppliersResponseBodyValidator = responseValidationFactory(
     [
       [
@@ -26169,11 +24945,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getClimateSuppliersRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -26236,8 +25008,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getClimateSuppliersSupplierRequestBodySchema = z.object({}).optional()
-
   const getClimateSuppliersSupplierResponseBodyValidator =
     responseValidationFactory([["200", s_climate_supplier]], s_error)
 
@@ -26257,11 +25027,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getClimateSuppliersSupplierRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -26321,10 +25087,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getConfirmationTokensConfirmationTokenRequestBodySchema = z
-    .object({})
-    .optional()
-
   const getConfirmationTokensConfirmationTokenResponseBodyValidator =
     responseValidationFactory([["200", s_confirmation_token]], s_error)
 
@@ -26344,11 +25106,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getConfirmationTokensConfirmationTokenRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -26416,8 +25174,6 @@ export function createRouter(implementation: Implementation): Router {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getCountrySpecsRequestBodySchema = z.object({}).optional()
-
   const getCountrySpecsResponseBodyValidator = responseValidationFactory(
     [
       [
@@ -26445,11 +25201,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getCountrySpecsRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -26512,8 +25264,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getCountrySpecsCountryRequestBodySchema = z.object({}).optional()
-
   const getCountrySpecsCountryResponseBodyValidator = responseValidationFactory(
     [["200", s_country_spec]],
     s_error,
@@ -26535,11 +25285,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getCountrySpecsCountryRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -26607,8 +25353,6 @@ export function createRouter(implementation: Implementation): Router {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getCouponsRequestBodySchema = z.object({}).optional()
-
   const getCouponsResponseBodyValidator = responseValidationFactory(
     [
       [
@@ -26636,11 +25380,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getCouponsRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -26778,8 +25518,6 @@ export function createRouter(implementation: Implementation): Router {
     coupon: z.string().max(5000),
   })
 
-  const deleteCouponsCouponRequestBodySchema = z.object({}).optional()
-
   const deleteCouponsCouponResponseBodyValidator = responseValidationFactory(
     [["200", s_deleted_coupon]],
     s_error,
@@ -26797,11 +25535,7 @@ export function createRouter(implementation: Implementation): Router {
             RequestInputType.RouteParam,
           ),
           query: undefined,
-          body: parseRequestInput(
-            deleteCouponsCouponRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -26857,8 +25591,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getCouponsCouponRequestBodySchema = z.object({}).optional()
-
   const getCouponsCouponResponseBodyValidator = responseValidationFactory(
     [["200", s_coupon]],
     s_error,
@@ -26880,11 +25612,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getCouponsCouponRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -27033,8 +25761,6 @@ export function createRouter(implementation: Implementation): Router {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getCreditNotesRequestBodySchema = z.object({}).optional()
-
   const getCreditNotesResponseBodyValidator = responseValidationFactory(
     [
       [
@@ -27062,11 +25788,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getCreditNotesRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -27309,8 +26031,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getCreditNotesPreviewRequestBodySchema = z.object({}).optional()
-
   const getCreditNotesPreviewResponseBodyValidator = responseValidationFactory(
     [["200", s_credit_note]],
     s_error,
@@ -27328,11 +26048,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getCreditNotesPreviewRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -27451,8 +26167,6 @@ export function createRouter(implementation: Implementation): Router {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getCreditNotesPreviewLinesRequestBodySchema = z.object({}).optional()
-
   const getCreditNotesPreviewLinesResponseBodyValidator =
     responseValidationFactory(
       [
@@ -27481,11 +26195,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getCreditNotesPreviewLinesRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -27553,8 +26263,6 @@ export function createRouter(implementation: Implementation): Router {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getCreditNotesCreditNoteLinesRequestBodySchema = z.object({}).optional()
-
   const getCreditNotesCreditNoteLinesResponseBodyValidator =
     responseValidationFactory(
       [
@@ -27587,11 +26295,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getCreditNotesCreditNoteLinesRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -27654,8 +26358,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getCreditNotesIdRequestBodySchema = z.object({}).optional()
-
   const getCreditNotesIdResponseBodyValidator = responseValidationFactory(
     [["200", s_credit_note]],
     s_error,
@@ -27677,11 +26379,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getCreditNotesIdRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -27991,8 +26689,6 @@ export function createRouter(implementation: Implementation): Router {
     test_clock: z.string().max(5000).optional(),
   })
 
-  const getCustomersRequestBodySchema = z.object({}).optional()
-
   const getCustomersResponseBodyValidator = responseValidationFactory(
     [
       [
@@ -28020,11 +26716,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getCustomersRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -28361,8 +27053,6 @@ export function createRouter(implementation: Implementation): Router {
     query: z.string().max(5000),
   })
 
-  const getCustomersSearchRequestBodySchema = z.object({}).optional()
-
   const getCustomersSearchResponseBodyValidator = responseValidationFactory(
     [
       [
@@ -28392,11 +27082,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getCustomersSearchRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -28452,8 +27138,6 @@ export function createRouter(implementation: Implementation): Router {
     customer: z.string().max(5000),
   })
 
-  const deleteCustomersCustomerRequestBodySchema = z.object({}).optional()
-
   const deleteCustomersCustomerResponseBodyValidator =
     responseValidationFactory([["200", s_deleted_customer]], s_error)
 
@@ -28469,11 +27153,7 @@ export function createRouter(implementation: Implementation): Router {
             RequestInputType.RouteParam,
           ),
           query: undefined,
-          body: parseRequestInput(
-            deleteCustomersCustomerRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -28531,8 +27211,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getCustomersCustomerRequestBodySchema = z.object({}).optional()
-
   const getCustomersCustomerResponseBodyValidator = responseValidationFactory(
     [["200", z.union([z.lazy(() => s_customer), s_deleted_customer])]],
     s_error,
@@ -28554,11 +27232,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getCustomersCustomerRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -28823,10 +27497,6 @@ export function createRouter(implementation: Implementation): Router {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getCustomersCustomerBalanceTransactionsRequestBodySchema = z
-    .object({})
-    .optional()
-
   const getCustomersCustomerBalanceTransactionsResponseBodyValidator =
     responseValidationFactory(
       [
@@ -28859,11 +27529,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getCustomersCustomerBalanceTransactionsRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -29029,10 +27695,6 @@ export function createRouter(implementation: Implementation): Router {
         .optional(),
     })
 
-  const getCustomersCustomerBalanceTransactionsTransactionRequestBodySchema = z
-    .object({})
-    .optional()
-
   const getCustomersCustomerBalanceTransactionsTransactionResponseBodyValidator =
     responseValidationFactory(
       [["200", s_customer_balance_transaction]],
@@ -29055,11 +27717,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getCustomersCustomerBalanceTransactionsTransactionRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -29227,10 +27885,6 @@ export function createRouter(implementation: Implementation): Router {
     starting_after: z.string().optional(),
   })
 
-  const getCustomersCustomerBankAccountsRequestBodySchema = z
-    .object({})
-    .optional()
-
   const getCustomersCustomerBankAccountsResponseBodyValidator =
     responseValidationFactory(
       [
@@ -29263,11 +27917,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getCustomersCustomerBankAccountsRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -29543,10 +28193,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getCustomersCustomerBankAccountsIdRequestBodySchema = z
-    .object({})
-    .optional()
-
   const getCustomersCustomerBankAccountsIdResponseBodyValidator =
     responseValidationFactory([["200", s_bank_account]], s_error)
 
@@ -29566,11 +28212,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getCustomersCustomerBankAccountsIdRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -29846,8 +28488,6 @@ export function createRouter(implementation: Implementation): Router {
     starting_after: z.string().optional(),
   })
 
-  const getCustomersCustomerCardsRequestBodySchema = z.object({}).optional()
-
   const getCustomersCustomerCardsResponseBodyValidator =
     responseValidationFactory(
       [
@@ -29880,11 +28520,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getCustomersCustomerCardsRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -30146,8 +28782,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getCustomersCustomerCardsIdRequestBodySchema = z.object({}).optional()
-
   const getCustomersCustomerCardsIdResponseBodyValidator =
     responseValidationFactory([["200", s_card]], s_error)
 
@@ -30167,11 +28801,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getCustomersCustomerCardsIdRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -30351,10 +28981,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getCustomersCustomerCashBalanceRequestBodySchema = z
-    .object({})
-    .optional()
-
   const getCustomersCustomerCashBalanceResponseBodyValidator =
     responseValidationFactory([["200", s_cash_balance]], s_error)
 
@@ -30374,11 +29000,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getCustomersCustomerCashBalanceRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -30524,10 +29146,6 @@ export function createRouter(implementation: Implementation): Router {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getCustomersCustomerCashBalanceTransactionsRequestBodySchema = z
-    .object({})
-    .optional()
-
   const getCustomersCustomerCashBalanceTransactionsResponseBodyValidator =
     responseValidationFactory(
       [
@@ -30560,11 +29178,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getCustomersCustomerCashBalanceTransactionsRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -30638,9 +29252,6 @@ export function createRouter(implementation: Implementation): Router {
         .optional(),
     })
 
-  const getCustomersCustomerCashBalanceTransactionsTransactionRequestBodySchema =
-    z.object({}).optional()
-
   const getCustomersCustomerCashBalanceTransactionsTransactionResponseBodyValidator =
     responseValidationFactory(
       [["200", s_customer_cash_balance_transaction]],
@@ -30663,11 +29274,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getCustomersCustomerCashBalanceTransactionsTransactionRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -30729,10 +29336,6 @@ export function createRouter(implementation: Implementation): Router {
     customer: z.string().max(5000),
   })
 
-  const deleteCustomersCustomerDiscountRequestBodySchema = z
-    .object({})
-    .optional()
-
   const deleteCustomersCustomerDiscountResponseBodyValidator =
     responseValidationFactory([["200", s_deleted_discount]], s_error)
 
@@ -30748,11 +29351,7 @@ export function createRouter(implementation: Implementation): Router {
             RequestInputType.RouteParam,
           ),
           query: undefined,
-          body: parseRequestInput(
-            deleteCustomersCustomerDiscountRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -30812,8 +29411,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getCustomersCustomerDiscountRequestBodySchema = z.object({}).optional()
-
   const getCustomersCustomerDiscountResponseBodyValidator =
     responseValidationFactory([["200", s_discount]], s_error)
 
@@ -30833,11 +29430,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getCustomersCustomerDiscountRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -31051,10 +29644,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getCustomersCustomerPaymentMethodsRequestBodySchema = z
-    .object({})
-    .optional()
-
   const getCustomersCustomerPaymentMethodsResponseBodyValidator =
     responseValidationFactory(
       [
@@ -31087,11 +29676,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getCustomersCustomerPaymentMethodsRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -31160,10 +29745,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getCustomersCustomerPaymentMethodsPaymentMethodRequestBodySchema = z
-    .object({})
-    .optional()
-
   const getCustomersCustomerPaymentMethodsPaymentMethodResponseBodyValidator =
     responseValidationFactory([["200", s_payment_method]], s_error)
 
@@ -31183,11 +29764,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getCustomersCustomerPaymentMethodsPaymentMethodRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -31260,8 +29837,6 @@ export function createRouter(implementation: Implementation): Router {
     starting_after: z.string().optional(),
   })
 
-  const getCustomersCustomerSourcesRequestBodySchema = z.object({}).optional()
-
   const getCustomersCustomerSourcesResponseBodyValidator =
     responseValidationFactory(
       [
@@ -31300,11 +29875,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getCustomersCustomerSourcesRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -31568,8 +30139,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getCustomersCustomerSourcesIdRequestBodySchema = z.object({}).optional()
-
   const getCustomersCustomerSourcesIdResponseBodyValidator =
     responseValidationFactory([["200", s_payment_source]], s_error)
 
@@ -31589,11 +30158,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getCustomersCustomerSourcesIdRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -31863,10 +30428,6 @@ export function createRouter(implementation: Implementation): Router {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getCustomersCustomerSubscriptionsRequestBodySchema = z
-    .object({})
-    .optional()
-
   const getCustomersCustomerSubscriptionsResponseBodyValidator =
     responseValidationFactory(
       [
@@ -31899,11 +30460,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getCustomersCustomerSubscriptionsRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -32494,9 +31051,6 @@ export function createRouter(implementation: Implementation): Router {
         .optional(),
     })
 
-  const getCustomersCustomerSubscriptionsSubscriptionExposedIdRequestBodySchema =
-    z.object({}).optional()
-
   const getCustomersCustomerSubscriptionsSubscriptionExposedIdResponseBodyValidator =
     responseValidationFactory([["200", s_subscription]], s_error)
 
@@ -32516,11 +31070,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getCustomersCustomerSubscriptionsSubscriptionExposedIdRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -33056,9 +31606,6 @@ export function createRouter(implementation: Implementation): Router {
       subscription_exposed_id: z.string().max(5000),
     })
 
-  const deleteCustomersCustomerSubscriptionsSubscriptionExposedIdDiscountRequestBodySchema =
-    z.object({}).optional()
-
   const deleteCustomersCustomerSubscriptionsSubscriptionExposedIdDiscountResponseBodyValidator =
     responseValidationFactory([["200", s_deleted_discount]], s_error)
 
@@ -33074,11 +31621,7 @@ export function createRouter(implementation: Implementation): Router {
             RequestInputType.RouteParam,
           ),
           query: undefined,
-          body: parseRequestInput(
-            deleteCustomersCustomerSubscriptionsSubscriptionExposedIdDiscountRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -33150,9 +31693,6 @@ export function createRouter(implementation: Implementation): Router {
         .optional(),
     })
 
-  const getCustomersCustomerSubscriptionsSubscriptionExposedIdDiscountRequestBodySchema =
-    z.object({}).optional()
-
   const getCustomersCustomerSubscriptionsSubscriptionExposedIdDiscountResponseBodyValidator =
     responseValidationFactory([["200", s_discount]], s_error)
 
@@ -33172,11 +31712,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getCustomersCustomerSubscriptionsSubscriptionExposedIdDiscountRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -33248,8 +31784,6 @@ export function createRouter(implementation: Implementation): Router {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getCustomersCustomerTaxIdsRequestBodySchema = z.object({}).optional()
-
   const getCustomersCustomerTaxIdsResponseBodyValidator =
     responseValidationFactory(
       [
@@ -33282,11 +31816,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getCustomersCustomerTaxIdsRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -33530,10 +32060,6 @@ export function createRouter(implementation: Implementation): Router {
     id: z.string(),
   })
 
-  const deleteCustomersCustomerTaxIdsIdRequestBodySchema = z
-    .object({})
-    .optional()
-
   const deleteCustomersCustomerTaxIdsIdResponseBodyValidator =
     responseValidationFactory([["200", s_deleted_tax_id]], s_error)
 
@@ -33549,11 +32075,7 @@ export function createRouter(implementation: Implementation): Router {
             RequestInputType.RouteParam,
           ),
           query: undefined,
-          body: parseRequestInput(
-            deleteCustomersCustomerTaxIdsIdRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -33614,8 +32136,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getCustomersCustomerTaxIdsIdRequestBodySchema = z.object({}).optional()
-
   const getCustomersCustomerTaxIdsIdResponseBodyValidator =
     responseValidationFactory([["200", s_tax_id]], s_error)
 
@@ -33635,11 +32155,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getCustomersCustomerTaxIdsIdRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -33711,8 +32227,6 @@ export function createRouter(implementation: Implementation): Router {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getDisputesRequestBodySchema = z.object({}).optional()
-
   const getDisputesResponseBodyValidator = responseValidationFactory(
     [
       [
@@ -33740,11 +32254,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getDisputesRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -33807,8 +32317,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getDisputesDisputeRequestBodySchema = z.object({}).optional()
-
   const getDisputesDisputeResponseBodyValidator = responseValidationFactory(
     [["200", s_dispute]],
     s_error,
@@ -33830,11 +32338,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getDisputesDisputeRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -34181,10 +32685,6 @@ export function createRouter(implementation: Implementation): Router {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getEntitlementsActiveEntitlementsRequestBodySchema = z
-    .object({})
-    .optional()
-
   const getEntitlementsActiveEntitlementsResponseBodyValidator =
     responseValidationFactory(
       [
@@ -34213,11 +32713,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getEntitlementsActiveEntitlementsRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -34285,10 +32781,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getEntitlementsActiveEntitlementsIdRequestBodySchema = z
-    .object({})
-    .optional()
-
   const getEntitlementsActiveEntitlementsIdResponseBodyValidator =
     responseValidationFactory(
       [["200", s_entitlements_active_entitlement]],
@@ -34311,11 +32803,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getEntitlementsActiveEntitlementsIdRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -34381,8 +32869,6 @@ export function createRouter(implementation: Implementation): Router {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getEntitlementsFeaturesRequestBodySchema = z.object({}).optional()
-
   const getEntitlementsFeaturesResponseBodyValidator =
     responseValidationFactory(
       [
@@ -34414,11 +32900,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getEntitlementsFeaturesRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -34548,8 +33030,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getEntitlementsFeaturesIdRequestBodySchema = z.object({}).optional()
-
   const getEntitlementsFeaturesIdResponseBodyValidator =
     responseValidationFactory([["200", s_entitlements_feature]], s_error)
 
@@ -34569,11 +33049,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getEntitlementsFeaturesIdRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -34874,8 +33350,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getEventsRequestBodySchema = z.object({}).optional()
-
   const getEventsResponseBodyValidator = responseValidationFactory(
     [
       [
@@ -34903,11 +33377,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getEventsRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -34968,8 +33438,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getEventsIdRequestBodySchema = z.object({}).optional()
-
   const getEventsIdResponseBodyValidator = responseValidationFactory(
     [["200", s_event]],
     s_error,
@@ -34991,11 +33459,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getEventsIdRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -35052,8 +33516,6 @@ export function createRouter(implementation: Implementation): Router {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getExchangeRatesRequestBodySchema = z.object({}).optional()
-
   const getExchangeRatesResponseBodyValidator = responseValidationFactory(
     [
       [
@@ -35081,11 +33543,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getExchangeRatesRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -35148,8 +33606,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getExchangeRatesRateIdRequestBodySchema = z.object({}).optional()
-
   const getExchangeRatesRateIdResponseBodyValidator = responseValidationFactory(
     [["200", s_exchange_rate]],
     s_error,
@@ -35171,11 +33627,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getExchangeRatesRateIdRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -35340,8 +33792,6 @@ export function createRouter(implementation: Implementation): Router {
     starting_after: z.string().optional(),
   })
 
-  const getFileLinksRequestBodySchema = z.object({}).optional()
-
   const getFileLinksResponseBodyValidator = responseValidationFactory(
     [
       [
@@ -35369,11 +33819,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getFileLinksRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -35503,8 +33949,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getFileLinksLinkRequestBodySchema = z.object({}).optional()
-
   const getFileLinksLinkResponseBodyValidator = responseValidationFactory(
     [["200", s_file_link]],
     s_error,
@@ -35526,11 +33970,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getFileLinksLinkRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -35697,8 +34137,6 @@ export function createRouter(implementation: Implementation): Router {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getFilesRequestBodySchema = z.object({}).optional()
-
   const getFilesResponseBodyValidator = responseValidationFactory(
     [
       [
@@ -35726,11 +34164,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getFilesRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -35878,8 +34312,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getFilesFileRequestBodySchema = z.object({}).optional()
-
   const getFilesFileResponseBodyValidator = responseValidationFactory(
     [["200", s_file]],
     s_error,
@@ -35901,11 +34333,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getFilesFileRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -35969,10 +34397,6 @@ export function createRouter(implementation: Implementation): Router {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getFinancialConnectionsAccountsRequestBodySchema = z
-    .object({})
-    .optional()
-
   const getFinancialConnectionsAccountsResponseBodyValidator =
     responseValidationFactory(
       [
@@ -36004,11 +34428,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getFinancialConnectionsAccountsRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -36073,10 +34493,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getFinancialConnectionsAccountsAccountRequestBodySchema = z
-    .object({})
-    .optional()
-
   const getFinancialConnectionsAccountsAccountResponseBodyValidator =
     responseValidationFactory(
       [["200", s_financial_connections_account]],
@@ -36099,11 +34515,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getFinancialConnectionsAccountsAccountRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -36266,10 +34678,6 @@ export function createRouter(implementation: Implementation): Router {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getFinancialConnectionsAccountsAccountOwnersRequestBodySchema = z
-    .object({})
-    .optional()
-
   const getFinancialConnectionsAccountsAccountOwnersResponseBodyValidator =
     responseValidationFactory(
       [
@@ -36302,11 +34710,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getFinancialConnectionsAccountsAccountOwnersRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -36748,10 +35152,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getFinancialConnectionsSessionsSessionRequestBodySchema = z
-    .object({})
-    .optional()
-
   const getFinancialConnectionsSessionsSessionResponseBodyValidator =
     responseValidationFactory(
       [["200", s_financial_connections_session]],
@@ -36774,11 +35174,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getFinancialConnectionsSessionsSessionRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -36861,10 +35257,6 @@ export function createRouter(implementation: Implementation): Router {
     transaction_refresh: z.object({after: z.string().max(5000)}).optional(),
   })
 
-  const getFinancialConnectionsTransactionsRequestBodySchema = z
-    .object({})
-    .optional()
-
   const getFinancialConnectionsTransactionsResponseBodyValidator =
     responseValidationFactory(
       [
@@ -36896,11 +35288,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getFinancialConnectionsTransactionsRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -36968,10 +35356,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getFinancialConnectionsTransactionsTransactionRequestBodySchema = z
-    .object({})
-    .optional()
-
   const getFinancialConnectionsTransactionsTransactionResponseBodyValidator =
     responseValidationFactory(
       [["200", s_financial_connections_transaction]],
@@ -36994,11 +35378,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getFinancialConnectionsTransactionsTransactionRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -37076,8 +35456,6 @@ export function createRouter(implementation: Implementation): Router {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getForwardingRequestsRequestBodySchema = z.object({}).optional()
-
   const getForwardingRequestsResponseBodyValidator = responseValidationFactory(
     [
       [
@@ -37105,11 +35483,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getForwardingRequestsRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -37260,8 +35634,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getForwardingRequestsIdRequestBodySchema = z.object({}).optional()
-
   const getForwardingRequestsIdResponseBodyValidator =
     responseValidationFactory([["200", s_forwarding_request]], s_error)
 
@@ -37281,11 +35653,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getForwardingRequestsIdRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -37356,10 +35724,6 @@ export function createRouter(implementation: Implementation): Router {
     verification_session: z.string().max(5000).optional(),
   })
 
-  const getIdentityVerificationReportsRequestBodySchema = z
-    .object({})
-    .optional()
-
   const getIdentityVerificationReportsResponseBodyValidator =
     responseValidationFactory(
       [
@@ -37391,11 +35755,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getIdentityVerificationReportsRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -37460,10 +35820,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getIdentityVerificationReportsReportRequestBodySchema = z
-    .object({})
-    .optional()
-
   const getIdentityVerificationReportsReportResponseBodyValidator =
     responseValidationFactory(
       [["200", s_identity_verification_report]],
@@ -37486,11 +35842,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getIdentityVerificationReportsReportRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -37576,10 +35928,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getIdentityVerificationSessionsRequestBodySchema = z
-    .object({})
-    .optional()
-
   const getIdentityVerificationSessionsResponseBodyValidator =
     responseValidationFactory(
       [
@@ -37611,11 +35959,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getIdentityVerificationSessionsRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -37782,10 +36126,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getIdentityVerificationSessionsSessionRequestBodySchema = z
-    .object({})
-    .optional()
-
   const getIdentityVerificationSessionsSessionResponseBodyValidator =
     responseValidationFactory(
       [["200", s_identity_verification_session]],
@@ -37808,11 +36148,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getIdentityVerificationSessionsSessionRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -38178,8 +36514,6 @@ export function createRouter(implementation: Implementation): Router {
     status: z.enum(["canceled", "open", "paid"]).optional(),
   })
 
-  const getInvoicePaymentsRequestBodySchema = z.object({}).optional()
-
   const getInvoicePaymentsResponseBodyValidator = responseValidationFactory(
     [
       [
@@ -38207,11 +36541,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getInvoicePaymentsRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -38274,10 +36604,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getInvoicePaymentsInvoicePaymentRequestBodySchema = z
-    .object({})
-    .optional()
-
   const getInvoicePaymentsInvoicePaymentResponseBodyValidator =
     responseValidationFactory([["200", s_invoice_payment]], s_error)
 
@@ -38297,11 +36623,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getInvoicePaymentsInvoicePaymentRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -38361,8 +36683,6 @@ export function createRouter(implementation: Implementation): Router {
     status: z.enum(["active", "archived"]).optional(),
   })
 
-  const getInvoiceRenderingTemplatesRequestBodySchema = z.object({}).optional()
-
   const getInvoiceRenderingTemplatesResponseBodyValidator =
     responseValidationFactory(
       [
@@ -38391,11 +36711,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getInvoiceRenderingTemplatesRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -38461,10 +36777,6 @@ export function createRouter(implementation: Implementation): Router {
     version: z.coerce.number().optional(),
   })
 
-  const getInvoiceRenderingTemplatesTemplateRequestBodySchema = z
-    .object({})
-    .optional()
-
   const getInvoiceRenderingTemplatesTemplateResponseBodyValidator =
     responseValidationFactory([["200", s_invoice_rendering_template]], s_error)
 
@@ -38484,11 +36796,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getInvoiceRenderingTemplatesTemplateRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -38736,8 +37044,6 @@ export function createRouter(implementation: Implementation): Router {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getInvoiceitemsRequestBodySchema = z.object({}).optional()
-
   const getInvoiceitemsResponseBodyValidator = responseValidationFactory(
     [
       [
@@ -38765,11 +37071,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getInvoiceitemsRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -38929,8 +37231,6 @@ export function createRouter(implementation: Implementation): Router {
     invoiceitem: z.string().max(5000),
   })
 
-  const deleteInvoiceitemsInvoiceitemRequestBodySchema = z.object({}).optional()
-
   const deleteInvoiceitemsInvoiceitemResponseBodyValidator =
     responseValidationFactory([["200", s_deleted_invoiceitem]], s_error)
 
@@ -38946,11 +37246,7 @@ export function createRouter(implementation: Implementation): Router {
             RequestInputType.RouteParam,
           ),
           query: undefined,
-          body: parseRequestInput(
-            deleteInvoiceitemsInvoiceitemRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -39010,8 +37306,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getInvoiceitemsInvoiceitemRequestBodySchema = z.object({}).optional()
-
   const getInvoiceitemsInvoiceitemResponseBodyValidator =
     responseValidationFactory([["200", s_invoiceitem]], s_error)
 
@@ -39031,11 +37325,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getInvoiceitemsInvoiceitemRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -39240,8 +37530,6 @@ export function createRouter(implementation: Implementation): Router {
     subscription: z.string().max(5000).optional(),
   })
 
-  const getInvoicesRequestBodySchema = z.object({}).optional()
-
   const getInvoicesResponseBodyValidator = responseValidationFactory(
     [
       [
@@ -39269,11 +37557,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getInvoicesRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -40283,8 +38567,6 @@ export function createRouter(implementation: Implementation): Router {
     query: z.string().max(5000),
   })
 
-  const getInvoicesSearchRequestBodySchema = z.object({}).optional()
-
   const getInvoicesSearchResponseBodyValidator = responseValidationFactory(
     [
       [
@@ -40314,11 +38596,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getInvoicesSearchRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -40374,8 +38652,6 @@ export function createRouter(implementation: Implementation): Router {
     invoice: z.string().max(5000),
   })
 
-  const deleteInvoicesInvoiceRequestBodySchema = z.object({}).optional()
-
   const deleteInvoicesInvoiceResponseBodyValidator = responseValidationFactory(
     [["200", s_deleted_invoice]],
     s_error,
@@ -40393,11 +38669,7 @@ export function createRouter(implementation: Implementation): Router {
             RequestInputType.RouteParam,
           ),
           query: undefined,
-          body: parseRequestInput(
-            deleteInvoicesInvoiceRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -40455,8 +38727,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getInvoicesInvoiceRequestBodySchema = z.object({}).optional()
-
   const getInvoicesInvoiceResponseBodyValidator = responseValidationFactory(
     [["200", s_invoice]],
     s_error,
@@ -40478,11 +38748,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getInvoicesInvoiceRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -41296,8 +39562,6 @@ export function createRouter(implementation: Implementation): Router {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getInvoicesInvoiceLinesRequestBodySchema = z.object({}).optional()
-
   const getInvoicesInvoiceLinesResponseBodyValidator =
     responseValidationFactory(
       [
@@ -41330,11 +39594,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getInvoicesInvoiceLinesRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -42182,8 +40442,6 @@ export function createRouter(implementation: Implementation): Router {
     status: z.enum(["closed", "expired", "pending", "reversed"]).optional(),
   })
 
-  const getIssuingAuthorizationsRequestBodySchema = z.object({}).optional()
-
   const getIssuingAuthorizationsResponseBodyValidator =
     responseValidationFactory(
       [
@@ -42215,11 +40473,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getIssuingAuthorizationsRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -42282,10 +40536,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getIssuingAuthorizationsAuthorizationRequestBodySchema = z
-    .object({})
-    .optional()
-
   const getIssuingAuthorizationsAuthorizationResponseBodyValidator =
     responseValidationFactory([["200", s_issuing_authorization]], s_error)
 
@@ -42305,11 +40555,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getIssuingAuthorizationsAuthorizationRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -42651,8 +40897,6 @@ export function createRouter(implementation: Implementation): Router {
     type: z.enum(["company", "individual"]).optional(),
   })
 
-  const getIssuingCardholdersRequestBodySchema = z.object({}).optional()
-
   const getIssuingCardholdersResponseBodyValidator = responseValidationFactory(
     [
       [
@@ -42683,11 +40927,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getIssuingCardholdersRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -43797,10 +42037,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getIssuingCardholdersCardholderRequestBodySchema = z
-    .object({})
-    .optional()
-
   const getIssuingCardholdersCardholderResponseBodyValidator =
     responseValidationFactory([["200", s_issuing_cardholder]], s_error)
 
@@ -43820,11 +42056,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getIssuingCardholdersCardholderRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -44958,8 +43190,6 @@ export function createRouter(implementation: Implementation): Router {
     type: z.enum(["physical", "virtual"]).optional(),
   })
 
-  const getIssuingCardsRequestBodySchema = z.object({}).optional()
-
   const getIssuingCardsResponseBodyValidator = responseValidationFactory(
     [
       [
@@ -44987,11 +43217,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getIssuingCardsRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -46086,8 +44312,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getIssuingCardsCardRequestBodySchema = z.object({}).optional()
-
   const getIssuingCardsCardResponseBodyValidator = responseValidationFactory(
     [["200", s_issuing_card]],
     s_error,
@@ -46109,11 +44333,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getIssuingCardsCardRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -47219,8 +45439,6 @@ export function createRouter(implementation: Implementation): Router {
     transaction: z.string().max(5000).optional(),
   })
 
-  const getIssuingDisputesRequestBodySchema = z.object({}).optional()
-
   const getIssuingDisputesResponseBodyValidator = responseValidationFactory(
     [
       [
@@ -47248,11 +45466,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getIssuingDisputesRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -47565,8 +45779,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getIssuingDisputesDisputeRequestBodySchema = z.object({}).optional()
-
   const getIssuingDisputesDisputeResponseBodyValidator =
     responseValidationFactory([["200", s_issuing_dispute]], s_error)
 
@@ -47586,11 +45798,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getIssuingDisputesDisputeRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -47993,10 +46201,6 @@ export function createRouter(implementation: Implementation): Router {
     status: z.enum(["active", "inactive", "rejected", "review"]).optional(),
   })
 
-  const getIssuingPersonalizationDesignsRequestBodySchema = z
-    .object({})
-    .optional()
-
   const getIssuingPersonalizationDesignsResponseBodyValidator =
     responseValidationFactory(
       [
@@ -48028,11 +46232,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getIssuingPersonalizationDesignsRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -48186,9 +46386,6 @@ export function createRouter(implementation: Implementation): Router {
         .optional(),
     })
 
-  const getIssuingPersonalizationDesignsPersonalizationDesignRequestBodySchema =
-    z.object({}).optional()
-
   const getIssuingPersonalizationDesignsPersonalizationDesignResponseBodyValidator =
     responseValidationFactory(
       [["200", s_issuing_personalization_design]],
@@ -48211,11 +46408,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getIssuingPersonalizationDesignsPersonalizationDesignRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -48403,8 +46596,6 @@ export function createRouter(implementation: Implementation): Router {
     type: z.enum(["custom", "standard"]).optional(),
   })
 
-  const getIssuingPhysicalBundlesRequestBodySchema = z.object({}).optional()
-
   const getIssuingPhysicalBundlesResponseBodyValidator =
     responseValidationFactory(
       [
@@ -48436,11 +46627,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getIssuingPhysicalBundlesRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -48503,10 +46690,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getIssuingPhysicalBundlesPhysicalBundleRequestBodySchema = z
-    .object({})
-    .optional()
-
   const getIssuingPhysicalBundlesPhysicalBundleResponseBodyValidator =
     responseValidationFactory([["200", s_issuing_physical_bundle]], s_error)
 
@@ -48526,11 +46709,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getIssuingPhysicalBundlesPhysicalBundleRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -48599,10 +46778,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getIssuingSettlementsSettlementRequestBodySchema = z
-    .object({})
-    .optional()
-
   const getIssuingSettlementsSettlementResponseBodyValidator =
     responseValidationFactory([["200", s_issuing_settlement]], s_error)
 
@@ -48622,11 +46797,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getIssuingSettlementsSettlementRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -48775,8 +46946,6 @@ export function createRouter(implementation: Implementation): Router {
     status: z.enum(["active", "deleted", "requested", "suspended"]).optional(),
   })
 
-  const getIssuingTokensRequestBodySchema = z.object({}).optional()
-
   const getIssuingTokensResponseBodyValidator = responseValidationFactory(
     [
       [
@@ -48804,11 +46973,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getIssuingTokensRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -48871,8 +47036,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getIssuingTokensTokenRequestBodySchema = z.object({}).optional()
-
   const getIssuingTokensTokenResponseBodyValidator = responseValidationFactory(
     [["200", s_issuing_token]],
     s_error,
@@ -48894,11 +47057,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getIssuingTokensTokenRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -49044,8 +47203,6 @@ export function createRouter(implementation: Implementation): Router {
     type: z.enum(["capture", "refund"]).optional(),
   })
 
-  const getIssuingTransactionsRequestBodySchema = z.object({}).optional()
-
   const getIssuingTransactionsResponseBodyValidator = responseValidationFactory(
     [
       [
@@ -49076,11 +47233,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getIssuingTransactionsRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -49143,10 +47296,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getIssuingTransactionsTransactionRequestBodySchema = z
-    .object({})
-    .optional()
-
   const getIssuingTransactionsTransactionResponseBodyValidator =
     responseValidationFactory([["200", s_issuing_transaction]], s_error)
 
@@ -49166,11 +47315,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getIssuingTransactionsTransactionRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -49410,8 +47555,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getLinkAccountSessionsSessionRequestBodySchema = z.object({}).optional()
-
   const getLinkAccountSessionsSessionResponseBodyValidator =
     responseValidationFactory(
       [["200", s_financial_connections_session]],
@@ -49434,11 +47577,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getLinkAccountSessionsSessionRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -49506,8 +47645,6 @@ export function createRouter(implementation: Implementation): Router {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getLinkedAccountsRequestBodySchema = z.object({}).optional()
-
   const getLinkedAccountsResponseBodyValidator = responseValidationFactory(
     [
       [
@@ -49538,11 +47675,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getLinkedAccountsRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -49605,8 +47738,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getLinkedAccountsAccountRequestBodySchema = z.object({}).optional()
-
   const getLinkedAccountsAccountResponseBodyValidator =
     responseValidationFactory(
       [["200", s_financial_connections_account]],
@@ -49629,11 +47760,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getLinkedAccountsAccountRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -49779,10 +47906,6 @@ export function createRouter(implementation: Implementation): Router {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getLinkedAccountsAccountOwnersRequestBodySchema = z
-    .object({})
-    .optional()
-
   const getLinkedAccountsAccountOwnersResponseBodyValidator =
     responseValidationFactory(
       [
@@ -49815,11 +47938,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getLinkedAccountsAccountOwnersRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -49962,8 +48081,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getMandatesMandateRequestBodySchema = z.object({}).optional()
-
   const getMandatesMandateResponseBodyValidator = responseValidationFactory(
     [["200", s_mandate]],
     s_error,
@@ -49985,11 +48102,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getMandatesMandateRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -50058,8 +48171,6 @@ export function createRouter(implementation: Implementation): Router {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getPaymentIntentsRequestBodySchema = z.object({}).optional()
-
   const getPaymentIntentsResponseBodyValidator = responseValidationFactory(
     [
       [
@@ -50087,11 +48198,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getPaymentIntentsRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -51348,8 +49455,6 @@ export function createRouter(implementation: Implementation): Router {
     query: z.string().max(5000),
   })
 
-  const getPaymentIntentsSearchRequestBodySchema = z.object({}).optional()
-
   const getPaymentIntentsSearchResponseBodyValidator =
     responseValidationFactory(
       [
@@ -51380,11 +49485,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getPaymentIntentsSearchRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -51450,8 +49551,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getPaymentIntentsIntentRequestBodySchema = z.object({}).optional()
-
   const getPaymentIntentsIntentResponseBodyValidator =
     responseValidationFactory([["200", s_payment_intent]], s_error)
 
@@ -51471,11 +49570,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getPaymentIntentsIntentRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -54346,8 +52441,6 @@ export function createRouter(implementation: Implementation): Router {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getPaymentLinksRequestBodySchema = z.object({}).optional()
-
   const getPaymentLinksResponseBodyValidator = responseValidationFactory(
     [
       [
@@ -54375,11 +52468,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getPaymentLinksRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -55020,8 +53109,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getPaymentLinksPaymentLinkRequestBodySchema = z.object({}).optional()
-
   const getPaymentLinksPaymentLinkResponseBodyValidator =
     responseValidationFactory([["200", s_payment_link]], s_error)
 
@@ -55041,11 +53128,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getPaymentLinksPaymentLinkRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -55687,10 +53770,6 @@ export function createRouter(implementation: Implementation): Router {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getPaymentLinksPaymentLinkLineItemsRequestBodySchema = z
-    .object({})
-    .optional()
-
   const getPaymentLinksPaymentLinkLineItemsResponseBodyValidator =
     responseValidationFactory(
       [
@@ -55723,11 +53802,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getPaymentLinksPaymentLinkLineItemsRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -55795,10 +53870,6 @@ export function createRouter(implementation: Implementation): Router {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getPaymentMethodConfigurationsRequestBodySchema = z
-    .object({})
-    .optional()
-
   const getPaymentMethodConfigurationsResponseBodyValidator =
     responseValidationFactory(
       [
@@ -55830,11 +53901,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getPaymentMethodConfigurationsRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -56338,10 +54405,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getPaymentMethodConfigurationsConfigurationRequestBodySchema = z
-    .object({})
-    .optional()
-
   const getPaymentMethodConfigurationsConfigurationResponseBodyValidator =
     responseValidationFactory(
       [["200", s_payment_method_configuration]],
@@ -56364,11 +54427,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getPaymentMethodConfigurationsConfigurationRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -56896,8 +54955,6 @@ export function createRouter(implementation: Implementation): Router {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getPaymentMethodDomainsRequestBodySchema = z.object({}).optional()
-
   const getPaymentMethodDomainsResponseBodyValidator =
     responseValidationFactory(
       [
@@ -56929,11 +54986,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getPaymentMethodDomainsRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -57062,10 +55115,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getPaymentMethodDomainsPaymentMethodDomainRequestBodySchema = z
-    .object({})
-    .optional()
-
   const getPaymentMethodDomainsPaymentMethodDomainResponseBodyValidator =
     responseValidationFactory([["200", s_payment_method_domain]], s_error)
 
@@ -57085,11 +55134,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getPaymentMethodDomainsPaymentMethodDomainRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -57378,8 +55423,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getPaymentMethodsRequestBodySchema = z.object({}).optional()
-
   const getPaymentMethodsResponseBodyValidator = responseValidationFactory(
     [
       [
@@ -57407,11 +55450,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getPaymentMethodsRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -57854,10 +55893,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getPaymentMethodsPaymentMethodRequestBodySchema = z
-    .object({})
-    .optional()
-
   const getPaymentMethodsPaymentMethodResponseBodyValidator =
     responseValidationFactory([["200", s_payment_method]], s_error)
 
@@ -57877,11 +55912,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getPaymentMethodsPaymentMethodRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -58251,8 +56282,6 @@ export function createRouter(implementation: Implementation): Router {
     status: z.string().max(5000).optional(),
   })
 
-  const getPayoutsRequestBodySchema = z.object({}).optional()
-
   const getPayoutsResponseBodyValidator = responseValidationFactory(
     [
       [
@@ -58280,11 +56309,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getPayoutsRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -58419,8 +56444,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getPayoutsPayoutRequestBodySchema = z.object({}).optional()
-
   const getPayoutsPayoutResponseBodyValidator = responseValidationFactory(
     [["200", s_payout]],
     s_error,
@@ -58442,11 +56465,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getPayoutsPayoutRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -58738,8 +56757,6 @@ export function createRouter(implementation: Implementation): Router {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getPlansRequestBodySchema = z.object({}).optional()
-
   const getPlansResponseBodyValidator = responseValidationFactory(
     [
       [
@@ -58767,11 +56784,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getPlansRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -58931,8 +56944,6 @@ export function createRouter(implementation: Implementation): Router {
 
   const deletePlansPlanParamSchema = z.object({plan: z.string().max(5000)})
 
-  const deletePlansPlanRequestBodySchema = z.object({}).optional()
-
   const deletePlansPlanResponseBodyValidator = responseValidationFactory(
     [["200", s_deleted_plan]],
     s_error,
@@ -58950,11 +56961,7 @@ export function createRouter(implementation: Implementation): Router {
             RequestInputType.RouteParam,
           ),
           query: undefined,
-          body: parseRequestInput(
-            deletePlansPlanRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -59010,8 +57017,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getPlansPlanRequestBodySchema = z.object({}).optional()
-
   const getPlansPlanResponseBodyValidator = responseValidationFactory(
     [["200", s_plan]],
     s_error,
@@ -59033,11 +57038,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getPlansPlanRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -59201,8 +57202,6 @@ export function createRouter(implementation: Implementation): Router {
     type: z.enum(["one_time", "recurring"]).optional(),
   })
 
-  const getPricesRequestBodySchema = z.object({}).optional()
-
   const getPricesResponseBodyValidator = responseValidationFactory(
     [
       [
@@ -59230,11 +57229,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getPricesRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -59445,8 +57440,6 @@ export function createRouter(implementation: Implementation): Router {
     query: z.string().max(5000),
   })
 
-  const getPricesSearchRequestBodySchema = z.object({}).optional()
-
   const getPricesSearchResponseBodyValidator = responseValidationFactory(
     [
       [
@@ -59476,11 +57469,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getPricesSearchRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -59543,8 +57532,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getPricesPriceRequestBodySchema = z.object({}).optional()
-
   const getPricesPriceResponseBodyValidator = responseValidationFactory(
     [["200", s_price]],
     s_error,
@@ -59566,11 +57553,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getPricesPriceRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -59762,8 +57745,6 @@ export function createRouter(implementation: Implementation): Router {
     url: z.string().max(5000).optional(),
   })
 
-  const getProductsRequestBodySchema = z.object({}).optional()
-
   const getProductsResponseBodyValidator = responseValidationFactory(
     [
       [
@@ -59791,11 +57772,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getProductsRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -60000,8 +57977,6 @@ export function createRouter(implementation: Implementation): Router {
     query: z.string().max(5000),
   })
 
-  const getProductsSearchRequestBodySchema = z.object({}).optional()
-
   const getProductsSearchResponseBodyValidator = responseValidationFactory(
     [
       [
@@ -60031,11 +58006,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getProductsSearchRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -60089,8 +58060,6 @@ export function createRouter(implementation: Implementation): Router {
 
   const deleteProductsIdParamSchema = z.object({id: z.string().max(5000)})
 
-  const deleteProductsIdRequestBodySchema = z.object({}).optional()
-
   const deleteProductsIdResponseBodyValidator = responseValidationFactory(
     [["200", s_deleted_product]],
     s_error,
@@ -60108,11 +58077,7 @@ export function createRouter(implementation: Implementation): Router {
             RequestInputType.RouteParam,
           ),
           query: undefined,
-          body: parseRequestInput(
-            deleteProductsIdRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -60168,8 +58133,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getProductsIdRequestBodySchema = z.object({}).optional()
-
   const getProductsIdResponseBodyValidator = responseValidationFactory(
     [["200", s_product]],
     s_error,
@@ -60191,11 +58154,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getProductsIdRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -60355,8 +58314,6 @@ export function createRouter(implementation: Implementation): Router {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getProductsProductFeaturesRequestBodySchema = z.object({}).optional()
-
   const getProductsProductFeaturesResponseBodyValidator =
     responseValidationFactory(
       [
@@ -60389,11 +58346,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getProductsProductFeaturesRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -60525,10 +58478,6 @@ export function createRouter(implementation: Implementation): Router {
     product: z.string().max(5000),
   })
 
-  const deleteProductsProductFeaturesIdRequestBodySchema = z
-    .object({})
-    .optional()
-
   const deleteProductsProductFeaturesIdResponseBodyValidator =
     responseValidationFactory([["200", s_deleted_product_feature]], s_error)
 
@@ -60544,11 +58493,7 @@ export function createRouter(implementation: Implementation): Router {
             RequestInputType.RouteParam,
           ),
           query: undefined,
-          body: parseRequestInput(
-            deleteProductsProductFeaturesIdRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -60609,8 +58554,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getProductsProductFeaturesIdRequestBodySchema = z.object({}).optional()
-
   const getProductsProductFeaturesIdResponseBodyValidator =
     responseValidationFactory([["200", s_product_feature]], s_error)
 
@@ -60630,11 +58573,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getProductsProductFeaturesIdRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -60708,8 +58647,6 @@ export function createRouter(implementation: Implementation): Router {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getPromotionCodesRequestBodySchema = z.object({}).optional()
-
   const getPromotionCodesResponseBodyValidator = responseValidationFactory(
     [
       [
@@ -60737,11 +58674,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getPromotionCodesRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -60887,10 +58820,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getPromotionCodesPromotionCodeRequestBodySchema = z
-    .object({})
-    .optional()
-
   const getPromotionCodesPromotionCodeResponseBodyValidator =
     responseValidationFactory([["200", s_promotion_code]], s_error)
 
@@ -60910,11 +58839,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getPromotionCodesPromotionCodeRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -61061,8 +58986,6 @@ export function createRouter(implementation: Implementation): Router {
     test_clock: z.string().max(5000).optional(),
   })
 
-  const getQuotesRequestBodySchema = z.object({}).optional()
-
   const getQuotesResponseBodyValidator = responseValidationFactory(
     [
       [
@@ -61090,11 +59013,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getQuotesRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -61352,8 +59271,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getQuotesQuoteRequestBodySchema = z.object({}).optional()
-
   const getQuotesQuoteResponseBodyValidator = responseValidationFactory(
     [["200", s_quote]],
     s_error,
@@ -61375,11 +59292,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getQuotesQuoteRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -61782,10 +59695,6 @@ export function createRouter(implementation: Implementation): Router {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getQuotesQuoteComputedUpfrontLineItemsRequestBodySchema = z
-    .object({})
-    .optional()
-
   const getQuotesQuoteComputedUpfrontLineItemsResponseBodyValidator =
     responseValidationFactory(
       [
@@ -61818,11 +59727,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getQuotesQuoteComputedUpfrontLineItemsRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -61974,8 +59879,6 @@ export function createRouter(implementation: Implementation): Router {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getQuotesQuoteLineItemsRequestBodySchema = z.object({}).optional()
-
   const getQuotesQuoteLineItemsResponseBodyValidator =
     responseValidationFactory(
       [
@@ -62008,11 +59911,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getQuotesQuoteLineItemsRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -62073,8 +59972,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getQuotesQuotePdfRequestBodySchema = z.object({}).optional()
-
   const getQuotesQuotePdfResponseBodyValidator = responseValidationFactory(
     [["200", z.string()]],
     s_error,
@@ -62096,11 +59993,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getQuotesQuotePdfRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -62170,8 +60063,6 @@ export function createRouter(implementation: Implementation): Router {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getRadarEarlyFraudWarningsRequestBodySchema = z.object({}).optional()
-
   const getRadarEarlyFraudWarningsResponseBodyValidator =
     responseValidationFactory(
       [
@@ -62203,11 +60094,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getRadarEarlyFraudWarningsRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -62272,10 +60159,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getRadarEarlyFraudWarningsEarlyFraudWarningRequestBodySchema = z
-    .object({})
-    .optional()
-
   const getRadarEarlyFraudWarningsEarlyFraudWarningResponseBodyValidator =
     responseValidationFactory([["200", s_radar_early_fraud_warning]], s_error)
 
@@ -62295,11 +60178,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getRadarEarlyFraudWarningsEarlyFraudWarningRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -62380,8 +60259,6 @@ export function createRouter(implementation: Implementation): Router {
     value_list: z.string().max(5000),
   })
 
-  const getRadarValueListItemsRequestBodySchema = z.object({}).optional()
-
   const getRadarValueListItemsResponseBodyValidator = responseValidationFactory(
     [
       [
@@ -62412,11 +60289,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getRadarValueListItemsRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -62536,8 +60409,6 @@ export function createRouter(implementation: Implementation): Router {
     item: z.string().max(5000),
   })
 
-  const deleteRadarValueListItemsItemRequestBodySchema = z.object({}).optional()
-
   const deleteRadarValueListItemsItemResponseBodyValidator =
     responseValidationFactory(
       [["200", s_deleted_radar_value_list_item]],
@@ -62556,11 +60427,7 @@ export function createRouter(implementation: Implementation): Router {
             RequestInputType.RouteParam,
           ),
           query: undefined,
-          body: parseRequestInput(
-            deleteRadarValueListItemsItemRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -62622,8 +60489,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getRadarValueListItemsItemRequestBodySchema = z.object({}).optional()
-
   const getRadarValueListItemsItemResponseBodyValidator =
     responseValidationFactory([["200", s_radar_value_list_item]], s_error)
 
@@ -62643,11 +60508,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getRadarValueListItemsItemRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -62719,8 +60580,6 @@ export function createRouter(implementation: Implementation): Router {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getRadarValueListsRequestBodySchema = z.object({}).optional()
-
   const getRadarValueListsResponseBodyValidator = responseValidationFactory(
     [
       [
@@ -62748,11 +60607,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getRadarValueListsRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -62889,10 +60744,6 @@ export function createRouter(implementation: Implementation): Router {
     value_list: z.string().max(5000),
   })
 
-  const deleteRadarValueListsValueListRequestBodySchema = z
-    .object({})
-    .optional()
-
   const deleteRadarValueListsValueListResponseBodyValidator =
     responseValidationFactory([["200", s_deleted_radar_value_list]], s_error)
 
@@ -62908,11 +60759,7 @@ export function createRouter(implementation: Implementation): Router {
             RequestInputType.RouteParam,
           ),
           query: undefined,
-          body: parseRequestInput(
-            deleteRadarValueListsValueListRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -62972,8 +60819,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getRadarValueListsValueListRequestBodySchema = z.object({}).optional()
-
   const getRadarValueListsValueListResponseBodyValidator =
     responseValidationFactory([["200", s_radar_value_list]], s_error)
 
@@ -62993,11 +60838,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getRadarValueListsValueListRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -63148,8 +60989,6 @@ export function createRouter(implementation: Implementation): Router {
     starting_after: z.string().optional(),
   })
 
-  const getRefundsRequestBodySchema = z.object({}).optional()
-
   const getRefundsResponseBodyValidator = responseValidationFactory(
     [
       [
@@ -63177,11 +61016,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getRefundsRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -63323,8 +61158,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getRefundsRefundRequestBodySchema = z.object({}).optional()
-
   const getRefundsRefundResponseBodyValidator = responseValidationFactory(
     [["200", s_refund]],
     s_error,
@@ -63346,11 +61179,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getRefundsRefundRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -63563,8 +61392,6 @@ export function createRouter(implementation: Implementation): Router {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getReportingReportRunsRequestBodySchema = z.object({}).optional()
-
   const getReportingReportRunsResponseBodyValidator = responseValidationFactory(
     [
       [
@@ -63595,11 +61422,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getReportingReportRunsRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -64380,10 +62203,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getReportingReportRunsReportRunRequestBodySchema = z
-    .object({})
-    .optional()
-
   const getReportingReportRunsReportRunResponseBodyValidator =
     responseValidationFactory([["200", s_reporting_report_run]], s_error)
 
@@ -64403,11 +62222,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getReportingReportRunsReportRunRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -64463,8 +62278,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getReportingReportTypesRequestBodySchema = z.object({}).optional()
-
   const getReportingReportTypesResponseBodyValidator =
     responseValidationFactory(
       [
@@ -64493,11 +62306,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getReportingReportTypesRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -64560,10 +62369,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getReportingReportTypesReportTypeRequestBodySchema = z
-    .object({})
-    .optional()
-
   const getReportingReportTypesReportTypeResponseBodyValidator =
     responseValidationFactory([["200", s_reporting_report_type]], s_error)
 
@@ -64583,11 +62388,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getReportingReportTypesReportTypeRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -64660,8 +62461,6 @@ export function createRouter(implementation: Implementation): Router {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getReviewsRequestBodySchema = z.object({}).optional()
-
   const getReviewsResponseBodyValidator = responseValidationFactory(
     [
       [
@@ -64689,11 +62488,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getReviewsRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -64754,8 +62549,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getReviewsReviewRequestBodySchema = z.object({}).optional()
-
   const getReviewsReviewResponseBodyValidator = responseValidationFactory(
     [["200", s_review]],
     s_error,
@@ -64777,11 +62570,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getReviewsReviewRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -64922,8 +62711,6 @@ export function createRouter(implementation: Implementation): Router {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getSetupAttemptsRequestBodySchema = z.object({}).optional()
-
   const getSetupAttemptsResponseBodyValidator = responseValidationFactory(
     [
       [
@@ -64951,11 +62738,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getSetupAttemptsRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -65031,8 +62814,6 @@ export function createRouter(implementation: Implementation): Router {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getSetupIntentsRequestBodySchema = z.object({}).optional()
-
   const getSetupIntentsResponseBodyValidator = responseValidationFactory(
     [
       [
@@ -65060,11 +62841,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getSetupIntentsRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -65781,8 +63558,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getSetupIntentsIntentRequestBodySchema = z.object({}).optional()
-
   const getSetupIntentsIntentResponseBodyValidator = responseValidationFactory(
     [["200", s_setup_intent]],
     s_error,
@@ -65804,11 +63579,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getSetupIntentsIntentRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -67325,8 +65096,6 @@ export function createRouter(implementation: Implementation): Router {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getShippingRatesRequestBodySchema = z.object({}).optional()
-
   const getShippingRatesResponseBodyValidator = responseValidationFactory(
     [
       [
@@ -67354,11 +65123,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getShippingRatesRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -67524,10 +65289,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getShippingRatesShippingRateTokenRequestBodySchema = z
-    .object({})
-    .optional()
-
   const getShippingRatesShippingRateTokenResponseBodyValidator =
     responseValidationFactory([["200", s_shipping_rate]], s_error)
 
@@ -67547,11 +65308,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getShippingRatesShippingRateTokenRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -67787,8 +65544,6 @@ export function createRouter(implementation: Implementation): Router {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getSigmaScheduledQueryRunsRequestBodySchema = z.object({}).optional()
-
   const getSigmaScheduledQueryRunsResponseBodyValidator =
     responseValidationFactory(
       [
@@ -67820,11 +65575,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getSigmaScheduledQueryRunsRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -67889,10 +65640,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getSigmaScheduledQueryRunsScheduledQueryRunRequestBodySchema = z
-    .object({})
-    .optional()
-
   const getSigmaScheduledQueryRunsScheduledQueryRunResponseBodyValidator =
     responseValidationFactory([["200", s_scheduled_query_run]], s_error)
 
@@ -67912,11 +65659,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getSigmaScheduledQueryRunsScheduledQueryRunRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -68154,8 +65897,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getSourcesSourceRequestBodySchema = z.object({}).optional()
-
   const getSourcesSourceResponseBodyValidator = responseValidationFactory(
     [["200", s_source]],
     s_error,
@@ -68177,11 +65918,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getSourcesSourceRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -68400,9 +66137,6 @@ export function createRouter(implementation: Implementation): Router {
         .optional(),
     })
 
-  const getSourcesSourceMandateNotificationsMandateNotificationRequestBodySchema =
-    z.object({}).optional()
-
   const getSourcesSourceMandateNotificationsMandateNotificationResponseBodyValidator =
     responseValidationFactory([["200", s_source_mandate_notification]], s_error)
 
@@ -68422,11 +66156,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getSourcesSourceMandateNotificationsMandateNotificationRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -68500,10 +66230,6 @@ export function createRouter(implementation: Implementation): Router {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getSourcesSourceSourceTransactionsRequestBodySchema = z
-    .object({})
-    .optional()
-
   const getSourcesSourceSourceTransactionsResponseBodyValidator =
     responseValidationFactory(
       [
@@ -68536,11 +66262,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getSourcesSourceSourceTransactionsRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -68611,10 +66333,6 @@ export function createRouter(implementation: Implementation): Router {
         .optional(),
     })
 
-  const getSourcesSourceSourceTransactionsSourceTransactionRequestBodySchema = z
-    .object({})
-    .optional()
-
   const getSourcesSourceSourceTransactionsSourceTransactionResponseBodyValidator =
     responseValidationFactory([["200", s_source_transaction]], s_error)
 
@@ -68634,11 +66352,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getSourcesSourceSourceTransactionsSourceTransactionRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -68780,8 +66494,6 @@ export function createRouter(implementation: Implementation): Router {
     subscription: z.string().max(5000),
   })
 
-  const getSubscriptionItemsRequestBodySchema = z.object({}).optional()
-
   const getSubscriptionItemsResponseBodyValidator = responseValidationFactory(
     [
       [
@@ -68812,11 +66524,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getSubscriptionItemsRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -69074,8 +66782,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getSubscriptionItemsItemRequestBodySchema = z.object({}).optional()
-
   const getSubscriptionItemsItemResponseBodyValidator =
     responseValidationFactory([["200", s_subscription_item]], s_error)
 
@@ -69095,11 +66801,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getSubscriptionItemsItemRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -69325,8 +67027,6 @@ export function createRouter(implementation: Implementation): Router {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getSubscriptionSchedulesRequestBodySchema = z.object({}).optional()
-
   const getSubscriptionSchedulesResponseBodyValidator =
     responseValidationFactory(
       [
@@ -69358,11 +67058,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getSubscriptionSchedulesRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -69710,10 +67406,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getSubscriptionSchedulesScheduleRequestBodySchema = z
-    .object({})
-    .optional()
-
   const getSubscriptionSchedulesScheduleResponseBodyValidator =
     responseValidationFactory([["200", s_subscription_schedule]], s_error)
 
@@ -69733,11 +67425,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getSubscriptionSchedulesScheduleRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -70320,8 +68008,6 @@ export function createRouter(implementation: Implementation): Router {
     test_clock: z.string().max(5000).optional(),
   })
 
-  const getSubscriptionsRequestBodySchema = z.object({}).optional()
-
   const getSubscriptionsResponseBodyValidator = responseValidationFactory(
     [
       [
@@ -70349,11 +68035,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getSubscriptionsRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -70841,8 +68523,6 @@ export function createRouter(implementation: Implementation): Router {
     query: z.string().max(5000),
   })
 
-  const getSubscriptionsSearchRequestBodySchema = z.object({}).optional()
-
   const getSubscriptionsSearchResponseBodyValidator = responseValidationFactory(
     [
       [
@@ -70872,11 +68552,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getSubscriptionsSearchRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -71046,10 +68722,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getSubscriptionsSubscriptionExposedIdRequestBodySchema = z
-    .object({})
-    .optional()
-
   const getSubscriptionsSubscriptionExposedIdResponseBodyValidator =
     responseValidationFactory([["200", s_subscription]], s_error)
 
@@ -71069,11 +68741,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getSubscriptionsSubscriptionExposedIdRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -71602,10 +69270,6 @@ export function createRouter(implementation: Implementation): Router {
     subscription_exposed_id: z.string().max(5000),
   })
 
-  const deleteSubscriptionsSubscriptionExposedIdDiscountRequestBodySchema = z
-    .object({})
-    .optional()
-
   const deleteSubscriptionsSubscriptionExposedIdDiscountResponseBodyValidator =
     responseValidationFactory([["200", s_deleted_discount]], s_error)
 
@@ -71621,11 +69285,7 @@ export function createRouter(implementation: Implementation): Router {
             RequestInputType.RouteParam,
           ),
           query: undefined,
-          body: parseRequestInput(
-            deleteSubscriptionsSubscriptionExposedIdDiscountRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -72102,8 +69762,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getTaxCalculationsCalculationRequestBodySchema = z.object({}).optional()
-
   const getTaxCalculationsCalculationResponseBodyValidator =
     responseValidationFactory([["200", s_tax_calculation]], s_error)
 
@@ -72123,11 +69781,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getTaxCalculationsCalculationRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -72190,10 +69844,6 @@ export function createRouter(implementation: Implementation): Router {
     starting_after: z.string().max(500).optional(),
   })
 
-  const getTaxCalculationsCalculationLineItemsRequestBodySchema = z
-    .object({})
-    .optional()
-
   const getTaxCalculationsCalculationLineItemsResponseBodyValidator =
     responseValidationFactory(
       [
@@ -72229,11 +69879,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getTaxCalculationsCalculationLineItemsRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -72307,8 +69953,6 @@ export function createRouter(implementation: Implementation): Router {
     status: z.enum(["active", "all", "expired", "scheduled"]).optional(),
   })
 
-  const getTaxRegistrationsRequestBodySchema = z.object({}).optional()
-
   const getTaxRegistrationsResponseBodyValidator = responseValidationFactory(
     [
       [
@@ -72336,11 +69980,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getTaxRegistrationsRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -72852,8 +70492,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getTaxRegistrationsIdRequestBodySchema = z.object({}).optional()
-
   const getTaxRegistrationsIdResponseBodyValidator = responseValidationFactory(
     [["200", s_tax_registration]],
     s_error,
@@ -72875,11 +70513,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getTaxRegistrationsIdRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -73011,8 +70645,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getTaxSettingsRequestBodySchema = z.object({}).optional()
-
   const getTaxSettingsResponseBodyValidator = responseValidationFactory(
     [["200", s_tax_settings]],
     s_error,
@@ -73030,11 +70662,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getTaxSettingsRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -73348,8 +70976,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getTaxTransactionsTransactionRequestBodySchema = z.object({}).optional()
-
   const getTaxTransactionsTransactionResponseBodyValidator =
     responseValidationFactory([["200", s_tax_transaction]], s_error)
 
@@ -73369,11 +70995,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getTaxTransactionsTransactionRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -73436,10 +71058,6 @@ export function createRouter(implementation: Implementation): Router {
     starting_after: z.string().max(500).optional(),
   })
 
-  const getTaxTransactionsTransactionLineItemsRequestBodySchema = z
-    .object({})
-    .optional()
-
   const getTaxTransactionsTransactionLineItemsResponseBodyValidator =
     responseValidationFactory(
       [
@@ -73475,11 +71093,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getTaxTransactionsTransactionLineItemsRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -73552,8 +71166,6 @@ export function createRouter(implementation: Implementation): Router {
     starting_after: z.string().optional(),
   })
 
-  const getTaxCodesRequestBodySchema = z.object({}).optional()
-
   const getTaxCodesResponseBodyValidator = responseValidationFactory(
     [
       [
@@ -73581,11 +71193,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getTaxCodesRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -73646,8 +71254,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getTaxCodesIdRequestBodySchema = z.object({}).optional()
-
   const getTaxCodesIdResponseBodyValidator = responseValidationFactory(
     [["200", s_tax_code]],
     s_error,
@@ -73669,11 +71275,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getTaxCodesIdRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -73737,8 +71339,6 @@ export function createRouter(implementation: Implementation): Router {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getTaxIdsRequestBodySchema = z.object({}).optional()
-
   const getTaxIdsResponseBodyValidator = responseValidationFactory(
     [
       [
@@ -73766,11 +71366,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getTaxIdsRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -74008,8 +71604,6 @@ export function createRouter(implementation: Implementation): Router {
 
   const deleteTaxIdsIdParamSchema = z.object({id: z.string().max(5000)})
 
-  const deleteTaxIdsIdRequestBodySchema = z.object({}).optional()
-
   const deleteTaxIdsIdResponseBodyValidator = responseValidationFactory(
     [["200", s_deleted_tax_id]],
     s_error,
@@ -74027,11 +71621,7 @@ export function createRouter(implementation: Implementation): Router {
             RequestInputType.RouteParam,
           ),
           query: undefined,
-          body: parseRequestInput(
-            deleteTaxIdsIdRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -74087,8 +71677,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getTaxIdsIdRequestBodySchema = z.object({}).optional()
-
   const getTaxIdsIdResponseBodyValidator = responseValidationFactory(
     [["200", s_tax_id]],
     s_error,
@@ -74110,11 +71698,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getTaxIdsIdRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -74184,8 +71768,6 @@ export function createRouter(implementation: Implementation): Router {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getTaxRatesRequestBodySchema = z.object({}).optional()
-
   const getTaxRatesResponseBodyValidator = responseValidationFactory(
     [
       [
@@ -74213,11 +71795,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getTaxRatesRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -74373,8 +71951,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getTaxRatesTaxRateRequestBodySchema = z.object({}).optional()
-
   const getTaxRatesTaxRateResponseBodyValidator = responseValidationFactory(
     [["200", s_tax_rate]],
     s_error,
@@ -74396,11 +71972,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getTaxRatesTaxRateRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -74559,8 +72131,6 @@ export function createRouter(implementation: Implementation): Router {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getTerminalConfigurationsRequestBodySchema = z.object({}).optional()
-
   const getTerminalConfigurationsResponseBodyValidator =
     responseValidationFactory(
       [
@@ -74592,11 +72162,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getTerminalConfigurationsRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -74888,10 +72454,6 @@ export function createRouter(implementation: Implementation): Router {
     configuration: z.string().max(5000),
   })
 
-  const deleteTerminalConfigurationsConfigurationRequestBodySchema = z
-    .object({})
-    .optional()
-
   const deleteTerminalConfigurationsConfigurationResponseBodyValidator =
     responseValidationFactory(
       [["200", s_deleted_terminal_configuration]],
@@ -74910,11 +72472,7 @@ export function createRouter(implementation: Implementation): Router {
             RequestInputType.RouteParam,
           ),
           query: undefined,
-          body: parseRequestInput(
-            deleteTerminalConfigurationsConfigurationRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -74985,10 +72543,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getTerminalConfigurationsConfigurationRequestBodySchema = z
-    .object({})
-    .optional()
-
   const getTerminalConfigurationsConfigurationResponseBodyValidator =
     responseValidationFactory(
       [
@@ -75019,11 +72573,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getTerminalConfigurationsConfigurationRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -75451,8 +73001,6 @@ export function createRouter(implementation: Implementation): Router {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getTerminalLocationsRequestBodySchema = z.object({}).optional()
-
   const getTerminalLocationsResponseBodyValidator = responseValidationFactory(
     [
       [
@@ -75483,11 +73031,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getTerminalLocationsRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -75618,10 +73162,6 @@ export function createRouter(implementation: Implementation): Router {
     location: z.string().max(5000),
   })
 
-  const deleteTerminalLocationsLocationRequestBodySchema = z
-    .object({})
-    .optional()
-
   const deleteTerminalLocationsLocationResponseBodyValidator =
     responseValidationFactory([["200", s_deleted_terminal_location]], s_error)
 
@@ -75637,11 +73177,7 @@ export function createRouter(implementation: Implementation): Router {
             RequestInputType.RouteParam,
           ),
           query: undefined,
-          body: parseRequestInput(
-            deleteTerminalLocationsLocationRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -75701,8 +73237,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getTerminalLocationsLocationRequestBodySchema = z.object({}).optional()
-
   const getTerminalLocationsLocationResponseBodyValidator =
     responseValidationFactory(
       [["200", z.union([s_terminal_location, s_deleted_terminal_location])]],
@@ -75725,11 +73259,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getTerminalLocationsLocationRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -75902,8 +73432,6 @@ export function createRouter(implementation: Implementation): Router {
     status: z.enum(["offline", "online"]).optional(),
   })
 
-  const getTerminalReadersRequestBodySchema = z.object({}).optional()
-
   const getTerminalReadersResponseBodyValidator = responseValidationFactory(
     [
       [
@@ -75931,11 +73459,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getTerminalReadersRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -76059,8 +73583,6 @@ export function createRouter(implementation: Implementation): Router {
     reader: z.string().max(5000),
   })
 
-  const deleteTerminalReadersReaderRequestBodySchema = z.object({}).optional()
-
   const deleteTerminalReadersReaderResponseBodyValidator =
     responseValidationFactory([["200", s_deleted_terminal_reader]], s_error)
 
@@ -76076,11 +73598,7 @@ export function createRouter(implementation: Implementation): Router {
             RequestInputType.RouteParam,
           ),
           query: undefined,
-          body: parseRequestInput(
-            deleteTerminalReadersReaderRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -76140,8 +73658,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getTerminalReadersReaderRequestBodySchema = z.object({}).optional()
-
   const getTerminalReadersReaderResponseBodyValidator =
     responseValidationFactory(
       [
@@ -76169,11 +73685,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getTerminalReadersReaderRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -81048,8 +78560,6 @@ export function createRouter(implementation: Implementation): Router {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getTestHelpersTestClocksRequestBodySchema = z.object({}).optional()
-
   const getTestHelpersTestClocksResponseBodyValidator =
     responseValidationFactory(
       [
@@ -81081,11 +78591,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getTestHelpersTestClocksRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -81205,10 +78711,6 @@ export function createRouter(implementation: Implementation): Router {
     test_clock: z.string().max(5000),
   })
 
-  const deleteTestHelpersTestClocksTestClockRequestBodySchema = z
-    .object({})
-    .optional()
-
   const deleteTestHelpersTestClocksTestClockResponseBodyValidator =
     responseValidationFactory(
       [["200", s_deleted_test_helpers_test_clock]],
@@ -81227,11 +78729,7 @@ export function createRouter(implementation: Implementation): Router {
             RequestInputType.RouteParam,
           ),
           query: undefined,
-          body: parseRequestInput(
-            deleteTestHelpersTestClocksTestClockRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -81302,10 +78800,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getTestHelpersTestClocksTestClockRequestBodySchema = z
-    .object({})
-    .optional()
-
   const getTestHelpersTestClocksTestClockResponseBodyValidator =
     responseValidationFactory([["200", s_test_helpers_test_clock]], s_error)
 
@@ -81325,11 +78819,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getTestHelpersTestClocksTestClockRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -83195,8 +80685,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getTokensTokenRequestBodySchema = z.object({}).optional()
-
   const getTokensTokenResponseBodyValidator = responseValidationFactory(
     [["200", s_token]],
     s_error,
@@ -83218,11 +80706,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getTokensTokenRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -83302,8 +80786,6 @@ export function createRouter(implementation: Implementation): Router {
     status: z.enum(["canceled", "failed", "pending", "succeeded"]).optional(),
   })
 
-  const getTopupsRequestBodySchema = z.object({}).optional()
-
   const getTopupsResponseBodyValidator = responseValidationFactory(
     [
       [
@@ -83331,11 +80813,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getTopupsRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -83469,8 +80947,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getTopupsTopupRequestBodySchema = z.object({}).optional()
-
   const getTopupsTopupResponseBodyValidator = responseValidationFactory(
     [["200", s_topup]],
     s_error,
@@ -83492,11 +80968,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getTopupsTopupRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -83716,8 +81188,6 @@ export function createRouter(implementation: Implementation): Router {
     transfer_group: z.string().max(5000).optional(),
   })
 
-  const getTransfersRequestBodySchema = z.object({}).optional()
-
   const getTransfersResponseBodyValidator = responseValidationFactory(
     [
       [
@@ -83745,11 +81215,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getTransfersRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -83889,8 +81355,6 @@ export function createRouter(implementation: Implementation): Router {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getTransfersIdReversalsRequestBodySchema = z.object({}).optional()
-
   const getTransfersIdReversalsResponseBodyValidator =
     responseValidationFactory(
       [
@@ -83923,11 +81387,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getTransfersIdReversalsRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -84068,8 +81528,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getTransfersTransferRequestBodySchema = z.object({}).optional()
-
   const getTransfersTransferResponseBodyValidator = responseValidationFactory(
     [["200", s_transfer]],
     s_error,
@@ -84091,11 +81549,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getTransfersTransferRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -84232,10 +81686,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getTransfersTransferReversalsIdRequestBodySchema = z
-    .object({})
-    .optional()
-
   const getTransfersTransferReversalsIdResponseBodyValidator =
     responseValidationFactory([["200", s_transfer_reversal]], s_error)
 
@@ -84255,11 +81705,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getTransfersTransferReversalsIdRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -84399,8 +81845,6 @@ export function createRouter(implementation: Implementation): Router {
     status: z.enum(["canceled", "posted", "processing"]).optional(),
   })
 
-  const getTreasuryCreditReversalsRequestBodySchema = z.object({}).optional()
-
   const getTreasuryCreditReversalsResponseBodyValidator =
     responseValidationFactory(
       [
@@ -84429,11 +81873,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getTreasuryCreditReversalsRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -84566,10 +82006,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getTreasuryCreditReversalsCreditReversalRequestBodySchema = z
-    .object({})
-    .optional()
-
   const getTreasuryCreditReversalsCreditReversalResponseBodyValidator =
     responseValidationFactory([["200", s_treasury_credit_reversal]], s_error)
 
@@ -84589,11 +82025,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getTreasuryCreditReversalsCreditReversalRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -84665,8 +82097,6 @@ export function createRouter(implementation: Implementation): Router {
     status: z.enum(["canceled", "completed", "processing"]).optional(),
   })
 
-  const getTreasuryDebitReversalsRequestBodySchema = z.object({}).optional()
-
   const getTreasuryDebitReversalsResponseBodyValidator =
     responseValidationFactory(
       [
@@ -84695,11 +82125,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getTreasuryDebitReversalsRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -84830,10 +82256,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getTreasuryDebitReversalsDebitReversalRequestBodySchema = z
-    .object({})
-    .optional()
-
   const getTreasuryDebitReversalsDebitReversalResponseBodyValidator =
     responseValidationFactory([["200", s_treasury_debit_reversal]], s_error)
 
@@ -84853,11 +82275,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getTreasuryDebitReversalsDebitReversalRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -84937,8 +82355,6 @@ export function createRouter(implementation: Implementation): Router {
     status: z.enum(["closed", "open"]).optional(),
   })
 
-  const getTreasuryFinancialAccountsRequestBodySchema = z.object({}).optional()
-
   const getTreasuryFinancialAccountsResponseBodyValidator =
     responseValidationFactory(
       [
@@ -84970,11 +82386,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getTreasuryFinancialAccountsRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -85143,10 +82555,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getTreasuryFinancialAccountsFinancialAccountRequestBodySchema = z
-    .object({})
-    .optional()
-
   const getTreasuryFinancialAccountsFinancialAccountResponseBodyValidator =
     responseValidationFactory([["200", s_treasury_financial_account]], s_error)
 
@@ -85166,11 +82574,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getTreasuryFinancialAccountsFinancialAccountRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -85463,9 +82867,6 @@ export function createRouter(implementation: Implementation): Router {
         .optional(),
     })
 
-  const getTreasuryFinancialAccountsFinancialAccountFeaturesRequestBodySchema =
-    z.object({}).optional()
-
   const getTreasuryFinancialAccountsFinancialAccountFeaturesResponseBodyValidator =
     responseValidationFactory(
       [["200", s_treasury_financial_account_features]],
@@ -85488,11 +82889,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getTreasuryFinancialAccountsFinancialAccountFeaturesRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -85681,8 +83078,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getTreasuryInboundTransfersRequestBodySchema = z.object({}).optional()
-
   const getTreasuryInboundTransfersResponseBodyValidator =
     responseValidationFactory(
       [
@@ -85711,11 +83106,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getTreasuryInboundTransfersRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -85853,8 +83244,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getTreasuryInboundTransfersIdRequestBodySchema = z.object({}).optional()
-
   const getTreasuryInboundTransfersIdResponseBodyValidator =
     responseValidationFactory([["200", s_treasury_inbound_transfer]], s_error)
 
@@ -85874,11 +83263,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getTreasuryInboundTransfersIdRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -86036,8 +83421,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getTreasuryOutboundPaymentsRequestBodySchema = z.object({}).optional()
-
   const getTreasuryOutboundPaymentsResponseBodyValidator =
     responseValidationFactory(
       [
@@ -86069,11 +83452,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getTreasuryOutboundPaymentsRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -86261,8 +83640,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getTreasuryOutboundPaymentsIdRequestBodySchema = z.object({}).optional()
-
   const getTreasuryOutboundPaymentsIdResponseBodyValidator =
     responseValidationFactory([["200", s_treasury_outbound_payment]], s_error)
 
@@ -86282,11 +83659,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getTreasuryOutboundPaymentsIdRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -86432,8 +83805,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getTreasuryOutboundTransfersRequestBodySchema = z.object({}).optional()
-
   const getTreasuryOutboundTransfersResponseBodyValidator =
     responseValidationFactory(
       [
@@ -86462,11 +83833,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getTreasuryOutboundTransfersRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -86620,10 +83987,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getTreasuryOutboundTransfersOutboundTransferRequestBodySchema = z
-    .object({})
-    .optional()
-
   const getTreasuryOutboundTransfersOutboundTransferResponseBodyValidator =
     responseValidationFactory([["200", s_treasury_outbound_transfer]], s_error)
 
@@ -86643,11 +84006,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getTreasuryOutboundTransfersOutboundTransferRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -86810,8 +84169,6 @@ export function createRouter(implementation: Implementation): Router {
     status: z.enum(["failed", "succeeded"]).optional(),
   })
 
-  const getTreasuryReceivedCreditsRequestBodySchema = z.object({}).optional()
-
   const getTreasuryReceivedCreditsResponseBodyValidator =
     responseValidationFactory(
       [
@@ -86840,11 +84197,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getTreasuryReceivedCreditsRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -86909,8 +84262,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getTreasuryReceivedCreditsIdRequestBodySchema = z.object({}).optional()
-
   const getTreasuryReceivedCreditsIdResponseBodyValidator =
     responseValidationFactory([["200", s_treasury_received_credit]], s_error)
 
@@ -86930,11 +84281,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getTreasuryReceivedCreditsIdRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -86995,8 +84342,6 @@ export function createRouter(implementation: Implementation): Router {
     status: z.enum(["failed", "succeeded"]).optional(),
   })
 
-  const getTreasuryReceivedDebitsRequestBodySchema = z.object({}).optional()
-
   const getTreasuryReceivedDebitsResponseBodyValidator =
     responseValidationFactory(
       [
@@ -87025,11 +84370,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getTreasuryReceivedDebitsRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -87092,8 +84433,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getTreasuryReceivedDebitsIdRequestBodySchema = z.object({}).optional()
-
   const getTreasuryReceivedDebitsIdResponseBodyValidator =
     responseValidationFactory([["200", s_treasury_received_debit]], s_error)
 
@@ -87113,11 +84452,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getTreasuryReceivedDebitsIdRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -87201,8 +84536,6 @@ export function createRouter(implementation: Implementation): Router {
     transaction: z.string().max(5000).optional(),
   })
 
-  const getTreasuryTransactionEntriesRequestBodySchema = z.object({}).optional()
-
   const getTreasuryTransactionEntriesResponseBodyValidator =
     responseValidationFactory(
       [
@@ -87234,11 +84567,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getTreasuryTransactionEntriesRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -87303,10 +84632,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getTreasuryTransactionEntriesIdRequestBodySchema = z
-    .object({})
-    .optional()
-
   const getTreasuryTransactionEntriesIdResponseBodyValidator =
     responseValidationFactory([["200", s_treasury_transaction_entry]], s_error)
 
@@ -87326,11 +84651,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getTreasuryTransactionEntriesIdRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -87418,8 +84739,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getTreasuryTransactionsRequestBodySchema = z.object({}).optional()
-
   const getTreasuryTransactionsResponseBodyValidator =
     responseValidationFactory(
       [
@@ -87448,11 +84767,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getTreasuryTransactionsRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -87515,8 +84830,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getTreasuryTransactionsIdRequestBodySchema = z.object({}).optional()
-
   const getTreasuryTransactionsIdResponseBodyValidator =
     responseValidationFactory([["200", s_treasury_transaction]], s_error)
 
@@ -87536,11 +84849,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getTreasuryTransactionsIdRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -87597,8 +84906,6 @@ export function createRouter(implementation: Implementation): Router {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getWebhookEndpointsRequestBodySchema = z.object({}).optional()
-
   const getWebhookEndpointsResponseBodyValidator = responseValidationFactory(
     [
       [
@@ -87626,11 +84933,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getWebhookEndpointsRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -88118,10 +85421,6 @@ export function createRouter(implementation: Implementation): Router {
     webhook_endpoint: z.string().max(5000),
   })
 
-  const deleteWebhookEndpointsWebhookEndpointRequestBodySchema = z
-    .object({})
-    .optional()
-
   const deleteWebhookEndpointsWebhookEndpointResponseBodyValidator =
     responseValidationFactory([["200", s_deleted_webhook_endpoint]], s_error)
 
@@ -88137,11 +85436,7 @@ export function createRouter(implementation: Implementation): Router {
             RequestInputType.RouteParam,
           ),
           query: undefined,
-          body: parseRequestInput(
-            deleteWebhookEndpointsWebhookEndpointRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 
@@ -88210,10 +85505,6 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
   })
 
-  const getWebhookEndpointsWebhookEndpointRequestBodySchema = z
-    .object({})
-    .optional()
-
   const getWebhookEndpointsWebhookEndpointResponseBodyValidator =
     responseValidationFactory([["200", s_webhook_endpoint]], s_error)
 
@@ -88233,11 +85524,7 @@ export function createRouter(implementation: Implementation): Router {
             req.query,
             RequestInputType.QueryString,
           ),
-          body: parseRequestInput(
-            getWebhookEndpointsWebhookEndpointRequestBodySchema,
-            req.body,
-            RequestInputType.RequestBody,
-          ),
+          body: undefined,
           headers: undefined,
         }
 

--- a/integration-tests/typescript-express/src/generated/stripe.yaml/models.ts
+++ b/integration-tests/typescript-express/src/generated/stripe.yaml/models.ts
@@ -15609,54 +15609,37 @@ export type t_DeleteAccountsAccountParamSchema = {
   account: string
 }
 
-export type t_DeleteAccountsAccountRequestBodySchema = EmptyObject
-
 export type t_DeleteAccountsAccountBankAccountsIdParamSchema = {
   account: string
   id: string
 }
-
-export type t_DeleteAccountsAccountBankAccountsIdRequestBodySchema = EmptyObject
 
 export type t_DeleteAccountsAccountExternalAccountsIdParamSchema = {
   account: string
   id: string
 }
 
-export type t_DeleteAccountsAccountExternalAccountsIdRequestBodySchema =
-  EmptyObject
-
 export type t_DeleteAccountsAccountPeoplePersonParamSchema = {
   account: string
   person: string
 }
-
-export type t_DeleteAccountsAccountPeoplePersonRequestBodySchema = EmptyObject
 
 export type t_DeleteAccountsAccountPersonsPersonParamSchema = {
   account: string
   person: string
 }
 
-export type t_DeleteAccountsAccountPersonsPersonRequestBodySchema = EmptyObject
-
 export type t_DeleteApplePayDomainsDomainParamSchema = {
   domain: string
 }
-
-export type t_DeleteApplePayDomainsDomainRequestBodySchema = EmptyObject
 
 export type t_DeleteCouponsCouponParamSchema = {
   coupon: string
 }
 
-export type t_DeleteCouponsCouponRequestBodySchema = EmptyObject
-
 export type t_DeleteCustomersCustomerParamSchema = {
   customer: string
 }
-
-export type t_DeleteCustomersCustomerRequestBodySchema = EmptyObject
 
 export type t_DeleteCustomersCustomerBankAccountsIdParamSchema = {
   customer: string
@@ -15679,8 +15662,6 @@ export type t_DeleteCustomersCustomerCardsIdRequestBodySchema = {
 export type t_DeleteCustomersCustomerDiscountParamSchema = {
   customer: string
 }
-
-export type t_DeleteCustomersCustomerDiscountRequestBodySchema = EmptyObject
 
 export type t_DeleteCustomersCustomerSourcesIdParamSchema = {
   customer: string
@@ -15710,15 +15691,10 @@ export type t_DeleteCustomersCustomerSubscriptionsSubscriptionExposedIdDiscountP
     subscription_exposed_id: string
   }
 
-export type t_DeleteCustomersCustomerSubscriptionsSubscriptionExposedIdDiscountRequestBodySchema =
-  EmptyObject
-
 export type t_DeleteCustomersCustomerTaxIdsIdParamSchema = {
   customer: string
   id: string
 }
-
-export type t_DeleteCustomersCustomerTaxIdsIdRequestBodySchema = EmptyObject
 
 export type t_DeleteEphemeralKeysKeyParamSchema = {
   key: string
@@ -15732,44 +15708,30 @@ export type t_DeleteInvoiceitemsInvoiceitemParamSchema = {
   invoiceitem: string
 }
 
-export type t_DeleteInvoiceitemsInvoiceitemRequestBodySchema = EmptyObject
-
 export type t_DeleteInvoicesInvoiceParamSchema = {
   invoice: string
 }
-
-export type t_DeleteInvoicesInvoiceRequestBodySchema = EmptyObject
 
 export type t_DeletePlansPlanParamSchema = {
   plan: string
 }
 
-export type t_DeletePlansPlanRequestBodySchema = EmptyObject
-
 export type t_DeleteProductsIdParamSchema = {
   id: string
 }
-
-export type t_DeleteProductsIdRequestBodySchema = EmptyObject
 
 export type t_DeleteProductsProductFeaturesIdParamSchema = {
   id: string
   product: string
 }
 
-export type t_DeleteProductsProductFeaturesIdRequestBodySchema = EmptyObject
-
 export type t_DeleteRadarValueListItemsItemParamSchema = {
   item: string
 }
 
-export type t_DeleteRadarValueListItemsItemRequestBodySchema = EmptyObject
-
 export type t_DeleteRadarValueListsValueListParamSchema = {
   value_list: string
 }
-
-export type t_DeleteRadarValueListsValueListRequestBodySchema = EmptyObject
 
 export type t_DeleteSubscriptionItemsItemParamSchema = {
   item: string
@@ -15815,53 +15777,33 @@ export type t_DeleteSubscriptionsSubscriptionExposedIdDiscountParamSchema = {
   subscription_exposed_id: string
 }
 
-export type t_DeleteSubscriptionsSubscriptionExposedIdDiscountRequestBodySchema =
-  EmptyObject
-
 export type t_DeleteTaxIdsIdParamSchema = {
   id: string
 }
-
-export type t_DeleteTaxIdsIdRequestBodySchema = EmptyObject
 
 export type t_DeleteTerminalConfigurationsConfigurationParamSchema = {
   configuration: string
 }
 
-export type t_DeleteTerminalConfigurationsConfigurationRequestBodySchema =
-  EmptyObject
-
 export type t_DeleteTerminalLocationsLocationParamSchema = {
   location: string
 }
-
-export type t_DeleteTerminalLocationsLocationRequestBodySchema = EmptyObject
 
 export type t_DeleteTerminalReadersReaderParamSchema = {
   reader: string
 }
 
-export type t_DeleteTerminalReadersReaderRequestBodySchema = EmptyObject
-
 export type t_DeleteTestHelpersTestClocksTestClockParamSchema = {
   test_clock: string
 }
-
-export type t_DeleteTestHelpersTestClocksTestClockRequestBodySchema =
-  EmptyObject
 
 export type t_DeleteWebhookEndpointsWebhookEndpointParamSchema = {
   webhook_endpoint: string
 }
 
-export type t_DeleteWebhookEndpointsWebhookEndpointRequestBodySchema =
-  EmptyObject
-
 export type t_GetAccountQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetAccountRequestBodySchema = EmptyObject
 
 export type t_GetAccountsQuerySchema = {
   created?:
@@ -15881,8 +15823,6 @@ export type t_GetAccountsQuerySchema = {
   starting_after?: string | undefined
 }
 
-export type t_GetAccountsRequestBodySchema = EmptyObject
-
 export type t_GetAccountsAccountParamSchema = {
   account: string
 }
@@ -15890,8 +15830,6 @@ export type t_GetAccountsAccountParamSchema = {
 export type t_GetAccountsAccountQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetAccountsAccountRequestBodySchema = EmptyObject
 
 export type t_GetAccountsAccountBankAccountsIdParamSchema = {
   account: string
@@ -15902,8 +15840,6 @@ export type t_GetAccountsAccountBankAccountsIdQuerySchema = {
   expand?: string[] | undefined
 }
 
-export type t_GetAccountsAccountBankAccountsIdRequestBodySchema = EmptyObject
-
 export type t_GetAccountsAccountCapabilitiesParamSchema = {
   account: string
 }
@@ -15911,8 +15847,6 @@ export type t_GetAccountsAccountCapabilitiesParamSchema = {
 export type t_GetAccountsAccountCapabilitiesQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetAccountsAccountCapabilitiesRequestBodySchema = EmptyObject
 
 export type t_GetAccountsAccountCapabilitiesCapabilityParamSchema = {
   account: string
@@ -15922,9 +15856,6 @@ export type t_GetAccountsAccountCapabilitiesCapabilityParamSchema = {
 export type t_GetAccountsAccountCapabilitiesCapabilityQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetAccountsAccountCapabilitiesCapabilityRequestBodySchema =
-  EmptyObject
 
 export type t_GetAccountsAccountExternalAccountsParamSchema = {
   account: string
@@ -15938,8 +15869,6 @@ export type t_GetAccountsAccountExternalAccountsQuerySchema = {
   starting_after?: string | undefined
 }
 
-export type t_GetAccountsAccountExternalAccountsRequestBodySchema = EmptyObject
-
 export type t_GetAccountsAccountExternalAccountsIdParamSchema = {
   account: string
   id: string
@@ -15948,9 +15877,6 @@ export type t_GetAccountsAccountExternalAccountsIdParamSchema = {
 export type t_GetAccountsAccountExternalAccountsIdQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetAccountsAccountExternalAccountsIdRequestBodySchema =
-  EmptyObject
 
 export type t_GetAccountsAccountPeopleParamSchema = {
   account: string
@@ -15973,8 +15899,6 @@ export type t_GetAccountsAccountPeopleQuerySchema = {
   starting_after?: string | undefined
 }
 
-export type t_GetAccountsAccountPeopleRequestBodySchema = EmptyObject
-
 export type t_GetAccountsAccountPeoplePersonParamSchema = {
   account: string
   person: string
@@ -15983,8 +15907,6 @@ export type t_GetAccountsAccountPeoplePersonParamSchema = {
 export type t_GetAccountsAccountPeoplePersonQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetAccountsAccountPeoplePersonRequestBodySchema = EmptyObject
 
 export type t_GetAccountsAccountPersonsParamSchema = {
   account: string
@@ -16007,8 +15929,6 @@ export type t_GetAccountsAccountPersonsQuerySchema = {
   starting_after?: string | undefined
 }
 
-export type t_GetAccountsAccountPersonsRequestBodySchema = EmptyObject
-
 export type t_GetAccountsAccountPersonsPersonParamSchema = {
   account: string
   person: string
@@ -16018,8 +15938,6 @@ export type t_GetAccountsAccountPersonsPersonQuerySchema = {
   expand?: string[] | undefined
 }
 
-export type t_GetAccountsAccountPersonsPersonRequestBodySchema = EmptyObject
-
 export type t_GetApplePayDomainsQuerySchema = {
   domain_name?: string | undefined
   ending_before?: string | undefined
@@ -16028,8 +15946,6 @@ export type t_GetApplePayDomainsQuerySchema = {
   starting_after?: string | undefined
 }
 
-export type t_GetApplePayDomainsRequestBodySchema = EmptyObject
-
 export type t_GetApplePayDomainsDomainParamSchema = {
   domain: string
 }
@@ -16037,8 +15953,6 @@ export type t_GetApplePayDomainsDomainParamSchema = {
 export type t_GetApplePayDomainsDomainQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetApplePayDomainsDomainRequestBodySchema = EmptyObject
 
 export type t_GetApplicationFeesQuerySchema = {
   charge?: string | undefined
@@ -16059,8 +15973,6 @@ export type t_GetApplicationFeesQuerySchema = {
   starting_after?: string | undefined
 }
 
-export type t_GetApplicationFeesRequestBodySchema = EmptyObject
-
 export type t_GetApplicationFeesFeeRefundsIdParamSchema = {
   fee: string
   id: string
@@ -16070,8 +15982,6 @@ export type t_GetApplicationFeesFeeRefundsIdQuerySchema = {
   expand?: string[] | undefined
 }
 
-export type t_GetApplicationFeesFeeRefundsIdRequestBodySchema = EmptyObject
-
 export type t_GetApplicationFeesIdParamSchema = {
   id: string
 }
@@ -16079,8 +15989,6 @@ export type t_GetApplicationFeesIdParamSchema = {
 export type t_GetApplicationFeesIdQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetApplicationFeesIdRequestBodySchema = EmptyObject
 
 export type t_GetApplicationFeesIdRefundsParamSchema = {
   id: string
@@ -16093,8 +16001,6 @@ export type t_GetApplicationFeesIdRefundsQuerySchema = {
   starting_after?: string | undefined
 }
 
-export type t_GetApplicationFeesIdRefundsRequestBodySchema = EmptyObject
-
 export type t_GetAppsSecretsQuerySchema = {
   ending_before?: string | undefined
   expand?: string[] | undefined
@@ -16106,8 +16012,6 @@ export type t_GetAppsSecretsQuerySchema = {
   starting_after?: string | undefined
 }
 
-export type t_GetAppsSecretsRequestBodySchema = EmptyObject
-
 export type t_GetAppsSecretsFindQuerySchema = {
   expand?: string[] | undefined
   name: string
@@ -16117,13 +16021,9 @@ export type t_GetAppsSecretsFindQuerySchema = {
   }
 }
 
-export type t_GetAppsSecretsFindRequestBodySchema = EmptyObject
-
 export type t_GetBalanceQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetBalanceRequestBodySchema = EmptyObject
 
 export type t_GetBalanceHistoryQuerySchema = {
   created?:
@@ -16147,8 +16047,6 @@ export type t_GetBalanceHistoryQuerySchema = {
   type?: string | undefined
 }
 
-export type t_GetBalanceHistoryRequestBodySchema = EmptyObject
-
 export type t_GetBalanceHistoryIdParamSchema = {
   id: string
 }
@@ -16156,8 +16054,6 @@ export type t_GetBalanceHistoryIdParamSchema = {
 export type t_GetBalanceHistoryIdQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetBalanceHistoryIdRequestBodySchema = EmptyObject
 
 export type t_GetBalanceTransactionsQuerySchema = {
   created?:
@@ -16181,8 +16077,6 @@ export type t_GetBalanceTransactionsQuerySchema = {
   type?: string | undefined
 }
 
-export type t_GetBalanceTransactionsRequestBodySchema = EmptyObject
-
 export type t_GetBalanceTransactionsIdParamSchema = {
   id: string
 }
@@ -16190,8 +16084,6 @@ export type t_GetBalanceTransactionsIdParamSchema = {
 export type t_GetBalanceTransactionsIdQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetBalanceTransactionsIdRequestBodySchema = EmptyObject
 
 export type t_GetBillingAlertsQuerySchema = {
   alert_type?: "usage_threshold" | undefined
@@ -16202,8 +16094,6 @@ export type t_GetBillingAlertsQuerySchema = {
   starting_after?: string | undefined
 }
 
-export type t_GetBillingAlertsRequestBodySchema = EmptyObject
-
 export type t_GetBillingAlertsIdParamSchema = {
   id: string
 }
@@ -16211,8 +16101,6 @@ export type t_GetBillingAlertsIdParamSchema = {
 export type t_GetBillingAlertsIdQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetBillingAlertsIdRequestBodySchema = EmptyObject
 
 export type t_GetBillingCreditBalanceSummaryQuerySchema = {
   customer: string
@@ -16233,8 +16121,6 @@ export type t_GetBillingCreditBalanceSummaryQuerySchema = {
   }
 }
 
-export type t_GetBillingCreditBalanceSummaryRequestBodySchema = EmptyObject
-
 export type t_GetBillingCreditBalanceTransactionsQuerySchema = {
   credit_grant?: string | undefined
   customer: string
@@ -16244,8 +16130,6 @@ export type t_GetBillingCreditBalanceTransactionsQuerySchema = {
   starting_after?: string | undefined
 }
 
-export type t_GetBillingCreditBalanceTransactionsRequestBodySchema = EmptyObject
-
 export type t_GetBillingCreditBalanceTransactionsIdParamSchema = {
   id: string
 }
@@ -16253,9 +16137,6 @@ export type t_GetBillingCreditBalanceTransactionsIdParamSchema = {
 export type t_GetBillingCreditBalanceTransactionsIdQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetBillingCreditBalanceTransactionsIdRequestBodySchema =
-  EmptyObject
 
 export type t_GetBillingCreditGrantsQuerySchema = {
   customer?: string | undefined
@@ -16265,8 +16146,6 @@ export type t_GetBillingCreditGrantsQuerySchema = {
   starting_after?: string | undefined
 }
 
-export type t_GetBillingCreditGrantsRequestBodySchema = EmptyObject
-
 export type t_GetBillingCreditGrantsIdParamSchema = {
   id: string
 }
@@ -16274,8 +16153,6 @@ export type t_GetBillingCreditGrantsIdParamSchema = {
 export type t_GetBillingCreditGrantsIdQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetBillingCreditGrantsIdRequestBodySchema = EmptyObject
 
 export type t_GetBillingMetersQuerySchema = {
   ending_before?: string | undefined
@@ -16285,8 +16162,6 @@ export type t_GetBillingMetersQuerySchema = {
   status?: ("active" | "inactive") | undefined
 }
 
-export type t_GetBillingMetersRequestBodySchema = EmptyObject
-
 export type t_GetBillingMetersIdParamSchema = {
   id: string
 }
@@ -16294,8 +16169,6 @@ export type t_GetBillingMetersIdParamSchema = {
 export type t_GetBillingMetersIdQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetBillingMetersIdRequestBodySchema = EmptyObject
 
 export type t_GetBillingMetersIdEventSummariesParamSchema = {
   id: string
@@ -16312,8 +16185,6 @@ export type t_GetBillingMetersIdEventSummariesQuerySchema = {
   value_grouping_window?: ("day" | "hour") | undefined
 }
 
-export type t_GetBillingMetersIdEventSummariesRequestBodySchema = EmptyObject
-
 export type t_GetBillingPortalConfigurationsQuerySchema = {
   active?: boolean | undefined
   ending_before?: string | undefined
@@ -16323,8 +16194,6 @@ export type t_GetBillingPortalConfigurationsQuerySchema = {
   starting_after?: string | undefined
 }
 
-export type t_GetBillingPortalConfigurationsRequestBodySchema = EmptyObject
-
 export type t_GetBillingPortalConfigurationsConfigurationParamSchema = {
   configuration: string
 }
@@ -16332,9 +16201,6 @@ export type t_GetBillingPortalConfigurationsConfigurationParamSchema = {
 export type t_GetBillingPortalConfigurationsConfigurationQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetBillingPortalConfigurationsConfigurationRequestBodySchema =
-  EmptyObject
 
 export type t_GetChargesQuerySchema = {
   created?:
@@ -16357,8 +16223,6 @@ export type t_GetChargesQuerySchema = {
   transfer_group?: string | undefined
 }
 
-export type t_GetChargesRequestBodySchema = EmptyObject
-
 export type t_GetChargesChargeParamSchema = {
   charge: string
 }
@@ -16367,8 +16231,6 @@ export type t_GetChargesChargeQuerySchema = {
   expand?: string[] | undefined
 }
 
-export type t_GetChargesChargeRequestBodySchema = EmptyObject
-
 export type t_GetChargesChargeDisputeParamSchema = {
   charge: string
 }
@@ -16376,8 +16238,6 @@ export type t_GetChargesChargeDisputeParamSchema = {
 export type t_GetChargesChargeDisputeQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetChargesChargeDisputeRequestBodySchema = EmptyObject
 
 export type t_GetChargesChargeRefundsParamSchema = {
   charge: string
@@ -16390,8 +16250,6 @@ export type t_GetChargesChargeRefundsQuerySchema = {
   starting_after?: string | undefined
 }
 
-export type t_GetChargesChargeRefundsRequestBodySchema = EmptyObject
-
 export type t_GetChargesChargeRefundsRefundParamSchema = {
   charge: string
   refund: string
@@ -16401,16 +16259,12 @@ export type t_GetChargesChargeRefundsRefundQuerySchema = {
   expand?: string[] | undefined
 }
 
-export type t_GetChargesChargeRefundsRefundRequestBodySchema = EmptyObject
-
 export type t_GetChargesSearchQuerySchema = {
   expand?: string[] | undefined
   limit?: number | undefined
   page?: string | undefined
   query: string
 }
-
-export type t_GetChargesSearchRequestBodySchema = EmptyObject
 
 export type t_GetCheckoutSessionsQuerySchema = {
   created?:
@@ -16440,8 +16294,6 @@ export type t_GetCheckoutSessionsQuerySchema = {
   subscription?: string | undefined
 }
 
-export type t_GetCheckoutSessionsRequestBodySchema = EmptyObject
-
 export type t_GetCheckoutSessionsSessionParamSchema = {
   session: string
 }
@@ -16449,8 +16301,6 @@ export type t_GetCheckoutSessionsSessionParamSchema = {
 export type t_GetCheckoutSessionsSessionQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetCheckoutSessionsSessionRequestBodySchema = EmptyObject
 
 export type t_GetCheckoutSessionsSessionLineItemsParamSchema = {
   session: string
@@ -16463,16 +16313,12 @@ export type t_GetCheckoutSessionsSessionLineItemsQuerySchema = {
   starting_after?: string | undefined
 }
 
-export type t_GetCheckoutSessionsSessionLineItemsRequestBodySchema = EmptyObject
-
 export type t_GetClimateOrdersQuerySchema = {
   ending_before?: string | undefined
   expand?: string[] | undefined
   limit?: number | undefined
   starting_after?: string | undefined
 }
-
-export type t_GetClimateOrdersRequestBodySchema = EmptyObject
 
 export type t_GetClimateOrdersOrderParamSchema = {
   order: string
@@ -16482,16 +16328,12 @@ export type t_GetClimateOrdersOrderQuerySchema = {
   expand?: string[] | undefined
 }
 
-export type t_GetClimateOrdersOrderRequestBodySchema = EmptyObject
-
 export type t_GetClimateProductsQuerySchema = {
   ending_before?: string | undefined
   expand?: string[] | undefined
   limit?: number | undefined
   starting_after?: string | undefined
 }
-
-export type t_GetClimateProductsRequestBodySchema = EmptyObject
 
 export type t_GetClimateProductsProductParamSchema = {
   product: string
@@ -16501,16 +16343,12 @@ export type t_GetClimateProductsProductQuerySchema = {
   expand?: string[] | undefined
 }
 
-export type t_GetClimateProductsProductRequestBodySchema = EmptyObject
-
 export type t_GetClimateSuppliersQuerySchema = {
   ending_before?: string | undefined
   expand?: string[] | undefined
   limit?: number | undefined
   starting_after?: string | undefined
 }
-
-export type t_GetClimateSuppliersRequestBodySchema = EmptyObject
 
 export type t_GetClimateSuppliersSupplierParamSchema = {
   supplier: string
@@ -16520,8 +16358,6 @@ export type t_GetClimateSuppliersSupplierQuerySchema = {
   expand?: string[] | undefined
 }
 
-export type t_GetClimateSuppliersSupplierRequestBodySchema = EmptyObject
-
 export type t_GetConfirmationTokensConfirmationTokenParamSchema = {
   confirmation_token: string
 }
@@ -16530,17 +16366,12 @@ export type t_GetConfirmationTokensConfirmationTokenQuerySchema = {
   expand?: string[] | undefined
 }
 
-export type t_GetConfirmationTokensConfirmationTokenRequestBodySchema =
-  EmptyObject
-
 export type t_GetCountrySpecsQuerySchema = {
   ending_before?: string | undefined
   expand?: string[] | undefined
   limit?: number | undefined
   starting_after?: string | undefined
 }
-
-export type t_GetCountrySpecsRequestBodySchema = EmptyObject
 
 export type t_GetCountrySpecsCountryParamSchema = {
   country: string
@@ -16549,8 +16380,6 @@ export type t_GetCountrySpecsCountryParamSchema = {
 export type t_GetCountrySpecsCountryQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetCountrySpecsCountryRequestBodySchema = EmptyObject
 
 export type t_GetCouponsQuerySchema = {
   created?:
@@ -16570,8 +16399,6 @@ export type t_GetCouponsQuerySchema = {
   starting_after?: string | undefined
 }
 
-export type t_GetCouponsRequestBodySchema = EmptyObject
-
 export type t_GetCouponsCouponParamSchema = {
   coupon: string
 }
@@ -16579,8 +16406,6 @@ export type t_GetCouponsCouponParamSchema = {
 export type t_GetCouponsCouponQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetCouponsCouponRequestBodySchema = EmptyObject
 
 export type t_GetCreditNotesQuerySchema = {
   created?:
@@ -16602,8 +16427,6 @@ export type t_GetCreditNotesQuerySchema = {
   starting_after?: string | undefined
 }
 
-export type t_GetCreditNotesRequestBodySchema = EmptyObject
-
 export type t_GetCreditNotesCreditNoteLinesParamSchema = {
   credit_note: string
 }
@@ -16615,8 +16438,6 @@ export type t_GetCreditNotesCreditNoteLinesQuerySchema = {
   starting_after?: string | undefined
 }
 
-export type t_GetCreditNotesCreditNoteLinesRequestBodySchema = EmptyObject
-
 export type t_GetCreditNotesIdParamSchema = {
   id: string
 }
@@ -16624,8 +16445,6 @@ export type t_GetCreditNotesIdParamSchema = {
 export type t_GetCreditNotesIdQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetCreditNotesIdRequestBodySchema = EmptyObject
 
 export type t_GetCreditNotesPreviewQuerySchema = {
   amount?: number | undefined
@@ -16679,8 +16498,6 @@ export type t_GetCreditNotesPreviewQuerySchema = {
       }
     | undefined
 }
-
-export type t_GetCreditNotesPreviewRequestBodySchema = EmptyObject
 
 export type t_GetCreditNotesPreviewLinesQuerySchema = {
   amount?: number | undefined
@@ -16738,8 +16555,6 @@ export type t_GetCreditNotesPreviewLinesQuerySchema = {
   starting_after?: string | undefined
 }
 
-export type t_GetCreditNotesPreviewLinesRequestBodySchema = EmptyObject
-
 export type t_GetCustomersQuerySchema = {
   created?:
     | (
@@ -16760,8 +16575,6 @@ export type t_GetCustomersQuerySchema = {
   test_clock?: string | undefined
 }
 
-export type t_GetCustomersRequestBodySchema = EmptyObject
-
 export type t_GetCustomersCustomerParamSchema = {
   customer: string
 }
@@ -16769,8 +16582,6 @@ export type t_GetCustomersCustomerParamSchema = {
 export type t_GetCustomersCustomerQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetCustomersCustomerRequestBodySchema = EmptyObject
 
 export type t_GetCustomersCustomerBalanceTransactionsParamSchema = {
   customer: string
@@ -16783,9 +16594,6 @@ export type t_GetCustomersCustomerBalanceTransactionsQuerySchema = {
   starting_after?: string | undefined
 }
 
-export type t_GetCustomersCustomerBalanceTransactionsRequestBodySchema =
-  EmptyObject
-
 export type t_GetCustomersCustomerBalanceTransactionsTransactionParamSchema = {
   customer: string
   transaction: string
@@ -16794,9 +16602,6 @@ export type t_GetCustomersCustomerBalanceTransactionsTransactionParamSchema = {
 export type t_GetCustomersCustomerBalanceTransactionsTransactionQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetCustomersCustomerBalanceTransactionsTransactionRequestBodySchema =
-  EmptyObject
 
 export type t_GetCustomersCustomerBankAccountsParamSchema = {
   customer: string
@@ -16809,8 +16614,6 @@ export type t_GetCustomersCustomerBankAccountsQuerySchema = {
   starting_after?: string | undefined
 }
 
-export type t_GetCustomersCustomerBankAccountsRequestBodySchema = EmptyObject
-
 export type t_GetCustomersCustomerBankAccountsIdParamSchema = {
   customer: string
   id: string
@@ -16819,8 +16622,6 @@ export type t_GetCustomersCustomerBankAccountsIdParamSchema = {
 export type t_GetCustomersCustomerBankAccountsIdQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetCustomersCustomerBankAccountsIdRequestBodySchema = EmptyObject
 
 export type t_GetCustomersCustomerCardsParamSchema = {
   customer: string
@@ -16833,8 +16634,6 @@ export type t_GetCustomersCustomerCardsQuerySchema = {
   starting_after?: string | undefined
 }
 
-export type t_GetCustomersCustomerCardsRequestBodySchema = EmptyObject
-
 export type t_GetCustomersCustomerCardsIdParamSchema = {
   customer: string
   id: string
@@ -16844,8 +16643,6 @@ export type t_GetCustomersCustomerCardsIdQuerySchema = {
   expand?: string[] | undefined
 }
 
-export type t_GetCustomersCustomerCardsIdRequestBodySchema = EmptyObject
-
 export type t_GetCustomersCustomerCashBalanceParamSchema = {
   customer: string
 }
@@ -16853,8 +16650,6 @@ export type t_GetCustomersCustomerCashBalanceParamSchema = {
 export type t_GetCustomersCustomerCashBalanceQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetCustomersCustomerCashBalanceRequestBodySchema = EmptyObject
 
 export type t_GetCustomersCustomerCashBalanceTransactionsParamSchema = {
   customer: string
@@ -16867,9 +16662,6 @@ export type t_GetCustomersCustomerCashBalanceTransactionsQuerySchema = {
   starting_after?: string | undefined
 }
 
-export type t_GetCustomersCustomerCashBalanceTransactionsRequestBodySchema =
-  EmptyObject
-
 export type t_GetCustomersCustomerCashBalanceTransactionsTransactionParamSchema =
   {
     customer: string
@@ -16881,9 +16673,6 @@ export type t_GetCustomersCustomerCashBalanceTransactionsTransactionQuerySchema 
     expand?: string[] | undefined
   }
 
-export type t_GetCustomersCustomerCashBalanceTransactionsTransactionRequestBodySchema =
-  EmptyObject
-
 export type t_GetCustomersCustomerDiscountParamSchema = {
   customer: string
 }
@@ -16891,8 +16680,6 @@ export type t_GetCustomersCustomerDiscountParamSchema = {
 export type t_GetCustomersCustomerDiscountQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetCustomersCustomerDiscountRequestBodySchema = EmptyObject
 
 export type t_GetCustomersCustomerPaymentMethodsParamSchema = {
   customer: string
@@ -16958,8 +16745,6 @@ export type t_GetCustomersCustomerPaymentMethodsQuerySchema = {
     | undefined
 }
 
-export type t_GetCustomersCustomerPaymentMethodsRequestBodySchema = EmptyObject
-
 export type t_GetCustomersCustomerPaymentMethodsPaymentMethodParamSchema = {
   customer: string
   payment_method: string
@@ -16968,9 +16753,6 @@ export type t_GetCustomersCustomerPaymentMethodsPaymentMethodParamSchema = {
 export type t_GetCustomersCustomerPaymentMethodsPaymentMethodQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetCustomersCustomerPaymentMethodsPaymentMethodRequestBodySchema =
-  EmptyObject
 
 export type t_GetCustomersCustomerSourcesParamSchema = {
   customer: string
@@ -16984,8 +16766,6 @@ export type t_GetCustomersCustomerSourcesQuerySchema = {
   starting_after?: string | undefined
 }
 
-export type t_GetCustomersCustomerSourcesRequestBodySchema = EmptyObject
-
 export type t_GetCustomersCustomerSourcesIdParamSchema = {
   customer: string
   id: string
@@ -16994,8 +16774,6 @@ export type t_GetCustomersCustomerSourcesIdParamSchema = {
 export type t_GetCustomersCustomerSourcesIdQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetCustomersCustomerSourcesIdRequestBodySchema = EmptyObject
 
 export type t_GetCustomersCustomerSubscriptionsParamSchema = {
   customer: string
@@ -17008,8 +16786,6 @@ export type t_GetCustomersCustomerSubscriptionsQuerySchema = {
   starting_after?: string | undefined
 }
 
-export type t_GetCustomersCustomerSubscriptionsRequestBodySchema = EmptyObject
-
 export type t_GetCustomersCustomerSubscriptionsSubscriptionExposedIdParamSchema =
   {
     customer: string
@@ -17020,9 +16796,6 @@ export type t_GetCustomersCustomerSubscriptionsSubscriptionExposedIdQuerySchema 
   {
     expand?: string[] | undefined
   }
-
-export type t_GetCustomersCustomerSubscriptionsSubscriptionExposedIdRequestBodySchema =
-  EmptyObject
 
 export type t_GetCustomersCustomerSubscriptionsSubscriptionExposedIdDiscountParamSchema =
   {
@@ -17035,9 +16808,6 @@ export type t_GetCustomersCustomerSubscriptionsSubscriptionExposedIdDiscountQuer
     expand?: string[] | undefined
   }
 
-export type t_GetCustomersCustomerSubscriptionsSubscriptionExposedIdDiscountRequestBodySchema =
-  EmptyObject
-
 export type t_GetCustomersCustomerTaxIdsParamSchema = {
   customer: string
 }
@@ -17049,8 +16819,6 @@ export type t_GetCustomersCustomerTaxIdsQuerySchema = {
   starting_after?: string | undefined
 }
 
-export type t_GetCustomersCustomerTaxIdsRequestBodySchema = EmptyObject
-
 export type t_GetCustomersCustomerTaxIdsIdParamSchema = {
   customer: string
   id: string
@@ -17060,16 +16828,12 @@ export type t_GetCustomersCustomerTaxIdsIdQuerySchema = {
   expand?: string[] | undefined
 }
 
-export type t_GetCustomersCustomerTaxIdsIdRequestBodySchema = EmptyObject
-
 export type t_GetCustomersSearchQuerySchema = {
   expand?: string[] | undefined
   limit?: number | undefined
   page?: string | undefined
   query: string
 }
-
-export type t_GetCustomersSearchRequestBodySchema = EmptyObject
 
 export type t_GetDisputesQuerySchema = {
   charge?: string | undefined
@@ -17091,8 +16855,6 @@ export type t_GetDisputesQuerySchema = {
   starting_after?: string | undefined
 }
 
-export type t_GetDisputesRequestBodySchema = EmptyObject
-
 export type t_GetDisputesDisputeParamSchema = {
   dispute: string
 }
@@ -17100,8 +16862,6 @@ export type t_GetDisputesDisputeParamSchema = {
 export type t_GetDisputesDisputeQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetDisputesDisputeRequestBodySchema = EmptyObject
 
 export type t_GetEntitlementsActiveEntitlementsQuerySchema = {
   customer: string
@@ -17111,8 +16871,6 @@ export type t_GetEntitlementsActiveEntitlementsQuerySchema = {
   starting_after?: string | undefined
 }
 
-export type t_GetEntitlementsActiveEntitlementsRequestBodySchema = EmptyObject
-
 export type t_GetEntitlementsActiveEntitlementsIdParamSchema = {
   id: string
 }
@@ -17120,8 +16878,6 @@ export type t_GetEntitlementsActiveEntitlementsIdParamSchema = {
 export type t_GetEntitlementsActiveEntitlementsIdQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetEntitlementsActiveEntitlementsIdRequestBodySchema = EmptyObject
 
 export type t_GetEntitlementsFeaturesQuerySchema = {
   archived?: boolean | undefined
@@ -17132,8 +16888,6 @@ export type t_GetEntitlementsFeaturesQuerySchema = {
   starting_after?: string | undefined
 }
 
-export type t_GetEntitlementsFeaturesRequestBodySchema = EmptyObject
-
 export type t_GetEntitlementsFeaturesIdParamSchema = {
   id: string
 }
@@ -17141,8 +16895,6 @@ export type t_GetEntitlementsFeaturesIdParamSchema = {
 export type t_GetEntitlementsFeaturesIdQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetEntitlementsFeaturesIdRequestBodySchema = EmptyObject
 
 export type t_GetEventsQuerySchema = {
   created?:
@@ -17165,8 +16917,6 @@ export type t_GetEventsQuerySchema = {
   types?: string[] | undefined
 }
 
-export type t_GetEventsRequestBodySchema = EmptyObject
-
 export type t_GetEventsIdParamSchema = {
   id: string
 }
@@ -17175,16 +16925,12 @@ export type t_GetEventsIdQuerySchema = {
   expand?: string[] | undefined
 }
 
-export type t_GetEventsIdRequestBodySchema = EmptyObject
-
 export type t_GetExchangeRatesQuerySchema = {
   ending_before?: string | undefined
   expand?: string[] | undefined
   limit?: number | undefined
   starting_after?: string | undefined
 }
-
-export type t_GetExchangeRatesRequestBodySchema = EmptyObject
 
 export type t_GetExchangeRatesRateIdParamSchema = {
   rate_id: string
@@ -17193,8 +16939,6 @@ export type t_GetExchangeRatesRateIdParamSchema = {
 export type t_GetExchangeRatesRateIdQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetExchangeRatesRateIdRequestBodySchema = EmptyObject
 
 export type t_GetFileLinksQuerySchema = {
   created?:
@@ -17216,8 +16960,6 @@ export type t_GetFileLinksQuerySchema = {
   starting_after?: string | undefined
 }
 
-export type t_GetFileLinksRequestBodySchema = EmptyObject
-
 export type t_GetFileLinksLinkParamSchema = {
   link: string
 }
@@ -17225,8 +16967,6 @@ export type t_GetFileLinksLinkParamSchema = {
 export type t_GetFileLinksLinkQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetFileLinksLinkRequestBodySchema = EmptyObject
 
 export type t_GetFilesQuerySchema = {
   created?:
@@ -17267,8 +17007,6 @@ export type t_GetFilesQuerySchema = {
   starting_after?: string | undefined
 }
 
-export type t_GetFilesRequestBodySchema = EmptyObject
-
 export type t_GetFilesFileParamSchema = {
   file: string
 }
@@ -17276,8 +17014,6 @@ export type t_GetFilesFileParamSchema = {
 export type t_GetFilesFileQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetFilesFileRequestBodySchema = EmptyObject
 
 export type t_GetFinancialConnectionsAccountsQuerySchema = {
   account_holder?:
@@ -17293,8 +17029,6 @@ export type t_GetFinancialConnectionsAccountsQuerySchema = {
   starting_after?: string | undefined
 }
 
-export type t_GetFinancialConnectionsAccountsRequestBodySchema = EmptyObject
-
 export type t_GetFinancialConnectionsAccountsAccountParamSchema = {
   account: string
 }
@@ -17302,9 +17036,6 @@ export type t_GetFinancialConnectionsAccountsAccountParamSchema = {
 export type t_GetFinancialConnectionsAccountsAccountQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetFinancialConnectionsAccountsAccountRequestBodySchema =
-  EmptyObject
 
 export type t_GetFinancialConnectionsAccountsAccountOwnersParamSchema = {
   account: string
@@ -17318,9 +17049,6 @@ export type t_GetFinancialConnectionsAccountsAccountOwnersQuerySchema = {
   starting_after?: string | undefined
 }
 
-export type t_GetFinancialConnectionsAccountsAccountOwnersRequestBodySchema =
-  EmptyObject
-
 export type t_GetFinancialConnectionsSessionsSessionParamSchema = {
   session: string
 }
@@ -17328,9 +17056,6 @@ export type t_GetFinancialConnectionsSessionsSessionParamSchema = {
 export type t_GetFinancialConnectionsSessionsSessionQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetFinancialConnectionsSessionsSessionRequestBodySchema =
-  EmptyObject
 
 export type t_GetFinancialConnectionsTransactionsQuerySchema = {
   account: string
@@ -17356,8 +17081,6 @@ export type t_GetFinancialConnectionsTransactionsQuerySchema = {
     | undefined
 }
 
-export type t_GetFinancialConnectionsTransactionsRequestBodySchema = EmptyObject
-
 export type t_GetFinancialConnectionsTransactionsTransactionParamSchema = {
   transaction: string
 }
@@ -17365,9 +17088,6 @@ export type t_GetFinancialConnectionsTransactionsTransactionParamSchema = {
 export type t_GetFinancialConnectionsTransactionsTransactionQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetFinancialConnectionsTransactionsTransactionRequestBodySchema =
-  EmptyObject
 
 export type t_GetForwardingRequestsQuerySchema = {
   created?:
@@ -17384,8 +17104,6 @@ export type t_GetForwardingRequestsQuerySchema = {
   starting_after?: string | undefined
 }
 
-export type t_GetForwardingRequestsRequestBodySchema = EmptyObject
-
 export type t_GetForwardingRequestsIdParamSchema = {
   id: string
 }
@@ -17393,8 +17111,6 @@ export type t_GetForwardingRequestsIdParamSchema = {
 export type t_GetForwardingRequestsIdQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetForwardingRequestsIdRequestBodySchema = EmptyObject
 
 export type t_GetIdentityVerificationReportsQuerySchema = {
   client_reference_id?: string | undefined
@@ -17417,8 +17133,6 @@ export type t_GetIdentityVerificationReportsQuerySchema = {
   verification_session?: string | undefined
 }
 
-export type t_GetIdentityVerificationReportsRequestBodySchema = EmptyObject
-
 export type t_GetIdentityVerificationReportsReportParamSchema = {
   report: string
 }
@@ -17426,9 +17140,6 @@ export type t_GetIdentityVerificationReportsReportParamSchema = {
 export type t_GetIdentityVerificationReportsReportQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetIdentityVerificationReportsReportRequestBodySchema =
-  EmptyObject
 
 export type t_GetIdentityVerificationSessionsQuerySchema = {
   client_reference_id?: string | undefined
@@ -17453,8 +17164,6 @@ export type t_GetIdentityVerificationSessionsQuerySchema = {
     | undefined
 }
 
-export type t_GetIdentityVerificationSessionsRequestBodySchema = EmptyObject
-
 export type t_GetIdentityVerificationSessionsSessionParamSchema = {
   session: string
 }
@@ -17462,9 +17171,6 @@ export type t_GetIdentityVerificationSessionsSessionParamSchema = {
 export type t_GetIdentityVerificationSessionsSessionQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetIdentityVerificationSessionsSessionRequestBodySchema =
-  EmptyObject
 
 export type t_GetInvoicePaymentsQuerySchema = {
   ending_before?: string | undefined
@@ -17481,8 +17187,6 @@ export type t_GetInvoicePaymentsQuerySchema = {
   status?: ("canceled" | "open" | "paid") | undefined
 }
 
-export type t_GetInvoicePaymentsRequestBodySchema = EmptyObject
-
 export type t_GetInvoicePaymentsInvoicePaymentParamSchema = {
   invoice_payment: string
 }
@@ -17490,8 +17194,6 @@ export type t_GetInvoicePaymentsInvoicePaymentParamSchema = {
 export type t_GetInvoicePaymentsInvoicePaymentQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetInvoicePaymentsInvoicePaymentRequestBodySchema = EmptyObject
 
 export type t_GetInvoiceRenderingTemplatesQuerySchema = {
   ending_before?: string | undefined
@@ -17501,8 +17203,6 @@ export type t_GetInvoiceRenderingTemplatesQuerySchema = {
   status?: ("active" | "archived") | undefined
 }
 
-export type t_GetInvoiceRenderingTemplatesRequestBodySchema = EmptyObject
-
 export type t_GetInvoiceRenderingTemplatesTemplateParamSchema = {
   template: string
 }
@@ -17511,9 +17211,6 @@ export type t_GetInvoiceRenderingTemplatesTemplateQuerySchema = {
   expand?: string[] | undefined
   version?: number | undefined
 }
-
-export type t_GetInvoiceRenderingTemplatesTemplateRequestBodySchema =
-  EmptyObject
 
 export type t_GetInvoiceitemsQuerySchema = {
   created?:
@@ -17536,8 +17233,6 @@ export type t_GetInvoiceitemsQuerySchema = {
   starting_after?: string | undefined
 }
 
-export type t_GetInvoiceitemsRequestBodySchema = EmptyObject
-
 export type t_GetInvoiceitemsInvoiceitemParamSchema = {
   invoiceitem: string
 }
@@ -17545,8 +17240,6 @@ export type t_GetInvoiceitemsInvoiceitemParamSchema = {
 export type t_GetInvoiceitemsInvoiceitemQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetInvoiceitemsInvoiceitemRequestBodySchema = EmptyObject
 
 export type t_GetInvoicesQuerySchema = {
   collection_method?: ("charge_automatically" | "send_invoice") | undefined
@@ -17581,8 +17274,6 @@ export type t_GetInvoicesQuerySchema = {
   subscription?: string | undefined
 }
 
-export type t_GetInvoicesRequestBodySchema = EmptyObject
-
 export type t_GetInvoicesInvoiceParamSchema = {
   invoice: string
 }
@@ -17590,8 +17281,6 @@ export type t_GetInvoicesInvoiceParamSchema = {
 export type t_GetInvoicesInvoiceQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetInvoicesInvoiceRequestBodySchema = EmptyObject
 
 export type t_GetInvoicesInvoiceLinesParamSchema = {
   invoice: string
@@ -17604,16 +17293,12 @@ export type t_GetInvoicesInvoiceLinesQuerySchema = {
   starting_after?: string | undefined
 }
 
-export type t_GetInvoicesInvoiceLinesRequestBodySchema = EmptyObject
-
 export type t_GetInvoicesSearchQuerySchema = {
   expand?: string[] | undefined
   limit?: number | undefined
   page?: string | undefined
   query: string
 }
-
-export type t_GetInvoicesSearchRequestBodySchema = EmptyObject
 
 export type t_GetIssuingAuthorizationsQuerySchema = {
   card?: string | undefined
@@ -17636,8 +17321,6 @@ export type t_GetIssuingAuthorizationsQuerySchema = {
   status?: ("closed" | "expired" | "pending" | "reversed") | undefined
 }
 
-export type t_GetIssuingAuthorizationsRequestBodySchema = EmptyObject
-
 export type t_GetIssuingAuthorizationsAuthorizationParamSchema = {
   authorization: string
 }
@@ -17645,9 +17328,6 @@ export type t_GetIssuingAuthorizationsAuthorizationParamSchema = {
 export type t_GetIssuingAuthorizationsAuthorizationQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetIssuingAuthorizationsAuthorizationRequestBodySchema =
-  EmptyObject
 
 export type t_GetIssuingCardholdersQuerySchema = {
   created?:
@@ -17671,8 +17351,6 @@ export type t_GetIssuingCardholdersQuerySchema = {
   type?: ("company" | "individual") | undefined
 }
 
-export type t_GetIssuingCardholdersRequestBodySchema = EmptyObject
-
 export type t_GetIssuingCardholdersCardholderParamSchema = {
   cardholder: string
 }
@@ -17680,8 +17358,6 @@ export type t_GetIssuingCardholdersCardholderParamSchema = {
 export type t_GetIssuingCardholdersCardholderQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetIssuingCardholdersCardholderRequestBodySchema = EmptyObject
 
 export type t_GetIssuingCardsQuerySchema = {
   cardholder?: string | undefined
@@ -17708,8 +17384,6 @@ export type t_GetIssuingCardsQuerySchema = {
   type?: ("physical" | "virtual") | undefined
 }
 
-export type t_GetIssuingCardsRequestBodySchema = EmptyObject
-
 export type t_GetIssuingCardsCardParamSchema = {
   card: string
 }
@@ -17717,8 +17391,6 @@ export type t_GetIssuingCardsCardParamSchema = {
 export type t_GetIssuingCardsCardQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetIssuingCardsCardRequestBodySchema = EmptyObject
 
 export type t_GetIssuingDisputesQuerySchema = {
   created?:
@@ -17742,8 +17414,6 @@ export type t_GetIssuingDisputesQuerySchema = {
   transaction?: string | undefined
 }
 
-export type t_GetIssuingDisputesRequestBodySchema = EmptyObject
-
 export type t_GetIssuingDisputesDisputeParamSchema = {
   dispute: string
 }
@@ -17751,8 +17421,6 @@ export type t_GetIssuingDisputesDisputeParamSchema = {
 export type t_GetIssuingDisputesDisputeQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetIssuingDisputesDisputeRequestBodySchema = EmptyObject
 
 export type t_GetIssuingPersonalizationDesignsQuerySchema = {
   ending_before?: string | undefined
@@ -17769,8 +17437,6 @@ export type t_GetIssuingPersonalizationDesignsQuerySchema = {
   status?: ("active" | "inactive" | "rejected" | "review") | undefined
 }
 
-export type t_GetIssuingPersonalizationDesignsRequestBodySchema = EmptyObject
-
 export type t_GetIssuingPersonalizationDesignsPersonalizationDesignParamSchema =
   {
     personalization_design: string
@@ -17781,9 +17447,6 @@ export type t_GetIssuingPersonalizationDesignsPersonalizationDesignQuerySchema =
     expand?: string[] | undefined
   }
 
-export type t_GetIssuingPersonalizationDesignsPersonalizationDesignRequestBodySchema =
-  EmptyObject
-
 export type t_GetIssuingPhysicalBundlesQuerySchema = {
   ending_before?: string | undefined
   expand?: string[] | undefined
@@ -17793,8 +17456,6 @@ export type t_GetIssuingPhysicalBundlesQuerySchema = {
   type?: ("custom" | "standard") | undefined
 }
 
-export type t_GetIssuingPhysicalBundlesRequestBodySchema = EmptyObject
-
 export type t_GetIssuingPhysicalBundlesPhysicalBundleParamSchema = {
   physical_bundle: string
 }
@@ -17803,9 +17464,6 @@ export type t_GetIssuingPhysicalBundlesPhysicalBundleQuerySchema = {
   expand?: string[] | undefined
 }
 
-export type t_GetIssuingPhysicalBundlesPhysicalBundleRequestBodySchema =
-  EmptyObject
-
 export type t_GetIssuingSettlementsSettlementParamSchema = {
   settlement: string
 }
@@ -17813,8 +17471,6 @@ export type t_GetIssuingSettlementsSettlementParamSchema = {
 export type t_GetIssuingSettlementsSettlementQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetIssuingSettlementsSettlementRequestBodySchema = EmptyObject
 
 export type t_GetIssuingTokensQuerySchema = {
   card: string
@@ -17836,8 +17492,6 @@ export type t_GetIssuingTokensQuerySchema = {
   status?: ("active" | "deleted" | "requested" | "suspended") | undefined
 }
 
-export type t_GetIssuingTokensRequestBodySchema = EmptyObject
-
 export type t_GetIssuingTokensTokenParamSchema = {
   token: string
 }
@@ -17845,8 +17499,6 @@ export type t_GetIssuingTokensTokenParamSchema = {
 export type t_GetIssuingTokensTokenQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetIssuingTokensTokenRequestBodySchema = EmptyObject
 
 export type t_GetIssuingTransactionsQuerySchema = {
   card?: string | undefined
@@ -17869,8 +17521,6 @@ export type t_GetIssuingTransactionsQuerySchema = {
   type?: ("capture" | "refund") | undefined
 }
 
-export type t_GetIssuingTransactionsRequestBodySchema = EmptyObject
-
 export type t_GetIssuingTransactionsTransactionParamSchema = {
   transaction: string
 }
@@ -17879,8 +17529,6 @@ export type t_GetIssuingTransactionsTransactionQuerySchema = {
   expand?: string[] | undefined
 }
 
-export type t_GetIssuingTransactionsTransactionRequestBodySchema = EmptyObject
-
 export type t_GetLinkAccountSessionsSessionParamSchema = {
   session: string
 }
@@ -17888,8 +17536,6 @@ export type t_GetLinkAccountSessionsSessionParamSchema = {
 export type t_GetLinkAccountSessionsSessionQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetLinkAccountSessionsSessionRequestBodySchema = EmptyObject
 
 export type t_GetLinkedAccountsQuerySchema = {
   account_holder?:
@@ -17905,8 +17551,6 @@ export type t_GetLinkedAccountsQuerySchema = {
   starting_after?: string | undefined
 }
 
-export type t_GetLinkedAccountsRequestBodySchema = EmptyObject
-
 export type t_GetLinkedAccountsAccountParamSchema = {
   account: string
 }
@@ -17914,8 +17558,6 @@ export type t_GetLinkedAccountsAccountParamSchema = {
 export type t_GetLinkedAccountsAccountQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetLinkedAccountsAccountRequestBodySchema = EmptyObject
 
 export type t_GetLinkedAccountsAccountOwnersParamSchema = {
   account: string
@@ -17929,8 +17571,6 @@ export type t_GetLinkedAccountsAccountOwnersQuerySchema = {
   starting_after?: string | undefined
 }
 
-export type t_GetLinkedAccountsAccountOwnersRequestBodySchema = EmptyObject
-
 export type t_GetMandatesMandateParamSchema = {
   mandate: string
 }
@@ -17938,8 +17578,6 @@ export type t_GetMandatesMandateParamSchema = {
 export type t_GetMandatesMandateQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetMandatesMandateRequestBodySchema = EmptyObject
 
 export type t_GetPaymentIntentsQuerySchema = {
   created?:
@@ -17960,8 +17598,6 @@ export type t_GetPaymentIntentsQuerySchema = {
   starting_after?: string | undefined
 }
 
-export type t_GetPaymentIntentsRequestBodySchema = EmptyObject
-
 export type t_GetPaymentIntentsIntentParamSchema = {
   intent: string
 }
@@ -17971,16 +17607,12 @@ export type t_GetPaymentIntentsIntentQuerySchema = {
   expand?: string[] | undefined
 }
 
-export type t_GetPaymentIntentsIntentRequestBodySchema = EmptyObject
-
 export type t_GetPaymentIntentsSearchQuerySchema = {
   expand?: string[] | undefined
   limit?: number | undefined
   page?: string | undefined
   query: string
 }
-
-export type t_GetPaymentIntentsSearchRequestBodySchema = EmptyObject
 
 export type t_GetPaymentLinksQuerySchema = {
   active?: boolean | undefined
@@ -17990,8 +17622,6 @@ export type t_GetPaymentLinksQuerySchema = {
   starting_after?: string | undefined
 }
 
-export type t_GetPaymentLinksRequestBodySchema = EmptyObject
-
 export type t_GetPaymentLinksPaymentLinkParamSchema = {
   payment_link: string
 }
@@ -17999,8 +17629,6 @@ export type t_GetPaymentLinksPaymentLinkParamSchema = {
 export type t_GetPaymentLinksPaymentLinkQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetPaymentLinksPaymentLinkRequestBodySchema = EmptyObject
 
 export type t_GetPaymentLinksPaymentLinkLineItemsParamSchema = {
   payment_link: string
@@ -18013,8 +17641,6 @@ export type t_GetPaymentLinksPaymentLinkLineItemsQuerySchema = {
   starting_after?: string | undefined
 }
 
-export type t_GetPaymentLinksPaymentLinkLineItemsRequestBodySchema = EmptyObject
-
 export type t_GetPaymentMethodConfigurationsQuerySchema = {
   application?: (string | "") | undefined
   ending_before?: string | undefined
@@ -18023,8 +17649,6 @@ export type t_GetPaymentMethodConfigurationsQuerySchema = {
   starting_after?: string | undefined
 }
 
-export type t_GetPaymentMethodConfigurationsRequestBodySchema = EmptyObject
-
 export type t_GetPaymentMethodConfigurationsConfigurationParamSchema = {
   configuration: string
 }
@@ -18032,9 +17656,6 @@ export type t_GetPaymentMethodConfigurationsConfigurationParamSchema = {
 export type t_GetPaymentMethodConfigurationsConfigurationQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetPaymentMethodConfigurationsConfigurationRequestBodySchema =
-  EmptyObject
 
 export type t_GetPaymentMethodDomainsQuerySchema = {
   domain_name?: string | undefined
@@ -18045,8 +17666,6 @@ export type t_GetPaymentMethodDomainsQuerySchema = {
   starting_after?: string | undefined
 }
 
-export type t_GetPaymentMethodDomainsRequestBodySchema = EmptyObject
-
 export type t_GetPaymentMethodDomainsPaymentMethodDomainParamSchema = {
   payment_method_domain: string
 }
@@ -18054,9 +17673,6 @@ export type t_GetPaymentMethodDomainsPaymentMethodDomainParamSchema = {
 export type t_GetPaymentMethodDomainsPaymentMethodDomainQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetPaymentMethodDomainsPaymentMethodDomainRequestBodySchema =
-  EmptyObject
 
 export type t_GetPaymentMethodsQuerySchema = {
   customer?: string | undefined
@@ -18118,8 +17734,6 @@ export type t_GetPaymentMethodsQuerySchema = {
     | undefined
 }
 
-export type t_GetPaymentMethodsRequestBodySchema = EmptyObject
-
 export type t_GetPaymentMethodsPaymentMethodParamSchema = {
   payment_method: string
 }
@@ -18127,8 +17741,6 @@ export type t_GetPaymentMethodsPaymentMethodParamSchema = {
 export type t_GetPaymentMethodsPaymentMethodQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetPaymentMethodsPaymentMethodRequestBodySchema = EmptyObject
 
 export type t_GetPayoutsQuerySchema = {
   arrival_date?:
@@ -18161,8 +17773,6 @@ export type t_GetPayoutsQuerySchema = {
   status?: string | undefined
 }
 
-export type t_GetPayoutsRequestBodySchema = EmptyObject
-
 export type t_GetPayoutsPayoutParamSchema = {
   payout: string
 }
@@ -18170,8 +17780,6 @@ export type t_GetPayoutsPayoutParamSchema = {
 export type t_GetPayoutsPayoutQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetPayoutsPayoutRequestBodySchema = EmptyObject
 
 export type t_GetPlansQuerySchema = {
   active?: boolean | undefined
@@ -18193,8 +17801,6 @@ export type t_GetPlansQuerySchema = {
   starting_after?: string | undefined
 }
 
-export type t_GetPlansRequestBodySchema = EmptyObject
-
 export type t_GetPlansPlanParamSchema = {
   plan: string
 }
@@ -18202,8 +17808,6 @@ export type t_GetPlansPlanParamSchema = {
 export type t_GetPlansPlanQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetPlansPlanRequestBodySchema = EmptyObject
 
 export type t_GetPricesQuerySchema = {
   active?: boolean | undefined
@@ -18235,8 +17839,6 @@ export type t_GetPricesQuerySchema = {
   type?: ("one_time" | "recurring") | undefined
 }
 
-export type t_GetPricesRequestBodySchema = EmptyObject
-
 export type t_GetPricesPriceParamSchema = {
   price: string
 }
@@ -18245,16 +17847,12 @@ export type t_GetPricesPriceQuerySchema = {
   expand?: string[] | undefined
 }
 
-export type t_GetPricesPriceRequestBodySchema = EmptyObject
-
 export type t_GetPricesSearchQuerySchema = {
   expand?: string[] | undefined
   limit?: number | undefined
   page?: string | undefined
   query: string
 }
-
-export type t_GetPricesSearchRequestBodySchema = EmptyObject
 
 export type t_GetProductsQuerySchema = {
   active?: boolean | undefined
@@ -18278,8 +17876,6 @@ export type t_GetProductsQuerySchema = {
   url?: string | undefined
 }
 
-export type t_GetProductsRequestBodySchema = EmptyObject
-
 export type t_GetProductsIdParamSchema = {
   id: string
 }
@@ -18287,8 +17883,6 @@ export type t_GetProductsIdParamSchema = {
 export type t_GetProductsIdQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetProductsIdRequestBodySchema = EmptyObject
 
 export type t_GetProductsProductFeaturesParamSchema = {
   product: string
@@ -18301,8 +17895,6 @@ export type t_GetProductsProductFeaturesQuerySchema = {
   starting_after?: string | undefined
 }
 
-export type t_GetProductsProductFeaturesRequestBodySchema = EmptyObject
-
 export type t_GetProductsProductFeaturesIdParamSchema = {
   id: string
   product: string
@@ -18312,16 +17904,12 @@ export type t_GetProductsProductFeaturesIdQuerySchema = {
   expand?: string[] | undefined
 }
 
-export type t_GetProductsProductFeaturesIdRequestBodySchema = EmptyObject
-
 export type t_GetProductsSearchQuerySchema = {
   expand?: string[] | undefined
   limit?: number | undefined
   page?: string | undefined
   query: string
 }
-
-export type t_GetProductsSearchRequestBodySchema = EmptyObject
 
 export type t_GetPromotionCodesQuerySchema = {
   active?: boolean | undefined
@@ -18345,8 +17933,6 @@ export type t_GetPromotionCodesQuerySchema = {
   starting_after?: string | undefined
 }
 
-export type t_GetPromotionCodesRequestBodySchema = EmptyObject
-
 export type t_GetPromotionCodesPromotionCodeParamSchema = {
   promotion_code: string
 }
@@ -18354,8 +17940,6 @@ export type t_GetPromotionCodesPromotionCodeParamSchema = {
 export type t_GetPromotionCodesPromotionCodeQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetPromotionCodesPromotionCodeRequestBodySchema = EmptyObject
 
 export type t_GetQuotesQuerySchema = {
   customer?: string | undefined
@@ -18367,8 +17951,6 @@ export type t_GetQuotesQuerySchema = {
   test_clock?: string | undefined
 }
 
-export type t_GetQuotesRequestBodySchema = EmptyObject
-
 export type t_GetQuotesQuoteParamSchema = {
   quote: string
 }
@@ -18376,8 +17958,6 @@ export type t_GetQuotesQuoteParamSchema = {
 export type t_GetQuotesQuoteQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetQuotesQuoteRequestBodySchema = EmptyObject
 
 export type t_GetQuotesQuoteComputedUpfrontLineItemsParamSchema = {
   quote: string
@@ -18390,9 +17970,6 @@ export type t_GetQuotesQuoteComputedUpfrontLineItemsQuerySchema = {
   starting_after?: string | undefined
 }
 
-export type t_GetQuotesQuoteComputedUpfrontLineItemsRequestBodySchema =
-  EmptyObject
-
 export type t_GetQuotesQuoteLineItemsParamSchema = {
   quote: string
 }
@@ -18404,8 +17981,6 @@ export type t_GetQuotesQuoteLineItemsQuerySchema = {
   starting_after?: string | undefined
 }
 
-export type t_GetQuotesQuoteLineItemsRequestBodySchema = EmptyObject
-
 export type t_GetQuotesQuotePdfParamSchema = {
   quote: string
 }
@@ -18413,8 +17988,6 @@ export type t_GetQuotesQuotePdfParamSchema = {
 export type t_GetQuotesQuotePdfQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetQuotesQuotePdfRequestBodySchema = EmptyObject
 
 export type t_GetRadarEarlyFraudWarningsQuerySchema = {
   charge?: string | undefined
@@ -18436,8 +18009,6 @@ export type t_GetRadarEarlyFraudWarningsQuerySchema = {
   starting_after?: string | undefined
 }
 
-export type t_GetRadarEarlyFraudWarningsRequestBodySchema = EmptyObject
-
 export type t_GetRadarEarlyFraudWarningsEarlyFraudWarningParamSchema = {
   early_fraud_warning: string
 }
@@ -18445,9 +18016,6 @@ export type t_GetRadarEarlyFraudWarningsEarlyFraudWarningParamSchema = {
 export type t_GetRadarEarlyFraudWarningsEarlyFraudWarningQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetRadarEarlyFraudWarningsEarlyFraudWarningRequestBodySchema =
-  EmptyObject
 
 export type t_GetRadarValueListItemsQuerySchema = {
   created?:
@@ -18469,8 +18037,6 @@ export type t_GetRadarValueListItemsQuerySchema = {
   value_list: string
 }
 
-export type t_GetRadarValueListItemsRequestBodySchema = EmptyObject
-
 export type t_GetRadarValueListItemsItemParamSchema = {
   item: string
 }
@@ -18478,8 +18044,6 @@ export type t_GetRadarValueListItemsItemParamSchema = {
 export type t_GetRadarValueListItemsItemQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetRadarValueListItemsItemRequestBodySchema = EmptyObject
 
 export type t_GetRadarValueListsQuerySchema = {
   alias?: string | undefined
@@ -18501,8 +18065,6 @@ export type t_GetRadarValueListsQuerySchema = {
   starting_after?: string | undefined
 }
 
-export type t_GetRadarValueListsRequestBodySchema = EmptyObject
-
 export type t_GetRadarValueListsValueListParamSchema = {
   value_list: string
 }
@@ -18510,8 +18072,6 @@ export type t_GetRadarValueListsValueListParamSchema = {
 export type t_GetRadarValueListsValueListQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetRadarValueListsValueListRequestBodySchema = EmptyObject
 
 export type t_GetRefundsQuerySchema = {
   charge?: string | undefined
@@ -18533,8 +18093,6 @@ export type t_GetRefundsQuerySchema = {
   starting_after?: string | undefined
 }
 
-export type t_GetRefundsRequestBodySchema = EmptyObject
-
 export type t_GetRefundsRefundParamSchema = {
   refund: string
 }
@@ -18542,8 +18100,6 @@ export type t_GetRefundsRefundParamSchema = {
 export type t_GetRefundsRefundQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetRefundsRefundRequestBodySchema = EmptyObject
 
 export type t_GetReportingReportRunsQuerySchema = {
   created?:
@@ -18563,8 +18119,6 @@ export type t_GetReportingReportRunsQuerySchema = {
   starting_after?: string | undefined
 }
 
-export type t_GetReportingReportRunsRequestBodySchema = EmptyObject
-
 export type t_GetReportingReportRunsReportRunParamSchema = {
   report_run: string
 }
@@ -18573,13 +18127,9 @@ export type t_GetReportingReportRunsReportRunQuerySchema = {
   expand?: string[] | undefined
 }
 
-export type t_GetReportingReportRunsReportRunRequestBodySchema = EmptyObject
-
 export type t_GetReportingReportTypesQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetReportingReportTypesRequestBodySchema = EmptyObject
 
 export type t_GetReportingReportTypesReportTypeParamSchema = {
   report_type: string
@@ -18588,8 +18138,6 @@ export type t_GetReportingReportTypesReportTypeParamSchema = {
 export type t_GetReportingReportTypesReportTypeQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetReportingReportTypesReportTypeRequestBodySchema = EmptyObject
 
 export type t_GetReviewsQuerySchema = {
   created?:
@@ -18609,8 +18157,6 @@ export type t_GetReviewsQuerySchema = {
   starting_after?: string | undefined
 }
 
-export type t_GetReviewsRequestBodySchema = EmptyObject
-
 export type t_GetReviewsReviewParamSchema = {
   review: string
 }
@@ -18618,8 +18164,6 @@ export type t_GetReviewsReviewParamSchema = {
 export type t_GetReviewsReviewQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetReviewsReviewRequestBodySchema = EmptyObject
 
 export type t_GetSetupAttemptsQuerySchema = {
   created?:
@@ -18639,8 +18183,6 @@ export type t_GetSetupAttemptsQuerySchema = {
   setup_intent: string
   starting_after?: string | undefined
 }
-
-export type t_GetSetupAttemptsRequestBodySchema = EmptyObject
 
 export type t_GetSetupIntentsQuerySchema = {
   attach_to_self?: boolean | undefined
@@ -18663,8 +18205,6 @@ export type t_GetSetupIntentsQuerySchema = {
   starting_after?: string | undefined
 }
 
-export type t_GetSetupIntentsRequestBodySchema = EmptyObject
-
 export type t_GetSetupIntentsIntentParamSchema = {
   intent: string
 }
@@ -18673,8 +18213,6 @@ export type t_GetSetupIntentsIntentQuerySchema = {
   client_secret?: string | undefined
   expand?: string[] | undefined
 }
-
-export type t_GetSetupIntentsIntentRequestBodySchema = EmptyObject
 
 export type t_GetShippingRatesQuerySchema = {
   active?: boolean | undefined
@@ -18696,8 +18234,6 @@ export type t_GetShippingRatesQuerySchema = {
   starting_after?: string | undefined
 }
 
-export type t_GetShippingRatesRequestBodySchema = EmptyObject
-
 export type t_GetShippingRatesShippingRateTokenParamSchema = {
   shipping_rate_token: string
 }
@@ -18706,16 +18242,12 @@ export type t_GetShippingRatesShippingRateTokenQuerySchema = {
   expand?: string[] | undefined
 }
 
-export type t_GetShippingRatesShippingRateTokenRequestBodySchema = EmptyObject
-
 export type t_GetSigmaScheduledQueryRunsQuerySchema = {
   ending_before?: string | undefined
   expand?: string[] | undefined
   limit?: number | undefined
   starting_after?: string | undefined
 }
-
-export type t_GetSigmaScheduledQueryRunsRequestBodySchema = EmptyObject
 
 export type t_GetSigmaScheduledQueryRunsScheduledQueryRunParamSchema = {
   scheduled_query_run: string
@@ -18725,9 +18257,6 @@ export type t_GetSigmaScheduledQueryRunsScheduledQueryRunQuerySchema = {
   expand?: string[] | undefined
 }
 
-export type t_GetSigmaScheduledQueryRunsScheduledQueryRunRequestBodySchema =
-  EmptyObject
-
 export type t_GetSourcesSourceParamSchema = {
   source: string
 }
@@ -18736,8 +18265,6 @@ export type t_GetSourcesSourceQuerySchema = {
   client_secret?: string | undefined
   expand?: string[] | undefined
 }
-
-export type t_GetSourcesSourceRequestBodySchema = EmptyObject
 
 export type t_GetSourcesSourceMandateNotificationsMandateNotificationParamSchema =
   {
@@ -18750,9 +18277,6 @@ export type t_GetSourcesSourceMandateNotificationsMandateNotificationQuerySchema
     expand?: string[] | undefined
   }
 
-export type t_GetSourcesSourceMandateNotificationsMandateNotificationRequestBodySchema =
-  EmptyObject
-
 export type t_GetSourcesSourceSourceTransactionsParamSchema = {
   source: string
 }
@@ -18764,8 +18288,6 @@ export type t_GetSourcesSourceSourceTransactionsQuerySchema = {
   starting_after?: string | undefined
 }
 
-export type t_GetSourcesSourceSourceTransactionsRequestBodySchema = EmptyObject
-
 export type t_GetSourcesSourceSourceTransactionsSourceTransactionParamSchema = {
   source: string
   source_transaction: string
@@ -18775,9 +18297,6 @@ export type t_GetSourcesSourceSourceTransactionsSourceTransactionQuerySchema = {
   expand?: string[] | undefined
 }
 
-export type t_GetSourcesSourceSourceTransactionsSourceTransactionRequestBodySchema =
-  EmptyObject
-
 export type t_GetSubscriptionItemsQuerySchema = {
   ending_before?: string | undefined
   expand?: string[] | undefined
@@ -18786,8 +18305,6 @@ export type t_GetSubscriptionItemsQuerySchema = {
   subscription: string
 }
 
-export type t_GetSubscriptionItemsRequestBodySchema = EmptyObject
-
 export type t_GetSubscriptionItemsItemParamSchema = {
   item: string
 }
@@ -18795,8 +18312,6 @@ export type t_GetSubscriptionItemsItemParamSchema = {
 export type t_GetSubscriptionItemsItemQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetSubscriptionItemsItemRequestBodySchema = EmptyObject
 
 export type t_GetSubscriptionSchedulesQuerySchema = {
   canceled_at?:
@@ -18851,8 +18366,6 @@ export type t_GetSubscriptionSchedulesQuerySchema = {
   starting_after?: string | undefined
 }
 
-export type t_GetSubscriptionSchedulesRequestBodySchema = EmptyObject
-
 export type t_GetSubscriptionSchedulesScheduleParamSchema = {
   schedule: string
 }
@@ -18860,8 +18373,6 @@ export type t_GetSubscriptionSchedulesScheduleParamSchema = {
 export type t_GetSubscriptionSchedulesScheduleQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetSubscriptionSchedulesScheduleRequestBodySchema = EmptyObject
 
 export type t_GetSubscriptionsQuerySchema = {
   automatic_tax?:
@@ -18926,16 +18437,12 @@ export type t_GetSubscriptionsQuerySchema = {
   test_clock?: string | undefined
 }
 
-export type t_GetSubscriptionsRequestBodySchema = EmptyObject
-
 export type t_GetSubscriptionsSearchQuerySchema = {
   expand?: string[] | undefined
   limit?: number | undefined
   page?: string | undefined
   query: string
 }
-
-export type t_GetSubscriptionsSearchRequestBodySchema = EmptyObject
 
 export type t_GetSubscriptionsSubscriptionExposedIdParamSchema = {
   subscription_exposed_id: string
@@ -18945,9 +18452,6 @@ export type t_GetSubscriptionsSubscriptionExposedIdQuerySchema = {
   expand?: string[] | undefined
 }
 
-export type t_GetSubscriptionsSubscriptionExposedIdRequestBodySchema =
-  EmptyObject
-
 export type t_GetTaxCalculationsCalculationParamSchema = {
   calculation: string
 }
@@ -18955,8 +18459,6 @@ export type t_GetTaxCalculationsCalculationParamSchema = {
 export type t_GetTaxCalculationsCalculationQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetTaxCalculationsCalculationRequestBodySchema = EmptyObject
 
 export type t_GetTaxCalculationsCalculationLineItemsParamSchema = {
   calculation: string
@@ -18969,17 +18471,12 @@ export type t_GetTaxCalculationsCalculationLineItemsQuerySchema = {
   starting_after?: string | undefined
 }
 
-export type t_GetTaxCalculationsCalculationLineItemsRequestBodySchema =
-  EmptyObject
-
 export type t_GetTaxCodesQuerySchema = {
   ending_before?: string | undefined
   expand?: string[] | undefined
   limit?: number | undefined
   starting_after?: string | undefined
 }
-
-export type t_GetTaxCodesRequestBodySchema = EmptyObject
 
 export type t_GetTaxCodesIdParamSchema = {
   id: string
@@ -18988,8 +18485,6 @@ export type t_GetTaxCodesIdParamSchema = {
 export type t_GetTaxCodesIdQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetTaxCodesIdRequestBodySchema = EmptyObject
 
 export type t_GetTaxIdsQuerySchema = {
   ending_before?: string | undefined
@@ -19005,8 +18500,6 @@ export type t_GetTaxIdsQuerySchema = {
   starting_after?: string | undefined
 }
 
-export type t_GetTaxIdsRequestBodySchema = EmptyObject
-
 export type t_GetTaxIdsIdParamSchema = {
   id: string
 }
@@ -19014,8 +18507,6 @@ export type t_GetTaxIdsIdParamSchema = {
 export type t_GetTaxIdsIdQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetTaxIdsIdRequestBodySchema = EmptyObject
 
 export type t_GetTaxRatesQuerySchema = {
   active?: boolean | undefined
@@ -19037,8 +18528,6 @@ export type t_GetTaxRatesQuerySchema = {
   starting_after?: string | undefined
 }
 
-export type t_GetTaxRatesRequestBodySchema = EmptyObject
-
 export type t_GetTaxRatesTaxRateParamSchema = {
   tax_rate: string
 }
@@ -19046,8 +18535,6 @@ export type t_GetTaxRatesTaxRateParamSchema = {
 export type t_GetTaxRatesTaxRateQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetTaxRatesTaxRateRequestBodySchema = EmptyObject
 
 export type t_GetTaxRegistrationsQuerySchema = {
   ending_before?: string | undefined
@@ -19057,8 +18544,6 @@ export type t_GetTaxRegistrationsQuerySchema = {
   status?: ("active" | "all" | "expired" | "scheduled") | undefined
 }
 
-export type t_GetTaxRegistrationsRequestBodySchema = EmptyObject
-
 export type t_GetTaxRegistrationsIdParamSchema = {
   id: string
 }
@@ -19067,13 +18552,9 @@ export type t_GetTaxRegistrationsIdQuerySchema = {
   expand?: string[] | undefined
 }
 
-export type t_GetTaxRegistrationsIdRequestBodySchema = EmptyObject
-
 export type t_GetTaxSettingsQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetTaxSettingsRequestBodySchema = EmptyObject
 
 export type t_GetTaxTransactionsTransactionParamSchema = {
   transaction: string
@@ -19082,8 +18563,6 @@ export type t_GetTaxTransactionsTransactionParamSchema = {
 export type t_GetTaxTransactionsTransactionQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetTaxTransactionsTransactionRequestBodySchema = EmptyObject
 
 export type t_GetTaxTransactionsTransactionLineItemsParamSchema = {
   transaction: string
@@ -19096,9 +18575,6 @@ export type t_GetTaxTransactionsTransactionLineItemsQuerySchema = {
   starting_after?: string | undefined
 }
 
-export type t_GetTaxTransactionsTransactionLineItemsRequestBodySchema =
-  EmptyObject
-
 export type t_GetTerminalConfigurationsQuerySchema = {
   ending_before?: string | undefined
   expand?: string[] | undefined
@@ -19106,8 +18582,6 @@ export type t_GetTerminalConfigurationsQuerySchema = {
   limit?: number | undefined
   starting_after?: string | undefined
 }
-
-export type t_GetTerminalConfigurationsRequestBodySchema = EmptyObject
 
 export type t_GetTerminalConfigurationsConfigurationParamSchema = {
   configuration: string
@@ -19117,17 +18591,12 @@ export type t_GetTerminalConfigurationsConfigurationQuerySchema = {
   expand?: string[] | undefined
 }
 
-export type t_GetTerminalConfigurationsConfigurationRequestBodySchema =
-  EmptyObject
-
 export type t_GetTerminalLocationsQuerySchema = {
   ending_before?: string | undefined
   expand?: string[] | undefined
   limit?: number | undefined
   starting_after?: string | undefined
 }
-
-export type t_GetTerminalLocationsRequestBodySchema = EmptyObject
 
 export type t_GetTerminalLocationsLocationParamSchema = {
   location: string
@@ -19136,8 +18605,6 @@ export type t_GetTerminalLocationsLocationParamSchema = {
 export type t_GetTerminalLocationsLocationQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetTerminalLocationsLocationRequestBodySchema = EmptyObject
 
 export type t_GetTerminalReadersQuerySchema = {
   device_type?:
@@ -19162,8 +18629,6 @@ export type t_GetTerminalReadersQuerySchema = {
   status?: ("offline" | "online") | undefined
 }
 
-export type t_GetTerminalReadersRequestBodySchema = EmptyObject
-
 export type t_GetTerminalReadersReaderParamSchema = {
   reader: string
 }
@@ -19172,16 +18637,12 @@ export type t_GetTerminalReadersReaderQuerySchema = {
   expand?: string[] | undefined
 }
 
-export type t_GetTerminalReadersReaderRequestBodySchema = EmptyObject
-
 export type t_GetTestHelpersTestClocksQuerySchema = {
   ending_before?: string | undefined
   expand?: string[] | undefined
   limit?: number | undefined
   starting_after?: string | undefined
 }
-
-export type t_GetTestHelpersTestClocksRequestBodySchema = EmptyObject
 
 export type t_GetTestHelpersTestClocksTestClockParamSchema = {
   test_clock: string
@@ -19191,8 +18652,6 @@ export type t_GetTestHelpersTestClocksTestClockQuerySchema = {
   expand?: string[] | undefined
 }
 
-export type t_GetTestHelpersTestClocksTestClockRequestBodySchema = EmptyObject
-
 export type t_GetTokensTokenParamSchema = {
   token: string
 }
@@ -19200,8 +18659,6 @@ export type t_GetTokensTokenParamSchema = {
 export type t_GetTokensTokenQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetTokensTokenRequestBodySchema = EmptyObject
 
 export type t_GetTopupsQuerySchema = {
   amount?:
@@ -19233,8 +18690,6 @@ export type t_GetTopupsQuerySchema = {
   status?: ("canceled" | "failed" | "pending" | "succeeded") | undefined
 }
 
-export type t_GetTopupsRequestBodySchema = EmptyObject
-
 export type t_GetTopupsTopupParamSchema = {
   topup: string
 }
@@ -19242,8 +18697,6 @@ export type t_GetTopupsTopupParamSchema = {
 export type t_GetTopupsTopupQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetTopupsTopupRequestBodySchema = EmptyObject
 
 export type t_GetTransfersQuerySchema = {
   created?:
@@ -19265,8 +18718,6 @@ export type t_GetTransfersQuerySchema = {
   transfer_group?: string | undefined
 }
 
-export type t_GetTransfersRequestBodySchema = EmptyObject
-
 export type t_GetTransfersIdReversalsParamSchema = {
   id: string
 }
@@ -19278,8 +18729,6 @@ export type t_GetTransfersIdReversalsQuerySchema = {
   starting_after?: string | undefined
 }
 
-export type t_GetTransfersIdReversalsRequestBodySchema = EmptyObject
-
 export type t_GetTransfersTransferParamSchema = {
   transfer: string
 }
@@ -19287,8 +18736,6 @@ export type t_GetTransfersTransferParamSchema = {
 export type t_GetTransfersTransferQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetTransfersTransferRequestBodySchema = EmptyObject
 
 export type t_GetTransfersTransferReversalsIdParamSchema = {
   id: string
@@ -19298,8 +18745,6 @@ export type t_GetTransfersTransferReversalsIdParamSchema = {
 export type t_GetTransfersTransferReversalsIdQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetTransfersTransferReversalsIdRequestBodySchema = EmptyObject
 
 export type t_GetTreasuryCreditReversalsQuerySchema = {
   ending_before?: string | undefined
@@ -19311,8 +18756,6 @@ export type t_GetTreasuryCreditReversalsQuerySchema = {
   status?: ("canceled" | "posted" | "processing") | undefined
 }
 
-export type t_GetTreasuryCreditReversalsRequestBodySchema = EmptyObject
-
 export type t_GetTreasuryCreditReversalsCreditReversalParamSchema = {
   credit_reversal: string
 }
@@ -19320,9 +18763,6 @@ export type t_GetTreasuryCreditReversalsCreditReversalParamSchema = {
 export type t_GetTreasuryCreditReversalsCreditReversalQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetTreasuryCreditReversalsCreditReversalRequestBodySchema =
-  EmptyObject
 
 export type t_GetTreasuryDebitReversalsQuerySchema = {
   ending_before?: string | undefined
@@ -19335,8 +18775,6 @@ export type t_GetTreasuryDebitReversalsQuerySchema = {
   status?: ("canceled" | "completed" | "processing") | undefined
 }
 
-export type t_GetTreasuryDebitReversalsRequestBodySchema = EmptyObject
-
 export type t_GetTreasuryDebitReversalsDebitReversalParamSchema = {
   debit_reversal: string
 }
@@ -19344,9 +18782,6 @@ export type t_GetTreasuryDebitReversalsDebitReversalParamSchema = {
 export type t_GetTreasuryDebitReversalsDebitReversalQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetTreasuryDebitReversalsDebitReversalRequestBodySchema =
-  EmptyObject
 
 export type t_GetTreasuryFinancialAccountsQuerySchema = {
   created?:
@@ -19367,8 +18802,6 @@ export type t_GetTreasuryFinancialAccountsQuerySchema = {
   status?: ("closed" | "open") | undefined
 }
 
-export type t_GetTreasuryFinancialAccountsRequestBodySchema = EmptyObject
-
 export type t_GetTreasuryFinancialAccountsFinancialAccountParamSchema = {
   financial_account: string
 }
@@ -19376,9 +18809,6 @@ export type t_GetTreasuryFinancialAccountsFinancialAccountParamSchema = {
 export type t_GetTreasuryFinancialAccountsFinancialAccountQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetTreasuryFinancialAccountsFinancialAccountRequestBodySchema =
-  EmptyObject
 
 export type t_GetTreasuryFinancialAccountsFinancialAccountFeaturesParamSchema =
   {
@@ -19390,9 +18820,6 @@ export type t_GetTreasuryFinancialAccountsFinancialAccountFeaturesQuerySchema =
     expand?: string[] | undefined
   }
 
-export type t_GetTreasuryFinancialAccountsFinancialAccountFeaturesRequestBodySchema =
-  EmptyObject
-
 export type t_GetTreasuryInboundTransfersQuerySchema = {
   ending_before?: string | undefined
   expand?: string[] | undefined
@@ -19402,8 +18829,6 @@ export type t_GetTreasuryInboundTransfersQuerySchema = {
   status?: ("canceled" | "failed" | "processing" | "succeeded") | undefined
 }
 
-export type t_GetTreasuryInboundTransfersRequestBodySchema = EmptyObject
-
 export type t_GetTreasuryInboundTransfersIdParamSchema = {
   id: string
 }
@@ -19411,8 +18836,6 @@ export type t_GetTreasuryInboundTransfersIdParamSchema = {
 export type t_GetTreasuryInboundTransfersIdQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetTreasuryInboundTransfersIdRequestBodySchema = EmptyObject
 
 export type t_GetTreasuryOutboundPaymentsQuerySchema = {
   created?:
@@ -19437,8 +18860,6 @@ export type t_GetTreasuryOutboundPaymentsQuerySchema = {
     | undefined
 }
 
-export type t_GetTreasuryOutboundPaymentsRequestBodySchema = EmptyObject
-
 export type t_GetTreasuryOutboundPaymentsIdParamSchema = {
   id: string
 }
@@ -19446,8 +18867,6 @@ export type t_GetTreasuryOutboundPaymentsIdParamSchema = {
 export type t_GetTreasuryOutboundPaymentsIdQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetTreasuryOutboundPaymentsIdRequestBodySchema = EmptyObject
 
 export type t_GetTreasuryOutboundTransfersQuerySchema = {
   ending_before?: string | undefined
@@ -19460,8 +18879,6 @@ export type t_GetTreasuryOutboundTransfersQuerySchema = {
     | undefined
 }
 
-export type t_GetTreasuryOutboundTransfersRequestBodySchema = EmptyObject
-
 export type t_GetTreasuryOutboundTransfersOutboundTransferParamSchema = {
   outbound_transfer: string
 }
@@ -19469,9 +18886,6 @@ export type t_GetTreasuryOutboundTransfersOutboundTransferParamSchema = {
 export type t_GetTreasuryOutboundTransfersOutboundTransferQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetTreasuryOutboundTransfersOutboundTransferRequestBodySchema =
-  EmptyObject
 
 export type t_GetTreasuryReceivedCreditsQuerySchema = {
   ending_before?: string | undefined
@@ -19492,8 +18906,6 @@ export type t_GetTreasuryReceivedCreditsQuerySchema = {
   status?: ("failed" | "succeeded") | undefined
 }
 
-export type t_GetTreasuryReceivedCreditsRequestBodySchema = EmptyObject
-
 export type t_GetTreasuryReceivedCreditsIdParamSchema = {
   id: string
 }
@@ -19501,8 +18913,6 @@ export type t_GetTreasuryReceivedCreditsIdParamSchema = {
 export type t_GetTreasuryReceivedCreditsIdQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetTreasuryReceivedCreditsIdRequestBodySchema = EmptyObject
 
 export type t_GetTreasuryReceivedDebitsQuerySchema = {
   ending_before?: string | undefined
@@ -19513,8 +18923,6 @@ export type t_GetTreasuryReceivedDebitsQuerySchema = {
   status?: ("failed" | "succeeded") | undefined
 }
 
-export type t_GetTreasuryReceivedDebitsRequestBodySchema = EmptyObject
-
 export type t_GetTreasuryReceivedDebitsIdParamSchema = {
   id: string
 }
@@ -19522,8 +18930,6 @@ export type t_GetTreasuryReceivedDebitsIdParamSchema = {
 export type t_GetTreasuryReceivedDebitsIdQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetTreasuryReceivedDebitsIdRequestBodySchema = EmptyObject
 
 export type t_GetTreasuryTransactionEntriesQuerySchema = {
   created?:
@@ -19557,8 +18963,6 @@ export type t_GetTreasuryTransactionEntriesQuerySchema = {
   transaction?: string | undefined
 }
 
-export type t_GetTreasuryTransactionEntriesRequestBodySchema = EmptyObject
-
 export type t_GetTreasuryTransactionEntriesIdParamSchema = {
   id: string
 }
@@ -19566,8 +18970,6 @@ export type t_GetTreasuryTransactionEntriesIdParamSchema = {
 export type t_GetTreasuryTransactionEntriesIdQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetTreasuryTransactionEntriesIdRequestBodySchema = EmptyObject
 
 export type t_GetTreasuryTransactionsQuerySchema = {
   created?:
@@ -19605,8 +19007,6 @@ export type t_GetTreasuryTransactionsQuerySchema = {
     | undefined
 }
 
-export type t_GetTreasuryTransactionsRequestBodySchema = EmptyObject
-
 export type t_GetTreasuryTransactionsIdParamSchema = {
   id: string
 }
@@ -19615,16 +19015,12 @@ export type t_GetTreasuryTransactionsIdQuerySchema = {
   expand?: string[] | undefined
 }
 
-export type t_GetTreasuryTransactionsIdRequestBodySchema = EmptyObject
-
 export type t_GetWebhookEndpointsQuerySchema = {
   ending_before?: string | undefined
   expand?: string[] | undefined
   limit?: number | undefined
   starting_after?: string | undefined
 }
-
-export type t_GetWebhookEndpointsRequestBodySchema = EmptyObject
 
 export type t_GetWebhookEndpointsWebhookEndpointParamSchema = {
   webhook_endpoint: string
@@ -19633,8 +19029,6 @@ export type t_GetWebhookEndpointsWebhookEndpointParamSchema = {
 export type t_GetWebhookEndpointsWebhookEndpointQuerySchema = {
   expand?: string[] | undefined
 }
-
-export type t_GetWebhookEndpointsWebhookEndpointRequestBodySchema = EmptyObject
 
 export type t_PostAccountLinksRequestBodySchema = {
   account: string

--- a/integration-tests/typescript-fetch/src/generated/stripe.yaml/client.ts
+++ b/integration-tests/typescript-fetch/src/generated/stripe.yaml/client.ts
@@ -241,24 +241,15 @@ export class StripeApi extends AbstractFetchClient {
   async getAccount(
     p: {
       expand?: string[]
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_account> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/account`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postAccountLinks(
@@ -451,7 +442,6 @@ export class StripeApi extends AbstractFetchClient {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: RequestInit = {},
@@ -468,10 +458,7 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/accounts`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       created: p["created"],
       ending_before: p["endingBefore"],
@@ -479,13 +466,8 @@ export class StripeApi extends AbstractFetchClient {
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postAccounts(
@@ -1084,43 +1066,29 @@ export class StripeApi extends AbstractFetchClient {
   async deleteAccountsAccount(
     p: {
       account: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_deleted_account> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/accounts/${p["account"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
-    const body = JSON.stringify(p.requestBody)
+    const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, {method: "DELETE", body, ...opts, headers}, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async getAccountsAccount(
     p: {
       account: string
       expand?: string[]
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_account> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/accounts/${p["account"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postAccountsAccount(
@@ -1730,20 +1698,15 @@ export class StripeApi extends AbstractFetchClient {
     p: {
       account: string
       id: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_deleted_external_account> | Res<StatusCode, t_error>> {
     const url =
       this.basePath + `/v1/accounts/${p["account"]}/bank_accounts/${p["id"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
-    const body = JSON.stringify(p.requestBody)
+    const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, {method: "DELETE", body, ...opts, headers}, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async getAccountsAccountBankAccountsId(
@@ -1751,25 +1714,16 @@ export class StripeApi extends AbstractFetchClient {
       account: string
       expand?: string[]
       id: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_external_account> | Res<StatusCode, t_error>> {
     const url =
       this.basePath + `/v1/accounts/${p["account"]}/bank_accounts/${p["id"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postAccountsAccountBankAccountsId(
@@ -1831,7 +1785,6 @@ export class StripeApi extends AbstractFetchClient {
     p: {
       account: string
       expand?: string[]
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -1848,18 +1801,10 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/accounts/${p["account"]}/capabilities`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getAccountsAccountCapabilitiesCapability(
@@ -1867,7 +1812,6 @@ export class StripeApi extends AbstractFetchClient {
       account: string
       capability: string
       expand?: string[]
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -1875,18 +1819,10 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath +
       `/v1/accounts/${p["account"]}/capabilities/${p["capability"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postAccountsAccountCapabilitiesCapability(
@@ -1921,7 +1857,6 @@ export class StripeApi extends AbstractFetchClient {
       limit?: number
       object?: "bank_account" | "card" | UnknownEnumStringValue
       startingAfter?: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -1938,10 +1873,7 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/accounts/${p["account"]}/external_accounts`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
@@ -1949,13 +1881,8 @@ export class StripeApi extends AbstractFetchClient {
       object: p["object"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postAccountsAccountExternalAccounts(
@@ -2012,7 +1939,6 @@ export class StripeApi extends AbstractFetchClient {
     p: {
       account: string
       id: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -2020,13 +1946,9 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath +
       `/v1/accounts/${p["account"]}/external_accounts/${p["id"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
-    const body = JSON.stringify(p.requestBody)
+    const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, {method: "DELETE", body, ...opts, headers}, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async getAccountsAccountExternalAccountsId(
@@ -2034,7 +1956,6 @@ export class StripeApi extends AbstractFetchClient {
       account: string
       expand?: string[]
       id: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -2042,18 +1963,10 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath +
       `/v1/accounts/${p["account"]}/external_accounts/${p["id"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postAccountsAccountExternalAccountsId(
@@ -2147,7 +2060,6 @@ export class StripeApi extends AbstractFetchClient {
         representative?: boolean
       }
       startingAfter?: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -2164,10 +2076,7 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/accounts/${p["account"]}/people`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
@@ -2175,13 +2084,8 @@ export class StripeApi extends AbstractFetchClient {
       relationship: p["relationship"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postAccountsAccountPeople(
@@ -2357,20 +2261,15 @@ export class StripeApi extends AbstractFetchClient {
     p: {
       account: string
       person: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_deleted_person> | Res<StatusCode, t_error>> {
     const url =
       this.basePath + `/v1/accounts/${p["account"]}/people/${p["person"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
-    const body = JSON.stringify(p.requestBody)
+    const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, {method: "DELETE", body, ...opts, headers}, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async getAccountsAccountPeoplePerson(
@@ -2378,25 +2277,16 @@ export class StripeApi extends AbstractFetchClient {
       account: string
       expand?: string[]
       person: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_person> | Res<StatusCode, t_error>> {
     const url =
       this.basePath + `/v1/accounts/${p["account"]}/people/${p["person"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postAccountsAccountPeoplePerson(
@@ -2585,7 +2475,6 @@ export class StripeApi extends AbstractFetchClient {
         representative?: boolean
       }
       startingAfter?: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -2602,10 +2491,7 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/accounts/${p["account"]}/persons`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
@@ -2613,13 +2499,8 @@ export class StripeApi extends AbstractFetchClient {
       relationship: p["relationship"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postAccountsAccountPersons(
@@ -2795,20 +2676,15 @@ export class StripeApi extends AbstractFetchClient {
     p: {
       account: string
       person: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_deleted_person> | Res<StatusCode, t_error>> {
     const url =
       this.basePath + `/v1/accounts/${p["account"]}/persons/${p["person"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
-    const body = JSON.stringify(p.requestBody)
+    const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, {method: "DELETE", body, ...opts, headers}, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async getAccountsAccountPersonsPerson(
@@ -2816,25 +2692,16 @@ export class StripeApi extends AbstractFetchClient {
       account: string
       expand?: string[]
       person: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_person> | Res<StatusCode, t_error>> {
     const url =
       this.basePath + `/v1/accounts/${p["account"]}/persons/${p["person"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postAccountsAccountPersonsPerson(
@@ -3036,7 +2903,6 @@ export class StripeApi extends AbstractFetchClient {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: RequestInit = {},
@@ -3053,10 +2919,7 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/apple_pay/domains`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       domain_name: p["domainName"],
       ending_before: p["endingBefore"],
@@ -3064,13 +2927,8 @@ export class StripeApi extends AbstractFetchClient {
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postApplePayDomains(
@@ -3096,43 +2954,29 @@ export class StripeApi extends AbstractFetchClient {
   async deleteApplePayDomainsDomain(
     p: {
       domain: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_deleted_apple_pay_domain> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/apple_pay/domains/${p["domain"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
-    const body = JSON.stringify(p.requestBody)
+    const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, {method: "DELETE", body, ...opts, headers}, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async getApplePayDomainsDomain(
     p: {
       domain: string
       expand?: string[]
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_apple_pay_domain> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/apple_pay/domains/${p["domain"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getApplicationFees(
@@ -3150,7 +2994,6 @@ export class StripeApi extends AbstractFetchClient {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: RequestInit = {},
@@ -3167,10 +3010,7 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/application_fees`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       charge: p["charge"],
       created: p["created"],
@@ -3179,13 +3019,8 @@ export class StripeApi extends AbstractFetchClient {
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getApplicationFeesFeeRefundsId(
@@ -3193,25 +3028,16 @@ export class StripeApi extends AbstractFetchClient {
       expand?: string[]
       fee: string
       id: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_fee_refund> | Res<StatusCode, t_error>> {
     const url =
       this.basePath + `/v1/application_fees/${p["fee"]}/refunds/${p["id"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postApplicationFeesFeeRefundsId(
@@ -3246,24 +3072,15 @@ export class StripeApi extends AbstractFetchClient {
     p: {
       expand?: string[]
       id: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_application_fee> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/application_fees/${p["id"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postApplicationFeesIdRefund(
@@ -3295,7 +3112,6 @@ export class StripeApi extends AbstractFetchClient {
       id: string
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -3312,23 +3128,15 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/application_fees/${p["id"]}/refunds`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postApplicationFeesIdRefunds(
@@ -3365,7 +3173,6 @@ export class StripeApi extends AbstractFetchClient {
         user?: string
       }
       startingAfter?: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -3382,10 +3189,7 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/apps/secrets`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
@@ -3393,13 +3197,8 @@ export class StripeApi extends AbstractFetchClient {
       scope: p["scope"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postAppsSecrets(
@@ -3460,51 +3259,33 @@ export class StripeApi extends AbstractFetchClient {
         type: "account" | "user" | UnknownEnumStringValue
         user?: string
       }
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_apps_secret> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/apps/secrets/find`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       expand: p["expand"],
       name: p["name"],
       scope: p["scope"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getBalance(
     p: {
       expand?: string[]
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_balance> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/balance`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getBalanceHistory(
@@ -3525,7 +3306,6 @@ export class StripeApi extends AbstractFetchClient {
       source?: string
       startingAfter?: string
       type?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: RequestInit = {},
@@ -3542,10 +3322,7 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/balance/history`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       created: p["created"],
       currency: p["currency"],
@@ -3557,37 +3334,23 @@ export class StripeApi extends AbstractFetchClient {
       starting_after: p["startingAfter"],
       type: p["type"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getBalanceHistoryId(
     p: {
       expand?: string[]
       id: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_balance_transaction> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/balance/history/${p["id"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getBalanceTransactions(
@@ -3608,7 +3371,6 @@ export class StripeApi extends AbstractFetchClient {
       source?: string
       startingAfter?: string
       type?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: RequestInit = {},
@@ -3625,10 +3387,7 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/balance_transactions`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       created: p["created"],
       currency: p["currency"],
@@ -3640,37 +3399,23 @@ export class StripeApi extends AbstractFetchClient {
       starting_after: p["startingAfter"],
       type: p["type"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getBalanceTransactionsId(
     p: {
       expand?: string[]
       id: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_balance_transaction> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/balance_transactions/${p["id"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getBillingAlerts(
@@ -3681,7 +3426,6 @@ export class StripeApi extends AbstractFetchClient {
       limit?: number
       meter?: string
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: RequestInit = {},
@@ -3698,10 +3442,7 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/billing/alerts`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       alert_type: p["alertType"],
       ending_before: p["endingBefore"],
@@ -3710,13 +3451,8 @@ export class StripeApi extends AbstractFetchClient {
       meter: p["meter"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postBillingAlerts(
@@ -3753,24 +3489,15 @@ export class StripeApi extends AbstractFetchClient {
     p: {
       expand?: string[]
       id: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_billing_alert> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/billing/alerts/${p["id"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postBillingAlertsIdActivate(
@@ -3847,7 +3574,6 @@ export class StripeApi extends AbstractFetchClient {
         credit_grant?: string
         type: "applicability_scope" | "credit_grant" | UnknownEnumStringValue
       }
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -3855,22 +3581,14 @@ export class StripeApi extends AbstractFetchClient {
     Res<200, t_billing_credit_balance_summary> | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/billing/credit_balance_summary`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       customer: p["customer"],
       expand: p["expand"],
       filter: p["filter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getBillingCreditBalanceTransactions(
@@ -3881,7 +3599,6 @@ export class StripeApi extends AbstractFetchClient {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -3898,10 +3615,7 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/billing/credit_balance_transactions`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       credit_grant: p["creditGrant"],
       customer: p["customer"],
@@ -3910,20 +3624,14 @@ export class StripeApi extends AbstractFetchClient {
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getBillingCreditBalanceTransactionsId(
     p: {
       expand?: string[]
       id: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -3932,18 +3640,10 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url =
       this.basePath + `/v1/billing/credit_balance_transactions/${p["id"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getBillingCreditGrants(
@@ -3953,7 +3653,6 @@ export class StripeApi extends AbstractFetchClient {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: RequestInit = {},
@@ -3970,10 +3669,7 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/billing/credit_grants`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       customer: p["customer"],
       ending_before: p["endingBefore"],
@@ -3981,13 +3677,8 @@ export class StripeApi extends AbstractFetchClient {
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postBillingCreditGrants(
@@ -4037,24 +3728,15 @@ export class StripeApi extends AbstractFetchClient {
     p: {
       expand?: string[]
       id: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_billing_credit_grant> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/billing/credit_grants/${p["id"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postBillingCreditGrantsId(
@@ -4179,7 +3861,6 @@ export class StripeApi extends AbstractFetchClient {
       limit?: number
       startingAfter?: string
       status?: "active" | "inactive" | UnknownEnumStringValue
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: RequestInit = {},
@@ -4196,10 +3877,7 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/billing/meters`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
@@ -4207,13 +3885,8 @@ export class StripeApi extends AbstractFetchClient {
       starting_after: p["startingAfter"],
       status: p["status"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postBillingMeters(
@@ -4252,24 +3925,15 @@ export class StripeApi extends AbstractFetchClient {
     p: {
       expand?: string[]
       id: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_billing_meter> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/billing/meters/${p["id"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postBillingMetersId(
@@ -4324,7 +3988,6 @@ export class StripeApi extends AbstractFetchClient {
       startTime: number
       startingAfter?: string
       valueGroupingWindow?: "day" | "hour" | UnknownEnumStringValue
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -4341,10 +4004,7 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/billing/meters/${p["id"]}/event_summaries`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       customer: p["customer"],
       end_time: p["endTime"],
@@ -4355,13 +4015,8 @@ export class StripeApi extends AbstractFetchClient {
       starting_after: p["startingAfter"],
       value_grouping_window: p["valueGroupingWindow"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postBillingMetersIdReactivate(
@@ -4392,7 +4047,6 @@ export class StripeApi extends AbstractFetchClient {
       isDefault?: boolean
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: RequestInit = {},
@@ -4409,10 +4063,7 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/billing_portal/configurations`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       active: p["active"],
       ending_before: p["endingBefore"],
@@ -4421,13 +4072,8 @@ export class StripeApi extends AbstractFetchClient {
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postBillingPortalConfigurations(
@@ -4548,7 +4194,6 @@ export class StripeApi extends AbstractFetchClient {
     p: {
       configuration: string
       expand?: string[]
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -4557,18 +4202,10 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url =
       this.basePath + `/v1/billing_portal/configurations/${p["configuration"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postBillingPortalConfigurationsConfiguration(
@@ -4828,7 +4465,6 @@ export class StripeApi extends AbstractFetchClient {
       paymentIntent?: string
       startingAfter?: string
       transferGroup?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: RequestInit = {},
@@ -4845,10 +4481,7 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/charges`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       created: p["created"],
       customer: p["customer"],
@@ -4859,13 +4492,8 @@ export class StripeApi extends AbstractFetchClient {
       starting_after: p["startingAfter"],
       transfer_group: p["transferGroup"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postCharges(
@@ -4958,7 +4586,6 @@ export class StripeApi extends AbstractFetchClient {
       limit?: number
       page?: string
       query: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -4977,47 +4604,30 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/charges/search`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       expand: p["expand"],
       limit: p["limit"],
       page: p["page"],
       query: p["query"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getChargesCharge(
     p: {
       charge: string
       expand?: string[]
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_charge> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/charges/${p["charge"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postChargesCharge(
@@ -5101,24 +4711,15 @@ export class StripeApi extends AbstractFetchClient {
     p: {
       charge: string
       expand?: string[]
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_dispute> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/charges/${p["charge"]}/dispute`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postChargesChargeDispute(
@@ -5299,7 +4900,6 @@ export class StripeApi extends AbstractFetchClient {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -5316,23 +4916,15 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/charges/${p["charge"]}/refunds`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postChargesChargeRefunds(
@@ -5379,25 +4971,16 @@ export class StripeApi extends AbstractFetchClient {
       charge: string
       expand?: string[]
       refund: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_refund> | Res<StatusCode, t_error>> {
     const url =
       this.basePath + `/v1/charges/${p["charge"]}/refunds/${p["refund"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postChargesChargeRefundsRefund(
@@ -5450,7 +5033,6 @@ export class StripeApi extends AbstractFetchClient {
       startingAfter?: string
       status?: "complete" | "expired" | "open" | UnknownEnumStringValue
       subscription?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: RequestInit = {},
@@ -5467,10 +5049,7 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/checkout/sessions`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       created: p["created"],
       customer: p["customer"],
@@ -5484,13 +5063,8 @@ export class StripeApi extends AbstractFetchClient {
       status: p["status"],
       subscription: p["subscription"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postCheckoutSessions(
@@ -6542,24 +6116,15 @@ export class StripeApi extends AbstractFetchClient {
     p: {
       expand?: string[]
       session: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_checkout_session> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/checkout/sessions/${p["session"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postCheckoutSessionsSession(
@@ -6685,7 +6250,6 @@ export class StripeApi extends AbstractFetchClient {
       limit?: number
       session: string
       startingAfter?: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -6703,23 +6267,15 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url =
       this.basePath + `/v1/checkout/sessions/${p["session"]}/line_items`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getClimateOrders(
@@ -6728,7 +6284,6 @@ export class StripeApi extends AbstractFetchClient {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: RequestInit = {},
@@ -6745,23 +6300,15 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/climate/orders`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postClimateOrders(
@@ -6797,24 +6344,15 @@ export class StripeApi extends AbstractFetchClient {
     p: {
       expand?: string[]
       order: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_climate_order> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/climate/orders/${p["order"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postClimateOrdersOrder(
@@ -6872,7 +6410,6 @@ export class StripeApi extends AbstractFetchClient {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: RequestInit = {},
@@ -6889,47 +6426,30 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/climate/products`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getClimateProductsProduct(
     p: {
       expand?: string[]
       product: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_climate_product> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/climate/products/${p["product"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getClimateSuppliers(
@@ -6938,7 +6458,6 @@ export class StripeApi extends AbstractFetchClient {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: RequestInit = {},
@@ -6955,72 +6474,46 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/climate/suppliers`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getClimateSuppliersSupplier(
     p: {
       expand?: string[]
       supplier: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_climate_supplier> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/climate/suppliers/${p["supplier"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getConfirmationTokensConfirmationToken(
     p: {
       confirmationToken: string
       expand?: string[]
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_confirmation_token> | Res<StatusCode, t_error>> {
     const url =
       this.basePath + `/v1/confirmation_tokens/${p["confirmationToken"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getCountrySpecs(
@@ -7029,7 +6522,6 @@ export class StripeApi extends AbstractFetchClient {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: RequestInit = {},
@@ -7046,47 +6538,30 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/country_specs`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getCountrySpecsCountry(
     p: {
       country: string
       expand?: string[]
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_country_spec> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/country_specs/${p["country"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getCoupons(
@@ -7103,7 +6578,6 @@ export class StripeApi extends AbstractFetchClient {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: RequestInit = {},
@@ -7120,10 +6594,7 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/coupons`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       created: p["created"],
       ending_before: p["endingBefore"],
@@ -7131,13 +6602,8 @@ export class StripeApi extends AbstractFetchClient {
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postCoupons(
@@ -7187,43 +6653,29 @@ export class StripeApi extends AbstractFetchClient {
   async deleteCouponsCoupon(
     p: {
       coupon: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_deleted_coupon> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/coupons/${p["coupon"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
-    const body = JSON.stringify(p.requestBody)
+    const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, {method: "DELETE", body, ...opts, headers}, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async getCouponsCoupon(
     p: {
       coupon: string
       expand?: string[]
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_coupon> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/coupons/${p["coupon"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postCouponsCoupon(
@@ -7276,7 +6728,6 @@ export class StripeApi extends AbstractFetchClient {
       invoice?: string
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: RequestInit = {},
@@ -7293,10 +6744,7 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/credit_notes`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       created: p["created"],
       customer: p["customer"],
@@ -7306,13 +6754,8 @@ export class StripeApi extends AbstractFetchClient {
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postCreditNotes(
@@ -7424,16 +6867,12 @@ export class StripeApi extends AbstractFetchClient {
       shippingCost?: {
         shipping_rate?: string
       }
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_credit_note> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/credit_notes/preview`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       amount: p["amount"],
       credit_amount: p["creditAmount"],
@@ -7450,13 +6889,8 @@ export class StripeApi extends AbstractFetchClient {
       refunds: p["refunds"],
       shipping_cost: p["shippingCost"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getCreditNotesPreviewLines(
@@ -7507,7 +6941,6 @@ export class StripeApi extends AbstractFetchClient {
         shipping_rate?: string
       }
       startingAfter?: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -7524,10 +6957,7 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/credit_notes/preview/lines`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       amount: p["amount"],
       credit_amount: p["creditAmount"],
@@ -7547,13 +6977,8 @@ export class StripeApi extends AbstractFetchClient {
       shipping_cost: p["shippingCost"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getCreditNotesCreditNoteLines(
@@ -7563,7 +6988,6 @@ export class StripeApi extends AbstractFetchClient {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -7580,47 +7004,30 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/credit_notes/${p["creditNote"]}/lines`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getCreditNotesId(
     p: {
       expand?: string[]
       id: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_credit_note> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/credit_notes/${p["id"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postCreditNotesId(
@@ -7739,7 +7146,6 @@ export class StripeApi extends AbstractFetchClient {
       limit?: number
       startingAfter?: string
       testClock?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: RequestInit = {},
@@ -7756,10 +7162,7 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/customers`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       created: p["created"],
       email: p["email"],
@@ -7769,13 +7172,8 @@ export class StripeApi extends AbstractFetchClient {
       starting_after: p["startingAfter"],
       test_clock: p["testClock"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postCustomers(
@@ -8000,7 +7398,6 @@ export class StripeApi extends AbstractFetchClient {
       limit?: number
       page?: string
       query: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -8019,48 +7416,34 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/customers/search`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       expand: p["expand"],
       limit: p["limit"],
       page: p["page"],
       query: p["query"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async deleteCustomersCustomer(
     p: {
       customer: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_deleted_customer> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/customers/${p["customer"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
-    const body = JSON.stringify(p.requestBody)
+    const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, {method: "DELETE", body, ...opts, headers}, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async getCustomersCustomer(
     p: {
       customer: string
       expand?: string[]
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -8068,18 +7451,10 @@ export class StripeApi extends AbstractFetchClient {
     Res<200, t_customer | t_deleted_customer> | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/customers/${p["customer"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postCustomersCustomer(
@@ -8227,7 +7602,6 @@ export class StripeApi extends AbstractFetchClient {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -8245,23 +7619,15 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url =
       this.basePath + `/v1/customers/${p["customer"]}/balance_transactions`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postCustomersCustomerBalanceTransactions(
@@ -8301,7 +7667,6 @@ export class StripeApi extends AbstractFetchClient {
       customer: string
       expand?: string[]
       transaction: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -8311,18 +7676,10 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath +
       `/v1/customers/${p["customer"]}/balance_transactions/${p["transaction"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postCustomersCustomerBalanceTransactionsTransaction(
@@ -8364,7 +7721,6 @@ export class StripeApi extends AbstractFetchClient {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -8381,23 +7737,15 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/customers/${p["customer"]}/bank_accounts`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postCustomersCustomerBankAccounts(
@@ -8488,25 +7836,16 @@ export class StripeApi extends AbstractFetchClient {
       customer: string
       expand?: string[]
       id: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_bank_account> | Res<StatusCode, t_error>> {
     const url =
       this.basePath + `/v1/customers/${p["customer"]}/bank_accounts/${p["id"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postCustomersCustomerBankAccountsId(
@@ -8594,7 +7933,6 @@ export class StripeApi extends AbstractFetchClient {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -8611,23 +7949,15 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/customers/${p["customer"]}/cards`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postCustomersCustomerCards(
@@ -8718,25 +8048,16 @@ export class StripeApi extends AbstractFetchClient {
       customer: string
       expand?: string[]
       id: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_card> | Res<StatusCode, t_error>> {
     const url =
       this.basePath + `/v1/customers/${p["customer"]}/cards/${p["id"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postCustomersCustomerCardsId(
@@ -8797,24 +8118,15 @@ export class StripeApi extends AbstractFetchClient {
     p: {
       customer: string
       expand?: string[]
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_cash_balance> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/customers/${p["customer"]}/cash_balance`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postCustomersCustomerCashBalance(
@@ -8851,7 +8163,6 @@ export class StripeApi extends AbstractFetchClient {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -8869,23 +8180,15 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url =
       this.basePath + `/v1/customers/${p["customer"]}/cash_balance_transactions`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getCustomersCustomerCashBalanceTransactionsTransaction(
@@ -8893,7 +8196,6 @@ export class StripeApi extends AbstractFetchClient {
       customer: string
       expand?: string[]
       transaction: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -8903,60 +8205,38 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath +
       `/v1/customers/${p["customer"]}/cash_balance_transactions/${p["transaction"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async deleteCustomersCustomerDiscount(
     p: {
       customer: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_deleted_discount> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/customers/${p["customer"]}/discount`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
-    const body = JSON.stringify(p.requestBody)
+    const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, {method: "DELETE", body, ...opts, headers}, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async getCustomersCustomerDiscount(
     p: {
       customer: string
       expand?: string[]
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_discount> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/customers/${p["customer"]}/discount`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postCustomersCustomerFundingInstructions(
@@ -9063,7 +8343,6 @@ export class StripeApi extends AbstractFetchClient {
         | "wechat_pay"
         | "zip"
         | UnknownEnumStringValue
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -9080,10 +8359,7 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/customers/${p["customer"]}/payment_methods`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       allow_redisplay: p["allowRedisplay"],
       ending_before: p["endingBefore"],
@@ -9092,13 +8368,8 @@ export class StripeApi extends AbstractFetchClient {
       starting_after: p["startingAfter"],
       type: p["type"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getCustomersCustomerPaymentMethodsPaymentMethod(
@@ -9106,7 +8377,6 @@ export class StripeApi extends AbstractFetchClient {
       customer: string
       expand?: string[]
       paymentMethod: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -9114,18 +8384,10 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath +
       `/v1/customers/${p["customer"]}/payment_methods/${p["paymentMethod"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getCustomersCustomerSources(
@@ -9136,7 +8398,6 @@ export class StripeApi extends AbstractFetchClient {
       limit?: number
       object?: string
       startingAfter?: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -9153,10 +8414,7 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/customers/${p["customer"]}/sources`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
@@ -9164,13 +8422,8 @@ export class StripeApi extends AbstractFetchClient {
       object: p["object"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postCustomersCustomerSources(
@@ -9261,25 +8514,16 @@ export class StripeApi extends AbstractFetchClient {
       customer: string
       expand?: string[]
       id: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_payment_source> | Res<StatusCode, t_error>> {
     const url =
       this.basePath + `/v1/customers/${p["customer"]}/sources/${p["id"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postCustomersCustomerSourcesId(
@@ -9366,7 +8610,6 @@ export class StripeApi extends AbstractFetchClient {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -9383,23 +8626,15 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/customers/${p["customer"]}/subscriptions`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postCustomersCustomerSubscriptions(
@@ -9760,7 +8995,6 @@ export class StripeApi extends AbstractFetchClient {
       customer: string
       expand?: string[]
       subscriptionExposedId: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -9768,18 +9002,10 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath +
       `/v1/customers/${p["customer"]}/subscriptions/${p["subscriptionExposedId"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postCustomersCustomerSubscriptionsSubscriptionExposedId(
@@ -10149,7 +9375,6 @@ export class StripeApi extends AbstractFetchClient {
     p: {
       customer: string
       subscriptionExposedId: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -10157,13 +9382,9 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath +
       `/v1/customers/${p["customer"]}/subscriptions/${p["subscriptionExposedId"]}/discount`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
-    const body = JSON.stringify(p.requestBody)
+    const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, {method: "DELETE", body, ...opts, headers}, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async getCustomersCustomerSubscriptionsSubscriptionExposedIdDiscount(
@@ -10171,7 +9392,6 @@ export class StripeApi extends AbstractFetchClient {
       customer: string
       expand?: string[]
       subscriptionExposedId: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -10179,18 +9399,10 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath +
       `/v1/customers/${p["customer"]}/subscriptions/${p["subscriptionExposedId"]}/discount`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getCustomersCustomerTaxIds(
@@ -10200,7 +9412,6 @@ export class StripeApi extends AbstractFetchClient {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -10217,23 +9428,15 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/customers/${p["customer"]}/tax_ids`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postCustomersCustomerTaxIds(
@@ -10373,20 +9576,15 @@ export class StripeApi extends AbstractFetchClient {
     p: {
       customer: string
       id: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_deleted_tax_id> | Res<StatusCode, t_error>> {
     const url =
       this.basePath + `/v1/customers/${p["customer"]}/tax_ids/${p["id"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
-    const body = JSON.stringify(p.requestBody)
+    const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, {method: "DELETE", body, ...opts, headers}, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async getCustomersCustomerTaxIdsId(
@@ -10394,25 +9592,16 @@ export class StripeApi extends AbstractFetchClient {
       customer: string
       expand?: string[]
       id: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_tax_id> | Res<StatusCode, t_error>> {
     const url =
       this.basePath + `/v1/customers/${p["customer"]}/tax_ids/${p["id"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getDisputes(
@@ -10431,7 +9620,6 @@ export class StripeApi extends AbstractFetchClient {
       limit?: number
       paymentIntent?: string
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: RequestInit = {},
@@ -10448,10 +9636,7 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/disputes`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       charge: p["charge"],
       created: p["created"],
@@ -10461,37 +9646,23 @@ export class StripeApi extends AbstractFetchClient {
       payment_intent: p["paymentIntent"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getDisputesDispute(
     p: {
       dispute: string
       expand?: string[]
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_dispute> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/disputes/${p["dispute"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postDisputesDispute(
@@ -10636,7 +9807,6 @@ export class StripeApi extends AbstractFetchClient {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -10653,10 +9823,7 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/entitlements/active_entitlements`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       customer: p["customer"],
       ending_before: p["endingBefore"],
@@ -10664,20 +9831,14 @@ export class StripeApi extends AbstractFetchClient {
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getEntitlementsActiveEntitlementsId(
     p: {
       expand?: string[]
       id: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -10686,18 +9847,10 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url =
       this.basePath + `/v1/entitlements/active_entitlements/${p["id"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getEntitlementsFeatures(
@@ -10708,7 +9861,6 @@ export class StripeApi extends AbstractFetchClient {
       limit?: number
       lookupKey?: string
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: RequestInit = {},
@@ -10725,10 +9877,7 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/entitlements/features`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       archived: p["archived"],
       ending_before: p["endingBefore"],
@@ -10737,13 +9886,8 @@ export class StripeApi extends AbstractFetchClient {
       lookup_key: p["lookupKey"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postEntitlementsFeatures(
@@ -10774,24 +9918,15 @@ export class StripeApi extends AbstractFetchClient {
     p: {
       expand?: string[]
       id: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_entitlements_feature> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/entitlements/features/${p["id"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postEntitlementsFeaturesId(
@@ -10882,7 +10017,6 @@ export class StripeApi extends AbstractFetchClient {
       startingAfter?: string
       type?: string
       types?: string[]
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: RequestInit = {},
@@ -10899,10 +10033,7 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/events`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       created: p["created"],
       delivery_success: p["deliverySuccess"],
@@ -10913,37 +10044,23 @@ export class StripeApi extends AbstractFetchClient {
       type: p["type"],
       types: p["types"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getEventsId(
     p: {
       expand?: string[]
       id: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_event> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/events/${p["id"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getExchangeRates(
@@ -10952,7 +10069,6 @@ export class StripeApi extends AbstractFetchClient {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: RequestInit = {},
@@ -10969,47 +10085,30 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/exchange_rates`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getExchangeRatesRateId(
     p: {
       expand?: string[]
       rateId: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_exchange_rate> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/exchange_rates/${p["rateId"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postExternalAccountsId(
@@ -11081,7 +10180,6 @@ export class StripeApi extends AbstractFetchClient {
       file?: string
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: RequestInit = {},
@@ -11098,10 +10196,7 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/file_links`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       created: p["created"],
       ending_before: p["endingBefore"],
@@ -11111,13 +10206,8 @@ export class StripeApi extends AbstractFetchClient {
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postFileLinks(
@@ -11151,24 +10241,15 @@ export class StripeApi extends AbstractFetchClient {
     p: {
       expand?: string[]
       link: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_file_link> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/file_links/${p["link"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postFileLinksLink(
@@ -11231,7 +10312,6 @@ export class StripeApi extends AbstractFetchClient {
         | "terminal_reader_splashscreen"
         | UnknownEnumStringValue
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: RequestInit = {},
@@ -11248,10 +10328,7 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/files`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       created: p["created"],
       ending_before: p["endingBefore"],
@@ -11260,13 +10337,8 @@ export class StripeApi extends AbstractFetchClient {
       purpose: p["purpose"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postFiles(
@@ -11319,24 +10391,15 @@ export class StripeApi extends AbstractFetchClient {
     p: {
       expand?: string[]
       file: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_file> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/files/${p["file"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getFinancialConnectionsAccounts(
@@ -11350,7 +10413,6 @@ export class StripeApi extends AbstractFetchClient {
       limit?: number
       session?: string
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: RequestInit = {},
@@ -11367,10 +10429,7 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/financial_connections/accounts`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       account_holder: p["accountHolder"],
       ending_before: p["endingBefore"],
@@ -11379,20 +10438,14 @@ export class StripeApi extends AbstractFetchClient {
       session: p["session"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getFinancialConnectionsAccountsAccount(
     p: {
       account: string
       expand?: string[]
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -11401,18 +10454,10 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url =
       this.basePath + `/v1/financial_connections/accounts/${p["account"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postFinancialConnectionsAccountsAccountDisconnect(
@@ -11447,7 +10492,6 @@ export class StripeApi extends AbstractFetchClient {
       limit?: number
       ownership: string
       startingAfter?: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -11466,10 +10510,7 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath +
       `/v1/financial_connections/accounts/${p["account"]}/owners`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
@@ -11477,13 +10518,8 @@ export class StripeApi extends AbstractFetchClient {
       ownership: p["ownership"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postFinancialConnectionsAccountsAccountRefresh(
@@ -11621,7 +10657,6 @@ export class StripeApi extends AbstractFetchClient {
     p: {
       expand?: string[]
       session: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -11630,18 +10665,10 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url =
       this.basePath + `/v1/financial_connections/sessions/${p["session"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getFinancialConnectionsTransactions(
@@ -11662,7 +10689,6 @@ export class StripeApi extends AbstractFetchClient {
       transactionRefresh?: {
         after: string
       }
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -11679,10 +10705,7 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/financial_connections/transactions`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       account: p["account"],
       ending_before: p["endingBefore"],
@@ -11692,20 +10715,14 @@ export class StripeApi extends AbstractFetchClient {
       transacted_at: p["transactedAt"],
       transaction_refresh: p["transactionRefresh"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getFinancialConnectionsTransactionsTransaction(
     p: {
       expand?: string[]
       transaction: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -11715,18 +10732,10 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath +
       `/v1/financial_connections/transactions/${p["transaction"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getForwardingRequests(
@@ -11741,7 +10750,6 @@ export class StripeApi extends AbstractFetchClient {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: RequestInit = {},
@@ -11758,10 +10766,7 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/forwarding/requests`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       created: p["created"],
       ending_before: p["endingBefore"],
@@ -11769,13 +10774,8 @@ export class StripeApi extends AbstractFetchClient {
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postForwardingRequests(
@@ -11821,24 +10821,15 @@ export class StripeApi extends AbstractFetchClient {
     p: {
       expand?: string[]
       id: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_forwarding_request> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/forwarding/requests/${p["id"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getIdentityVerificationReports(
@@ -11858,7 +10849,6 @@ export class StripeApi extends AbstractFetchClient {
       startingAfter?: string
       type?: "document" | "id_number" | UnknownEnumStringValue
       verificationSession?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: RequestInit = {},
@@ -11875,10 +10865,7 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/identity/verification_reports`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       client_reference_id: p["clientReferenceId"],
       created: p["created"],
@@ -11889,20 +10876,14 @@ export class StripeApi extends AbstractFetchClient {
       type: p["type"],
       verification_session: p["verificationSession"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getIdentityVerificationReportsReport(
     p: {
       expand?: string[]
       report: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -11911,18 +10892,10 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url =
       this.basePath + `/v1/identity/verification_reports/${p["report"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getIdentityVerificationSessions(
@@ -11947,7 +10920,6 @@ export class StripeApi extends AbstractFetchClient {
         | "requires_input"
         | "verified"
         | UnknownEnumStringValue
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: RequestInit = {},
@@ -11964,10 +10936,7 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/identity/verification_sessions`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       client_reference_id: p["clientReferenceId"],
       created: p["created"],
@@ -11978,13 +10947,8 @@ export class StripeApi extends AbstractFetchClient {
       starting_after: p["startingAfter"],
       status: p["status"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postIdentityVerificationSessions(
@@ -12044,7 +11008,6 @@ export class StripeApi extends AbstractFetchClient {
     p: {
       expand?: string[]
       session: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -12053,18 +11016,10 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url =
       this.basePath + `/v1/identity/verification_sessions/${p["session"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postIdentityVerificationSessionsSession(
@@ -12174,7 +11129,6 @@ export class StripeApi extends AbstractFetchClient {
       }
       startingAfter?: string
       status?: "canceled" | "open" | "paid" | UnknownEnumStringValue
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: RequestInit = {},
@@ -12191,10 +11145,7 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/invoice_payments`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
@@ -12204,37 +11155,23 @@ export class StripeApi extends AbstractFetchClient {
       starting_after: p["startingAfter"],
       status: p["status"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getInvoicePaymentsInvoicePayment(
     p: {
       expand?: string[]
       invoicePayment: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_invoice_payment> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/invoice_payments/${p["invoicePayment"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getInvoiceRenderingTemplates(
@@ -12244,7 +11181,6 @@ export class StripeApi extends AbstractFetchClient {
       limit?: number
       startingAfter?: string
       status?: "active" | "archived" | UnknownEnumStringValue
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: RequestInit = {},
@@ -12261,10 +11197,7 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/invoice_rendering_templates`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
@@ -12272,13 +11205,8 @@ export class StripeApi extends AbstractFetchClient {
       starting_after: p["startingAfter"],
       status: p["status"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getInvoiceRenderingTemplatesTemplate(
@@ -12286,7 +11214,6 @@ export class StripeApi extends AbstractFetchClient {
       expand?: string[]
       template: string
       version?: number
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -12295,18 +11222,10 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url =
       this.basePath + `/v1/invoice_rendering_templates/${p["template"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"], version: p["version"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postInvoiceRenderingTemplatesTemplateArchive(
@@ -12373,7 +11292,6 @@ export class StripeApi extends AbstractFetchClient {
       limit?: number
       pending?: boolean
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: RequestInit = {},
@@ -12390,10 +11308,7 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/invoiceitems`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       created: p["created"],
       customer: p["customer"],
@@ -12404,13 +11319,8 @@ export class StripeApi extends AbstractFetchClient {
       pending: p["pending"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postInvoiceitems(
@@ -12483,43 +11393,29 @@ export class StripeApi extends AbstractFetchClient {
   async deleteInvoiceitemsInvoiceitem(
     p: {
       invoiceitem: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_deleted_invoiceitem> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/invoiceitems/${p["invoiceitem"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
-    const body = JSON.stringify(p.requestBody)
+    const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, {method: "DELETE", body, ...opts, headers}, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async getInvoiceitemsInvoiceitem(
     p: {
       expand?: string[]
       invoiceitem: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_invoiceitem> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/invoiceitems/${p["invoiceitem"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postInvoiceitemsInvoiceitem(
@@ -12621,7 +11517,6 @@ export class StripeApi extends AbstractFetchClient {
         | "void"
         | UnknownEnumStringValue
       subscription?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: RequestInit = {},
@@ -12638,10 +11533,7 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/invoices`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       collection_method: p["collectionMethod"],
       created: p["created"],
@@ -12654,13 +11546,8 @@ export class StripeApi extends AbstractFetchClient {
       status: p["status"],
       subscription: p["subscription"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postInvoices(
@@ -13430,7 +12317,6 @@ export class StripeApi extends AbstractFetchClient {
       limit?: number
       page?: string
       query: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -13449,65 +12335,43 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/invoices/search`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       expand: p["expand"],
       limit: p["limit"],
       page: p["page"],
       query: p["query"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async deleteInvoicesInvoice(
     p: {
       invoice: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_deleted_invoice> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/invoices/${p["invoice"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
-    const body = JSON.stringify(p.requestBody)
+    const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, {method: "DELETE", body, ...opts, headers}, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async getInvoicesInvoice(
     p: {
       expand?: string[]
       invoice: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_invoice> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/invoices/${p["invoice"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postInvoicesInvoice(
@@ -14001,7 +12865,6 @@ export class StripeApi extends AbstractFetchClient {
       invoice: string
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -14018,23 +12881,15 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/invoices/${p["invoice"]}/lines`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postInvoicesInvoiceLinesLineItemId(
@@ -14433,7 +13288,6 @@ export class StripeApi extends AbstractFetchClient {
         | "pending"
         | "reversed"
         | UnknownEnumStringValue
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: RequestInit = {},
@@ -14450,10 +13304,7 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/issuing/authorizations`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       card: p["card"],
       cardholder: p["cardholder"],
@@ -14464,38 +13315,24 @@ export class StripeApi extends AbstractFetchClient {
       starting_after: p["startingAfter"],
       status: p["status"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getIssuingAuthorizationsAuthorization(
     p: {
       authorization: string
       expand?: string[]
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_issuing_authorization> | Res<StatusCode, t_error>> {
     const url =
       this.basePath + `/v1/issuing/authorizations/${p["authorization"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postIssuingAuthorizationsAuthorization(
@@ -14598,7 +13435,6 @@ export class StripeApi extends AbstractFetchClient {
       startingAfter?: string
       status?: "active" | "blocked" | "inactive" | UnknownEnumStringValue
       type?: "company" | "individual" | UnknownEnumStringValue
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: RequestInit = {},
@@ -14615,10 +13451,7 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/issuing/cardholders`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       created: p["created"],
       email: p["email"],
@@ -14630,13 +13463,8 @@ export class StripeApi extends AbstractFetchClient {
       status: p["status"],
       type: p["type"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postIssuingCardholders(
@@ -15623,24 +14451,15 @@ export class StripeApi extends AbstractFetchClient {
     p: {
       cardholder: string
       expand?: string[]
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_issuing_cardholder> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/issuing/cardholders/${p["cardholder"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postIssuingCardholdersCardholder(
@@ -16643,7 +15462,6 @@ export class StripeApi extends AbstractFetchClient {
       startingAfter?: string
       status?: "active" | "canceled" | "inactive" | UnknownEnumStringValue
       type?: "physical" | "virtual" | UnknownEnumStringValue
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: RequestInit = {},
@@ -16660,10 +15478,7 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/issuing/cards`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       cardholder: p["cardholder"],
       created: p["created"],
@@ -16678,13 +15493,8 @@ export class StripeApi extends AbstractFetchClient {
       status: p["status"],
       type: p["type"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postIssuingCards(
@@ -17664,24 +16474,15 @@ export class StripeApi extends AbstractFetchClient {
     p: {
       card: string
       expand?: string[]
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_issuing_card> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/issuing/cards/${p["card"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postIssuingCardsCard(
@@ -18672,7 +17473,6 @@ export class StripeApi extends AbstractFetchClient {
         | "won"
         | UnknownEnumStringValue
       transaction?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: RequestInit = {},
@@ -18689,10 +17489,7 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/issuing/disputes`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       created: p["created"],
       ending_before: p["endingBefore"],
@@ -18702,13 +17499,8 @@ export class StripeApi extends AbstractFetchClient {
       status: p["status"],
       transaction: p["transaction"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postIssuingDisputes(
@@ -18857,24 +17649,15 @@ export class StripeApi extends AbstractFetchClient {
     p: {
       dispute: string
       expand?: string[]
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_issuing_dispute> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/issuing/disputes/${p["dispute"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postIssuingDisputesDispute(
@@ -19062,7 +17845,6 @@ export class StripeApi extends AbstractFetchClient {
         | "rejected"
         | "review"
         | UnknownEnumStringValue
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: RequestInit = {},
@@ -19079,10 +17861,7 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/issuing/personalization_designs`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
@@ -19092,13 +17871,8 @@ export class StripeApi extends AbstractFetchClient {
       starting_after: p["startingAfter"],
       status: p["status"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postIssuingPersonalizationDesigns(
@@ -19143,7 +17917,6 @@ export class StripeApi extends AbstractFetchClient {
     p: {
       expand?: string[]
       personalizationDesign: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -19153,18 +17926,10 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath +
       `/v1/issuing/personalization_designs/${p["personalizationDesign"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postIssuingPersonalizationDesignsPersonalizationDesign(
@@ -19219,7 +17984,6 @@ export class StripeApi extends AbstractFetchClient {
       startingAfter?: string
       status?: "active" | "inactive" | "review" | UnknownEnumStringValue
       type?: "custom" | "standard" | UnknownEnumStringValue
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: RequestInit = {},
@@ -19236,10 +18000,7 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/issuing/physical_bundles`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
@@ -19248,62 +18009,39 @@ export class StripeApi extends AbstractFetchClient {
       status: p["status"],
       type: p["type"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getIssuingPhysicalBundlesPhysicalBundle(
     p: {
       expand?: string[]
       physicalBundle: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_issuing_physical_bundle> | Res<StatusCode, t_error>> {
     const url =
       this.basePath + `/v1/issuing/physical_bundles/${p["physicalBundle"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getIssuingSettlementsSettlement(
     p: {
       expand?: string[]
       settlement: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_issuing_settlement> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/issuing/settlements/${p["settlement"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postIssuingSettlementsSettlement(
@@ -19350,7 +18088,6 @@ export class StripeApi extends AbstractFetchClient {
         | "requested"
         | "suspended"
         | UnknownEnumStringValue
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -19367,10 +18104,7 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/issuing/tokens`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       card: p["card"],
       created: p["created"],
@@ -19380,37 +18114,23 @@ export class StripeApi extends AbstractFetchClient {
       starting_after: p["startingAfter"],
       status: p["status"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getIssuingTokensToken(
     p: {
       expand?: string[]
       token: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_issuing_token> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/issuing/tokens/${p["token"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postIssuingTokensToken(
@@ -19451,7 +18171,6 @@ export class StripeApi extends AbstractFetchClient {
       limit?: number
       startingAfter?: string
       type?: "capture" | "refund" | UnknownEnumStringValue
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: RequestInit = {},
@@ -19468,10 +18187,7 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/issuing/transactions`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       card: p["card"],
       cardholder: p["cardholder"],
@@ -19482,37 +18198,23 @@ export class StripeApi extends AbstractFetchClient {
       starting_after: p["startingAfter"],
       type: p["type"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getIssuingTransactionsTransaction(
     p: {
       expand?: string[]
       transaction: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_issuing_transaction> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/issuing/transactions/${p["transaction"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postIssuingTransactionsTransaction(
@@ -19596,7 +18298,6 @@ export class StripeApi extends AbstractFetchClient {
     p: {
       expand?: string[]
       session: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -19604,18 +18305,10 @@ export class StripeApi extends AbstractFetchClient {
     Res<200, t_financial_connections_session> | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/link_account_sessions/${p["session"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getLinkedAccounts(
@@ -19629,7 +18322,6 @@ export class StripeApi extends AbstractFetchClient {
       limit?: number
       session?: string
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: RequestInit = {},
@@ -19646,10 +18338,7 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/linked_accounts`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       account_holder: p["accountHolder"],
       ending_before: p["endingBefore"],
@@ -19658,20 +18347,14 @@ export class StripeApi extends AbstractFetchClient {
       session: p["session"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getLinkedAccountsAccount(
     p: {
       account: string
       expand?: string[]
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -19679,18 +18362,10 @@ export class StripeApi extends AbstractFetchClient {
     Res<200, t_financial_connections_account> | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/linked_accounts/${p["account"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postLinkedAccountsAccountDisconnect(
@@ -19723,7 +18398,6 @@ export class StripeApi extends AbstractFetchClient {
       limit?: number
       ownership: string
       startingAfter?: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -19740,10 +18414,7 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/linked_accounts/${p["account"]}/owners`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
@@ -19751,13 +18422,8 @@ export class StripeApi extends AbstractFetchClient {
       ownership: p["ownership"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postLinkedAccountsAccountRefresh(
@@ -19792,24 +18458,15 @@ export class StripeApi extends AbstractFetchClient {
     p: {
       expand?: string[]
       mandate: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_mandate> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/mandates/${p["mandate"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getPaymentIntents(
@@ -19827,7 +18484,6 @@ export class StripeApi extends AbstractFetchClient {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: RequestInit = {},
@@ -19844,10 +18500,7 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/payment_intents`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       created: p["created"],
       customer: p["customer"],
@@ -19856,13 +18509,8 @@ export class StripeApi extends AbstractFetchClient {
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postPaymentIntents(
@@ -20994,7 +19642,6 @@ export class StripeApi extends AbstractFetchClient {
       limit?: number
       page?: string
       query: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -21013,23 +19660,15 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/payment_intents/search`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       expand: p["expand"],
       limit: p["limit"],
       page: p["page"],
       query: p["query"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getPaymentIntentsIntent(
@@ -21037,27 +19676,18 @@ export class StripeApi extends AbstractFetchClient {
       clientSecret?: string
       expand?: string[]
       intent: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_payment_intent> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/payment_intents/${p["intent"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       client_secret: p["clientSecret"],
       expand: p["expand"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postPaymentIntentsIntent(
@@ -23422,7 +22052,6 @@ export class StripeApi extends AbstractFetchClient {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: RequestInit = {},
@@ -23439,10 +22068,7 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/payment_links`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       active: p["active"],
       ending_before: p["endingBefore"],
@@ -23450,13 +22076,8 @@ export class StripeApi extends AbstractFetchClient {
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postPaymentLinks(
@@ -23977,24 +22598,15 @@ export class StripeApi extends AbstractFetchClient {
     p: {
       expand?: string[]
       paymentLink: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_payment_link> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/payment_links/${p["paymentLink"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postPaymentLinksPaymentLink(
@@ -24504,7 +23116,6 @@ export class StripeApi extends AbstractFetchClient {
       limit?: number
       paymentLink: string
       startingAfter?: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -24522,23 +23133,15 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url =
       this.basePath + `/v1/payment_links/${p["paymentLink"]}/line_items`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getPaymentMethodConfigurations(
@@ -24548,7 +23151,6 @@ export class StripeApi extends AbstractFetchClient {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: RequestInit = {},
@@ -24565,10 +23167,7 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/payment_method_configurations`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       application: p["application"],
       ending_before: p["endingBefore"],
@@ -24576,13 +23175,8 @@ export class StripeApi extends AbstractFetchClient {
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postPaymentMethodConfigurations(
@@ -24872,7 +23466,6 @@ export class StripeApi extends AbstractFetchClient {
     p: {
       configuration: string
       expand?: string[]
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -24881,18 +23474,10 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url =
       this.basePath + `/v1/payment_method_configurations/${p["configuration"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postPaymentMethodConfigurationsConfiguration(
@@ -25188,7 +23773,6 @@ export class StripeApi extends AbstractFetchClient {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: RequestInit = {},
@@ -25205,10 +23789,7 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/payment_method_domains`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       domain_name: p["domainName"],
       enabled: p["enabled"],
@@ -25217,13 +23798,8 @@ export class StripeApi extends AbstractFetchClient {
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postPaymentMethodDomains(
@@ -25251,25 +23827,16 @@ export class StripeApi extends AbstractFetchClient {
     p: {
       expand?: string[]
       paymentMethodDomain: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_payment_method_domain> | Res<StatusCode, t_error>> {
     const url =
       this.basePath + `/v1/payment_method_domains/${p["paymentMethodDomain"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postPaymentMethodDomainsPaymentMethodDomain(
@@ -25373,7 +23940,6 @@ export class StripeApi extends AbstractFetchClient {
         | "wechat_pay"
         | "zip"
         | UnknownEnumStringValue
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: RequestInit = {},
@@ -25390,10 +23956,7 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/payment_methods`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       customer: p["customer"],
       ending_before: p["endingBefore"],
@@ -25402,13 +23965,8 @@ export class StripeApi extends AbstractFetchClient {
       starting_after: p["startingAfter"],
       type: p["type"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postPaymentMethods(
@@ -25731,24 +24289,15 @@ export class StripeApi extends AbstractFetchClient {
     p: {
       expand?: string[]
       paymentMethod: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_payment_method> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/payment_methods/${p["paymentMethod"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postPaymentMethodsPaymentMethod(
@@ -25887,7 +24436,6 @@ export class StripeApi extends AbstractFetchClient {
       limit?: number
       startingAfter?: string
       status?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: RequestInit = {},
@@ -25904,10 +24452,7 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/payouts`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       arrival_date: p["arrivalDate"],
       created: p["created"],
@@ -25918,13 +24463,8 @@ export class StripeApi extends AbstractFetchClient {
       starting_after: p["startingAfter"],
       status: p["status"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postPayouts(
@@ -25960,24 +24500,15 @@ export class StripeApi extends AbstractFetchClient {
     p: {
       expand?: string[]
       payout: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_payout> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/payouts/${p["payout"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postPayoutsPayout(
@@ -26065,7 +24596,6 @@ export class StripeApi extends AbstractFetchClient {
       limit?: number
       product?: string
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: RequestInit = {},
@@ -26082,10 +24612,7 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/plans`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       active: p["active"],
       created: p["created"],
@@ -26095,13 +24622,8 @@ export class StripeApi extends AbstractFetchClient {
       product: p["product"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postPlans(
@@ -26169,43 +24691,29 @@ export class StripeApi extends AbstractFetchClient {
   async deletePlansPlan(
     p: {
       plan: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_deleted_plan> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/plans/${p["plan"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
-    const body = JSON.stringify(p.requestBody)
+    const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, {method: "DELETE", body, ...opts, headers}, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async getPlansPlan(
     p: {
       expand?: string[]
       plan: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_plan> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/plans/${p["plan"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postPlansPlan(
@@ -26262,7 +24770,6 @@ export class StripeApi extends AbstractFetchClient {
       }
       startingAfter?: string
       type?: "one_time" | "recurring" | UnknownEnumStringValue
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: RequestInit = {},
@@ -26279,10 +24786,7 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/prices`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       active: p["active"],
       created: p["created"],
@@ -26296,13 +24800,8 @@ export class StripeApi extends AbstractFetchClient {
       starting_after: p["startingAfter"],
       type: p["type"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postPrices(
@@ -26408,7 +24907,6 @@ export class StripeApi extends AbstractFetchClient {
       limit?: number
       page?: string
       query: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -26427,47 +24925,30 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/prices/search`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       expand: p["expand"],
       limit: p["limit"],
       page: p["page"],
       query: p["query"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getPricesPrice(
     p: {
       expand?: string[]
       price: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_price> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/prices/${p["price"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postPricesPrice(
@@ -26552,7 +25033,6 @@ export class StripeApi extends AbstractFetchClient {
       shippable?: boolean
       startingAfter?: string
       url?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: RequestInit = {},
@@ -26569,10 +25049,7 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/products`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       active: p["active"],
       created: p["created"],
@@ -26584,13 +25061,8 @@ export class StripeApi extends AbstractFetchClient {
       starting_after: p["startingAfter"],
       url: p["url"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postProducts(
@@ -26689,7 +25161,6 @@ export class StripeApi extends AbstractFetchClient {
       limit?: number
       page?: string
       query: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -26708,65 +25179,43 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/products/search`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       expand: p["expand"],
       limit: p["limit"],
       page: p["page"],
       query: p["query"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async deleteProductsId(
     p: {
       id: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_deleted_product> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/products/${p["id"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
-    const body = JSON.stringify(p.requestBody)
+    const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, {method: "DELETE", body, ...opts, headers}, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async getProductsId(
     p: {
       expand?: string[]
       id: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_product> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/products/${p["id"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postProductsId(
@@ -26827,7 +25276,6 @@ export class StripeApi extends AbstractFetchClient {
       limit?: number
       product: string
       startingAfter?: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -26844,23 +25292,15 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/products/${p["product"]}/features`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postProductsProductFeatures(
@@ -26888,20 +25328,15 @@ export class StripeApi extends AbstractFetchClient {
     p: {
       id: string
       product: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_deleted_product_feature> | Res<StatusCode, t_error>> {
     const url =
       this.basePath + `/v1/products/${p["product"]}/features/${p["id"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
-    const body = JSON.stringify(p.requestBody)
+    const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, {method: "DELETE", body, ...opts, headers}, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async getProductsProductFeaturesId(
@@ -26909,25 +25344,16 @@ export class StripeApi extends AbstractFetchClient {
       expand?: string[]
       id: string
       product: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_product_feature> | Res<StatusCode, t_error>> {
     const url =
       this.basePath + `/v1/products/${p["product"]}/features/${p["id"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getPromotionCodes(
@@ -26948,7 +25374,6 @@ export class StripeApi extends AbstractFetchClient {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: RequestInit = {},
@@ -26965,10 +25390,7 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/promotion_codes`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       active: p["active"],
       code: p["code"],
@@ -26980,13 +25402,8 @@ export class StripeApi extends AbstractFetchClient {
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postPromotionCodes(
@@ -27033,24 +25450,15 @@ export class StripeApi extends AbstractFetchClient {
     p: {
       expand?: string[]
       promotionCode: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_promotion_code> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/promotion_codes/${p["promotionCode"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postPromotionCodesPromotionCode(
@@ -27103,7 +25511,6 @@ export class StripeApi extends AbstractFetchClient {
         | "open"
         | UnknownEnumStringValue
       testClock?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: RequestInit = {},
@@ -27120,10 +25527,7 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/quotes`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       customer: p["customer"],
       ending_before: p["endingBefore"],
@@ -27133,13 +25537,8 @@ export class StripeApi extends AbstractFetchClient {
       status: p["status"],
       test_clock: p["testClock"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postQuotes(
@@ -27264,24 +25663,15 @@ export class StripeApi extends AbstractFetchClient {
     p: {
       expand?: string[]
       quote: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_quote> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/quotes/${p["quote"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postQuotesQuote(
@@ -27443,7 +25833,6 @@ export class StripeApi extends AbstractFetchClient {
       limit?: number
       quote: string
       startingAfter?: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -27461,23 +25850,15 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url =
       this.basePath + `/v1/quotes/${p["quote"]}/computed_upfront_line_items`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postQuotesQuoteFinalize(
@@ -27508,7 +25889,6 @@ export class StripeApi extends AbstractFetchClient {
       limit?: number
       quote: string
       startingAfter?: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -27525,30 +25905,21 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/quotes/${p["quote"]}/line_items`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getQuotesQuotePdf(
     p: {
       expand?: string[]
       quote: string
-      requestBody?: EmptyObject
     },
     basePath:
       | Server<"getQuotesQuotePdf_StripeApi">
@@ -27557,18 +25928,10 @@ export class StripeApi extends AbstractFetchClient {
     opts: RequestInit = {},
   ): Promise<Res<200, string> | Res<StatusCode, t_error>> {
     const url = basePath + `/v1/quotes/${p["quote"]}/pdf`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getRadarEarlyFraudWarnings(
@@ -27587,7 +25950,6 @@ export class StripeApi extends AbstractFetchClient {
       limit?: number
       paymentIntent?: string
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: RequestInit = {},
@@ -27604,10 +25966,7 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/radar/early_fraud_warnings`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       charge: p["charge"],
       created: p["created"],
@@ -27617,38 +25976,24 @@ export class StripeApi extends AbstractFetchClient {
       payment_intent: p["paymentIntent"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getRadarEarlyFraudWarningsEarlyFraudWarning(
     p: {
       earlyFraudWarning: string
       expand?: string[]
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_radar_early_fraud_warning> | Res<StatusCode, t_error>> {
     const url =
       this.basePath + `/v1/radar/early_fraud_warnings/${p["earlyFraudWarning"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getRadarValueListItems(
@@ -27667,7 +26012,6 @@ export class StripeApi extends AbstractFetchClient {
       startingAfter?: string
       value?: string
       valueList: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -27684,10 +26028,7 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/radar/value_list_items`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       created: p["created"],
       ending_before: p["endingBefore"],
@@ -27697,13 +26038,8 @@ export class StripeApi extends AbstractFetchClient {
       value: p["value"],
       value_list: p["valueList"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postRadarValueListItems(
@@ -27730,7 +26066,6 @@ export class StripeApi extends AbstractFetchClient {
   async deleteRadarValueListItemsItem(
     p: {
       item: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -27738,37 +26073,24 @@ export class StripeApi extends AbstractFetchClient {
     Res<200, t_deleted_radar_value_list_item> | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/radar/value_list_items/${p["item"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
-    const body = JSON.stringify(p.requestBody)
+    const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, {method: "DELETE", body, ...opts, headers}, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async getRadarValueListItemsItem(
     p: {
       expand?: string[]
       item: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_radar_value_list_item> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/radar/value_list_items/${p["item"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getRadarValueLists(
@@ -27787,7 +26109,6 @@ export class StripeApi extends AbstractFetchClient {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: RequestInit = {},
@@ -27804,10 +26125,7 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/radar/value_lists`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       alias: p["alias"],
       contains: p["contains"],
@@ -27817,13 +26135,8 @@ export class StripeApi extends AbstractFetchClient {
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postRadarValueLists(
@@ -27865,43 +26178,29 @@ export class StripeApi extends AbstractFetchClient {
   async deleteRadarValueListsValueList(
     p: {
       valueList: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_deleted_radar_value_list> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/radar/value_lists/${p["valueList"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
-    const body = JSON.stringify(p.requestBody)
+    const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, {method: "DELETE", body, ...opts, headers}, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async getRadarValueListsValueList(
     p: {
       expand?: string[]
       valueList: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_radar_value_list> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/radar/value_lists/${p["valueList"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postRadarValueListsValueList(
@@ -27945,7 +26244,6 @@ export class StripeApi extends AbstractFetchClient {
       limit?: number
       paymentIntent?: string
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: RequestInit = {},
@@ -27962,10 +26260,7 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/refunds`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       charge: p["charge"],
       created: p["created"],
@@ -27975,13 +26270,8 @@ export class StripeApi extends AbstractFetchClient {
       payment_intent: p["paymentIntent"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postRefunds(
@@ -28027,24 +26317,15 @@ export class StripeApi extends AbstractFetchClient {
     p: {
       expand?: string[]
       refund: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_refund> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/refunds/${p["refund"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postRefundsRefund(
@@ -28107,7 +26388,6 @@ export class StripeApi extends AbstractFetchClient {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: RequestInit = {},
@@ -28124,10 +26404,7 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/reporting/report_runs`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       created: p["created"],
       ending_before: p["endingBefore"],
@@ -28135,13 +26412,8 @@ export class StripeApi extends AbstractFetchClient {
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postReportingReportRuns(
@@ -28815,30 +27087,20 @@ export class StripeApi extends AbstractFetchClient {
     p: {
       expand?: string[]
       reportRun: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_reporting_report_run> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/reporting/report_runs/${p["reportRun"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getReportingReportTypes(
     p: {
       expand?: string[]
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: RequestInit = {},
@@ -28855,42 +27117,25 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/reporting/report_types`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getReportingReportTypesReportType(
     p: {
       expand?: string[]
       reportType: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_reporting_report_type> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/reporting/report_types/${p["reportType"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getReviews(
@@ -28907,7 +27152,6 @@ export class StripeApi extends AbstractFetchClient {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: RequestInit = {},
@@ -28924,10 +27168,7 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/reviews`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       created: p["created"],
       ending_before: p["endingBefore"],
@@ -28935,37 +27176,23 @@ export class StripeApi extends AbstractFetchClient {
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getReviewsReview(
     p: {
       expand?: string[]
       review: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_review> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/reviews/${p["review"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postReviewsReviewApprove(
@@ -29003,7 +27230,6 @@ export class StripeApi extends AbstractFetchClient {
       limit?: number
       setupIntent: string
       startingAfter?: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -29020,10 +27246,7 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/setup_attempts`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       created: p["created"],
       ending_before: p["endingBefore"],
@@ -29032,13 +27255,8 @@ export class StripeApi extends AbstractFetchClient {
       setup_intent: p["setupIntent"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getSetupIntents(
@@ -29058,7 +27276,6 @@ export class StripeApi extends AbstractFetchClient {
       limit?: number
       paymentMethod?: string
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: RequestInit = {},
@@ -29075,10 +27292,7 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/setup_intents`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       attach_to_self: p["attachToSelf"],
       created: p["created"],
@@ -29089,13 +27303,8 @@ export class StripeApi extends AbstractFetchClient {
       payment_method: p["paymentMethod"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postSetupIntents(
@@ -29680,27 +27889,18 @@ export class StripeApi extends AbstractFetchClient {
       clientSecret?: string
       expand?: string[]
       intent: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_setup_intent> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/setup_intents/${p["intent"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       client_secret: p["clientSecret"],
       expand: p["expand"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postSetupIntentsIntent(
@@ -30889,7 +29089,6 @@ export class StripeApi extends AbstractFetchClient {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: RequestInit = {},
@@ -30906,10 +29105,7 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/shipping_rates`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       active: p["active"],
       created: p["created"],
@@ -30919,13 +29115,8 @@ export class StripeApi extends AbstractFetchClient {
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postShippingRates(
@@ -31000,24 +29191,15 @@ export class StripeApi extends AbstractFetchClient {
     p: {
       expand?: string[]
       shippingRateToken: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_shipping_rate> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/shipping_rates/${p["shippingRateToken"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postShippingRatesShippingRateToken(
@@ -31094,7 +29276,6 @@ export class StripeApi extends AbstractFetchClient {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: RequestInit = {},
@@ -31111,48 +29292,31 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/sigma/scheduled_query_runs`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getSigmaScheduledQueryRunsScheduledQueryRun(
     p: {
       expand?: string[]
       scheduledQueryRun: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_scheduled_query_run> | Res<StatusCode, t_error>> {
     const url =
       this.basePath + `/v1/sigma/scheduled_query_runs/${p["scheduledQueryRun"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postSources(
@@ -31284,27 +29448,18 @@ export class StripeApi extends AbstractFetchClient {
       clientSecret?: string
       expand?: string[]
       source: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_source> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/sources/${p["source"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       client_secret: p["clientSecret"],
       expand: p["expand"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postSourcesSource(
@@ -31417,7 +29572,6 @@ export class StripeApi extends AbstractFetchClient {
       expand?: string[]
       mandateNotification: string
       source: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -31427,18 +29581,10 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath +
       `/v1/sources/${p["source"]}/mandate_notifications/${p["mandateNotification"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getSourcesSourceSourceTransactions(
@@ -31448,7 +29594,6 @@ export class StripeApi extends AbstractFetchClient {
       limit?: number
       source: string
       startingAfter?: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -31465,23 +29610,15 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/sources/${p["source"]}/source_transactions`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getSourcesSourceSourceTransactionsSourceTransaction(
@@ -31489,7 +29626,6 @@ export class StripeApi extends AbstractFetchClient {
       expand?: string[]
       source: string
       sourceTransaction: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -31497,18 +29633,10 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath +
       `/v1/sources/${p["source"]}/source_transactions/${p["sourceTransaction"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postSourcesSourceVerify(
@@ -31539,7 +29667,6 @@ export class StripeApi extends AbstractFetchClient {
       limit?: number
       startingAfter?: string
       subscription: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -31556,10 +29683,7 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/subscription_items`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
@@ -31567,13 +29691,8 @@ export class StripeApi extends AbstractFetchClient {
       starting_after: p["startingAfter"],
       subscription: p["subscription"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postSubscriptionItems(
@@ -31673,24 +29792,15 @@ export class StripeApi extends AbstractFetchClient {
     p: {
       expand?: string[]
       item: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_subscription_item> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/subscription_items/${p["item"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postSubscriptionItemsItem(
@@ -31804,7 +29914,6 @@ export class StripeApi extends AbstractFetchClient {
         | number
       scheduled?: boolean
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: RequestInit = {},
@@ -31821,10 +29930,7 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/subscription_schedules`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       canceled_at: p["canceledAt"],
       completed_at: p["completedAt"],
@@ -31837,13 +29943,8 @@ export class StripeApi extends AbstractFetchClient {
       scheduled: p["scheduled"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postSubscriptionSchedules(
@@ -32055,24 +30156,15 @@ export class StripeApi extends AbstractFetchClient {
     p: {
       expand?: string[]
       schedule: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_subscription_schedule> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/subscription_schedules/${p["schedule"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postSubscriptionSchedulesSchedule(
@@ -32377,7 +30469,6 @@ export class StripeApi extends AbstractFetchClient {
         | "unpaid"
         | UnknownEnumStringValue
       testClock?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: RequestInit = {},
@@ -32394,10 +30485,7 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/subscriptions`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       automatic_tax: p["automaticTax"],
       collection_method: p["collectionMethod"],
@@ -32413,13 +30501,8 @@ export class StripeApi extends AbstractFetchClient {
       status: p["status"],
       test_clock: p["testClock"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postSubscriptions(
@@ -32768,7 +30851,6 @@ export class StripeApi extends AbstractFetchClient {
       limit?: number
       page?: string
       query: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -32787,23 +30869,15 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/subscriptions/search`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       expand: p["expand"],
       limit: p["limit"],
       page: p["page"],
       query: p["query"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async deleteSubscriptionsSubscriptionExposedId(
@@ -32847,25 +30921,16 @@ export class StripeApi extends AbstractFetchClient {
     p: {
       expand?: string[]
       subscriptionExposedId: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_subscription> | Res<StatusCode, t_error>> {
     const url =
       this.basePath + `/v1/subscriptions/${p["subscriptionExposedId"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postSubscriptionsSubscriptionExposedId(
@@ -33234,20 +31299,15 @@ export class StripeApi extends AbstractFetchClient {
   async deleteSubscriptionsSubscriptionExposedIdDiscount(
     p: {
       subscriptionExposedId: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_deleted_discount> | Res<StatusCode, t_error>> {
     const url =
       this.basePath + `/v1/subscriptions/${p["subscriptionExposedId"]}/discount`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
-    const body = JSON.stringify(p.requestBody)
+    const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, {method: "DELETE", body, ...opts, headers}, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async postSubscriptionsSubscriptionMigrate(
@@ -33485,24 +31545,15 @@ export class StripeApi extends AbstractFetchClient {
     p: {
       calculation: string
       expand?: string[]
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_tax_calculation> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/tax/calculations/${p["calculation"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getTaxCalculationsCalculationLineItems(
@@ -33512,7 +31563,6 @@ export class StripeApi extends AbstractFetchClient {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -33530,23 +31580,15 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url =
       this.basePath + `/v1/tax/calculations/${p["calculation"]}/line_items`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getTaxRegistrations(
@@ -33561,7 +31603,6 @@ export class StripeApi extends AbstractFetchClient {
         | "expired"
         | "scheduled"
         | UnknownEnumStringValue
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: RequestInit = {},
@@ -33578,10 +31619,7 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/tax/registrations`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
@@ -33589,13 +31627,8 @@ export class StripeApi extends AbstractFetchClient {
       starting_after: p["startingAfter"],
       status: p["status"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postTaxRegistrations(
@@ -34250,24 +32283,15 @@ export class StripeApi extends AbstractFetchClient {
     p: {
       expand?: string[]
       id: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_tax_registration> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/tax/registrations/${p["id"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postTaxRegistrationsId(
@@ -34295,24 +32319,15 @@ export class StripeApi extends AbstractFetchClient {
   async getTaxSettings(
     p: {
       expand?: string[]
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_tax_settings> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/tax/settings`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postTaxSettings(
@@ -34421,24 +32436,15 @@ export class StripeApi extends AbstractFetchClient {
     p: {
       expand?: string[]
       transaction: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_tax_transaction> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/tax/transactions/${p["transaction"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getTaxTransactionsTransactionLineItems(
@@ -34448,7 +32454,6 @@ export class StripeApi extends AbstractFetchClient {
       limit?: number
       startingAfter?: string
       transaction: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -34466,23 +32471,15 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url =
       this.basePath + `/v1/tax/transactions/${p["transaction"]}/line_items`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getTaxCodes(
@@ -34491,7 +32488,6 @@ export class StripeApi extends AbstractFetchClient {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: RequestInit = {},
@@ -34508,47 +32504,30 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/tax_codes`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getTaxCodesId(
     p: {
       expand?: string[]
       id: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_tax_code> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/tax_codes/${p["id"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getTaxIds(
@@ -34567,7 +32546,6 @@ export class StripeApi extends AbstractFetchClient {
           | UnknownEnumStringValue
       }
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: RequestInit = {},
@@ -34584,10 +32562,7 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/tax_ids`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
@@ -34595,13 +32570,8 @@ export class StripeApi extends AbstractFetchClient {
       owner: p["owner"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postTaxIds(
@@ -34749,43 +32719,29 @@ export class StripeApi extends AbstractFetchClient {
   async deleteTaxIdsId(
     p: {
       id: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_deleted_tax_id> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/tax_ids/${p["id"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
-    const body = JSON.stringify(p.requestBody)
+    const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, {method: "DELETE", body, ...opts, headers}, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async getTaxIdsId(
     p: {
       expand?: string[]
       id: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_tax_id> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/tax_ids/${p["id"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getTaxRates(
@@ -34804,7 +32760,6 @@ export class StripeApi extends AbstractFetchClient {
       inclusive?: boolean
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: RequestInit = {},
@@ -34821,10 +32776,7 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/tax_rates`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       active: p["active"],
       created: p["created"],
@@ -34834,13 +32786,8 @@ export class StripeApi extends AbstractFetchClient {
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postTaxRates(
@@ -34893,24 +32840,15 @@ export class StripeApi extends AbstractFetchClient {
     p: {
       expand?: string[]
       taxRate: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_tax_rate> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/tax_rates/${p["taxRate"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postTaxRatesTaxRate(
@@ -34968,7 +32906,6 @@ export class StripeApi extends AbstractFetchClient {
       isAccountDefault?: boolean
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: RequestInit = {},
@@ -34985,10 +32922,7 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/terminal/configurations`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
@@ -34996,13 +32930,8 @@ export class StripeApi extends AbstractFetchClient {
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postTerminalConfigurations(
@@ -35159,7 +33088,6 @@ export class StripeApi extends AbstractFetchClient {
   async deleteTerminalConfigurationsConfiguration(
     p: {
       configuration: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -35168,20 +33096,15 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url =
       this.basePath + `/v1/terminal/configurations/${p["configuration"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
-    const body = JSON.stringify(p.requestBody)
+    const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, {method: "DELETE", body, ...opts, headers}, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async getTerminalConfigurationsConfiguration(
     p: {
       configuration: string
       expand?: string[]
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -35191,18 +33114,10 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url =
       this.basePath + `/v1/terminal/configurations/${p["configuration"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postTerminalConfigurationsConfiguration(
@@ -35399,7 +33314,6 @@ export class StripeApi extends AbstractFetchClient {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: RequestInit = {},
@@ -35416,23 +33330,15 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/terminal/locations`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postTerminalLocations(
@@ -35473,26 +33379,20 @@ export class StripeApi extends AbstractFetchClient {
   async deleteTerminalLocationsLocation(
     p: {
       location: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_deleted_terminal_location> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/terminal/locations/${p["location"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
-    const body = JSON.stringify(p.requestBody)
+    const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, {method: "DELETE", body, ...opts, headers}, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async getTerminalLocationsLocation(
     p: {
       expand?: string[]
       location: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -35501,18 +33401,10 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/terminal/locations/${p["location"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postTerminalLocationsLocation(
@@ -35574,7 +33466,6 @@ export class StripeApi extends AbstractFetchClient {
       serialNumber?: string
       startingAfter?: string
       status?: "offline" | "online" | UnknownEnumStringValue
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: RequestInit = {},
@@ -35591,10 +33482,7 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/terminal/readers`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       device_type: p["deviceType"],
       ending_before: p["endingBefore"],
@@ -35605,13 +33493,8 @@ export class StripeApi extends AbstractFetchClient {
       starting_after: p["startingAfter"],
       status: p["status"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postTerminalReaders(
@@ -35645,26 +33528,20 @@ export class StripeApi extends AbstractFetchClient {
   async deleteTerminalReadersReader(
     p: {
       reader: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_deleted_terminal_reader> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/terminal/readers/${p["reader"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
-    const body = JSON.stringify(p.requestBody)
+    const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, {method: "DELETE", body, ...opts, headers}, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async getTerminalReadersReader(
     p: {
       expand?: string[]
       reader: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -35673,18 +33550,10 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/terminal/readers/${p["reader"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postTerminalReadersReader(
@@ -38252,7 +36121,6 @@ export class StripeApi extends AbstractFetchClient {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: RequestInit = {},
@@ -38269,23 +36137,15 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/test_helpers/test_clocks`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postTestHelpersTestClocks(
@@ -38312,7 +36172,6 @@ export class StripeApi extends AbstractFetchClient {
   async deleteTestHelpersTestClocksTestClock(
     p: {
       testClock: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -38320,37 +36179,24 @@ export class StripeApi extends AbstractFetchClient {
     Res<200, t_deleted_test_helpers_test_clock> | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/test_helpers/test_clocks/${p["testClock"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
-    const body = JSON.stringify(p.requestBody)
+    const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, {method: "DELETE", body, ...opts, headers}, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async getTestHelpersTestClocksTestClock(
     p: {
       expand?: string[]
       testClock: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_test_helpers_test_clock> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/test_helpers/test_clocks/${p["testClock"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postTestHelpersTestClocksTestClockAdvance(
@@ -39164,24 +37010,15 @@ export class StripeApi extends AbstractFetchClient {
     p: {
       expand?: string[]
       token: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_token> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/tokens/${p["token"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getTopups(
@@ -39212,7 +37049,6 @@ export class StripeApi extends AbstractFetchClient {
         | "pending"
         | "succeeded"
         | UnknownEnumStringValue
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: RequestInit = {},
@@ -39229,10 +37065,7 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/topups`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       amount: p["amount"],
       created: p["created"],
@@ -39242,13 +37075,8 @@ export class StripeApi extends AbstractFetchClient {
       starting_after: p["startingAfter"],
       status: p["status"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postTopups(
@@ -39286,24 +37114,15 @@ export class StripeApi extends AbstractFetchClient {
     p: {
       expand?: string[]
       topup: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_topup> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/topups/${p["topup"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postTopupsTopup(
@@ -39369,7 +37188,6 @@ export class StripeApi extends AbstractFetchClient {
       limit?: number
       startingAfter?: string
       transferGroup?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: RequestInit = {},
@@ -39386,10 +37204,7 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/transfers`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       created: p["created"],
       destination: p["destination"],
@@ -39399,13 +37214,8 @@ export class StripeApi extends AbstractFetchClient {
       starting_after: p["startingAfter"],
       transfer_group: p["transferGroup"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postTransfers(
@@ -39444,7 +37254,6 @@ export class StripeApi extends AbstractFetchClient {
       id: string
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -39461,23 +37270,15 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/transfers/${p["id"]}/reversals`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postTransfersIdReversals(
@@ -39513,24 +37314,15 @@ export class StripeApi extends AbstractFetchClient {
     p: {
       expand?: string[]
       transfer: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_transfer> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/transfers/${p["transfer"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postTransfersTransfer(
@@ -39565,25 +37357,16 @@ export class StripeApi extends AbstractFetchClient {
       expand?: string[]
       id: string
       transfer: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_transfer_reversal> | Res<StatusCode, t_error>> {
     const url =
       this.basePath + `/v1/transfers/${p["transfer"]}/reversals/${p["id"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postTransfersTransferReversalsId(
@@ -39623,7 +37406,6 @@ export class StripeApi extends AbstractFetchClient {
       receivedCredit?: string
       startingAfter?: string
       status?: "canceled" | "posted" | "processing" | UnknownEnumStringValue
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -39640,10 +37422,7 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/treasury/credit_reversals`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
@@ -39653,13 +37432,8 @@ export class StripeApi extends AbstractFetchClient {
       starting_after: p["startingAfter"],
       status: p["status"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postTreasuryCreditReversals(
@@ -39689,25 +37463,16 @@ export class StripeApi extends AbstractFetchClient {
     p: {
       creditReversal: string
       expand?: string[]
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_treasury_credit_reversal> | Res<StatusCode, t_error>> {
     const url =
       this.basePath + `/v1/treasury/credit_reversals/${p["creditReversal"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getTreasuryDebitReversals(
@@ -39720,7 +37485,6 @@ export class StripeApi extends AbstractFetchClient {
       resolution?: "lost" | "won" | UnknownEnumStringValue
       startingAfter?: string
       status?: "canceled" | "completed" | "processing" | UnknownEnumStringValue
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -39737,10 +37501,7 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/treasury/debit_reversals`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
@@ -39751,13 +37512,8 @@ export class StripeApi extends AbstractFetchClient {
       starting_after: p["startingAfter"],
       status: p["status"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postTreasuryDebitReversals(
@@ -39787,25 +37543,16 @@ export class StripeApi extends AbstractFetchClient {
     p: {
       debitReversal: string
       expand?: string[]
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_treasury_debit_reversal> | Res<StatusCode, t_error>> {
     const url =
       this.basePath + `/v1/treasury/debit_reversals/${p["debitReversal"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getTreasuryFinancialAccounts(
@@ -39823,7 +37570,6 @@ export class StripeApi extends AbstractFetchClient {
       limit?: number
       startingAfter?: string
       status?: "closed" | "open" | UnknownEnumStringValue
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: RequestInit = {},
@@ -39840,10 +37586,7 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/treasury/financial_accounts`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       created: p["created"],
       ending_before: p["endingBefore"],
@@ -39852,13 +37595,8 @@ export class StripeApi extends AbstractFetchClient {
       starting_after: p["startingAfter"],
       status: p["status"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postTreasuryFinancialAccounts(
@@ -39935,7 +37673,6 @@ export class StripeApi extends AbstractFetchClient {
     p: {
       expand?: string[]
       financialAccount: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -39944,18 +37681,10 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url =
       this.basePath + `/v1/treasury/financial_accounts/${p["financialAccount"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postTreasuryFinancialAccountsFinancialAccount(
@@ -40067,7 +37796,6 @@ export class StripeApi extends AbstractFetchClient {
     p: {
       expand?: string[]
       financialAccount: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -40077,18 +37805,10 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath +
       `/v1/treasury/financial_accounts/${p["financialAccount"]}/features`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postTreasuryFinancialAccountsFinancialAccountFeatures(
@@ -40163,7 +37883,6 @@ export class StripeApi extends AbstractFetchClient {
         | "processing"
         | "succeeded"
         | UnknownEnumStringValue
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -40180,10 +37899,7 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/treasury/inbound_transfers`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
@@ -40192,13 +37908,8 @@ export class StripeApi extends AbstractFetchClient {
       starting_after: p["startingAfter"],
       status: p["status"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postTreasuryInboundTransfers(
@@ -40233,24 +37944,15 @@ export class StripeApi extends AbstractFetchClient {
     p: {
       expand?: string[]
       id: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_treasury_inbound_transfer> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/treasury/inbound_transfers/${p["id"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postTreasuryInboundTransfersInboundTransferCancel(
@@ -40298,7 +38000,6 @@ export class StripeApi extends AbstractFetchClient {
         | "processing"
         | "returned"
         | UnknownEnumStringValue
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -40315,10 +38016,7 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/treasury/outbound_payments`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       created: p["created"],
       customer: p["customer"],
@@ -40329,13 +38027,8 @@ export class StripeApi extends AbstractFetchClient {
       starting_after: p["startingAfter"],
       status: p["status"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postTreasuryOutboundPayments(
@@ -40416,24 +38109,15 @@ export class StripeApi extends AbstractFetchClient {
     p: {
       expand?: string[]
       id: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_treasury_outbound_payment> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/treasury/outbound_payments/${p["id"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postTreasuryOutboundPaymentsIdCancel(
@@ -40471,7 +38155,6 @@ export class StripeApi extends AbstractFetchClient {
         | "processing"
         | "returned"
         | UnknownEnumStringValue
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -40488,10 +38171,7 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/treasury/outbound_transfers`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
@@ -40500,13 +38180,8 @@ export class StripeApi extends AbstractFetchClient {
       starting_after: p["startingAfter"],
       status: p["status"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postTreasuryOutboundTransfers(
@@ -40555,7 +38230,6 @@ export class StripeApi extends AbstractFetchClient {
     p: {
       expand?: string[]
       outboundTransfer: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -40564,18 +38238,10 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url =
       this.basePath + `/v1/treasury/outbound_transfers/${p["outboundTransfer"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postTreasuryOutboundTransfersOutboundTransferCancel(
@@ -40619,7 +38285,6 @@ export class StripeApi extends AbstractFetchClient {
       }
       startingAfter?: string
       status?: "failed" | "succeeded" | UnknownEnumStringValue
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -40636,10 +38301,7 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/treasury/received_credits`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
@@ -40649,37 +38311,23 @@ export class StripeApi extends AbstractFetchClient {
       starting_after: p["startingAfter"],
       status: p["status"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getTreasuryReceivedCreditsId(
     p: {
       expand?: string[]
       id: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_treasury_received_credit> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/treasury/received_credits/${p["id"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getTreasuryReceivedDebits(
@@ -40690,7 +38338,6 @@ export class StripeApi extends AbstractFetchClient {
       limit?: number
       startingAfter?: string
       status?: "failed" | "succeeded" | UnknownEnumStringValue
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -40707,10 +38354,7 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/treasury/received_debits`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
@@ -40719,37 +38363,23 @@ export class StripeApi extends AbstractFetchClient {
       starting_after: p["startingAfter"],
       status: p["status"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getTreasuryReceivedDebitsId(
     p: {
       expand?: string[]
       id: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_treasury_received_debit> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/treasury/received_debits/${p["id"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getTreasuryTransactionEntries(
@@ -40777,7 +38407,6 @@ export class StripeApi extends AbstractFetchClient {
       orderBy?: "created" | "effective_at" | UnknownEnumStringValue
       startingAfter?: string
       transaction?: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -40794,10 +38423,7 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/treasury/transaction_entries`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       created: p["created"],
       effective_at: p["effectiveAt"],
@@ -40809,20 +38435,14 @@ export class StripeApi extends AbstractFetchClient {
       starting_after: p["startingAfter"],
       transaction: p["transaction"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getTreasuryTransactionEntriesId(
     p: {
       expand?: string[]
       id: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -40830,18 +38450,10 @@ export class StripeApi extends AbstractFetchClient {
     Res<200, t_treasury_transaction_entry> | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/treasury/transaction_entries/${p["id"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getTreasuryTransactions(
@@ -40871,7 +38483,6 @@ export class StripeApi extends AbstractFetchClient {
             }
           | number
       }
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -40888,10 +38499,7 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/treasury/transactions`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       created: p["created"],
       ending_before: p["endingBefore"],
@@ -40903,37 +38511,23 @@ export class StripeApi extends AbstractFetchClient {
       status: p["status"],
       status_transitions: p["statusTransitions"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getTreasuryTransactionsId(
     p: {
       expand?: string[]
       id: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_treasury_transaction> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/treasury/transactions/${p["id"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getWebhookEndpoints(
@@ -40942,7 +38536,6 @@ export class StripeApi extends AbstractFetchClient {
       expand?: string[]
       limit?: number
       startingAfter?: string
-      requestBody?: EmptyObject
     } = {},
     timeout?: number,
     opts: RequestInit = {},
@@ -40959,23 +38552,15 @@ export class StripeApi extends AbstractFetchClient {
     | Res<StatusCode, t_error>
   > {
     const url = this.basePath + `/v1/webhook_endpoints`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({
       ending_before: p["endingBefore"],
       expand: p["expand"],
       limit: p["limit"],
       starting_after: p["startingAfter"],
     })
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postWebhookEndpoints(
@@ -41370,43 +38955,29 @@ export class StripeApi extends AbstractFetchClient {
   async deleteWebhookEndpointsWebhookEndpoint(
     p: {
       webhookEndpoint: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_deleted_webhook_endpoint> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/webhook_endpoints/${p["webhookEndpoint"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
-    const body = JSON.stringify(p.requestBody)
+    const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, {method: "DELETE", body, ...opts, headers}, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async getWebhookEndpointsWebhookEndpoint(
     p: {
       expand?: string[]
       webhookEndpoint: string
-      requestBody?: EmptyObject
     },
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<Res<200, t_webhook_endpoint> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/webhook_endpoints/${p["webhookEndpoint"]}`
-    const headers = this._headers(
-      {"Content-Type": "application/x-www-form-urlencoded"},
-      opts.headers,
-    )
+    const headers = this._headers({}, opts.headers)
     const query = this._query({expand: p["expand"]})
-    const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url + query,
-      {method: "GET", body, ...opts, headers},
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async postWebhookEndpointsWebhookEndpoint(

--- a/integration-tests/typescript-koa/src/generated/stripe.yaml/generated.ts
+++ b/integration-tests/typescript-koa/src/generated/stripe.yaml/generated.ts
@@ -3,731 +3,450 @@
 /* eslint-disable */
 
 import {
-  t_DeleteAccountsAccountBankAccountsIdBodySchema,
   t_DeleteAccountsAccountBankAccountsIdParamSchema,
-  t_DeleteAccountsAccountBodySchema,
-  t_DeleteAccountsAccountExternalAccountsIdBodySchema,
   t_DeleteAccountsAccountExternalAccountsIdParamSchema,
   t_DeleteAccountsAccountParamSchema,
-  t_DeleteAccountsAccountPeoplePersonBodySchema,
   t_DeleteAccountsAccountPeoplePersonParamSchema,
-  t_DeleteAccountsAccountPersonsPersonBodySchema,
   t_DeleteAccountsAccountPersonsPersonParamSchema,
-  t_DeleteApplePayDomainsDomainBodySchema,
   t_DeleteApplePayDomainsDomainParamSchema,
-  t_DeleteCouponsCouponBodySchema,
   t_DeleteCouponsCouponParamSchema,
   t_DeleteCustomersCustomerBankAccountsIdBodySchema,
   t_DeleteCustomersCustomerBankAccountsIdParamSchema,
-  t_DeleteCustomersCustomerBodySchema,
   t_DeleteCustomersCustomerCardsIdBodySchema,
   t_DeleteCustomersCustomerCardsIdParamSchema,
-  t_DeleteCustomersCustomerDiscountBodySchema,
   t_DeleteCustomersCustomerDiscountParamSchema,
   t_DeleteCustomersCustomerParamSchema,
   t_DeleteCustomersCustomerSourcesIdBodySchema,
   t_DeleteCustomersCustomerSourcesIdParamSchema,
   t_DeleteCustomersCustomerSubscriptionsSubscriptionExposedIdBodySchema,
-  t_DeleteCustomersCustomerSubscriptionsSubscriptionExposedIdDiscountBodySchema,
   t_DeleteCustomersCustomerSubscriptionsSubscriptionExposedIdDiscountParamSchema,
   t_DeleteCustomersCustomerSubscriptionsSubscriptionExposedIdParamSchema,
-  t_DeleteCustomersCustomerTaxIdsIdBodySchema,
   t_DeleteCustomersCustomerTaxIdsIdParamSchema,
   t_DeleteEphemeralKeysKeyBodySchema,
   t_DeleteEphemeralKeysKeyParamSchema,
-  t_DeleteInvoiceitemsInvoiceitemBodySchema,
   t_DeleteInvoiceitemsInvoiceitemParamSchema,
-  t_DeleteInvoicesInvoiceBodySchema,
   t_DeleteInvoicesInvoiceParamSchema,
-  t_DeletePlansPlanBodySchema,
   t_DeletePlansPlanParamSchema,
-  t_DeleteProductsIdBodySchema,
   t_DeleteProductsIdParamSchema,
-  t_DeleteProductsProductFeaturesIdBodySchema,
   t_DeleteProductsProductFeaturesIdParamSchema,
-  t_DeleteRadarValueListItemsItemBodySchema,
   t_DeleteRadarValueListItemsItemParamSchema,
-  t_DeleteRadarValueListsValueListBodySchema,
   t_DeleteRadarValueListsValueListParamSchema,
   t_DeleteSubscriptionItemsItemBodySchema,
   t_DeleteSubscriptionItemsItemParamSchema,
   t_DeleteSubscriptionsSubscriptionExposedIdBodySchema,
-  t_DeleteSubscriptionsSubscriptionExposedIdDiscountBodySchema,
   t_DeleteSubscriptionsSubscriptionExposedIdDiscountParamSchema,
   t_DeleteSubscriptionsSubscriptionExposedIdParamSchema,
-  t_DeleteTaxIdsIdBodySchema,
   t_DeleteTaxIdsIdParamSchema,
-  t_DeleteTerminalConfigurationsConfigurationBodySchema,
   t_DeleteTerminalConfigurationsConfigurationParamSchema,
-  t_DeleteTerminalLocationsLocationBodySchema,
   t_DeleteTerminalLocationsLocationParamSchema,
-  t_DeleteTerminalReadersReaderBodySchema,
   t_DeleteTerminalReadersReaderParamSchema,
-  t_DeleteTestHelpersTestClocksTestClockBodySchema,
   t_DeleteTestHelpersTestClocksTestClockParamSchema,
-  t_DeleteWebhookEndpointsWebhookEndpointBodySchema,
   t_DeleteWebhookEndpointsWebhookEndpointParamSchema,
-  t_GetAccountBodySchema,
   t_GetAccountQuerySchema,
-  t_GetAccountsAccountBankAccountsIdBodySchema,
   t_GetAccountsAccountBankAccountsIdParamSchema,
   t_GetAccountsAccountBankAccountsIdQuerySchema,
-  t_GetAccountsAccountBodySchema,
-  t_GetAccountsAccountCapabilitiesBodySchema,
-  t_GetAccountsAccountCapabilitiesCapabilityBodySchema,
   t_GetAccountsAccountCapabilitiesCapabilityParamSchema,
   t_GetAccountsAccountCapabilitiesCapabilityQuerySchema,
   t_GetAccountsAccountCapabilitiesParamSchema,
   t_GetAccountsAccountCapabilitiesQuerySchema,
-  t_GetAccountsAccountExternalAccountsBodySchema,
-  t_GetAccountsAccountExternalAccountsIdBodySchema,
   t_GetAccountsAccountExternalAccountsIdParamSchema,
   t_GetAccountsAccountExternalAccountsIdQuerySchema,
   t_GetAccountsAccountExternalAccountsParamSchema,
   t_GetAccountsAccountExternalAccountsQuerySchema,
   t_GetAccountsAccountParamSchema,
-  t_GetAccountsAccountPeopleBodySchema,
   t_GetAccountsAccountPeopleParamSchema,
-  t_GetAccountsAccountPeoplePersonBodySchema,
   t_GetAccountsAccountPeoplePersonParamSchema,
   t_GetAccountsAccountPeoplePersonQuerySchema,
   t_GetAccountsAccountPeopleQuerySchema,
-  t_GetAccountsAccountPersonsBodySchema,
   t_GetAccountsAccountPersonsParamSchema,
-  t_GetAccountsAccountPersonsPersonBodySchema,
   t_GetAccountsAccountPersonsPersonParamSchema,
   t_GetAccountsAccountPersonsPersonQuerySchema,
   t_GetAccountsAccountPersonsQuerySchema,
   t_GetAccountsAccountQuerySchema,
-  t_GetAccountsBodySchema,
   t_GetAccountsQuerySchema,
-  t_GetApplePayDomainsBodySchema,
-  t_GetApplePayDomainsDomainBodySchema,
   t_GetApplePayDomainsDomainParamSchema,
   t_GetApplePayDomainsDomainQuerySchema,
   t_GetApplePayDomainsQuerySchema,
-  t_GetApplicationFeesBodySchema,
-  t_GetApplicationFeesFeeRefundsIdBodySchema,
   t_GetApplicationFeesFeeRefundsIdParamSchema,
   t_GetApplicationFeesFeeRefundsIdQuerySchema,
-  t_GetApplicationFeesIdBodySchema,
   t_GetApplicationFeesIdParamSchema,
   t_GetApplicationFeesIdQuerySchema,
-  t_GetApplicationFeesIdRefundsBodySchema,
   t_GetApplicationFeesIdRefundsParamSchema,
   t_GetApplicationFeesIdRefundsQuerySchema,
   t_GetApplicationFeesQuerySchema,
-  t_GetAppsSecretsBodySchema,
-  t_GetAppsSecretsFindBodySchema,
   t_GetAppsSecretsFindQuerySchema,
   t_GetAppsSecretsQuerySchema,
-  t_GetBalanceBodySchema,
-  t_GetBalanceHistoryBodySchema,
-  t_GetBalanceHistoryIdBodySchema,
   t_GetBalanceHistoryIdParamSchema,
   t_GetBalanceHistoryIdQuerySchema,
   t_GetBalanceHistoryQuerySchema,
   t_GetBalanceQuerySchema,
-  t_GetBalanceTransactionsBodySchema,
-  t_GetBalanceTransactionsIdBodySchema,
   t_GetBalanceTransactionsIdParamSchema,
   t_GetBalanceTransactionsIdQuerySchema,
   t_GetBalanceTransactionsQuerySchema,
-  t_GetBillingAlertsBodySchema,
-  t_GetBillingAlertsIdBodySchema,
   t_GetBillingAlertsIdParamSchema,
   t_GetBillingAlertsIdQuerySchema,
   t_GetBillingAlertsQuerySchema,
-  t_GetBillingCreditBalanceSummaryBodySchema,
   t_GetBillingCreditBalanceSummaryQuerySchema,
-  t_GetBillingCreditBalanceTransactionsBodySchema,
-  t_GetBillingCreditBalanceTransactionsIdBodySchema,
   t_GetBillingCreditBalanceTransactionsIdParamSchema,
   t_GetBillingCreditBalanceTransactionsIdQuerySchema,
   t_GetBillingCreditBalanceTransactionsQuerySchema,
-  t_GetBillingCreditGrantsBodySchema,
-  t_GetBillingCreditGrantsIdBodySchema,
   t_GetBillingCreditGrantsIdParamSchema,
   t_GetBillingCreditGrantsIdQuerySchema,
   t_GetBillingCreditGrantsQuerySchema,
-  t_GetBillingMetersBodySchema,
-  t_GetBillingMetersIdBodySchema,
-  t_GetBillingMetersIdEventSummariesBodySchema,
   t_GetBillingMetersIdEventSummariesParamSchema,
   t_GetBillingMetersIdEventSummariesQuerySchema,
   t_GetBillingMetersIdParamSchema,
   t_GetBillingMetersIdQuerySchema,
   t_GetBillingMetersQuerySchema,
-  t_GetBillingPortalConfigurationsBodySchema,
-  t_GetBillingPortalConfigurationsConfigurationBodySchema,
   t_GetBillingPortalConfigurationsConfigurationParamSchema,
   t_GetBillingPortalConfigurationsConfigurationQuerySchema,
   t_GetBillingPortalConfigurationsQuerySchema,
-  t_GetChargesBodySchema,
-  t_GetChargesChargeBodySchema,
-  t_GetChargesChargeDisputeBodySchema,
   t_GetChargesChargeDisputeParamSchema,
   t_GetChargesChargeDisputeQuerySchema,
   t_GetChargesChargeParamSchema,
   t_GetChargesChargeQuerySchema,
-  t_GetChargesChargeRefundsBodySchema,
   t_GetChargesChargeRefundsParamSchema,
   t_GetChargesChargeRefundsQuerySchema,
-  t_GetChargesChargeRefundsRefundBodySchema,
   t_GetChargesChargeRefundsRefundParamSchema,
   t_GetChargesChargeRefundsRefundQuerySchema,
   t_GetChargesQuerySchema,
-  t_GetChargesSearchBodySchema,
   t_GetChargesSearchQuerySchema,
-  t_GetCheckoutSessionsBodySchema,
   t_GetCheckoutSessionsQuerySchema,
-  t_GetCheckoutSessionsSessionBodySchema,
-  t_GetCheckoutSessionsSessionLineItemsBodySchema,
   t_GetCheckoutSessionsSessionLineItemsParamSchema,
   t_GetCheckoutSessionsSessionLineItemsQuerySchema,
   t_GetCheckoutSessionsSessionParamSchema,
   t_GetCheckoutSessionsSessionQuerySchema,
-  t_GetClimateOrdersBodySchema,
-  t_GetClimateOrdersOrderBodySchema,
   t_GetClimateOrdersOrderParamSchema,
   t_GetClimateOrdersOrderQuerySchema,
   t_GetClimateOrdersQuerySchema,
-  t_GetClimateProductsBodySchema,
-  t_GetClimateProductsProductBodySchema,
   t_GetClimateProductsProductParamSchema,
   t_GetClimateProductsProductQuerySchema,
   t_GetClimateProductsQuerySchema,
-  t_GetClimateSuppliersBodySchema,
   t_GetClimateSuppliersQuerySchema,
-  t_GetClimateSuppliersSupplierBodySchema,
   t_GetClimateSuppliersSupplierParamSchema,
   t_GetClimateSuppliersSupplierQuerySchema,
-  t_GetConfirmationTokensConfirmationTokenBodySchema,
   t_GetConfirmationTokensConfirmationTokenParamSchema,
   t_GetConfirmationTokensConfirmationTokenQuerySchema,
-  t_GetCountrySpecsBodySchema,
-  t_GetCountrySpecsCountryBodySchema,
   t_GetCountrySpecsCountryParamSchema,
   t_GetCountrySpecsCountryQuerySchema,
   t_GetCountrySpecsQuerySchema,
-  t_GetCouponsBodySchema,
-  t_GetCouponsCouponBodySchema,
   t_GetCouponsCouponParamSchema,
   t_GetCouponsCouponQuerySchema,
   t_GetCouponsQuerySchema,
-  t_GetCreditNotesBodySchema,
-  t_GetCreditNotesCreditNoteLinesBodySchema,
   t_GetCreditNotesCreditNoteLinesParamSchema,
   t_GetCreditNotesCreditNoteLinesQuerySchema,
-  t_GetCreditNotesIdBodySchema,
   t_GetCreditNotesIdParamSchema,
   t_GetCreditNotesIdQuerySchema,
-  t_GetCreditNotesPreviewBodySchema,
-  t_GetCreditNotesPreviewLinesBodySchema,
   t_GetCreditNotesPreviewLinesQuerySchema,
   t_GetCreditNotesPreviewQuerySchema,
   t_GetCreditNotesQuerySchema,
-  t_GetCustomersBodySchema,
-  t_GetCustomersCustomerBalanceTransactionsBodySchema,
   t_GetCustomersCustomerBalanceTransactionsParamSchema,
   t_GetCustomersCustomerBalanceTransactionsQuerySchema,
-  t_GetCustomersCustomerBalanceTransactionsTransactionBodySchema,
   t_GetCustomersCustomerBalanceTransactionsTransactionParamSchema,
   t_GetCustomersCustomerBalanceTransactionsTransactionQuerySchema,
-  t_GetCustomersCustomerBankAccountsBodySchema,
-  t_GetCustomersCustomerBankAccountsIdBodySchema,
   t_GetCustomersCustomerBankAccountsIdParamSchema,
   t_GetCustomersCustomerBankAccountsIdQuerySchema,
   t_GetCustomersCustomerBankAccountsParamSchema,
   t_GetCustomersCustomerBankAccountsQuerySchema,
-  t_GetCustomersCustomerBodySchema,
-  t_GetCustomersCustomerCardsBodySchema,
-  t_GetCustomersCustomerCardsIdBodySchema,
   t_GetCustomersCustomerCardsIdParamSchema,
   t_GetCustomersCustomerCardsIdQuerySchema,
   t_GetCustomersCustomerCardsParamSchema,
   t_GetCustomersCustomerCardsQuerySchema,
-  t_GetCustomersCustomerCashBalanceBodySchema,
   t_GetCustomersCustomerCashBalanceParamSchema,
   t_GetCustomersCustomerCashBalanceQuerySchema,
-  t_GetCustomersCustomerCashBalanceTransactionsBodySchema,
   t_GetCustomersCustomerCashBalanceTransactionsParamSchema,
   t_GetCustomersCustomerCashBalanceTransactionsQuerySchema,
-  t_GetCustomersCustomerCashBalanceTransactionsTransactionBodySchema,
   t_GetCustomersCustomerCashBalanceTransactionsTransactionParamSchema,
   t_GetCustomersCustomerCashBalanceTransactionsTransactionQuerySchema,
-  t_GetCustomersCustomerDiscountBodySchema,
   t_GetCustomersCustomerDiscountParamSchema,
   t_GetCustomersCustomerDiscountQuerySchema,
   t_GetCustomersCustomerParamSchema,
-  t_GetCustomersCustomerPaymentMethodsBodySchema,
   t_GetCustomersCustomerPaymentMethodsParamSchema,
-  t_GetCustomersCustomerPaymentMethodsPaymentMethodBodySchema,
   t_GetCustomersCustomerPaymentMethodsPaymentMethodParamSchema,
   t_GetCustomersCustomerPaymentMethodsPaymentMethodQuerySchema,
   t_GetCustomersCustomerPaymentMethodsQuerySchema,
   t_GetCustomersCustomerQuerySchema,
-  t_GetCustomersCustomerSourcesBodySchema,
-  t_GetCustomersCustomerSourcesIdBodySchema,
   t_GetCustomersCustomerSourcesIdParamSchema,
   t_GetCustomersCustomerSourcesIdQuerySchema,
   t_GetCustomersCustomerSourcesParamSchema,
   t_GetCustomersCustomerSourcesQuerySchema,
-  t_GetCustomersCustomerSubscriptionsBodySchema,
   t_GetCustomersCustomerSubscriptionsParamSchema,
   t_GetCustomersCustomerSubscriptionsQuerySchema,
-  t_GetCustomersCustomerSubscriptionsSubscriptionExposedIdBodySchema,
-  t_GetCustomersCustomerSubscriptionsSubscriptionExposedIdDiscountBodySchema,
   t_GetCustomersCustomerSubscriptionsSubscriptionExposedIdDiscountParamSchema,
   t_GetCustomersCustomerSubscriptionsSubscriptionExposedIdDiscountQuerySchema,
   t_GetCustomersCustomerSubscriptionsSubscriptionExposedIdParamSchema,
   t_GetCustomersCustomerSubscriptionsSubscriptionExposedIdQuerySchema,
-  t_GetCustomersCustomerTaxIdsBodySchema,
-  t_GetCustomersCustomerTaxIdsIdBodySchema,
   t_GetCustomersCustomerTaxIdsIdParamSchema,
   t_GetCustomersCustomerTaxIdsIdQuerySchema,
   t_GetCustomersCustomerTaxIdsParamSchema,
   t_GetCustomersCustomerTaxIdsQuerySchema,
   t_GetCustomersQuerySchema,
-  t_GetCustomersSearchBodySchema,
   t_GetCustomersSearchQuerySchema,
-  t_GetDisputesBodySchema,
-  t_GetDisputesDisputeBodySchema,
   t_GetDisputesDisputeParamSchema,
   t_GetDisputesDisputeQuerySchema,
   t_GetDisputesQuerySchema,
-  t_GetEntitlementsActiveEntitlementsBodySchema,
-  t_GetEntitlementsActiveEntitlementsIdBodySchema,
   t_GetEntitlementsActiveEntitlementsIdParamSchema,
   t_GetEntitlementsActiveEntitlementsIdQuerySchema,
   t_GetEntitlementsActiveEntitlementsQuerySchema,
-  t_GetEntitlementsFeaturesBodySchema,
-  t_GetEntitlementsFeaturesIdBodySchema,
   t_GetEntitlementsFeaturesIdParamSchema,
   t_GetEntitlementsFeaturesIdQuerySchema,
   t_GetEntitlementsFeaturesQuerySchema,
-  t_GetEventsBodySchema,
-  t_GetEventsIdBodySchema,
   t_GetEventsIdParamSchema,
   t_GetEventsIdQuerySchema,
   t_GetEventsQuerySchema,
-  t_GetExchangeRatesBodySchema,
   t_GetExchangeRatesQuerySchema,
-  t_GetExchangeRatesRateIdBodySchema,
   t_GetExchangeRatesRateIdParamSchema,
   t_GetExchangeRatesRateIdQuerySchema,
-  t_GetFileLinksBodySchema,
-  t_GetFileLinksLinkBodySchema,
   t_GetFileLinksLinkParamSchema,
   t_GetFileLinksLinkQuerySchema,
   t_GetFileLinksQuerySchema,
-  t_GetFilesBodySchema,
-  t_GetFilesFileBodySchema,
   t_GetFilesFileParamSchema,
   t_GetFilesFileQuerySchema,
   t_GetFilesQuerySchema,
-  t_GetFinancialConnectionsAccountsAccountBodySchema,
-  t_GetFinancialConnectionsAccountsAccountOwnersBodySchema,
   t_GetFinancialConnectionsAccountsAccountOwnersParamSchema,
   t_GetFinancialConnectionsAccountsAccountOwnersQuerySchema,
   t_GetFinancialConnectionsAccountsAccountParamSchema,
   t_GetFinancialConnectionsAccountsAccountQuerySchema,
-  t_GetFinancialConnectionsAccountsBodySchema,
   t_GetFinancialConnectionsAccountsQuerySchema,
-  t_GetFinancialConnectionsSessionsSessionBodySchema,
   t_GetFinancialConnectionsSessionsSessionParamSchema,
   t_GetFinancialConnectionsSessionsSessionQuerySchema,
-  t_GetFinancialConnectionsTransactionsBodySchema,
   t_GetFinancialConnectionsTransactionsQuerySchema,
-  t_GetFinancialConnectionsTransactionsTransactionBodySchema,
   t_GetFinancialConnectionsTransactionsTransactionParamSchema,
   t_GetFinancialConnectionsTransactionsTransactionQuerySchema,
-  t_GetForwardingRequestsBodySchema,
-  t_GetForwardingRequestsIdBodySchema,
   t_GetForwardingRequestsIdParamSchema,
   t_GetForwardingRequestsIdQuerySchema,
   t_GetForwardingRequestsQuerySchema,
-  t_GetIdentityVerificationReportsBodySchema,
   t_GetIdentityVerificationReportsQuerySchema,
-  t_GetIdentityVerificationReportsReportBodySchema,
   t_GetIdentityVerificationReportsReportParamSchema,
   t_GetIdentityVerificationReportsReportQuerySchema,
-  t_GetIdentityVerificationSessionsBodySchema,
   t_GetIdentityVerificationSessionsQuerySchema,
-  t_GetIdentityVerificationSessionsSessionBodySchema,
   t_GetIdentityVerificationSessionsSessionParamSchema,
   t_GetIdentityVerificationSessionsSessionQuerySchema,
-  t_GetInvoicePaymentsBodySchema,
-  t_GetInvoicePaymentsInvoicePaymentBodySchema,
   t_GetInvoicePaymentsInvoicePaymentParamSchema,
   t_GetInvoicePaymentsInvoicePaymentQuerySchema,
   t_GetInvoicePaymentsQuerySchema,
-  t_GetInvoiceRenderingTemplatesBodySchema,
   t_GetInvoiceRenderingTemplatesQuerySchema,
-  t_GetInvoiceRenderingTemplatesTemplateBodySchema,
   t_GetInvoiceRenderingTemplatesTemplateParamSchema,
   t_GetInvoiceRenderingTemplatesTemplateQuerySchema,
-  t_GetInvoiceitemsBodySchema,
-  t_GetInvoiceitemsInvoiceitemBodySchema,
   t_GetInvoiceitemsInvoiceitemParamSchema,
   t_GetInvoiceitemsInvoiceitemQuerySchema,
   t_GetInvoiceitemsQuerySchema,
-  t_GetInvoicesBodySchema,
-  t_GetInvoicesInvoiceBodySchema,
-  t_GetInvoicesInvoiceLinesBodySchema,
   t_GetInvoicesInvoiceLinesParamSchema,
   t_GetInvoicesInvoiceLinesQuerySchema,
   t_GetInvoicesInvoiceParamSchema,
   t_GetInvoicesInvoiceQuerySchema,
   t_GetInvoicesQuerySchema,
-  t_GetInvoicesSearchBodySchema,
   t_GetInvoicesSearchQuerySchema,
-  t_GetIssuingAuthorizationsAuthorizationBodySchema,
   t_GetIssuingAuthorizationsAuthorizationParamSchema,
   t_GetIssuingAuthorizationsAuthorizationQuerySchema,
-  t_GetIssuingAuthorizationsBodySchema,
   t_GetIssuingAuthorizationsQuerySchema,
-  t_GetIssuingCardholdersBodySchema,
-  t_GetIssuingCardholdersCardholderBodySchema,
   t_GetIssuingCardholdersCardholderParamSchema,
   t_GetIssuingCardholdersCardholderQuerySchema,
   t_GetIssuingCardholdersQuerySchema,
-  t_GetIssuingCardsBodySchema,
-  t_GetIssuingCardsCardBodySchema,
   t_GetIssuingCardsCardParamSchema,
   t_GetIssuingCardsCardQuerySchema,
   t_GetIssuingCardsQuerySchema,
-  t_GetIssuingDisputesBodySchema,
-  t_GetIssuingDisputesDisputeBodySchema,
   t_GetIssuingDisputesDisputeParamSchema,
   t_GetIssuingDisputesDisputeQuerySchema,
   t_GetIssuingDisputesQuerySchema,
-  t_GetIssuingPersonalizationDesignsBodySchema,
-  t_GetIssuingPersonalizationDesignsPersonalizationDesignBodySchema,
   t_GetIssuingPersonalizationDesignsPersonalizationDesignParamSchema,
   t_GetIssuingPersonalizationDesignsPersonalizationDesignQuerySchema,
   t_GetIssuingPersonalizationDesignsQuerySchema,
-  t_GetIssuingPhysicalBundlesBodySchema,
-  t_GetIssuingPhysicalBundlesPhysicalBundleBodySchema,
   t_GetIssuingPhysicalBundlesPhysicalBundleParamSchema,
   t_GetIssuingPhysicalBundlesPhysicalBundleQuerySchema,
   t_GetIssuingPhysicalBundlesQuerySchema,
-  t_GetIssuingSettlementsSettlementBodySchema,
   t_GetIssuingSettlementsSettlementParamSchema,
   t_GetIssuingSettlementsSettlementQuerySchema,
-  t_GetIssuingTokensBodySchema,
   t_GetIssuingTokensQuerySchema,
-  t_GetIssuingTokensTokenBodySchema,
   t_GetIssuingTokensTokenParamSchema,
   t_GetIssuingTokensTokenQuerySchema,
-  t_GetIssuingTransactionsBodySchema,
   t_GetIssuingTransactionsQuerySchema,
-  t_GetIssuingTransactionsTransactionBodySchema,
   t_GetIssuingTransactionsTransactionParamSchema,
   t_GetIssuingTransactionsTransactionQuerySchema,
-  t_GetLinkAccountSessionsSessionBodySchema,
   t_GetLinkAccountSessionsSessionParamSchema,
   t_GetLinkAccountSessionsSessionQuerySchema,
-  t_GetLinkedAccountsAccountBodySchema,
-  t_GetLinkedAccountsAccountOwnersBodySchema,
   t_GetLinkedAccountsAccountOwnersParamSchema,
   t_GetLinkedAccountsAccountOwnersQuerySchema,
   t_GetLinkedAccountsAccountParamSchema,
   t_GetLinkedAccountsAccountQuerySchema,
-  t_GetLinkedAccountsBodySchema,
   t_GetLinkedAccountsQuerySchema,
-  t_GetMandatesMandateBodySchema,
   t_GetMandatesMandateParamSchema,
   t_GetMandatesMandateQuerySchema,
-  t_GetPaymentIntentsBodySchema,
-  t_GetPaymentIntentsIntentBodySchema,
   t_GetPaymentIntentsIntentParamSchema,
   t_GetPaymentIntentsIntentQuerySchema,
   t_GetPaymentIntentsQuerySchema,
-  t_GetPaymentIntentsSearchBodySchema,
   t_GetPaymentIntentsSearchQuerySchema,
-  t_GetPaymentLinksBodySchema,
-  t_GetPaymentLinksPaymentLinkBodySchema,
-  t_GetPaymentLinksPaymentLinkLineItemsBodySchema,
   t_GetPaymentLinksPaymentLinkLineItemsParamSchema,
   t_GetPaymentLinksPaymentLinkLineItemsQuerySchema,
   t_GetPaymentLinksPaymentLinkParamSchema,
   t_GetPaymentLinksPaymentLinkQuerySchema,
   t_GetPaymentLinksQuerySchema,
-  t_GetPaymentMethodConfigurationsBodySchema,
-  t_GetPaymentMethodConfigurationsConfigurationBodySchema,
   t_GetPaymentMethodConfigurationsConfigurationParamSchema,
   t_GetPaymentMethodConfigurationsConfigurationQuerySchema,
   t_GetPaymentMethodConfigurationsQuerySchema,
-  t_GetPaymentMethodDomainsBodySchema,
-  t_GetPaymentMethodDomainsPaymentMethodDomainBodySchema,
   t_GetPaymentMethodDomainsPaymentMethodDomainParamSchema,
   t_GetPaymentMethodDomainsPaymentMethodDomainQuerySchema,
   t_GetPaymentMethodDomainsQuerySchema,
-  t_GetPaymentMethodsBodySchema,
-  t_GetPaymentMethodsPaymentMethodBodySchema,
   t_GetPaymentMethodsPaymentMethodParamSchema,
   t_GetPaymentMethodsPaymentMethodQuerySchema,
   t_GetPaymentMethodsQuerySchema,
-  t_GetPayoutsBodySchema,
-  t_GetPayoutsPayoutBodySchema,
   t_GetPayoutsPayoutParamSchema,
   t_GetPayoutsPayoutQuerySchema,
   t_GetPayoutsQuerySchema,
-  t_GetPlansBodySchema,
-  t_GetPlansPlanBodySchema,
   t_GetPlansPlanParamSchema,
   t_GetPlansPlanQuerySchema,
   t_GetPlansQuerySchema,
-  t_GetPricesBodySchema,
-  t_GetPricesPriceBodySchema,
   t_GetPricesPriceParamSchema,
   t_GetPricesPriceQuerySchema,
   t_GetPricesQuerySchema,
-  t_GetPricesSearchBodySchema,
   t_GetPricesSearchQuerySchema,
-  t_GetProductsBodySchema,
-  t_GetProductsIdBodySchema,
   t_GetProductsIdParamSchema,
   t_GetProductsIdQuerySchema,
-  t_GetProductsProductFeaturesBodySchema,
-  t_GetProductsProductFeaturesIdBodySchema,
   t_GetProductsProductFeaturesIdParamSchema,
   t_GetProductsProductFeaturesIdQuerySchema,
   t_GetProductsProductFeaturesParamSchema,
   t_GetProductsProductFeaturesQuerySchema,
   t_GetProductsQuerySchema,
-  t_GetProductsSearchBodySchema,
   t_GetProductsSearchQuerySchema,
-  t_GetPromotionCodesBodySchema,
-  t_GetPromotionCodesPromotionCodeBodySchema,
   t_GetPromotionCodesPromotionCodeParamSchema,
   t_GetPromotionCodesPromotionCodeQuerySchema,
   t_GetPromotionCodesQuerySchema,
-  t_GetQuotesBodySchema,
   t_GetQuotesQuerySchema,
-  t_GetQuotesQuoteBodySchema,
-  t_GetQuotesQuoteComputedUpfrontLineItemsBodySchema,
   t_GetQuotesQuoteComputedUpfrontLineItemsParamSchema,
   t_GetQuotesQuoteComputedUpfrontLineItemsQuerySchema,
-  t_GetQuotesQuoteLineItemsBodySchema,
   t_GetQuotesQuoteLineItemsParamSchema,
   t_GetQuotesQuoteLineItemsQuerySchema,
   t_GetQuotesQuoteParamSchema,
-  t_GetQuotesQuotePdfBodySchema,
   t_GetQuotesQuotePdfParamSchema,
   t_GetQuotesQuotePdfQuerySchema,
   t_GetQuotesQuoteQuerySchema,
-  t_GetRadarEarlyFraudWarningsBodySchema,
-  t_GetRadarEarlyFraudWarningsEarlyFraudWarningBodySchema,
   t_GetRadarEarlyFraudWarningsEarlyFraudWarningParamSchema,
   t_GetRadarEarlyFraudWarningsEarlyFraudWarningQuerySchema,
   t_GetRadarEarlyFraudWarningsQuerySchema,
-  t_GetRadarValueListItemsBodySchema,
-  t_GetRadarValueListItemsItemBodySchema,
   t_GetRadarValueListItemsItemParamSchema,
   t_GetRadarValueListItemsItemQuerySchema,
   t_GetRadarValueListItemsQuerySchema,
-  t_GetRadarValueListsBodySchema,
   t_GetRadarValueListsQuerySchema,
-  t_GetRadarValueListsValueListBodySchema,
   t_GetRadarValueListsValueListParamSchema,
   t_GetRadarValueListsValueListQuerySchema,
-  t_GetRefundsBodySchema,
   t_GetRefundsQuerySchema,
-  t_GetRefundsRefundBodySchema,
   t_GetRefundsRefundParamSchema,
   t_GetRefundsRefundQuerySchema,
-  t_GetReportingReportRunsBodySchema,
   t_GetReportingReportRunsQuerySchema,
-  t_GetReportingReportRunsReportRunBodySchema,
   t_GetReportingReportRunsReportRunParamSchema,
   t_GetReportingReportRunsReportRunQuerySchema,
-  t_GetReportingReportTypesBodySchema,
   t_GetReportingReportTypesQuerySchema,
-  t_GetReportingReportTypesReportTypeBodySchema,
   t_GetReportingReportTypesReportTypeParamSchema,
   t_GetReportingReportTypesReportTypeQuerySchema,
-  t_GetReviewsBodySchema,
   t_GetReviewsQuerySchema,
-  t_GetReviewsReviewBodySchema,
   t_GetReviewsReviewParamSchema,
   t_GetReviewsReviewQuerySchema,
-  t_GetSetupAttemptsBodySchema,
   t_GetSetupAttemptsQuerySchema,
-  t_GetSetupIntentsBodySchema,
-  t_GetSetupIntentsIntentBodySchema,
   t_GetSetupIntentsIntentParamSchema,
   t_GetSetupIntentsIntentQuerySchema,
   t_GetSetupIntentsQuerySchema,
-  t_GetShippingRatesBodySchema,
   t_GetShippingRatesQuerySchema,
-  t_GetShippingRatesShippingRateTokenBodySchema,
   t_GetShippingRatesShippingRateTokenParamSchema,
   t_GetShippingRatesShippingRateTokenQuerySchema,
-  t_GetSigmaScheduledQueryRunsBodySchema,
   t_GetSigmaScheduledQueryRunsQuerySchema,
-  t_GetSigmaScheduledQueryRunsScheduledQueryRunBodySchema,
   t_GetSigmaScheduledQueryRunsScheduledQueryRunParamSchema,
   t_GetSigmaScheduledQueryRunsScheduledQueryRunQuerySchema,
-  t_GetSourcesSourceBodySchema,
-  t_GetSourcesSourceMandateNotificationsMandateNotificationBodySchema,
   t_GetSourcesSourceMandateNotificationsMandateNotificationParamSchema,
   t_GetSourcesSourceMandateNotificationsMandateNotificationQuerySchema,
   t_GetSourcesSourceParamSchema,
   t_GetSourcesSourceQuerySchema,
-  t_GetSourcesSourceSourceTransactionsBodySchema,
   t_GetSourcesSourceSourceTransactionsParamSchema,
   t_GetSourcesSourceSourceTransactionsQuerySchema,
-  t_GetSourcesSourceSourceTransactionsSourceTransactionBodySchema,
   t_GetSourcesSourceSourceTransactionsSourceTransactionParamSchema,
   t_GetSourcesSourceSourceTransactionsSourceTransactionQuerySchema,
-  t_GetSubscriptionItemsBodySchema,
-  t_GetSubscriptionItemsItemBodySchema,
   t_GetSubscriptionItemsItemParamSchema,
   t_GetSubscriptionItemsItemQuerySchema,
   t_GetSubscriptionItemsQuerySchema,
-  t_GetSubscriptionSchedulesBodySchema,
   t_GetSubscriptionSchedulesQuerySchema,
-  t_GetSubscriptionSchedulesScheduleBodySchema,
   t_GetSubscriptionSchedulesScheduleParamSchema,
   t_GetSubscriptionSchedulesScheduleQuerySchema,
-  t_GetSubscriptionsBodySchema,
   t_GetSubscriptionsQuerySchema,
-  t_GetSubscriptionsSearchBodySchema,
   t_GetSubscriptionsSearchQuerySchema,
-  t_GetSubscriptionsSubscriptionExposedIdBodySchema,
   t_GetSubscriptionsSubscriptionExposedIdParamSchema,
   t_GetSubscriptionsSubscriptionExposedIdQuerySchema,
-  t_GetTaxCalculationsCalculationBodySchema,
-  t_GetTaxCalculationsCalculationLineItemsBodySchema,
   t_GetTaxCalculationsCalculationLineItemsParamSchema,
   t_GetTaxCalculationsCalculationLineItemsQuerySchema,
   t_GetTaxCalculationsCalculationParamSchema,
   t_GetTaxCalculationsCalculationQuerySchema,
-  t_GetTaxCodesBodySchema,
-  t_GetTaxCodesIdBodySchema,
   t_GetTaxCodesIdParamSchema,
   t_GetTaxCodesIdQuerySchema,
   t_GetTaxCodesQuerySchema,
-  t_GetTaxIdsBodySchema,
-  t_GetTaxIdsIdBodySchema,
   t_GetTaxIdsIdParamSchema,
   t_GetTaxIdsIdQuerySchema,
   t_GetTaxIdsQuerySchema,
-  t_GetTaxRatesBodySchema,
   t_GetTaxRatesQuerySchema,
-  t_GetTaxRatesTaxRateBodySchema,
   t_GetTaxRatesTaxRateParamSchema,
   t_GetTaxRatesTaxRateQuerySchema,
-  t_GetTaxRegistrationsBodySchema,
-  t_GetTaxRegistrationsIdBodySchema,
   t_GetTaxRegistrationsIdParamSchema,
   t_GetTaxRegistrationsIdQuerySchema,
   t_GetTaxRegistrationsQuerySchema,
-  t_GetTaxSettingsBodySchema,
   t_GetTaxSettingsQuerySchema,
-  t_GetTaxTransactionsTransactionBodySchema,
-  t_GetTaxTransactionsTransactionLineItemsBodySchema,
   t_GetTaxTransactionsTransactionLineItemsParamSchema,
   t_GetTaxTransactionsTransactionLineItemsQuerySchema,
   t_GetTaxTransactionsTransactionParamSchema,
   t_GetTaxTransactionsTransactionQuerySchema,
-  t_GetTerminalConfigurationsBodySchema,
-  t_GetTerminalConfigurationsConfigurationBodySchema,
   t_GetTerminalConfigurationsConfigurationParamSchema,
   t_GetTerminalConfigurationsConfigurationQuerySchema,
   t_GetTerminalConfigurationsQuerySchema,
-  t_GetTerminalLocationsBodySchema,
-  t_GetTerminalLocationsLocationBodySchema,
   t_GetTerminalLocationsLocationParamSchema,
   t_GetTerminalLocationsLocationQuerySchema,
   t_GetTerminalLocationsQuerySchema,
-  t_GetTerminalReadersBodySchema,
   t_GetTerminalReadersQuerySchema,
-  t_GetTerminalReadersReaderBodySchema,
   t_GetTerminalReadersReaderParamSchema,
   t_GetTerminalReadersReaderQuerySchema,
-  t_GetTestHelpersTestClocksBodySchema,
   t_GetTestHelpersTestClocksQuerySchema,
-  t_GetTestHelpersTestClocksTestClockBodySchema,
   t_GetTestHelpersTestClocksTestClockParamSchema,
   t_GetTestHelpersTestClocksTestClockQuerySchema,
-  t_GetTokensTokenBodySchema,
   t_GetTokensTokenParamSchema,
   t_GetTokensTokenQuerySchema,
-  t_GetTopupsBodySchema,
   t_GetTopupsQuerySchema,
-  t_GetTopupsTopupBodySchema,
   t_GetTopupsTopupParamSchema,
   t_GetTopupsTopupQuerySchema,
-  t_GetTransfersBodySchema,
-  t_GetTransfersIdReversalsBodySchema,
   t_GetTransfersIdReversalsParamSchema,
   t_GetTransfersIdReversalsQuerySchema,
   t_GetTransfersQuerySchema,
-  t_GetTransfersTransferBodySchema,
   t_GetTransfersTransferParamSchema,
   t_GetTransfersTransferQuerySchema,
-  t_GetTransfersTransferReversalsIdBodySchema,
   t_GetTransfersTransferReversalsIdParamSchema,
   t_GetTransfersTransferReversalsIdQuerySchema,
-  t_GetTreasuryCreditReversalsBodySchema,
-  t_GetTreasuryCreditReversalsCreditReversalBodySchema,
   t_GetTreasuryCreditReversalsCreditReversalParamSchema,
   t_GetTreasuryCreditReversalsCreditReversalQuerySchema,
   t_GetTreasuryCreditReversalsQuerySchema,
-  t_GetTreasuryDebitReversalsBodySchema,
-  t_GetTreasuryDebitReversalsDebitReversalBodySchema,
   t_GetTreasuryDebitReversalsDebitReversalParamSchema,
   t_GetTreasuryDebitReversalsDebitReversalQuerySchema,
   t_GetTreasuryDebitReversalsQuerySchema,
-  t_GetTreasuryFinancialAccountsBodySchema,
-  t_GetTreasuryFinancialAccountsFinancialAccountBodySchema,
-  t_GetTreasuryFinancialAccountsFinancialAccountFeaturesBodySchema,
   t_GetTreasuryFinancialAccountsFinancialAccountFeaturesParamSchema,
   t_GetTreasuryFinancialAccountsFinancialAccountFeaturesQuerySchema,
   t_GetTreasuryFinancialAccountsFinancialAccountParamSchema,
   t_GetTreasuryFinancialAccountsFinancialAccountQuerySchema,
   t_GetTreasuryFinancialAccountsQuerySchema,
-  t_GetTreasuryInboundTransfersBodySchema,
-  t_GetTreasuryInboundTransfersIdBodySchema,
   t_GetTreasuryInboundTransfersIdParamSchema,
   t_GetTreasuryInboundTransfersIdQuerySchema,
   t_GetTreasuryInboundTransfersQuerySchema,
-  t_GetTreasuryOutboundPaymentsBodySchema,
-  t_GetTreasuryOutboundPaymentsIdBodySchema,
   t_GetTreasuryOutboundPaymentsIdParamSchema,
   t_GetTreasuryOutboundPaymentsIdQuerySchema,
   t_GetTreasuryOutboundPaymentsQuerySchema,
-  t_GetTreasuryOutboundTransfersBodySchema,
-  t_GetTreasuryOutboundTransfersOutboundTransferBodySchema,
   t_GetTreasuryOutboundTransfersOutboundTransferParamSchema,
   t_GetTreasuryOutboundTransfersOutboundTransferQuerySchema,
   t_GetTreasuryOutboundTransfersQuerySchema,
-  t_GetTreasuryReceivedCreditsBodySchema,
-  t_GetTreasuryReceivedCreditsIdBodySchema,
   t_GetTreasuryReceivedCreditsIdParamSchema,
   t_GetTreasuryReceivedCreditsIdQuerySchema,
   t_GetTreasuryReceivedCreditsQuerySchema,
-  t_GetTreasuryReceivedDebitsBodySchema,
-  t_GetTreasuryReceivedDebitsIdBodySchema,
   t_GetTreasuryReceivedDebitsIdParamSchema,
   t_GetTreasuryReceivedDebitsIdQuerySchema,
   t_GetTreasuryReceivedDebitsQuerySchema,
-  t_GetTreasuryTransactionEntriesBodySchema,
-  t_GetTreasuryTransactionEntriesIdBodySchema,
   t_GetTreasuryTransactionEntriesIdParamSchema,
   t_GetTreasuryTransactionEntriesIdQuerySchema,
   t_GetTreasuryTransactionEntriesQuerySchema,
-  t_GetTreasuryTransactionsBodySchema,
-  t_GetTreasuryTransactionsIdBodySchema,
   t_GetTreasuryTransactionsIdParamSchema,
   t_GetTreasuryTransactionsIdQuerySchema,
   t_GetTreasuryTransactionsQuerySchema,
-  t_GetWebhookEndpointsBodySchema,
   t_GetWebhookEndpointsQuerySchema,
-  t_GetWebhookEndpointsWebhookEndpointBodySchema,
   t_GetWebhookEndpointsWebhookEndpointParamSchema,
   t_GetWebhookEndpointsWebhookEndpointQuerySchema,
   t_PostAccountLinksBodySchema,
@@ -1555,12 +1274,7 @@ export type GetAccountResponder = {
 } & KoaRuntimeResponder
 
 export type GetAccount = (
-  params: Params<
-    void,
-    t_GetAccountQuerySchema,
-    t_GetAccountBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetAccountQuerySchema, void, void>,
   respond: GetAccountResponder,
   ctx: RouterContext,
   next: Next,
@@ -1616,12 +1330,7 @@ export type GetAccountsResponder = {
 } & KoaRuntimeResponder
 
 export type GetAccounts = (
-  params: Params<
-    void,
-    t_GetAccountsQuerySchema,
-    t_GetAccountsBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetAccountsQuerySchema, void, void>,
   respond: GetAccountsResponder,
   ctx: RouterContext,
   next: Next,
@@ -1663,12 +1372,7 @@ export type DeleteAccountsAccountResponder = {
 } & KoaRuntimeResponder
 
 export type DeleteAccountsAccount = (
-  params: Params<
-    t_DeleteAccountsAccountParamSchema,
-    void,
-    t_DeleteAccountsAccountBodySchema | undefined,
-    void
-  >,
+  params: Params<t_DeleteAccountsAccountParamSchema, void, void, void>,
   respond: DeleteAccountsAccountResponder,
   ctx: RouterContext,
   next: Next,
@@ -1688,7 +1392,7 @@ export type GetAccountsAccount = (
   params: Params<
     t_GetAccountsAccountParamSchema,
     t_GetAccountsAccountQuerySchema,
-    t_GetAccountsAccountBodySchema | undefined,
+    void,
     void
   >,
   respond: GetAccountsAccountResponder,
@@ -1754,7 +1458,7 @@ export type DeleteAccountsAccountBankAccountsId = (
   params: Params<
     t_DeleteAccountsAccountBankAccountsIdParamSchema,
     void,
-    t_DeleteAccountsAccountBankAccountsIdBodySchema | undefined,
+    void,
     void
   >,
   respond: DeleteAccountsAccountBankAccountsIdResponder,
@@ -1776,7 +1480,7 @@ export type GetAccountsAccountBankAccountsId = (
   params: Params<
     t_GetAccountsAccountBankAccountsIdParamSchema,
     t_GetAccountsAccountBankAccountsIdQuerySchema,
-    t_GetAccountsAccountBankAccountsIdBodySchema | undefined,
+    void,
     void
   >,
   respond: GetAccountsAccountBankAccountsIdResponder,
@@ -1825,7 +1529,7 @@ export type GetAccountsAccountCapabilities = (
   params: Params<
     t_GetAccountsAccountCapabilitiesParamSchema,
     t_GetAccountsAccountCapabilitiesQuerySchema,
-    t_GetAccountsAccountCapabilitiesBodySchema | undefined,
+    void,
     void
   >,
   respond: GetAccountsAccountCapabilitiesResponder,
@@ -1855,7 +1559,7 @@ export type GetAccountsAccountCapabilitiesCapability = (
   params: Params<
     t_GetAccountsAccountCapabilitiesCapabilityParamSchema,
     t_GetAccountsAccountCapabilitiesCapabilityQuerySchema,
-    t_GetAccountsAccountCapabilitiesCapabilityBodySchema | undefined,
+    void,
     void
   >,
   respond: GetAccountsAccountCapabilitiesCapabilityResponder,
@@ -1904,7 +1608,7 @@ export type GetAccountsAccountExternalAccounts = (
   params: Params<
     t_GetAccountsAccountExternalAccountsParamSchema,
     t_GetAccountsAccountExternalAccountsQuerySchema,
-    t_GetAccountsAccountExternalAccountsBodySchema | undefined,
+    void,
     void
   >,
   respond: GetAccountsAccountExternalAccountsResponder,
@@ -1956,7 +1660,7 @@ export type DeleteAccountsAccountExternalAccountsId = (
   params: Params<
     t_DeleteAccountsAccountExternalAccountsIdParamSchema,
     void,
-    t_DeleteAccountsAccountExternalAccountsIdBodySchema | undefined,
+    void,
     void
   >,
   respond: DeleteAccountsAccountExternalAccountsIdResponder,
@@ -1978,7 +1682,7 @@ export type GetAccountsAccountExternalAccountsId = (
   params: Params<
     t_GetAccountsAccountExternalAccountsIdParamSchema,
     t_GetAccountsAccountExternalAccountsIdQuerySchema,
-    t_GetAccountsAccountExternalAccountsIdBodySchema | undefined,
+    void,
     void
   >,
   respond: GetAccountsAccountExternalAccountsIdResponder,
@@ -2049,7 +1753,7 @@ export type GetAccountsAccountPeople = (
   params: Params<
     t_GetAccountsAccountPeopleParamSchema,
     t_GetAccountsAccountPeopleQuerySchema,
-    t_GetAccountsAccountPeopleBodySchema | undefined,
+    void,
     void
   >,
   respond: GetAccountsAccountPeopleResponder,
@@ -2101,7 +1805,7 @@ export type DeleteAccountsAccountPeoplePerson = (
   params: Params<
     t_DeleteAccountsAccountPeoplePersonParamSchema,
     void,
-    t_DeleteAccountsAccountPeoplePersonBodySchema | undefined,
+    void,
     void
   >,
   respond: DeleteAccountsAccountPeoplePersonResponder,
@@ -2123,7 +1827,7 @@ export type GetAccountsAccountPeoplePerson = (
   params: Params<
     t_GetAccountsAccountPeoplePersonParamSchema,
     t_GetAccountsAccountPeoplePersonQuerySchema,
-    t_GetAccountsAccountPeoplePersonBodySchema | undefined,
+    void,
     void
   >,
   respond: GetAccountsAccountPeoplePersonResponder,
@@ -2172,7 +1876,7 @@ export type GetAccountsAccountPersons = (
   params: Params<
     t_GetAccountsAccountPersonsParamSchema,
     t_GetAccountsAccountPersonsQuerySchema,
-    t_GetAccountsAccountPersonsBodySchema | undefined,
+    void,
     void
   >,
   respond: GetAccountsAccountPersonsResponder,
@@ -2224,7 +1928,7 @@ export type DeleteAccountsAccountPersonsPerson = (
   params: Params<
     t_DeleteAccountsAccountPersonsPersonParamSchema,
     void,
-    t_DeleteAccountsAccountPersonsPersonBodySchema | undefined,
+    void,
     void
   >,
   respond: DeleteAccountsAccountPersonsPersonResponder,
@@ -2246,7 +1950,7 @@ export type GetAccountsAccountPersonsPerson = (
   params: Params<
     t_GetAccountsAccountPersonsPersonParamSchema,
     t_GetAccountsAccountPersonsPersonQuerySchema,
-    t_GetAccountsAccountPersonsPersonBodySchema | undefined,
+    void,
     void
   >,
   respond: GetAccountsAccountPersonsPersonResponder,
@@ -2314,12 +2018,7 @@ export type GetApplePayDomainsResponder = {
 } & KoaRuntimeResponder
 
 export type GetApplePayDomains = (
-  params: Params<
-    void,
-    t_GetApplePayDomainsQuerySchema,
-    t_GetApplePayDomainsBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetApplePayDomainsQuerySchema, void, void>,
   respond: GetApplePayDomainsResponder,
   ctx: RouterContext,
   next: Next,
@@ -2361,12 +2060,7 @@ export type DeleteApplePayDomainsDomainResponder = {
 } & KoaRuntimeResponder
 
 export type DeleteApplePayDomainsDomain = (
-  params: Params<
-    t_DeleteApplePayDomainsDomainParamSchema,
-    void,
-    t_DeleteApplePayDomainsDomainBodySchema | undefined,
-    void
-  >,
+  params: Params<t_DeleteApplePayDomainsDomainParamSchema, void, void, void>,
   respond: DeleteApplePayDomainsDomainResponder,
   ctx: RouterContext,
   next: Next,
@@ -2386,7 +2080,7 @@ export type GetApplePayDomainsDomain = (
   params: Params<
     t_GetApplePayDomainsDomainParamSchema,
     t_GetApplePayDomainsDomainQuerySchema,
-    t_GetApplePayDomainsDomainBodySchema | undefined,
+    void,
     void
   >,
   respond: GetApplePayDomainsDomainResponder,
@@ -2410,12 +2104,7 @@ export type GetApplicationFeesResponder = {
 } & KoaRuntimeResponder
 
 export type GetApplicationFees = (
-  params: Params<
-    void,
-    t_GetApplicationFeesQuerySchema,
-    t_GetApplicationFeesBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetApplicationFeesQuerySchema, void, void>,
   respond: GetApplicationFeesResponder,
   ctx: RouterContext,
   next: Next,
@@ -2443,7 +2132,7 @@ export type GetApplicationFeesFeeRefundsId = (
   params: Params<
     t_GetApplicationFeesFeeRefundsIdParamSchema,
     t_GetApplicationFeesFeeRefundsIdQuerySchema,
-    t_GetApplicationFeesFeeRefundsIdBodySchema | undefined,
+    void,
     void
   >,
   respond: GetApplicationFeesFeeRefundsIdResponder,
@@ -2487,7 +2176,7 @@ export type GetApplicationFeesId = (
   params: Params<
     t_GetApplicationFeesIdParamSchema,
     t_GetApplicationFeesIdQuerySchema,
-    t_GetApplicationFeesIdBodySchema | undefined,
+    void,
     void
   >,
   respond: GetApplicationFeesIdResponder,
@@ -2536,7 +2225,7 @@ export type GetApplicationFeesIdRefunds = (
   params: Params<
     t_GetApplicationFeesIdRefundsParamSchema,
     t_GetApplicationFeesIdRefundsQuerySchema,
-    t_GetApplicationFeesIdRefundsBodySchema | undefined,
+    void,
     void
   >,
   respond: GetApplicationFeesIdRefundsResponder,
@@ -2590,12 +2279,7 @@ export type GetAppsSecretsResponder = {
 } & KoaRuntimeResponder
 
 export type GetAppsSecrets = (
-  params: Params<
-    void,
-    t_GetAppsSecretsQuerySchema,
-    t_GetAppsSecretsBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetAppsSecretsQuerySchema, void, void>,
   respond: GetAppsSecretsResponder,
   ctx: RouterContext,
   next: Next,
@@ -2654,12 +2338,7 @@ export type GetAppsSecretsFindResponder = {
 } & KoaRuntimeResponder
 
 export type GetAppsSecretsFind = (
-  params: Params<
-    void,
-    t_GetAppsSecretsFindQuerySchema,
-    t_GetAppsSecretsFindBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetAppsSecretsFindQuerySchema, void, void>,
   respond: GetAppsSecretsFindResponder,
   ctx: RouterContext,
   next: Next,
@@ -2676,12 +2355,7 @@ export type GetBalanceResponder = {
 } & KoaRuntimeResponder
 
 export type GetBalance = (
-  params: Params<
-    void,
-    t_GetBalanceQuerySchema,
-    t_GetBalanceBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetBalanceQuerySchema, void, void>,
   respond: GetBalanceResponder,
   ctx: RouterContext,
   next: Next,
@@ -2703,12 +2377,7 @@ export type GetBalanceHistoryResponder = {
 } & KoaRuntimeResponder
 
 export type GetBalanceHistory = (
-  params: Params<
-    void,
-    t_GetBalanceHistoryQuerySchema,
-    t_GetBalanceHistoryBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetBalanceHistoryQuerySchema, void, void>,
   respond: GetBalanceHistoryResponder,
   ctx: RouterContext,
   next: Next,
@@ -2736,7 +2405,7 @@ export type GetBalanceHistoryId = (
   params: Params<
     t_GetBalanceHistoryIdParamSchema,
     t_GetBalanceHistoryIdQuerySchema,
-    t_GetBalanceHistoryIdBodySchema | undefined,
+    void,
     void
   >,
   respond: GetBalanceHistoryIdResponder,
@@ -2760,12 +2429,7 @@ export type GetBalanceTransactionsResponder = {
 } & KoaRuntimeResponder
 
 export type GetBalanceTransactions = (
-  params: Params<
-    void,
-    t_GetBalanceTransactionsQuerySchema,
-    t_GetBalanceTransactionsBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetBalanceTransactionsQuerySchema, void, void>,
   respond: GetBalanceTransactionsResponder,
   ctx: RouterContext,
   next: Next,
@@ -2793,7 +2457,7 @@ export type GetBalanceTransactionsId = (
   params: Params<
     t_GetBalanceTransactionsIdParamSchema,
     t_GetBalanceTransactionsIdQuerySchema,
-    t_GetBalanceTransactionsIdBodySchema | undefined,
+    void,
     void
   >,
   respond: GetBalanceTransactionsIdResponder,
@@ -2817,12 +2481,7 @@ export type GetBillingAlertsResponder = {
 } & KoaRuntimeResponder
 
 export type GetBillingAlerts = (
-  params: Params<
-    void,
-    t_GetBillingAlertsQuerySchema,
-    t_GetBillingAlertsBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetBillingAlertsQuerySchema, void, void>,
   respond: GetBillingAlertsResponder,
   ctx: RouterContext,
   next: Next,
@@ -2867,7 +2526,7 @@ export type GetBillingAlertsId = (
   params: Params<
     t_GetBillingAlertsIdParamSchema,
     t_GetBillingAlertsIdQuerySchema,
-    t_GetBillingAlertsIdBodySchema | undefined,
+    void,
     void
   >,
   respond: GetBillingAlertsIdResponder,
@@ -2952,12 +2611,7 @@ export type GetBillingCreditBalanceSummaryResponder = {
 } & KoaRuntimeResponder
 
 export type GetBillingCreditBalanceSummary = (
-  params: Params<
-    void,
-    t_GetBillingCreditBalanceSummaryQuerySchema,
-    t_GetBillingCreditBalanceSummaryBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetBillingCreditBalanceSummaryQuerySchema, void, void>,
   respond: GetBillingCreditBalanceSummaryResponder,
   ctx: RouterContext,
   next: Next,
@@ -2982,7 +2636,7 @@ export type GetBillingCreditBalanceTransactions = (
   params: Params<
     void,
     t_GetBillingCreditBalanceTransactionsQuerySchema,
-    t_GetBillingCreditBalanceTransactionsBodySchema | undefined,
+    void,
     void
   >,
   respond: GetBillingCreditBalanceTransactionsResponder,
@@ -3012,7 +2666,7 @@ export type GetBillingCreditBalanceTransactionsId = (
   params: Params<
     t_GetBillingCreditBalanceTransactionsIdParamSchema,
     t_GetBillingCreditBalanceTransactionsIdQuerySchema,
-    t_GetBillingCreditBalanceTransactionsIdBodySchema | undefined,
+    void,
     void
   >,
   respond: GetBillingCreditBalanceTransactionsIdResponder,
@@ -3036,12 +2690,7 @@ export type GetBillingCreditGrantsResponder = {
 } & KoaRuntimeResponder
 
 export type GetBillingCreditGrants = (
-  params: Params<
-    void,
-    t_GetBillingCreditGrantsQuerySchema,
-    t_GetBillingCreditGrantsBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetBillingCreditGrantsQuerySchema, void, void>,
   respond: GetBillingCreditGrantsResponder,
   ctx: RouterContext,
   next: Next,
@@ -3086,7 +2735,7 @@ export type GetBillingCreditGrantsId = (
   params: Params<
     t_GetBillingCreditGrantsIdParamSchema,
     t_GetBillingCreditGrantsIdQuerySchema,
-    t_GetBillingCreditGrantsIdBodySchema | undefined,
+    void,
     void
   >,
   respond: GetBillingCreditGrantsIdResponder,
@@ -3215,12 +2864,7 @@ export type GetBillingMetersResponder = {
 } & KoaRuntimeResponder
 
 export type GetBillingMeters = (
-  params: Params<
-    void,
-    t_GetBillingMetersQuerySchema,
-    t_GetBillingMetersBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetBillingMetersQuerySchema, void, void>,
   respond: GetBillingMetersResponder,
   ctx: RouterContext,
   next: Next,
@@ -3265,7 +2909,7 @@ export type GetBillingMetersId = (
   params: Params<
     t_GetBillingMetersIdParamSchema,
     t_GetBillingMetersIdQuerySchema,
-    t_GetBillingMetersIdBodySchema | undefined,
+    void,
     void
   >,
   respond: GetBillingMetersIdResponder,
@@ -3336,7 +2980,7 @@ export type GetBillingMetersIdEventSummaries = (
   params: Params<
     t_GetBillingMetersIdEventSummariesParamSchema,
     t_GetBillingMetersIdEventSummariesQuerySchema,
-    t_GetBillingMetersIdEventSummariesBodySchema | undefined,
+    void,
     void
   >,
   respond: GetBillingMetersIdEventSummariesResponder,
@@ -3390,12 +3034,7 @@ export type GetBillingPortalConfigurationsResponder = {
 } & KoaRuntimeResponder
 
 export type GetBillingPortalConfigurations = (
-  params: Params<
-    void,
-    t_GetBillingPortalConfigurationsQuerySchema,
-    t_GetBillingPortalConfigurationsBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetBillingPortalConfigurationsQuerySchema, void, void>,
   respond: GetBillingPortalConfigurationsResponder,
   ctx: RouterContext,
   next: Next,
@@ -3440,7 +3079,7 @@ export type GetBillingPortalConfigurationsConfiguration = (
   params: Params<
     t_GetBillingPortalConfigurationsConfigurationParamSchema,
     t_GetBillingPortalConfigurationsConfigurationQuerySchema,
-    t_GetBillingPortalConfigurationsConfigurationBodySchema | undefined,
+    void,
     void
   >,
   respond: GetBillingPortalConfigurationsConfigurationResponder,
@@ -3503,12 +3142,7 @@ export type GetChargesResponder = {
 } & KoaRuntimeResponder
 
 export type GetCharges = (
-  params: Params<
-    void,
-    t_GetChargesQuerySchema,
-    t_GetChargesBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetChargesQuerySchema, void, void>,
   respond: GetChargesResponder,
   ctx: RouterContext,
   next: Next,
@@ -3557,12 +3191,7 @@ export type GetChargesSearchResponder = {
 } & KoaRuntimeResponder
 
 export type GetChargesSearch = (
-  params: Params<
-    void,
-    t_GetChargesSearchQuerySchema,
-    t_GetChargesSearchBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetChargesSearchQuerySchema, void, void>,
   respond: GetChargesSearchResponder,
   ctx: RouterContext,
   next: Next,
@@ -3592,7 +3221,7 @@ export type GetChargesCharge = (
   params: Params<
     t_GetChargesChargeParamSchema,
     t_GetChargesChargeQuerySchema,
-    t_GetChargesChargeBodySchema | undefined,
+    void,
     void
   >,
   respond: GetChargesChargeResponder,
@@ -3658,7 +3287,7 @@ export type GetChargesChargeDispute = (
   params: Params<
     t_GetChargesChargeDisputeParamSchema,
     t_GetChargesChargeDisputeQuerySchema,
-    t_GetChargesChargeDisputeBodySchema | undefined,
+    void,
     void
   >,
   respond: GetChargesChargeDisputeResponder,
@@ -3751,7 +3380,7 @@ export type GetChargesChargeRefunds = (
   params: Params<
     t_GetChargesChargeRefundsParamSchema,
     t_GetChargesChargeRefundsQuerySchema,
-    t_GetChargesChargeRefundsBodySchema | undefined,
+    void,
     void
   >,
   respond: GetChargesChargeRefundsResponder,
@@ -3803,7 +3432,7 @@ export type GetChargesChargeRefundsRefund = (
   params: Params<
     t_GetChargesChargeRefundsRefundParamSchema,
     t_GetChargesChargeRefundsRefundQuerySchema,
-    t_GetChargesChargeRefundsRefundBodySchema | undefined,
+    void,
     void
   >,
   respond: GetChargesChargeRefundsRefundResponder,
@@ -3849,12 +3478,7 @@ export type GetCheckoutSessionsResponder = {
 } & KoaRuntimeResponder
 
 export type GetCheckoutSessions = (
-  params: Params<
-    void,
-    t_GetCheckoutSessionsQuerySchema,
-    t_GetCheckoutSessionsBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetCheckoutSessionsQuerySchema, void, void>,
   respond: GetCheckoutSessionsResponder,
   ctx: RouterContext,
   next: Next,
@@ -3904,7 +3528,7 @@ export type GetCheckoutSessionsSession = (
   params: Params<
     t_GetCheckoutSessionsSessionParamSchema,
     t_GetCheckoutSessionsSessionQuerySchema,
-    t_GetCheckoutSessionsSessionBodySchema | undefined,
+    void,
     void
   >,
   respond: GetCheckoutSessionsSessionResponder,
@@ -3975,7 +3599,7 @@ export type GetCheckoutSessionsSessionLineItems = (
   params: Params<
     t_GetCheckoutSessionsSessionLineItemsParamSchema,
     t_GetCheckoutSessionsSessionLineItemsQuerySchema,
-    t_GetCheckoutSessionsSessionLineItemsBodySchema | undefined,
+    void,
     void
   >,
   respond: GetCheckoutSessionsSessionLineItemsResponder,
@@ -4007,12 +3631,7 @@ export type GetClimateOrdersResponder = {
 } & KoaRuntimeResponder
 
 export type GetClimateOrders = (
-  params: Params<
-    void,
-    t_GetClimateOrdersQuerySchema,
-    t_GetClimateOrdersBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetClimateOrdersQuerySchema, void, void>,
   respond: GetClimateOrdersResponder,
   ctx: RouterContext,
   next: Next,
@@ -4057,7 +3676,7 @@ export type GetClimateOrdersOrder = (
   params: Params<
     t_GetClimateOrdersOrderParamSchema,
     t_GetClimateOrdersOrderQuerySchema,
-    t_GetClimateOrdersOrderBodySchema | undefined,
+    void,
     void
   >,
   respond: GetClimateOrdersOrderResponder,
@@ -4125,12 +3744,7 @@ export type GetClimateProductsResponder = {
 } & KoaRuntimeResponder
 
 export type GetClimateProducts = (
-  params: Params<
-    void,
-    t_GetClimateProductsQuerySchema,
-    t_GetClimateProductsBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetClimateProductsQuerySchema, void, void>,
   respond: GetClimateProductsResponder,
   ctx: RouterContext,
   next: Next,
@@ -4158,7 +3772,7 @@ export type GetClimateProductsProduct = (
   params: Params<
     t_GetClimateProductsProductParamSchema,
     t_GetClimateProductsProductQuerySchema,
-    t_GetClimateProductsProductBodySchema | undefined,
+    void,
     void
   >,
   respond: GetClimateProductsProductResponder,
@@ -4182,12 +3796,7 @@ export type GetClimateSuppliersResponder = {
 } & KoaRuntimeResponder
 
 export type GetClimateSuppliers = (
-  params: Params<
-    void,
-    t_GetClimateSuppliersQuerySchema,
-    t_GetClimateSuppliersBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetClimateSuppliersQuerySchema, void, void>,
   respond: GetClimateSuppliersResponder,
   ctx: RouterContext,
   next: Next,
@@ -4215,7 +3824,7 @@ export type GetClimateSuppliersSupplier = (
   params: Params<
     t_GetClimateSuppliersSupplierParamSchema,
     t_GetClimateSuppliersSupplierQuerySchema,
-    t_GetClimateSuppliersSupplierBodySchema | undefined,
+    void,
     void
   >,
   respond: GetClimateSuppliersSupplierResponder,
@@ -4237,7 +3846,7 @@ export type GetConfirmationTokensConfirmationToken = (
   params: Params<
     t_GetConfirmationTokensConfirmationTokenParamSchema,
     t_GetConfirmationTokensConfirmationTokenQuerySchema,
-    t_GetConfirmationTokensConfirmationTokenBodySchema | undefined,
+    void,
     void
   >,
   respond: GetConfirmationTokensConfirmationTokenResponder,
@@ -4261,12 +3870,7 @@ export type GetCountrySpecsResponder = {
 } & KoaRuntimeResponder
 
 export type GetCountrySpecs = (
-  params: Params<
-    void,
-    t_GetCountrySpecsQuerySchema,
-    t_GetCountrySpecsBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetCountrySpecsQuerySchema, void, void>,
   respond: GetCountrySpecsResponder,
   ctx: RouterContext,
   next: Next,
@@ -4294,7 +3898,7 @@ export type GetCountrySpecsCountry = (
   params: Params<
     t_GetCountrySpecsCountryParamSchema,
     t_GetCountrySpecsCountryQuerySchema,
-    t_GetCountrySpecsCountryBodySchema | undefined,
+    void,
     void
   >,
   respond: GetCountrySpecsCountryResponder,
@@ -4318,12 +3922,7 @@ export type GetCouponsResponder = {
 } & KoaRuntimeResponder
 
 export type GetCoupons = (
-  params: Params<
-    void,
-    t_GetCouponsQuerySchema,
-    t_GetCouponsBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetCouponsQuerySchema, void, void>,
   respond: GetCouponsResponder,
   ctx: RouterContext,
   next: Next,
@@ -4365,12 +3964,7 @@ export type DeleteCouponsCouponResponder = {
 } & KoaRuntimeResponder
 
 export type DeleteCouponsCoupon = (
-  params: Params<
-    t_DeleteCouponsCouponParamSchema,
-    void,
-    t_DeleteCouponsCouponBodySchema | undefined,
-    void
-  >,
+  params: Params<t_DeleteCouponsCouponParamSchema, void, void, void>,
   respond: DeleteCouponsCouponResponder,
   ctx: RouterContext,
   next: Next,
@@ -4390,7 +3984,7 @@ export type GetCouponsCoupon = (
   params: Params<
     t_GetCouponsCouponParamSchema,
     t_GetCouponsCouponQuerySchema,
-    t_GetCouponsCouponBodySchema | undefined,
+    void,
     void
   >,
   respond: GetCouponsCouponResponder,
@@ -4436,12 +4030,7 @@ export type GetCreditNotesResponder = {
 } & KoaRuntimeResponder
 
 export type GetCreditNotes = (
-  params: Params<
-    void,
-    t_GetCreditNotesQuerySchema,
-    t_GetCreditNotesBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetCreditNotesQuerySchema, void, void>,
   respond: GetCreditNotesResponder,
   ctx: RouterContext,
   next: Next,
@@ -4483,12 +4072,7 @@ export type GetCreditNotesPreviewResponder = {
 } & KoaRuntimeResponder
 
 export type GetCreditNotesPreview = (
-  params: Params<
-    void,
-    t_GetCreditNotesPreviewQuerySchema,
-    t_GetCreditNotesPreviewBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetCreditNotesPreviewQuerySchema, void, void>,
   respond: GetCreditNotesPreviewResponder,
   ctx: RouterContext,
   next: Next,
@@ -4510,12 +4094,7 @@ export type GetCreditNotesPreviewLinesResponder = {
 } & KoaRuntimeResponder
 
 export type GetCreditNotesPreviewLines = (
-  params: Params<
-    void,
-    t_GetCreditNotesPreviewLinesQuerySchema,
-    t_GetCreditNotesPreviewLinesBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetCreditNotesPreviewLinesQuerySchema, void, void>,
   respond: GetCreditNotesPreviewLinesResponder,
   ctx: RouterContext,
   next: Next,
@@ -4548,7 +4127,7 @@ export type GetCreditNotesCreditNoteLines = (
   params: Params<
     t_GetCreditNotesCreditNoteLinesParamSchema,
     t_GetCreditNotesCreditNoteLinesQuerySchema,
-    t_GetCreditNotesCreditNoteLinesBodySchema | undefined,
+    void,
     void
   >,
   respond: GetCreditNotesCreditNoteLinesResponder,
@@ -4578,7 +4157,7 @@ export type GetCreditNotesId = (
   params: Params<
     t_GetCreditNotesIdParamSchema,
     t_GetCreditNotesIdQuerySchema,
-    t_GetCreditNotesIdBodySchema | undefined,
+    void,
     void
   >,
   respond: GetCreditNotesIdResponder,
@@ -4663,12 +4242,7 @@ export type GetCustomersResponder = {
 } & KoaRuntimeResponder
 
 export type GetCustomers = (
-  params: Params<
-    void,
-    t_GetCustomersQuerySchema,
-    t_GetCustomersBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetCustomersQuerySchema, void, void>,
   respond: GetCustomersResponder,
   ctx: RouterContext,
   next: Next,
@@ -4717,12 +4291,7 @@ export type GetCustomersSearchResponder = {
 } & KoaRuntimeResponder
 
 export type GetCustomersSearch = (
-  params: Params<
-    void,
-    t_GetCustomersSearchQuerySchema,
-    t_GetCustomersSearchBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetCustomersSearchQuerySchema, void, void>,
   respond: GetCustomersSearchResponder,
   ctx: RouterContext,
   next: Next,
@@ -4749,12 +4318,7 @@ export type DeleteCustomersCustomerResponder = {
 } & KoaRuntimeResponder
 
 export type DeleteCustomersCustomer = (
-  params: Params<
-    t_DeleteCustomersCustomerParamSchema,
-    void,
-    t_DeleteCustomersCustomerBodySchema | undefined,
-    void
-  >,
+  params: Params<t_DeleteCustomersCustomerParamSchema, void, void, void>,
   respond: DeleteCustomersCustomerResponder,
   ctx: RouterContext,
   next: Next,
@@ -4774,7 +4338,7 @@ export type GetCustomersCustomer = (
   params: Params<
     t_GetCustomersCustomerParamSchema,
     t_GetCustomersCustomerQuerySchema,
-    t_GetCustomersCustomerBodySchema | undefined,
+    void,
     void
   >,
   respond: GetCustomersCustomerResponder,
@@ -4823,7 +4387,7 @@ export type GetCustomersCustomerBalanceTransactions = (
   params: Params<
     t_GetCustomersCustomerBalanceTransactionsParamSchema,
     t_GetCustomersCustomerBalanceTransactionsQuerySchema,
-    t_GetCustomersCustomerBalanceTransactionsBodySchema | undefined,
+    void,
     void
   >,
   respond: GetCustomersCustomerBalanceTransactionsResponder,
@@ -4875,7 +4439,7 @@ export type GetCustomersCustomerBalanceTransactionsTransaction = (
   params: Params<
     t_GetCustomersCustomerBalanceTransactionsTransactionParamSchema,
     t_GetCustomersCustomerBalanceTransactionsTransactionQuerySchema,
-    t_GetCustomersCustomerBalanceTransactionsTransactionBodySchema | undefined,
+    void,
     void
   >,
   respond: GetCustomersCustomerBalanceTransactionsTransactionResponder,
@@ -4924,7 +4488,7 @@ export type GetCustomersCustomerBankAccounts = (
   params: Params<
     t_GetCustomersCustomerBankAccountsParamSchema,
     t_GetCustomersCustomerBankAccountsQuerySchema,
-    t_GetCustomersCustomerBankAccountsBodySchema | undefined,
+    void,
     void
   >,
   respond: GetCustomersCustomerBankAccountsResponder,
@@ -4998,7 +4562,7 @@ export type GetCustomersCustomerBankAccountsId = (
   params: Params<
     t_GetCustomersCustomerBankAccountsIdParamSchema,
     t_GetCustomersCustomerBankAccountsIdQuerySchema,
-    t_GetCustomersCustomerBankAccountsIdBodySchema | undefined,
+    void,
     void
   >,
   respond: GetCustomersCustomerBankAccountsIdResponder,
@@ -5069,7 +4633,7 @@ export type GetCustomersCustomerCards = (
   params: Params<
     t_GetCustomersCustomerCardsParamSchema,
     t_GetCustomersCustomerCardsQuerySchema,
-    t_GetCustomersCustomerCardsBodySchema | undefined,
+    void,
     void
   >,
   respond: GetCustomersCustomerCardsResponder,
@@ -5143,7 +4707,7 @@ export type GetCustomersCustomerCardsId = (
   params: Params<
     t_GetCustomersCustomerCardsIdParamSchema,
     t_GetCustomersCustomerCardsIdQuerySchema,
-    t_GetCustomersCustomerCardsIdBodySchema | undefined,
+    void,
     void
   >,
   respond: GetCustomersCustomerCardsIdResponder,
@@ -5187,7 +4751,7 @@ export type GetCustomersCustomerCashBalance = (
   params: Params<
     t_GetCustomersCustomerCashBalanceParamSchema,
     t_GetCustomersCustomerCashBalanceQuerySchema,
-    t_GetCustomersCustomerCashBalanceBodySchema | undefined,
+    void,
     void
   >,
   respond: GetCustomersCustomerCashBalanceResponder,
@@ -5236,7 +4800,7 @@ export type GetCustomersCustomerCashBalanceTransactions = (
   params: Params<
     t_GetCustomersCustomerCashBalanceTransactionsParamSchema,
     t_GetCustomersCustomerCashBalanceTransactionsQuerySchema,
-    t_GetCustomersCustomerCashBalanceTransactionsBodySchema | undefined,
+    void,
     void
   >,
   respond: GetCustomersCustomerCashBalanceTransactionsResponder,
@@ -5266,8 +4830,7 @@ export type GetCustomersCustomerCashBalanceTransactionsTransaction = (
   params: Params<
     t_GetCustomersCustomerCashBalanceTransactionsTransactionParamSchema,
     t_GetCustomersCustomerCashBalanceTransactionsTransactionQuerySchema,
-    | t_GetCustomersCustomerCashBalanceTransactionsTransactionBodySchema
-    | undefined,
+    void,
     void
   >,
   respond: GetCustomersCustomerCashBalanceTransactionsTransactionResponder,
@@ -5289,7 +4852,7 @@ export type DeleteCustomersCustomerDiscount = (
   params: Params<
     t_DeleteCustomersCustomerDiscountParamSchema,
     void,
-    t_DeleteCustomersCustomerDiscountBodySchema | undefined,
+    void,
     void
   >,
   respond: DeleteCustomersCustomerDiscountResponder,
@@ -5311,7 +4874,7 @@ export type GetCustomersCustomerDiscount = (
   params: Params<
     t_GetCustomersCustomerDiscountParamSchema,
     t_GetCustomersCustomerDiscountQuerySchema,
-    t_GetCustomersCustomerDiscountBodySchema | undefined,
+    void,
     void
   >,
   respond: GetCustomersCustomerDiscountResponder,
@@ -5360,7 +4923,7 @@ export type GetCustomersCustomerPaymentMethods = (
   params: Params<
     t_GetCustomersCustomerPaymentMethodsParamSchema,
     t_GetCustomersCustomerPaymentMethodsQuerySchema,
-    t_GetCustomersCustomerPaymentMethodsBodySchema | undefined,
+    void,
     void
   >,
   respond: GetCustomersCustomerPaymentMethodsResponder,
@@ -5390,7 +4953,7 @@ export type GetCustomersCustomerPaymentMethodsPaymentMethod = (
   params: Params<
     t_GetCustomersCustomerPaymentMethodsPaymentMethodParamSchema,
     t_GetCustomersCustomerPaymentMethodsPaymentMethodQuerySchema,
-    t_GetCustomersCustomerPaymentMethodsPaymentMethodBodySchema | undefined,
+    void,
     void
   >,
   respond: GetCustomersCustomerPaymentMethodsPaymentMethodResponder,
@@ -5417,7 +4980,7 @@ export type GetCustomersCustomerSources = (
   params: Params<
     t_GetCustomersCustomerSourcesParamSchema,
     t_GetCustomersCustomerSourcesQuerySchema,
-    t_GetCustomersCustomerSourcesBodySchema | undefined,
+    void,
     void
   >,
   respond: GetCustomersCustomerSourcesResponder,
@@ -5491,7 +5054,7 @@ export type GetCustomersCustomerSourcesId = (
   params: Params<
     t_GetCustomersCustomerSourcesIdParamSchema,
     t_GetCustomersCustomerSourcesIdQuerySchema,
-    t_GetCustomersCustomerSourcesIdBodySchema | undefined,
+    void,
     void
   >,
   respond: GetCustomersCustomerSourcesIdResponder,
@@ -5562,7 +5125,7 @@ export type GetCustomersCustomerSubscriptions = (
   params: Params<
     t_GetCustomersCustomerSubscriptionsParamSchema,
     t_GetCustomersCustomerSubscriptionsQuerySchema,
-    t_GetCustomersCustomerSubscriptionsBodySchema | undefined,
+    void,
     void
   >,
   respond: GetCustomersCustomerSubscriptionsResponder,
@@ -5638,8 +5201,7 @@ export type GetCustomersCustomerSubscriptionsSubscriptionExposedId = (
   params: Params<
     t_GetCustomersCustomerSubscriptionsSubscriptionExposedIdParamSchema,
     t_GetCustomersCustomerSubscriptionsSubscriptionExposedIdQuerySchema,
-    | t_GetCustomersCustomerSubscriptionsSubscriptionExposedIdBodySchema
-    | undefined,
+    void,
     void
   >,
   respond: GetCustomersCustomerSubscriptionsSubscriptionExposedIdResponder,
@@ -5686,8 +5248,7 @@ export type DeleteCustomersCustomerSubscriptionsSubscriptionExposedIdDiscount =
     params: Params<
       t_DeleteCustomersCustomerSubscriptionsSubscriptionExposedIdDiscountParamSchema,
       void,
-      | t_DeleteCustomersCustomerSubscriptionsSubscriptionExposedIdDiscountBodySchema
-      | undefined,
+      void,
       void
     >,
     respond: DeleteCustomersCustomerSubscriptionsSubscriptionExposedIdDiscountResponder,
@@ -5710,8 +5271,7 @@ export type GetCustomersCustomerSubscriptionsSubscriptionExposedIdDiscount = (
   params: Params<
     t_GetCustomersCustomerSubscriptionsSubscriptionExposedIdDiscountParamSchema,
     t_GetCustomersCustomerSubscriptionsSubscriptionExposedIdDiscountQuerySchema,
-    | t_GetCustomersCustomerSubscriptionsSubscriptionExposedIdDiscountBodySchema
-    | undefined,
+    void,
     void
   >,
   respond: GetCustomersCustomerSubscriptionsSubscriptionExposedIdDiscountResponder,
@@ -5738,7 +5298,7 @@ export type GetCustomersCustomerTaxIds = (
   params: Params<
     t_GetCustomersCustomerTaxIdsParamSchema,
     t_GetCustomersCustomerTaxIdsQuerySchema,
-    t_GetCustomersCustomerTaxIdsBodySchema | undefined,
+    void,
     void
   >,
   respond: GetCustomersCustomerTaxIdsResponder,
@@ -5790,7 +5350,7 @@ export type DeleteCustomersCustomerTaxIdsId = (
   params: Params<
     t_DeleteCustomersCustomerTaxIdsIdParamSchema,
     void,
-    t_DeleteCustomersCustomerTaxIdsIdBodySchema | undefined,
+    void,
     void
   >,
   respond: DeleteCustomersCustomerTaxIdsIdResponder,
@@ -5812,7 +5372,7 @@ export type GetCustomersCustomerTaxIdsId = (
   params: Params<
     t_GetCustomersCustomerTaxIdsIdParamSchema,
     t_GetCustomersCustomerTaxIdsIdQuerySchema,
-    t_GetCustomersCustomerTaxIdsIdBodySchema | undefined,
+    void,
     void
   >,
   respond: GetCustomersCustomerTaxIdsIdResponder,
@@ -5836,12 +5396,7 @@ export type GetDisputesResponder = {
 } & KoaRuntimeResponder
 
 export type GetDisputes = (
-  params: Params<
-    void,
-    t_GetDisputesQuerySchema,
-    t_GetDisputesBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetDisputesQuerySchema, void, void>,
   respond: GetDisputesResponder,
   ctx: RouterContext,
   next: Next,
@@ -5869,7 +5424,7 @@ export type GetDisputesDispute = (
   params: Params<
     t_GetDisputesDisputeParamSchema,
     t_GetDisputesDisputeQuerySchema,
-    t_GetDisputesDisputeBodySchema | undefined,
+    void,
     void
   >,
   respond: GetDisputesDisputeResponder,
@@ -5940,7 +5495,7 @@ export type GetEntitlementsActiveEntitlements = (
   params: Params<
     void,
     t_GetEntitlementsActiveEntitlementsQuerySchema,
-    t_GetEntitlementsActiveEntitlementsBodySchema | undefined,
+    void,
     void
   >,
   respond: GetEntitlementsActiveEntitlementsResponder,
@@ -5970,7 +5525,7 @@ export type GetEntitlementsActiveEntitlementsId = (
   params: Params<
     t_GetEntitlementsActiveEntitlementsIdParamSchema,
     t_GetEntitlementsActiveEntitlementsIdQuerySchema,
-    t_GetEntitlementsActiveEntitlementsIdBodySchema | undefined,
+    void,
     void
   >,
   respond: GetEntitlementsActiveEntitlementsIdResponder,
@@ -5994,12 +5549,7 @@ export type GetEntitlementsFeaturesResponder = {
 } & KoaRuntimeResponder
 
 export type GetEntitlementsFeatures = (
-  params: Params<
-    void,
-    t_GetEntitlementsFeaturesQuerySchema,
-    t_GetEntitlementsFeaturesBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetEntitlementsFeaturesQuerySchema, void, void>,
   respond: GetEntitlementsFeaturesResponder,
   ctx: RouterContext,
   next: Next,
@@ -6044,7 +5594,7 @@ export type GetEntitlementsFeaturesId = (
   params: Params<
     t_GetEntitlementsFeaturesIdParamSchema,
     t_GetEntitlementsFeaturesIdQuerySchema,
-    t_GetEntitlementsFeaturesIdBodySchema | undefined,
+    void,
     void
   >,
   respond: GetEntitlementsFeaturesIdResponder,
@@ -6129,12 +5679,7 @@ export type GetEventsResponder = {
 } & KoaRuntimeResponder
 
 export type GetEvents = (
-  params: Params<
-    void,
-    t_GetEventsQuerySchema,
-    t_GetEventsBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetEventsQuerySchema, void, void>,
   respond: GetEventsResponder,
   ctx: RouterContext,
   next: Next,
@@ -6162,7 +5707,7 @@ export type GetEventsId = (
   params: Params<
     t_GetEventsIdParamSchema,
     t_GetEventsIdQuerySchema,
-    t_GetEventsIdBodySchema | undefined,
+    void,
     void
   >,
   respond: GetEventsIdResponder,
@@ -6186,12 +5731,7 @@ export type GetExchangeRatesResponder = {
 } & KoaRuntimeResponder
 
 export type GetExchangeRates = (
-  params: Params<
-    void,
-    t_GetExchangeRatesQuerySchema,
-    t_GetExchangeRatesBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetExchangeRatesQuerySchema, void, void>,
   respond: GetExchangeRatesResponder,
   ctx: RouterContext,
   next: Next,
@@ -6219,7 +5759,7 @@ export type GetExchangeRatesRateId = (
   params: Params<
     t_GetExchangeRatesRateIdParamSchema,
     t_GetExchangeRatesRateIdQuerySchema,
-    t_GetExchangeRatesRateIdBodySchema | undefined,
+    void,
     void
   >,
   respond: GetExchangeRatesRateIdResponder,
@@ -6265,12 +5805,7 @@ export type GetFileLinksResponder = {
 } & KoaRuntimeResponder
 
 export type GetFileLinks = (
-  params: Params<
-    void,
-    t_GetFileLinksQuerySchema,
-    t_GetFileLinksBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetFileLinksQuerySchema, void, void>,
   respond: GetFileLinksResponder,
   ctx: RouterContext,
   next: Next,
@@ -6315,7 +5850,7 @@ export type GetFileLinksLink = (
   params: Params<
     t_GetFileLinksLinkParamSchema,
     t_GetFileLinksLinkQuerySchema,
-    t_GetFileLinksLinkBodySchema | undefined,
+    void,
     void
   >,
   respond: GetFileLinksLinkResponder,
@@ -6361,12 +5896,7 @@ export type GetFilesResponder = {
 } & KoaRuntimeResponder
 
 export type GetFiles = (
-  params: Params<
-    void,
-    t_GetFilesQuerySchema,
-    t_GetFilesBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetFilesQuerySchema, void, void>,
   respond: GetFilesResponder,
   ctx: RouterContext,
   next: Next,
@@ -6411,7 +5941,7 @@ export type GetFilesFile = (
   params: Params<
     t_GetFilesFileParamSchema,
     t_GetFilesFileQuerySchema,
-    t_GetFilesFileBodySchema | undefined,
+    void,
     void
   >,
   respond: GetFilesFileResponder,
@@ -6438,7 +5968,7 @@ export type GetFinancialConnectionsAccounts = (
   params: Params<
     void,
     t_GetFinancialConnectionsAccountsQuerySchema,
-    t_GetFinancialConnectionsAccountsBodySchema | undefined,
+    void,
     void
   >,
   respond: GetFinancialConnectionsAccountsResponder,
@@ -6468,7 +5998,7 @@ export type GetFinancialConnectionsAccountsAccount = (
   params: Params<
     t_GetFinancialConnectionsAccountsAccountParamSchema,
     t_GetFinancialConnectionsAccountsAccountQuerySchema,
-    t_GetFinancialConnectionsAccountsAccountBodySchema | undefined,
+    void,
     void
   >,
   respond: GetFinancialConnectionsAccountsAccountResponder,
@@ -6517,7 +6047,7 @@ export type GetFinancialConnectionsAccountsAccountOwners = (
   params: Params<
     t_GetFinancialConnectionsAccountsAccountOwnersParamSchema,
     t_GetFinancialConnectionsAccountsAccountOwnersQuerySchema,
-    t_GetFinancialConnectionsAccountsAccountOwnersBodySchema | undefined,
+    void,
     void
   >,
   respond: GetFinancialConnectionsAccountsAccountOwnersResponder,
@@ -6635,7 +6165,7 @@ export type GetFinancialConnectionsSessionsSession = (
   params: Params<
     t_GetFinancialConnectionsSessionsSessionParamSchema,
     t_GetFinancialConnectionsSessionsSessionQuerySchema,
-    t_GetFinancialConnectionsSessionsSessionBodySchema | undefined,
+    void,
     void
   >,
   respond: GetFinancialConnectionsSessionsSessionResponder,
@@ -6662,7 +6192,7 @@ export type GetFinancialConnectionsTransactions = (
   params: Params<
     void,
     t_GetFinancialConnectionsTransactionsQuerySchema,
-    t_GetFinancialConnectionsTransactionsBodySchema | undefined,
+    void,
     void
   >,
   respond: GetFinancialConnectionsTransactionsResponder,
@@ -6692,7 +6222,7 @@ export type GetFinancialConnectionsTransactionsTransaction = (
   params: Params<
     t_GetFinancialConnectionsTransactionsTransactionParamSchema,
     t_GetFinancialConnectionsTransactionsTransactionQuerySchema,
-    t_GetFinancialConnectionsTransactionsTransactionBodySchema | undefined,
+    void,
     void
   >,
   respond: GetFinancialConnectionsTransactionsTransactionResponder,
@@ -6716,12 +6246,7 @@ export type GetForwardingRequestsResponder = {
 } & KoaRuntimeResponder
 
 export type GetForwardingRequests = (
-  params: Params<
-    void,
-    t_GetForwardingRequestsQuerySchema,
-    t_GetForwardingRequestsBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetForwardingRequestsQuerySchema, void, void>,
   respond: GetForwardingRequestsResponder,
   ctx: RouterContext,
   next: Next,
@@ -6766,7 +6291,7 @@ export type GetForwardingRequestsId = (
   params: Params<
     t_GetForwardingRequestsIdParamSchema,
     t_GetForwardingRequestsIdQuerySchema,
-    t_GetForwardingRequestsIdBodySchema | undefined,
+    void,
     void
   >,
   respond: GetForwardingRequestsIdResponder,
@@ -6790,12 +6315,7 @@ export type GetIdentityVerificationReportsResponder = {
 } & KoaRuntimeResponder
 
 export type GetIdentityVerificationReports = (
-  params: Params<
-    void,
-    t_GetIdentityVerificationReportsQuerySchema,
-    t_GetIdentityVerificationReportsBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetIdentityVerificationReportsQuerySchema, void, void>,
   respond: GetIdentityVerificationReportsResponder,
   ctx: RouterContext,
   next: Next,
@@ -6823,7 +6343,7 @@ export type GetIdentityVerificationReportsReport = (
   params: Params<
     t_GetIdentityVerificationReportsReportParamSchema,
     t_GetIdentityVerificationReportsReportQuerySchema,
-    t_GetIdentityVerificationReportsReportBodySchema | undefined,
+    void,
     void
   >,
   respond: GetIdentityVerificationReportsReportResponder,
@@ -6850,7 +6370,7 @@ export type GetIdentityVerificationSessions = (
   params: Params<
     void,
     t_GetIdentityVerificationSessionsQuerySchema,
-    t_GetIdentityVerificationSessionsBodySchema | undefined,
+    void,
     void
   >,
   respond: GetIdentityVerificationSessionsResponder,
@@ -6902,7 +6422,7 @@ export type GetIdentityVerificationSessionsSession = (
   params: Params<
     t_GetIdentityVerificationSessionsSessionParamSchema,
     t_GetIdentityVerificationSessionsSessionQuerySchema,
-    t_GetIdentityVerificationSessionsSessionBodySchema | undefined,
+    void,
     void
   >,
   respond: GetIdentityVerificationSessionsSessionResponder,
@@ -6992,12 +6512,7 @@ export type GetInvoicePaymentsResponder = {
 } & KoaRuntimeResponder
 
 export type GetInvoicePayments = (
-  params: Params<
-    void,
-    t_GetInvoicePaymentsQuerySchema,
-    t_GetInvoicePaymentsBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetInvoicePaymentsQuerySchema, void, void>,
   respond: GetInvoicePaymentsResponder,
   ctx: RouterContext,
   next: Next,
@@ -7025,7 +6540,7 @@ export type GetInvoicePaymentsInvoicePayment = (
   params: Params<
     t_GetInvoicePaymentsInvoicePaymentParamSchema,
     t_GetInvoicePaymentsInvoicePaymentQuerySchema,
-    t_GetInvoicePaymentsInvoicePaymentBodySchema | undefined,
+    void,
     void
   >,
   respond: GetInvoicePaymentsInvoicePaymentResponder,
@@ -7049,12 +6564,7 @@ export type GetInvoiceRenderingTemplatesResponder = {
 } & KoaRuntimeResponder
 
 export type GetInvoiceRenderingTemplates = (
-  params: Params<
-    void,
-    t_GetInvoiceRenderingTemplatesQuerySchema,
-    t_GetInvoiceRenderingTemplatesBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetInvoiceRenderingTemplatesQuerySchema, void, void>,
   respond: GetInvoiceRenderingTemplatesResponder,
   ctx: RouterContext,
   next: Next,
@@ -7082,7 +6592,7 @@ export type GetInvoiceRenderingTemplatesTemplate = (
   params: Params<
     t_GetInvoiceRenderingTemplatesTemplateParamSchema,
     t_GetInvoiceRenderingTemplatesTemplateQuerySchema,
-    t_GetInvoiceRenderingTemplatesTemplateBodySchema | undefined,
+    void,
     void
   >,
   respond: GetInvoiceRenderingTemplatesTemplateResponder,
@@ -7150,12 +6660,7 @@ export type GetInvoiceitemsResponder = {
 } & KoaRuntimeResponder
 
 export type GetInvoiceitems = (
-  params: Params<
-    void,
-    t_GetInvoiceitemsQuerySchema,
-    t_GetInvoiceitemsBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetInvoiceitemsQuerySchema, void, void>,
   respond: GetInvoiceitemsResponder,
   ctx: RouterContext,
   next: Next,
@@ -7197,12 +6702,7 @@ export type DeleteInvoiceitemsInvoiceitemResponder = {
 } & KoaRuntimeResponder
 
 export type DeleteInvoiceitemsInvoiceitem = (
-  params: Params<
-    t_DeleteInvoiceitemsInvoiceitemParamSchema,
-    void,
-    t_DeleteInvoiceitemsInvoiceitemBodySchema | undefined,
-    void
-  >,
+  params: Params<t_DeleteInvoiceitemsInvoiceitemParamSchema, void, void, void>,
   respond: DeleteInvoiceitemsInvoiceitemResponder,
   ctx: RouterContext,
   next: Next,
@@ -7222,7 +6722,7 @@ export type GetInvoiceitemsInvoiceitem = (
   params: Params<
     t_GetInvoiceitemsInvoiceitemParamSchema,
     t_GetInvoiceitemsInvoiceitemQuerySchema,
-    t_GetInvoiceitemsInvoiceitemBodySchema | undefined,
+    void,
     void
   >,
   respond: GetInvoiceitemsInvoiceitemResponder,
@@ -7268,12 +6768,7 @@ export type GetInvoicesResponder = {
 } & KoaRuntimeResponder
 
 export type GetInvoices = (
-  params: Params<
-    void,
-    t_GetInvoicesQuerySchema,
-    t_GetInvoicesBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetInvoicesQuerySchema, void, void>,
   respond: GetInvoicesResponder,
   ctx: RouterContext,
   next: Next,
@@ -7344,12 +6839,7 @@ export type GetInvoicesSearchResponder = {
 } & KoaRuntimeResponder
 
 export type GetInvoicesSearch = (
-  params: Params<
-    void,
-    t_GetInvoicesSearchQuerySchema,
-    t_GetInvoicesSearchBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetInvoicesSearchQuerySchema, void, void>,
   respond: GetInvoicesSearchResponder,
   ctx: RouterContext,
   next: Next,
@@ -7376,12 +6866,7 @@ export type DeleteInvoicesInvoiceResponder = {
 } & KoaRuntimeResponder
 
 export type DeleteInvoicesInvoice = (
-  params: Params<
-    t_DeleteInvoicesInvoiceParamSchema,
-    void,
-    t_DeleteInvoicesInvoiceBodySchema | undefined,
-    void
-  >,
+  params: Params<t_DeleteInvoicesInvoiceParamSchema, void, void, void>,
   respond: DeleteInvoicesInvoiceResponder,
   ctx: RouterContext,
   next: Next,
@@ -7401,7 +6886,7 @@ export type GetInvoicesInvoice = (
   params: Params<
     t_GetInvoicesInvoiceParamSchema,
     t_GetInvoicesInvoiceQuerySchema,
-    t_GetInvoicesInvoiceBodySchema | undefined,
+    void,
     void
   >,
   respond: GetInvoicesInvoiceResponder,
@@ -7516,7 +7001,7 @@ export type GetInvoicesInvoiceLines = (
   params: Params<
     t_GetInvoicesInvoiceLinesParamSchema,
     t_GetInvoicesInvoiceLinesQuerySchema,
-    t_GetInvoicesInvoiceLinesBodySchema | undefined,
+    void,
     void
   >,
   respond: GetInvoicesInvoiceLinesResponder,
@@ -7702,12 +7187,7 @@ export type GetIssuingAuthorizationsResponder = {
 } & KoaRuntimeResponder
 
 export type GetIssuingAuthorizations = (
-  params: Params<
-    void,
-    t_GetIssuingAuthorizationsQuerySchema,
-    t_GetIssuingAuthorizationsBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetIssuingAuthorizationsQuerySchema, void, void>,
   respond: GetIssuingAuthorizationsResponder,
   ctx: RouterContext,
   next: Next,
@@ -7735,7 +7215,7 @@ export type GetIssuingAuthorizationsAuthorization = (
   params: Params<
     t_GetIssuingAuthorizationsAuthorizationParamSchema,
     t_GetIssuingAuthorizationsAuthorizationQuerySchema,
-    t_GetIssuingAuthorizationsAuthorizationBodySchema | undefined,
+    void,
     void
   >,
   respond: GetIssuingAuthorizationsAuthorizationResponder,
@@ -7825,12 +7305,7 @@ export type GetIssuingCardholdersResponder = {
 } & KoaRuntimeResponder
 
 export type GetIssuingCardholders = (
-  params: Params<
-    void,
-    t_GetIssuingCardholdersQuerySchema,
-    t_GetIssuingCardholdersBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetIssuingCardholdersQuerySchema, void, void>,
   respond: GetIssuingCardholdersResponder,
   ctx: RouterContext,
   next: Next,
@@ -7875,7 +7350,7 @@ export type GetIssuingCardholdersCardholder = (
   params: Params<
     t_GetIssuingCardholdersCardholderParamSchema,
     t_GetIssuingCardholdersCardholderQuerySchema,
-    t_GetIssuingCardholdersCardholderBodySchema | undefined,
+    void,
     void
   >,
   respond: GetIssuingCardholdersCardholderResponder,
@@ -7921,12 +7396,7 @@ export type GetIssuingCardsResponder = {
 } & KoaRuntimeResponder
 
 export type GetIssuingCards = (
-  params: Params<
-    void,
-    t_GetIssuingCardsQuerySchema,
-    t_GetIssuingCardsBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetIssuingCardsQuerySchema, void, void>,
   respond: GetIssuingCardsResponder,
   ctx: RouterContext,
   next: Next,
@@ -7971,7 +7441,7 @@ export type GetIssuingCardsCard = (
   params: Params<
     t_GetIssuingCardsCardParamSchema,
     t_GetIssuingCardsCardQuerySchema,
-    t_GetIssuingCardsCardBodySchema | undefined,
+    void,
     void
   >,
   respond: GetIssuingCardsCardResponder,
@@ -8017,12 +7487,7 @@ export type GetIssuingDisputesResponder = {
 } & KoaRuntimeResponder
 
 export type GetIssuingDisputes = (
-  params: Params<
-    void,
-    t_GetIssuingDisputesQuerySchema,
-    t_GetIssuingDisputesBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetIssuingDisputesQuerySchema, void, void>,
   respond: GetIssuingDisputesResponder,
   ctx: RouterContext,
   next: Next,
@@ -8067,7 +7532,7 @@ export type GetIssuingDisputesDispute = (
   params: Params<
     t_GetIssuingDisputesDisputeParamSchema,
     t_GetIssuingDisputesDisputeQuerySchema,
-    t_GetIssuingDisputesDisputeBodySchema | undefined,
+    void,
     void
   >,
   respond: GetIssuingDisputesDisputeResponder,
@@ -8138,7 +7603,7 @@ export type GetIssuingPersonalizationDesigns = (
   params: Params<
     void,
     t_GetIssuingPersonalizationDesignsQuerySchema,
-    t_GetIssuingPersonalizationDesignsBodySchema | undefined,
+    void,
     void
   >,
   respond: GetIssuingPersonalizationDesignsResponder,
@@ -8190,8 +7655,7 @@ export type GetIssuingPersonalizationDesignsPersonalizationDesign = (
   params: Params<
     t_GetIssuingPersonalizationDesignsPersonalizationDesignParamSchema,
     t_GetIssuingPersonalizationDesignsPersonalizationDesignQuerySchema,
-    | t_GetIssuingPersonalizationDesignsPersonalizationDesignBodySchema
-    | undefined,
+    void,
     void
   >,
   respond: GetIssuingPersonalizationDesignsPersonalizationDesignResponder,
@@ -8238,12 +7702,7 @@ export type GetIssuingPhysicalBundlesResponder = {
 } & KoaRuntimeResponder
 
 export type GetIssuingPhysicalBundles = (
-  params: Params<
-    void,
-    t_GetIssuingPhysicalBundlesQuerySchema,
-    t_GetIssuingPhysicalBundlesBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetIssuingPhysicalBundlesQuerySchema, void, void>,
   respond: GetIssuingPhysicalBundlesResponder,
   ctx: RouterContext,
   next: Next,
@@ -8271,7 +7730,7 @@ export type GetIssuingPhysicalBundlesPhysicalBundle = (
   params: Params<
     t_GetIssuingPhysicalBundlesPhysicalBundleParamSchema,
     t_GetIssuingPhysicalBundlesPhysicalBundleQuerySchema,
-    t_GetIssuingPhysicalBundlesPhysicalBundleBodySchema | undefined,
+    void,
     void
   >,
   respond: GetIssuingPhysicalBundlesPhysicalBundleResponder,
@@ -8293,7 +7752,7 @@ export type GetIssuingSettlementsSettlement = (
   params: Params<
     t_GetIssuingSettlementsSettlementParamSchema,
     t_GetIssuingSettlementsSettlementQuerySchema,
-    t_GetIssuingSettlementsSettlementBodySchema | undefined,
+    void,
     void
   >,
   respond: GetIssuingSettlementsSettlementResponder,
@@ -8339,12 +7798,7 @@ export type GetIssuingTokensResponder = {
 } & KoaRuntimeResponder
 
 export type GetIssuingTokens = (
-  params: Params<
-    void,
-    t_GetIssuingTokensQuerySchema,
-    t_GetIssuingTokensBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetIssuingTokensQuerySchema, void, void>,
   respond: GetIssuingTokensResponder,
   ctx: RouterContext,
   next: Next,
@@ -8372,7 +7826,7 @@ export type GetIssuingTokensToken = (
   params: Params<
     t_GetIssuingTokensTokenParamSchema,
     t_GetIssuingTokensTokenQuerySchema,
-    t_GetIssuingTokensTokenBodySchema | undefined,
+    void,
     void
   >,
   respond: GetIssuingTokensTokenResponder,
@@ -8418,12 +7872,7 @@ export type GetIssuingTransactionsResponder = {
 } & KoaRuntimeResponder
 
 export type GetIssuingTransactions = (
-  params: Params<
-    void,
-    t_GetIssuingTransactionsQuerySchema,
-    t_GetIssuingTransactionsBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetIssuingTransactionsQuerySchema, void, void>,
   respond: GetIssuingTransactionsResponder,
   ctx: RouterContext,
   next: Next,
@@ -8451,7 +7900,7 @@ export type GetIssuingTransactionsTransaction = (
   params: Params<
     t_GetIssuingTransactionsTransactionParamSchema,
     t_GetIssuingTransactionsTransactionQuerySchema,
-    t_GetIssuingTransactionsTransactionBodySchema | undefined,
+    void,
     void
   >,
   respond: GetIssuingTransactionsTransactionResponder,
@@ -8512,7 +7961,7 @@ export type GetLinkAccountSessionsSession = (
   params: Params<
     t_GetLinkAccountSessionsSessionParamSchema,
     t_GetLinkAccountSessionsSessionQuerySchema,
-    t_GetLinkAccountSessionsSessionBodySchema | undefined,
+    void,
     void
   >,
   respond: GetLinkAccountSessionsSessionResponder,
@@ -8536,12 +7985,7 @@ export type GetLinkedAccountsResponder = {
 } & KoaRuntimeResponder
 
 export type GetLinkedAccounts = (
-  params: Params<
-    void,
-    t_GetLinkedAccountsQuerySchema,
-    t_GetLinkedAccountsBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetLinkedAccountsQuerySchema, void, void>,
   respond: GetLinkedAccountsResponder,
   ctx: RouterContext,
   next: Next,
@@ -8569,7 +8013,7 @@ export type GetLinkedAccountsAccount = (
   params: Params<
     t_GetLinkedAccountsAccountParamSchema,
     t_GetLinkedAccountsAccountQuerySchema,
-    t_GetLinkedAccountsAccountBodySchema | undefined,
+    void,
     void
   >,
   respond: GetLinkedAccountsAccountResponder,
@@ -8618,7 +8062,7 @@ export type GetLinkedAccountsAccountOwners = (
   params: Params<
     t_GetLinkedAccountsAccountOwnersParamSchema,
     t_GetLinkedAccountsAccountOwnersQuerySchema,
-    t_GetLinkedAccountsAccountOwnersBodySchema | undefined,
+    void,
     void
   >,
   respond: GetLinkedAccountsAccountOwnersResponder,
@@ -8670,7 +8114,7 @@ export type GetMandatesMandate = (
   params: Params<
     t_GetMandatesMandateParamSchema,
     t_GetMandatesMandateQuerySchema,
-    t_GetMandatesMandateBodySchema | undefined,
+    void,
     void
   >,
   respond: GetMandatesMandateResponder,
@@ -8694,12 +8138,7 @@ export type GetPaymentIntentsResponder = {
 } & KoaRuntimeResponder
 
 export type GetPaymentIntents = (
-  params: Params<
-    void,
-    t_GetPaymentIntentsQuerySchema,
-    t_GetPaymentIntentsBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetPaymentIntentsQuerySchema, void, void>,
   respond: GetPaymentIntentsResponder,
   ctx: RouterContext,
   next: Next,
@@ -8748,12 +8187,7 @@ export type GetPaymentIntentsSearchResponder = {
 } & KoaRuntimeResponder
 
 export type GetPaymentIntentsSearch = (
-  params: Params<
-    void,
-    t_GetPaymentIntentsSearchQuerySchema,
-    t_GetPaymentIntentsSearchBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetPaymentIntentsSearchQuerySchema, void, void>,
   respond: GetPaymentIntentsSearchResponder,
   ctx: RouterContext,
   next: Next,
@@ -8783,7 +8217,7 @@ export type GetPaymentIntentsIntent = (
   params: Params<
     t_GetPaymentIntentsIntentParamSchema,
     t_GetPaymentIntentsIntentQuerySchema,
-    t_GetPaymentIntentsIntentBodySchema | undefined,
+    void,
     void
   >,
   respond: GetPaymentIntentsIntentResponder,
@@ -8961,12 +8395,7 @@ export type GetPaymentLinksResponder = {
 } & KoaRuntimeResponder
 
 export type GetPaymentLinks = (
-  params: Params<
-    void,
-    t_GetPaymentLinksQuerySchema,
-    t_GetPaymentLinksBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetPaymentLinksQuerySchema, void, void>,
   respond: GetPaymentLinksResponder,
   ctx: RouterContext,
   next: Next,
@@ -9011,7 +8440,7 @@ export type GetPaymentLinksPaymentLink = (
   params: Params<
     t_GetPaymentLinksPaymentLinkParamSchema,
     t_GetPaymentLinksPaymentLinkQuerySchema,
-    t_GetPaymentLinksPaymentLinkBodySchema | undefined,
+    void,
     void
   >,
   respond: GetPaymentLinksPaymentLinkResponder,
@@ -9060,7 +8489,7 @@ export type GetPaymentLinksPaymentLinkLineItems = (
   params: Params<
     t_GetPaymentLinksPaymentLinkLineItemsParamSchema,
     t_GetPaymentLinksPaymentLinkLineItemsQuerySchema,
-    t_GetPaymentLinksPaymentLinkLineItemsBodySchema | undefined,
+    void,
     void
   >,
   respond: GetPaymentLinksPaymentLinkLineItemsResponder,
@@ -9092,12 +8521,7 @@ export type GetPaymentMethodConfigurationsResponder = {
 } & KoaRuntimeResponder
 
 export type GetPaymentMethodConfigurations = (
-  params: Params<
-    void,
-    t_GetPaymentMethodConfigurationsQuerySchema,
-    t_GetPaymentMethodConfigurationsBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetPaymentMethodConfigurationsQuerySchema, void, void>,
   respond: GetPaymentMethodConfigurationsResponder,
   ctx: RouterContext,
   next: Next,
@@ -9147,7 +8571,7 @@ export type GetPaymentMethodConfigurationsConfiguration = (
   params: Params<
     t_GetPaymentMethodConfigurationsConfigurationParamSchema,
     t_GetPaymentMethodConfigurationsConfigurationQuerySchema,
-    t_GetPaymentMethodConfigurationsConfigurationBodySchema | undefined,
+    void,
     void
   >,
   respond: GetPaymentMethodConfigurationsConfigurationResponder,
@@ -9193,12 +8617,7 @@ export type GetPaymentMethodDomainsResponder = {
 } & KoaRuntimeResponder
 
 export type GetPaymentMethodDomains = (
-  params: Params<
-    void,
-    t_GetPaymentMethodDomainsQuerySchema,
-    t_GetPaymentMethodDomainsBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetPaymentMethodDomainsQuerySchema, void, void>,
   respond: GetPaymentMethodDomainsResponder,
   ctx: RouterContext,
   next: Next,
@@ -9243,7 +8662,7 @@ export type GetPaymentMethodDomainsPaymentMethodDomain = (
   params: Params<
     t_GetPaymentMethodDomainsPaymentMethodDomainParamSchema,
     t_GetPaymentMethodDomainsPaymentMethodDomainQuerySchema,
-    t_GetPaymentMethodDomainsPaymentMethodDomainBodySchema | undefined,
+    void,
     void
   >,
   respond: GetPaymentMethodDomainsPaymentMethodDomainResponder,
@@ -9311,12 +8730,7 @@ export type GetPaymentMethodsResponder = {
 } & KoaRuntimeResponder
 
 export type GetPaymentMethods = (
-  params: Params<
-    void,
-    t_GetPaymentMethodsQuerySchema,
-    t_GetPaymentMethodsBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetPaymentMethodsQuerySchema, void, void>,
   respond: GetPaymentMethodsResponder,
   ctx: RouterContext,
   next: Next,
@@ -9361,7 +8775,7 @@ export type GetPaymentMethodsPaymentMethod = (
   params: Params<
     t_GetPaymentMethodsPaymentMethodParamSchema,
     t_GetPaymentMethodsPaymentMethodQuerySchema,
-    t_GetPaymentMethodsPaymentMethodBodySchema | undefined,
+    void,
     void
   >,
   respond: GetPaymentMethodsPaymentMethodResponder,
@@ -9451,12 +8865,7 @@ export type GetPayoutsResponder = {
 } & KoaRuntimeResponder
 
 export type GetPayouts = (
-  params: Params<
-    void,
-    t_GetPayoutsQuerySchema,
-    t_GetPayoutsBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetPayoutsQuerySchema, void, void>,
   respond: GetPayoutsResponder,
   ctx: RouterContext,
   next: Next,
@@ -9501,7 +8910,7 @@ export type GetPayoutsPayout = (
   params: Params<
     t_GetPayoutsPayoutParamSchema,
     t_GetPayoutsPayoutQuerySchema,
-    t_GetPayoutsPayoutBodySchema | undefined,
+    void,
     void
   >,
   respond: GetPayoutsPayoutResponder,
@@ -9591,12 +9000,7 @@ export type GetPlansResponder = {
 } & KoaRuntimeResponder
 
 export type GetPlans = (
-  params: Params<
-    void,
-    t_GetPlansQuerySchema,
-    t_GetPlansBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetPlansQuerySchema, void, void>,
   respond: GetPlansResponder,
   ctx: RouterContext,
   next: Next,
@@ -9638,12 +9042,7 @@ export type DeletePlansPlanResponder = {
 } & KoaRuntimeResponder
 
 export type DeletePlansPlan = (
-  params: Params<
-    t_DeletePlansPlanParamSchema,
-    void,
-    t_DeletePlansPlanBodySchema | undefined,
-    void
-  >,
+  params: Params<t_DeletePlansPlanParamSchema, void, void, void>,
   respond: DeletePlansPlanResponder,
   ctx: RouterContext,
   next: Next,
@@ -9663,7 +9062,7 @@ export type GetPlansPlan = (
   params: Params<
     t_GetPlansPlanParamSchema,
     t_GetPlansPlanQuerySchema,
-    t_GetPlansPlanBodySchema | undefined,
+    void,
     void
   >,
   respond: GetPlansPlanResponder,
@@ -9709,12 +9108,7 @@ export type GetPricesResponder = {
 } & KoaRuntimeResponder
 
 export type GetPrices = (
-  params: Params<
-    void,
-    t_GetPricesQuerySchema,
-    t_GetPricesBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetPricesQuerySchema, void, void>,
   respond: GetPricesResponder,
   ctx: RouterContext,
   next: Next,
@@ -9763,12 +9157,7 @@ export type GetPricesSearchResponder = {
 } & KoaRuntimeResponder
 
 export type GetPricesSearch = (
-  params: Params<
-    void,
-    t_GetPricesSearchQuerySchema,
-    t_GetPricesSearchBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetPricesSearchQuerySchema, void, void>,
   respond: GetPricesSearchResponder,
   ctx: RouterContext,
   next: Next,
@@ -9798,7 +9187,7 @@ export type GetPricesPrice = (
   params: Params<
     t_GetPricesPriceParamSchema,
     t_GetPricesPriceQuerySchema,
-    t_GetPricesPriceBodySchema | undefined,
+    void,
     void
   >,
   respond: GetPricesPriceResponder,
@@ -9844,12 +9233,7 @@ export type GetProductsResponder = {
 } & KoaRuntimeResponder
 
 export type GetProducts = (
-  params: Params<
-    void,
-    t_GetProductsQuerySchema,
-    t_GetProductsBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetProductsQuerySchema, void, void>,
   respond: GetProductsResponder,
   ctx: RouterContext,
   next: Next,
@@ -9898,12 +9282,7 @@ export type GetProductsSearchResponder = {
 } & KoaRuntimeResponder
 
 export type GetProductsSearch = (
-  params: Params<
-    void,
-    t_GetProductsSearchQuerySchema,
-    t_GetProductsSearchBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetProductsSearchQuerySchema, void, void>,
   respond: GetProductsSearchResponder,
   ctx: RouterContext,
   next: Next,
@@ -9930,12 +9309,7 @@ export type DeleteProductsIdResponder = {
 } & KoaRuntimeResponder
 
 export type DeleteProductsId = (
-  params: Params<
-    t_DeleteProductsIdParamSchema,
-    void,
-    t_DeleteProductsIdBodySchema | undefined,
-    void
-  >,
+  params: Params<t_DeleteProductsIdParamSchema, void, void, void>,
   respond: DeleteProductsIdResponder,
   ctx: RouterContext,
   next: Next,
@@ -9955,7 +9329,7 @@ export type GetProductsId = (
   params: Params<
     t_GetProductsIdParamSchema,
     t_GetProductsIdQuerySchema,
-    t_GetProductsIdBodySchema | undefined,
+    void,
     void
   >,
   respond: GetProductsIdResponder,
@@ -10004,7 +9378,7 @@ export type GetProductsProductFeatures = (
   params: Params<
     t_GetProductsProductFeaturesParamSchema,
     t_GetProductsProductFeaturesQuerySchema,
-    t_GetProductsProductFeaturesBodySchema | undefined,
+    void,
     void
   >,
   respond: GetProductsProductFeaturesResponder,
@@ -10056,7 +9430,7 @@ export type DeleteProductsProductFeaturesId = (
   params: Params<
     t_DeleteProductsProductFeaturesIdParamSchema,
     void,
-    t_DeleteProductsProductFeaturesIdBodySchema | undefined,
+    void,
     void
   >,
   respond: DeleteProductsProductFeaturesIdResponder,
@@ -10078,7 +9452,7 @@ export type GetProductsProductFeaturesId = (
   params: Params<
     t_GetProductsProductFeaturesIdParamSchema,
     t_GetProductsProductFeaturesIdQuerySchema,
-    t_GetProductsProductFeaturesIdBodySchema | undefined,
+    void,
     void
   >,
   respond: GetProductsProductFeaturesIdResponder,
@@ -10102,12 +9476,7 @@ export type GetPromotionCodesResponder = {
 } & KoaRuntimeResponder
 
 export type GetPromotionCodes = (
-  params: Params<
-    void,
-    t_GetPromotionCodesQuerySchema,
-    t_GetPromotionCodesBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetPromotionCodesQuerySchema, void, void>,
   respond: GetPromotionCodesResponder,
   ctx: RouterContext,
   next: Next,
@@ -10152,7 +9521,7 @@ export type GetPromotionCodesPromotionCode = (
   params: Params<
     t_GetPromotionCodesPromotionCodeParamSchema,
     t_GetPromotionCodesPromotionCodeQuerySchema,
-    t_GetPromotionCodesPromotionCodeBodySchema | undefined,
+    void,
     void
   >,
   respond: GetPromotionCodesPromotionCodeResponder,
@@ -10198,12 +9567,7 @@ export type GetQuotesResponder = {
 } & KoaRuntimeResponder
 
 export type GetQuotes = (
-  params: Params<
-    void,
-    t_GetQuotesQuerySchema,
-    t_GetQuotesBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetQuotesQuerySchema, void, void>,
   respond: GetQuotesResponder,
   ctx: RouterContext,
   next: Next,
@@ -10248,7 +9612,7 @@ export type GetQuotesQuote = (
   params: Params<
     t_GetQuotesQuoteParamSchema,
     t_GetQuotesQuoteQuerySchema,
-    t_GetQuotesQuoteBodySchema | undefined,
+    void,
     void
   >,
   respond: GetQuotesQuoteResponder,
@@ -10341,7 +9705,7 @@ export type GetQuotesQuoteComputedUpfrontLineItems = (
   params: Params<
     t_GetQuotesQuoteComputedUpfrontLineItemsParamSchema,
     t_GetQuotesQuoteComputedUpfrontLineItemsQuerySchema,
-    t_GetQuotesQuoteComputedUpfrontLineItemsBodySchema | undefined,
+    void,
     void
   >,
   respond: GetQuotesQuoteComputedUpfrontLineItemsResponder,
@@ -10398,7 +9762,7 @@ export type GetQuotesQuoteLineItems = (
   params: Params<
     t_GetQuotesQuoteLineItemsParamSchema,
     t_GetQuotesQuoteLineItemsQuerySchema,
-    t_GetQuotesQuoteLineItemsBodySchema | undefined,
+    void,
     void
   >,
   respond: GetQuotesQuoteLineItemsResponder,
@@ -10428,7 +9792,7 @@ export type GetQuotesQuotePdf = (
   params: Params<
     t_GetQuotesQuotePdfParamSchema,
     t_GetQuotesQuotePdfQuerySchema,
-    t_GetQuotesQuotePdfBodySchema | undefined,
+    void,
     void
   >,
   respond: GetQuotesQuotePdfResponder,
@@ -10452,12 +9816,7 @@ export type GetRadarEarlyFraudWarningsResponder = {
 } & KoaRuntimeResponder
 
 export type GetRadarEarlyFraudWarnings = (
-  params: Params<
-    void,
-    t_GetRadarEarlyFraudWarningsQuerySchema,
-    t_GetRadarEarlyFraudWarningsBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetRadarEarlyFraudWarningsQuerySchema, void, void>,
   respond: GetRadarEarlyFraudWarningsResponder,
   ctx: RouterContext,
   next: Next,
@@ -10485,7 +9844,7 @@ export type GetRadarEarlyFraudWarningsEarlyFraudWarning = (
   params: Params<
     t_GetRadarEarlyFraudWarningsEarlyFraudWarningParamSchema,
     t_GetRadarEarlyFraudWarningsEarlyFraudWarningQuerySchema,
-    t_GetRadarEarlyFraudWarningsEarlyFraudWarningBodySchema | undefined,
+    void,
     void
   >,
   respond: GetRadarEarlyFraudWarningsEarlyFraudWarningResponder,
@@ -10509,12 +9868,7 @@ export type GetRadarValueListItemsResponder = {
 } & KoaRuntimeResponder
 
 export type GetRadarValueListItems = (
-  params: Params<
-    void,
-    t_GetRadarValueListItemsQuerySchema,
-    t_GetRadarValueListItemsBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetRadarValueListItemsQuerySchema, void, void>,
   respond: GetRadarValueListItemsResponder,
   ctx: RouterContext,
   next: Next,
@@ -10556,12 +9910,7 @@ export type DeleteRadarValueListItemsItemResponder = {
 } & KoaRuntimeResponder
 
 export type DeleteRadarValueListItemsItem = (
-  params: Params<
-    t_DeleteRadarValueListItemsItemParamSchema,
-    void,
-    t_DeleteRadarValueListItemsItemBodySchema | undefined,
-    void
-  >,
+  params: Params<t_DeleteRadarValueListItemsItemParamSchema, void, void, void>,
   respond: DeleteRadarValueListItemsItemResponder,
   ctx: RouterContext,
   next: Next,
@@ -10581,7 +9930,7 @@ export type GetRadarValueListItemsItem = (
   params: Params<
     t_GetRadarValueListItemsItemParamSchema,
     t_GetRadarValueListItemsItemQuerySchema,
-    t_GetRadarValueListItemsItemBodySchema | undefined,
+    void,
     void
   >,
   respond: GetRadarValueListItemsItemResponder,
@@ -10605,12 +9954,7 @@ export type GetRadarValueListsResponder = {
 } & KoaRuntimeResponder
 
 export type GetRadarValueLists = (
-  params: Params<
-    void,
-    t_GetRadarValueListsQuerySchema,
-    t_GetRadarValueListsBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetRadarValueListsQuerySchema, void, void>,
   respond: GetRadarValueListsResponder,
   ctx: RouterContext,
   next: Next,
@@ -10652,12 +9996,7 @@ export type DeleteRadarValueListsValueListResponder = {
 } & KoaRuntimeResponder
 
 export type DeleteRadarValueListsValueList = (
-  params: Params<
-    t_DeleteRadarValueListsValueListParamSchema,
-    void,
-    t_DeleteRadarValueListsValueListBodySchema | undefined,
-    void
-  >,
+  params: Params<t_DeleteRadarValueListsValueListParamSchema, void, void, void>,
   respond: DeleteRadarValueListsValueListResponder,
   ctx: RouterContext,
   next: Next,
@@ -10677,7 +10016,7 @@ export type GetRadarValueListsValueList = (
   params: Params<
     t_GetRadarValueListsValueListParamSchema,
     t_GetRadarValueListsValueListQuerySchema,
-    t_GetRadarValueListsValueListBodySchema | undefined,
+    void,
     void
   >,
   respond: GetRadarValueListsValueListResponder,
@@ -10723,12 +10062,7 @@ export type GetRefundsResponder = {
 } & KoaRuntimeResponder
 
 export type GetRefunds = (
-  params: Params<
-    void,
-    t_GetRefundsQuerySchema,
-    t_GetRefundsBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetRefundsQuerySchema, void, void>,
   respond: GetRefundsResponder,
   ctx: RouterContext,
   next: Next,
@@ -10773,7 +10107,7 @@ export type GetRefundsRefund = (
   params: Params<
     t_GetRefundsRefundParamSchema,
     t_GetRefundsRefundQuerySchema,
-    t_GetRefundsRefundBodySchema | undefined,
+    void,
     void
   >,
   respond: GetRefundsRefundResponder,
@@ -10841,12 +10175,7 @@ export type GetReportingReportRunsResponder = {
 } & KoaRuntimeResponder
 
 export type GetReportingReportRuns = (
-  params: Params<
-    void,
-    t_GetReportingReportRunsQuerySchema,
-    t_GetReportingReportRunsBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetReportingReportRunsQuerySchema, void, void>,
   respond: GetReportingReportRunsResponder,
   ctx: RouterContext,
   next: Next,
@@ -10891,7 +10220,7 @@ export type GetReportingReportRunsReportRun = (
   params: Params<
     t_GetReportingReportRunsReportRunParamSchema,
     t_GetReportingReportRunsReportRunQuerySchema,
-    t_GetReportingReportRunsReportRunBodySchema | undefined,
+    void,
     void
   >,
   respond: GetReportingReportRunsReportRunResponder,
@@ -10915,12 +10244,7 @@ export type GetReportingReportTypesResponder = {
 } & KoaRuntimeResponder
 
 export type GetReportingReportTypes = (
-  params: Params<
-    void,
-    t_GetReportingReportTypesQuerySchema,
-    t_GetReportingReportTypesBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetReportingReportTypesQuerySchema, void, void>,
   respond: GetReportingReportTypesResponder,
   ctx: RouterContext,
   next: Next,
@@ -10948,7 +10272,7 @@ export type GetReportingReportTypesReportType = (
   params: Params<
     t_GetReportingReportTypesReportTypeParamSchema,
     t_GetReportingReportTypesReportTypeQuerySchema,
-    t_GetReportingReportTypesReportTypeBodySchema | undefined,
+    void,
     void
   >,
   respond: GetReportingReportTypesReportTypeResponder,
@@ -10972,12 +10296,7 @@ export type GetReviewsResponder = {
 } & KoaRuntimeResponder
 
 export type GetReviews = (
-  params: Params<
-    void,
-    t_GetReviewsQuerySchema,
-    t_GetReviewsBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetReviewsQuerySchema, void, void>,
   respond: GetReviewsResponder,
   ctx: RouterContext,
   next: Next,
@@ -11005,7 +10324,7 @@ export type GetReviewsReview = (
   params: Params<
     t_GetReviewsReviewParamSchema,
     t_GetReviewsReviewQuerySchema,
-    t_GetReviewsReviewBodySchema | undefined,
+    void,
     void
   >,
   respond: GetReviewsReviewResponder,
@@ -11051,12 +10370,7 @@ export type GetSetupAttemptsResponder = {
 } & KoaRuntimeResponder
 
 export type GetSetupAttempts = (
-  params: Params<
-    void,
-    t_GetSetupAttemptsQuerySchema,
-    t_GetSetupAttemptsBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetSetupAttemptsQuerySchema, void, void>,
   respond: GetSetupAttemptsResponder,
   ctx: RouterContext,
   next: Next,
@@ -11086,12 +10400,7 @@ export type GetSetupIntentsResponder = {
 } & KoaRuntimeResponder
 
 export type GetSetupIntents = (
-  params: Params<
-    void,
-    t_GetSetupIntentsQuerySchema,
-    t_GetSetupIntentsBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetSetupIntentsQuerySchema, void, void>,
   respond: GetSetupIntentsResponder,
   ctx: RouterContext,
   next: Next,
@@ -11136,7 +10445,7 @@ export type GetSetupIntentsIntent = (
   params: Params<
     t_GetSetupIntentsIntentParamSchema,
     t_GetSetupIntentsIntentQuerySchema,
-    t_GetSetupIntentsIntentBodySchema | undefined,
+    void,
     void
   >,
   respond: GetSetupIntentsIntentResponder,
@@ -11248,12 +10557,7 @@ export type GetShippingRatesResponder = {
 } & KoaRuntimeResponder
 
 export type GetShippingRates = (
-  params: Params<
-    void,
-    t_GetShippingRatesQuerySchema,
-    t_GetShippingRatesBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetShippingRatesQuerySchema, void, void>,
   respond: GetShippingRatesResponder,
   ctx: RouterContext,
   next: Next,
@@ -11298,7 +10602,7 @@ export type GetShippingRatesShippingRateToken = (
   params: Params<
     t_GetShippingRatesShippingRateTokenParamSchema,
     t_GetShippingRatesShippingRateTokenQuerySchema,
-    t_GetShippingRatesShippingRateTokenBodySchema | undefined,
+    void,
     void
   >,
   respond: GetShippingRatesShippingRateTokenResponder,
@@ -11366,12 +10670,7 @@ export type GetSigmaScheduledQueryRunsResponder = {
 } & KoaRuntimeResponder
 
 export type GetSigmaScheduledQueryRuns = (
-  params: Params<
-    void,
-    t_GetSigmaScheduledQueryRunsQuerySchema,
-    t_GetSigmaScheduledQueryRunsBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetSigmaScheduledQueryRunsQuerySchema, void, void>,
   respond: GetSigmaScheduledQueryRunsResponder,
   ctx: RouterContext,
   next: Next,
@@ -11399,7 +10698,7 @@ export type GetSigmaScheduledQueryRunsScheduledQueryRun = (
   params: Params<
     t_GetSigmaScheduledQueryRunsScheduledQueryRunParamSchema,
     t_GetSigmaScheduledQueryRunsScheduledQueryRunQuerySchema,
-    t_GetSigmaScheduledQueryRunsScheduledQueryRunBodySchema | undefined,
+    void,
     void
   >,
   respond: GetSigmaScheduledQueryRunsScheduledQueryRunResponder,
@@ -11438,7 +10737,7 @@ export type GetSourcesSource = (
   params: Params<
     t_GetSourcesSourceParamSchema,
     t_GetSourcesSourceQuerySchema,
-    t_GetSourcesSourceBodySchema | undefined,
+    void,
     void
   >,
   respond: GetSourcesSourceResponder,
@@ -11482,8 +10781,7 @@ export type GetSourcesSourceMandateNotificationsMandateNotification = (
   params: Params<
     t_GetSourcesSourceMandateNotificationsMandateNotificationParamSchema,
     t_GetSourcesSourceMandateNotificationsMandateNotificationQuerySchema,
-    | t_GetSourcesSourceMandateNotificationsMandateNotificationBodySchema
-    | undefined,
+    void,
     void
   >,
   respond: GetSourcesSourceMandateNotificationsMandateNotificationResponder,
@@ -11510,7 +10808,7 @@ export type GetSourcesSourceSourceTransactions = (
   params: Params<
     t_GetSourcesSourceSourceTransactionsParamSchema,
     t_GetSourcesSourceSourceTransactionsQuerySchema,
-    t_GetSourcesSourceSourceTransactionsBodySchema | undefined,
+    void,
     void
   >,
   respond: GetSourcesSourceSourceTransactionsResponder,
@@ -11540,7 +10838,7 @@ export type GetSourcesSourceSourceTransactionsSourceTransaction = (
   params: Params<
     t_GetSourcesSourceSourceTransactionsSourceTransactionParamSchema,
     t_GetSourcesSourceSourceTransactionsSourceTransactionQuerySchema,
-    t_GetSourcesSourceSourceTransactionsSourceTransactionBodySchema | undefined,
+    void,
     void
   >,
   respond: GetSourcesSourceSourceTransactionsSourceTransactionResponder,
@@ -11586,12 +10884,7 @@ export type GetSubscriptionItemsResponder = {
 } & KoaRuntimeResponder
 
 export type GetSubscriptionItems = (
-  params: Params<
-    void,
-    t_GetSubscriptionItemsQuerySchema,
-    t_GetSubscriptionItemsBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetSubscriptionItemsQuerySchema, void, void>,
   respond: GetSubscriptionItemsResponder,
   ctx: RouterContext,
   next: Next,
@@ -11658,7 +10951,7 @@ export type GetSubscriptionItemsItem = (
   params: Params<
     t_GetSubscriptionItemsItemParamSchema,
     t_GetSubscriptionItemsItemQuerySchema,
-    t_GetSubscriptionItemsItemBodySchema | undefined,
+    void,
     void
   >,
   respond: GetSubscriptionItemsItemResponder,
@@ -11704,12 +10997,7 @@ export type GetSubscriptionSchedulesResponder = {
 } & KoaRuntimeResponder
 
 export type GetSubscriptionSchedules = (
-  params: Params<
-    void,
-    t_GetSubscriptionSchedulesQuerySchema,
-    t_GetSubscriptionSchedulesBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetSubscriptionSchedulesQuerySchema, void, void>,
   respond: GetSubscriptionSchedulesResponder,
   ctx: RouterContext,
   next: Next,
@@ -11759,7 +11047,7 @@ export type GetSubscriptionSchedulesSchedule = (
   params: Params<
     t_GetSubscriptionSchedulesScheduleParamSchema,
     t_GetSubscriptionSchedulesScheduleQuerySchema,
-    t_GetSubscriptionSchedulesScheduleBodySchema | undefined,
+    void,
     void
   >,
   respond: GetSubscriptionSchedulesScheduleResponder,
@@ -11849,12 +11137,7 @@ export type GetSubscriptionsResponder = {
 } & KoaRuntimeResponder
 
 export type GetSubscriptions = (
-  params: Params<
-    void,
-    t_GetSubscriptionsQuerySchema,
-    t_GetSubscriptionsBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetSubscriptionsQuerySchema, void, void>,
   respond: GetSubscriptionsResponder,
   ctx: RouterContext,
   next: Next,
@@ -11903,12 +11186,7 @@ export type GetSubscriptionsSearchResponder = {
 } & KoaRuntimeResponder
 
 export type GetSubscriptionsSearch = (
-  params: Params<
-    void,
-    t_GetSubscriptionsSearchQuerySchema,
-    t_GetSubscriptionsSearchBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetSubscriptionsSearchQuerySchema, void, void>,
   respond: GetSubscriptionsSearchResponder,
   ctx: RouterContext,
   next: Next,
@@ -11960,7 +11238,7 @@ export type GetSubscriptionsSubscriptionExposedId = (
   params: Params<
     t_GetSubscriptionsSubscriptionExposedIdParamSchema,
     t_GetSubscriptionsSubscriptionExposedIdQuerySchema,
-    t_GetSubscriptionsSubscriptionExposedIdBodySchema | undefined,
+    void,
     void
   >,
   respond: GetSubscriptionsSubscriptionExposedIdResponder,
@@ -12004,7 +11282,7 @@ export type DeleteSubscriptionsSubscriptionExposedIdDiscount = (
   params: Params<
     t_DeleteSubscriptionsSubscriptionExposedIdDiscountParamSchema,
     void,
-    t_DeleteSubscriptionsSubscriptionExposedIdDiscountBodySchema | undefined,
+    void,
     void
   >,
   respond: DeleteSubscriptionsSubscriptionExposedIdDiscountResponder,
@@ -12087,7 +11365,7 @@ export type GetTaxCalculationsCalculation = (
   params: Params<
     t_GetTaxCalculationsCalculationParamSchema,
     t_GetTaxCalculationsCalculationQuerySchema,
-    t_GetTaxCalculationsCalculationBodySchema | undefined,
+    void,
     void
   >,
   respond: GetTaxCalculationsCalculationResponder,
@@ -12114,7 +11392,7 @@ export type GetTaxCalculationsCalculationLineItems = (
   params: Params<
     t_GetTaxCalculationsCalculationLineItemsParamSchema,
     t_GetTaxCalculationsCalculationLineItemsQuerySchema,
-    t_GetTaxCalculationsCalculationLineItemsBodySchema | undefined,
+    void,
     void
   >,
   respond: GetTaxCalculationsCalculationLineItemsResponder,
@@ -12146,12 +11424,7 @@ export type GetTaxRegistrationsResponder = {
 } & KoaRuntimeResponder
 
 export type GetTaxRegistrations = (
-  params: Params<
-    void,
-    t_GetTaxRegistrationsQuerySchema,
-    t_GetTaxRegistrationsBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetTaxRegistrationsQuerySchema, void, void>,
   respond: GetTaxRegistrationsResponder,
   ctx: RouterContext,
   next: Next,
@@ -12196,7 +11469,7 @@ export type GetTaxRegistrationsId = (
   params: Params<
     t_GetTaxRegistrationsIdParamSchema,
     t_GetTaxRegistrationsIdQuerySchema,
-    t_GetTaxRegistrationsIdBodySchema | undefined,
+    void,
     void
   >,
   respond: GetTaxRegistrationsIdResponder,
@@ -12237,12 +11510,7 @@ export type GetTaxSettingsResponder = {
 } & KoaRuntimeResponder
 
 export type GetTaxSettings = (
-  params: Params<
-    void,
-    t_GetTaxSettingsQuerySchema,
-    t_GetTaxSettingsBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetTaxSettingsQuerySchema, void, void>,
   respond: GetTaxSettingsResponder,
   ctx: RouterContext,
   next: Next,
@@ -12323,7 +11591,7 @@ export type GetTaxTransactionsTransaction = (
   params: Params<
     t_GetTaxTransactionsTransactionParamSchema,
     t_GetTaxTransactionsTransactionQuerySchema,
-    t_GetTaxTransactionsTransactionBodySchema | undefined,
+    void,
     void
   >,
   respond: GetTaxTransactionsTransactionResponder,
@@ -12350,7 +11618,7 @@ export type GetTaxTransactionsTransactionLineItems = (
   params: Params<
     t_GetTaxTransactionsTransactionLineItemsParamSchema,
     t_GetTaxTransactionsTransactionLineItemsQuerySchema,
-    t_GetTaxTransactionsTransactionLineItemsBodySchema | undefined,
+    void,
     void
   >,
   respond: GetTaxTransactionsTransactionLineItemsResponder,
@@ -12382,12 +11650,7 @@ export type GetTaxCodesResponder = {
 } & KoaRuntimeResponder
 
 export type GetTaxCodes = (
-  params: Params<
-    void,
-    t_GetTaxCodesQuerySchema,
-    t_GetTaxCodesBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetTaxCodesQuerySchema, void, void>,
   respond: GetTaxCodesResponder,
   ctx: RouterContext,
   next: Next,
@@ -12415,7 +11678,7 @@ export type GetTaxCodesId = (
   params: Params<
     t_GetTaxCodesIdParamSchema,
     t_GetTaxCodesIdQuerySchema,
-    t_GetTaxCodesIdBodySchema | undefined,
+    void,
     void
   >,
   respond: GetTaxCodesIdResponder,
@@ -12439,12 +11702,7 @@ export type GetTaxIdsResponder = {
 } & KoaRuntimeResponder
 
 export type GetTaxIds = (
-  params: Params<
-    void,
-    t_GetTaxIdsQuerySchema,
-    t_GetTaxIdsBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetTaxIdsQuerySchema, void, void>,
   respond: GetTaxIdsResponder,
   ctx: RouterContext,
   next: Next,
@@ -12486,12 +11744,7 @@ export type DeleteTaxIdsIdResponder = {
 } & KoaRuntimeResponder
 
 export type DeleteTaxIdsId = (
-  params: Params<
-    t_DeleteTaxIdsIdParamSchema,
-    void,
-    t_DeleteTaxIdsIdBodySchema | undefined,
-    void
-  >,
+  params: Params<t_DeleteTaxIdsIdParamSchema, void, void, void>,
   respond: DeleteTaxIdsIdResponder,
   ctx: RouterContext,
   next: Next,
@@ -12511,7 +11764,7 @@ export type GetTaxIdsId = (
   params: Params<
     t_GetTaxIdsIdParamSchema,
     t_GetTaxIdsIdQuerySchema,
-    t_GetTaxIdsIdBodySchema | undefined,
+    void,
     void
   >,
   respond: GetTaxIdsIdResponder,
@@ -12535,12 +11788,7 @@ export type GetTaxRatesResponder = {
 } & KoaRuntimeResponder
 
 export type GetTaxRates = (
-  params: Params<
-    void,
-    t_GetTaxRatesQuerySchema,
-    t_GetTaxRatesBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetTaxRatesQuerySchema, void, void>,
   respond: GetTaxRatesResponder,
   ctx: RouterContext,
   next: Next,
@@ -12585,7 +11833,7 @@ export type GetTaxRatesTaxRate = (
   params: Params<
     t_GetTaxRatesTaxRateParamSchema,
     t_GetTaxRatesTaxRateQuerySchema,
-    t_GetTaxRatesTaxRateBodySchema | undefined,
+    void,
     void
   >,
   respond: GetTaxRatesTaxRateResponder,
@@ -12631,12 +11879,7 @@ export type GetTerminalConfigurationsResponder = {
 } & KoaRuntimeResponder
 
 export type GetTerminalConfigurations = (
-  params: Params<
-    void,
-    t_GetTerminalConfigurationsQuerySchema,
-    t_GetTerminalConfigurationsBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetTerminalConfigurationsQuerySchema, void, void>,
   respond: GetTerminalConfigurationsResponder,
   ctx: RouterContext,
   next: Next,
@@ -12686,7 +11929,7 @@ export type DeleteTerminalConfigurationsConfiguration = (
   params: Params<
     t_DeleteTerminalConfigurationsConfigurationParamSchema,
     void,
-    t_DeleteTerminalConfigurationsConfigurationBodySchema | undefined,
+    void,
     void
   >,
   respond: DeleteTerminalConfigurationsConfigurationResponder,
@@ -12710,7 +11953,7 @@ export type GetTerminalConfigurationsConfiguration = (
   params: Params<
     t_GetTerminalConfigurationsConfigurationParamSchema,
     t_GetTerminalConfigurationsConfigurationQuerySchema,
-    t_GetTerminalConfigurationsConfigurationBodySchema | undefined,
+    void,
     void
   >,
   respond: GetTerminalConfigurationsConfigurationResponder,
@@ -12780,12 +12023,7 @@ export type GetTerminalLocationsResponder = {
 } & KoaRuntimeResponder
 
 export type GetTerminalLocations = (
-  params: Params<
-    void,
-    t_GetTerminalLocationsQuerySchema,
-    t_GetTerminalLocationsBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetTerminalLocationsQuerySchema, void, void>,
   respond: GetTerminalLocationsResponder,
   ctx: RouterContext,
   next: Next,
@@ -12830,7 +12068,7 @@ export type DeleteTerminalLocationsLocation = (
   params: Params<
     t_DeleteTerminalLocationsLocationParamSchema,
     void,
-    t_DeleteTerminalLocationsLocationBodySchema | undefined,
+    void,
     void
   >,
   respond: DeleteTerminalLocationsLocationResponder,
@@ -12854,7 +12092,7 @@ export type GetTerminalLocationsLocation = (
   params: Params<
     t_GetTerminalLocationsLocationParamSchema,
     t_GetTerminalLocationsLocationQuerySchema,
-    t_GetTerminalLocationsLocationBodySchema | undefined,
+    void,
     void
   >,
   respond: GetTerminalLocationsLocationResponder,
@@ -12902,12 +12140,7 @@ export type GetTerminalReadersResponder = {
 } & KoaRuntimeResponder
 
 export type GetTerminalReaders = (
-  params: Params<
-    void,
-    t_GetTerminalReadersQuerySchema,
-    t_GetTerminalReadersBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetTerminalReadersQuerySchema, void, void>,
   respond: GetTerminalReadersResponder,
   ctx: RouterContext,
   next: Next,
@@ -12949,12 +12182,7 @@ export type DeleteTerminalReadersReaderResponder = {
 } & KoaRuntimeResponder
 
 export type DeleteTerminalReadersReader = (
-  params: Params<
-    t_DeleteTerminalReadersReaderParamSchema,
-    void,
-    t_DeleteTerminalReadersReaderBodySchema | undefined,
-    void
-  >,
+  params: Params<t_DeleteTerminalReadersReaderParamSchema, void, void, void>,
   respond: DeleteTerminalReadersReaderResponder,
   ctx: RouterContext,
   next: Next,
@@ -12974,7 +12202,7 @@ export type GetTerminalReadersReader = (
   params: Params<
     t_GetTerminalReadersReaderParamSchema,
     t_GetTerminalReadersReaderQuerySchema,
-    t_GetTerminalReadersReaderBodySchema | undefined,
+    void,
     void
   >,
   respond: GetTerminalReadersReaderResponder,
@@ -13791,12 +13019,7 @@ export type GetTestHelpersTestClocksResponder = {
 } & KoaRuntimeResponder
 
 export type GetTestHelpersTestClocks = (
-  params: Params<
-    void,
-    t_GetTestHelpersTestClocksQuerySchema,
-    t_GetTestHelpersTestClocksBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetTestHelpersTestClocksQuerySchema, void, void>,
   respond: GetTestHelpersTestClocksResponder,
   ctx: RouterContext,
   next: Next,
@@ -13841,7 +13064,7 @@ export type DeleteTestHelpersTestClocksTestClock = (
   params: Params<
     t_DeleteTestHelpersTestClocksTestClockParamSchema,
     void,
-    t_DeleteTestHelpersTestClocksTestClockBodySchema | undefined,
+    void,
     void
   >,
   respond: DeleteTestHelpersTestClocksTestClockResponder,
@@ -13863,7 +13086,7 @@ export type GetTestHelpersTestClocksTestClock = (
   params: Params<
     t_GetTestHelpersTestClocksTestClockParamSchema,
     t_GetTestHelpersTestClocksTestClockQuerySchema,
-    t_GetTestHelpersTestClocksTestClockBodySchema | undefined,
+    void,
     void
   >,
   respond: GetTestHelpersTestClocksTestClockResponder,
@@ -14217,7 +13440,7 @@ export type GetTokensToken = (
   params: Params<
     t_GetTokensTokenParamSchema,
     t_GetTokensTokenQuerySchema,
-    t_GetTokensTokenBodySchema | undefined,
+    void,
     void
   >,
   respond: GetTokensTokenResponder,
@@ -14241,12 +13464,7 @@ export type GetTopupsResponder = {
 } & KoaRuntimeResponder
 
 export type GetTopups = (
-  params: Params<
-    void,
-    t_GetTopupsQuerySchema,
-    t_GetTopupsBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetTopupsQuerySchema, void, void>,
   respond: GetTopupsResponder,
   ctx: RouterContext,
   next: Next,
@@ -14291,7 +13509,7 @@ export type GetTopupsTopup = (
   params: Params<
     t_GetTopupsTopupParamSchema,
     t_GetTopupsTopupQuerySchema,
-    t_GetTopupsTopupBodySchema | undefined,
+    void,
     void
   >,
   respond: GetTopupsTopupResponder,
@@ -14359,12 +13577,7 @@ export type GetTransfersResponder = {
 } & KoaRuntimeResponder
 
 export type GetTransfers = (
-  params: Params<
-    void,
-    t_GetTransfersQuerySchema,
-    t_GetTransfersBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetTransfersQuerySchema, void, void>,
   respond: GetTransfersResponder,
   ctx: RouterContext,
   next: Next,
@@ -14414,7 +13627,7 @@ export type GetTransfersIdReversals = (
   params: Params<
     t_GetTransfersIdReversalsParamSchema,
     t_GetTransfersIdReversalsQuerySchema,
-    t_GetTransfersIdReversalsBodySchema | undefined,
+    void,
     void
   >,
   respond: GetTransfersIdReversalsResponder,
@@ -14466,7 +13679,7 @@ export type GetTransfersTransfer = (
   params: Params<
     t_GetTransfersTransferParamSchema,
     t_GetTransfersTransferQuerySchema,
-    t_GetTransfersTransferBodySchema | undefined,
+    void,
     void
   >,
   respond: GetTransfersTransferResponder,
@@ -14510,7 +13723,7 @@ export type GetTransfersTransferReversalsId = (
   params: Params<
     t_GetTransfersTransferReversalsIdParamSchema,
     t_GetTransfersTransferReversalsIdQuerySchema,
-    t_GetTransfersTransferReversalsIdBodySchema | undefined,
+    void,
     void
   >,
   respond: GetTransfersTransferReversalsIdResponder,
@@ -14556,12 +13769,7 @@ export type GetTreasuryCreditReversalsResponder = {
 } & KoaRuntimeResponder
 
 export type GetTreasuryCreditReversals = (
-  params: Params<
-    void,
-    t_GetTreasuryCreditReversalsQuerySchema,
-    t_GetTreasuryCreditReversalsBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetTreasuryCreditReversalsQuerySchema, void, void>,
   respond: GetTreasuryCreditReversalsResponder,
   ctx: RouterContext,
   next: Next,
@@ -14606,7 +13814,7 @@ export type GetTreasuryCreditReversalsCreditReversal = (
   params: Params<
     t_GetTreasuryCreditReversalsCreditReversalParamSchema,
     t_GetTreasuryCreditReversalsCreditReversalQuerySchema,
-    t_GetTreasuryCreditReversalsCreditReversalBodySchema | undefined,
+    void,
     void
   >,
   respond: GetTreasuryCreditReversalsCreditReversalResponder,
@@ -14630,12 +13838,7 @@ export type GetTreasuryDebitReversalsResponder = {
 } & KoaRuntimeResponder
 
 export type GetTreasuryDebitReversals = (
-  params: Params<
-    void,
-    t_GetTreasuryDebitReversalsQuerySchema,
-    t_GetTreasuryDebitReversalsBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetTreasuryDebitReversalsQuerySchema, void, void>,
   respond: GetTreasuryDebitReversalsResponder,
   ctx: RouterContext,
   next: Next,
@@ -14680,7 +13883,7 @@ export type GetTreasuryDebitReversalsDebitReversal = (
   params: Params<
     t_GetTreasuryDebitReversalsDebitReversalParamSchema,
     t_GetTreasuryDebitReversalsDebitReversalQuerySchema,
-    t_GetTreasuryDebitReversalsDebitReversalBodySchema | undefined,
+    void,
     void
   >,
   respond: GetTreasuryDebitReversalsDebitReversalResponder,
@@ -14704,12 +13907,7 @@ export type GetTreasuryFinancialAccountsResponder = {
 } & KoaRuntimeResponder
 
 export type GetTreasuryFinancialAccounts = (
-  params: Params<
-    void,
-    t_GetTreasuryFinancialAccountsQuerySchema,
-    t_GetTreasuryFinancialAccountsBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetTreasuryFinancialAccountsQuerySchema, void, void>,
   respond: GetTreasuryFinancialAccountsResponder,
   ctx: RouterContext,
   next: Next,
@@ -14754,7 +13952,7 @@ export type GetTreasuryFinancialAccountsFinancialAccount = (
   params: Params<
     t_GetTreasuryFinancialAccountsFinancialAccountParamSchema,
     t_GetTreasuryFinancialAccountsFinancialAccountQuerySchema,
-    t_GetTreasuryFinancialAccountsFinancialAccountBodySchema | undefined,
+    void,
     void
   >,
   respond: GetTreasuryFinancialAccountsFinancialAccountResponder,
@@ -14820,8 +14018,7 @@ export type GetTreasuryFinancialAccountsFinancialAccountFeatures = (
   params: Params<
     t_GetTreasuryFinancialAccountsFinancialAccountFeaturesParamSchema,
     t_GetTreasuryFinancialAccountsFinancialAccountFeaturesQuerySchema,
-    | t_GetTreasuryFinancialAccountsFinancialAccountFeaturesBodySchema
-    | undefined,
+    void,
     void
   >,
   respond: GetTreasuryFinancialAccountsFinancialAccountFeaturesResponder,
@@ -14868,12 +14065,7 @@ export type GetTreasuryInboundTransfersResponder = {
 } & KoaRuntimeResponder
 
 export type GetTreasuryInboundTransfers = (
-  params: Params<
-    void,
-    t_GetTreasuryInboundTransfersQuerySchema,
-    t_GetTreasuryInboundTransfersBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetTreasuryInboundTransfersQuerySchema, void, void>,
   respond: GetTreasuryInboundTransfersResponder,
   ctx: RouterContext,
   next: Next,
@@ -14918,7 +14110,7 @@ export type GetTreasuryInboundTransfersId = (
   params: Params<
     t_GetTreasuryInboundTransfersIdParamSchema,
     t_GetTreasuryInboundTransfersIdQuerySchema,
-    t_GetTreasuryInboundTransfersIdBodySchema | undefined,
+    void,
     void
   >,
   respond: GetTreasuryInboundTransfersIdResponder,
@@ -14964,12 +14156,7 @@ export type GetTreasuryOutboundPaymentsResponder = {
 } & KoaRuntimeResponder
 
 export type GetTreasuryOutboundPayments = (
-  params: Params<
-    void,
-    t_GetTreasuryOutboundPaymentsQuerySchema,
-    t_GetTreasuryOutboundPaymentsBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetTreasuryOutboundPaymentsQuerySchema, void, void>,
   respond: GetTreasuryOutboundPaymentsResponder,
   ctx: RouterContext,
   next: Next,
@@ -15014,7 +14201,7 @@ export type GetTreasuryOutboundPaymentsId = (
   params: Params<
     t_GetTreasuryOutboundPaymentsIdParamSchema,
     t_GetTreasuryOutboundPaymentsIdQuerySchema,
-    t_GetTreasuryOutboundPaymentsIdBodySchema | undefined,
+    void,
     void
   >,
   respond: GetTreasuryOutboundPaymentsIdResponder,
@@ -15060,12 +14247,7 @@ export type GetTreasuryOutboundTransfersResponder = {
 } & KoaRuntimeResponder
 
 export type GetTreasuryOutboundTransfers = (
-  params: Params<
-    void,
-    t_GetTreasuryOutboundTransfersQuerySchema,
-    t_GetTreasuryOutboundTransfersBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetTreasuryOutboundTransfersQuerySchema, void, void>,
   respond: GetTreasuryOutboundTransfersResponder,
   ctx: RouterContext,
   next: Next,
@@ -15110,7 +14292,7 @@ export type GetTreasuryOutboundTransfersOutboundTransfer = (
   params: Params<
     t_GetTreasuryOutboundTransfersOutboundTransferParamSchema,
     t_GetTreasuryOutboundTransfersOutboundTransferQuerySchema,
-    t_GetTreasuryOutboundTransfersOutboundTransferBodySchema | undefined,
+    void,
     void
   >,
   respond: GetTreasuryOutboundTransfersOutboundTransferResponder,
@@ -15156,12 +14338,7 @@ export type GetTreasuryReceivedCreditsResponder = {
 } & KoaRuntimeResponder
 
 export type GetTreasuryReceivedCredits = (
-  params: Params<
-    void,
-    t_GetTreasuryReceivedCreditsQuerySchema,
-    t_GetTreasuryReceivedCreditsBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetTreasuryReceivedCreditsQuerySchema, void, void>,
   respond: GetTreasuryReceivedCreditsResponder,
   ctx: RouterContext,
   next: Next,
@@ -15189,7 +14366,7 @@ export type GetTreasuryReceivedCreditsId = (
   params: Params<
     t_GetTreasuryReceivedCreditsIdParamSchema,
     t_GetTreasuryReceivedCreditsIdQuerySchema,
-    t_GetTreasuryReceivedCreditsIdBodySchema | undefined,
+    void,
     void
   >,
   respond: GetTreasuryReceivedCreditsIdResponder,
@@ -15213,12 +14390,7 @@ export type GetTreasuryReceivedDebitsResponder = {
 } & KoaRuntimeResponder
 
 export type GetTreasuryReceivedDebits = (
-  params: Params<
-    void,
-    t_GetTreasuryReceivedDebitsQuerySchema,
-    t_GetTreasuryReceivedDebitsBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetTreasuryReceivedDebitsQuerySchema, void, void>,
   respond: GetTreasuryReceivedDebitsResponder,
   ctx: RouterContext,
   next: Next,
@@ -15246,7 +14418,7 @@ export type GetTreasuryReceivedDebitsId = (
   params: Params<
     t_GetTreasuryReceivedDebitsIdParamSchema,
     t_GetTreasuryReceivedDebitsIdQuerySchema,
-    t_GetTreasuryReceivedDebitsIdBodySchema | undefined,
+    void,
     void
   >,
   respond: GetTreasuryReceivedDebitsIdResponder,
@@ -15270,12 +14442,7 @@ export type GetTreasuryTransactionEntriesResponder = {
 } & KoaRuntimeResponder
 
 export type GetTreasuryTransactionEntries = (
-  params: Params<
-    void,
-    t_GetTreasuryTransactionEntriesQuerySchema,
-    t_GetTreasuryTransactionEntriesBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetTreasuryTransactionEntriesQuerySchema, void, void>,
   respond: GetTreasuryTransactionEntriesResponder,
   ctx: RouterContext,
   next: Next,
@@ -15303,7 +14470,7 @@ export type GetTreasuryTransactionEntriesId = (
   params: Params<
     t_GetTreasuryTransactionEntriesIdParamSchema,
     t_GetTreasuryTransactionEntriesIdQuerySchema,
-    t_GetTreasuryTransactionEntriesIdBodySchema | undefined,
+    void,
     void
   >,
   respond: GetTreasuryTransactionEntriesIdResponder,
@@ -15327,12 +14494,7 @@ export type GetTreasuryTransactionsResponder = {
 } & KoaRuntimeResponder
 
 export type GetTreasuryTransactions = (
-  params: Params<
-    void,
-    t_GetTreasuryTransactionsQuerySchema,
-    t_GetTreasuryTransactionsBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetTreasuryTransactionsQuerySchema, void, void>,
   respond: GetTreasuryTransactionsResponder,
   ctx: RouterContext,
   next: Next,
@@ -15360,7 +14522,7 @@ export type GetTreasuryTransactionsId = (
   params: Params<
     t_GetTreasuryTransactionsIdParamSchema,
     t_GetTreasuryTransactionsIdQuerySchema,
-    t_GetTreasuryTransactionsIdBodySchema | undefined,
+    void,
     void
   >,
   respond: GetTreasuryTransactionsIdResponder,
@@ -15384,12 +14546,7 @@ export type GetWebhookEndpointsResponder = {
 } & KoaRuntimeResponder
 
 export type GetWebhookEndpoints = (
-  params: Params<
-    void,
-    t_GetWebhookEndpointsQuerySchema,
-    t_GetWebhookEndpointsBodySchema | undefined,
-    void
-  >,
+  params: Params<void, t_GetWebhookEndpointsQuerySchema, void, void>,
   respond: GetWebhookEndpointsResponder,
   ctx: RouterContext,
   next: Next,
@@ -15434,7 +14591,7 @@ export type DeleteWebhookEndpointsWebhookEndpoint = (
   params: Params<
     t_DeleteWebhookEndpointsWebhookEndpointParamSchema,
     void,
-    t_DeleteWebhookEndpointsWebhookEndpointBodySchema | undefined,
+    void,
     void
   >,
   respond: DeleteWebhookEndpointsWebhookEndpointResponder,
@@ -15456,7 +14613,7 @@ export type GetWebhookEndpointsWebhookEndpoint = (
   params: Params<
     t_GetWebhookEndpointsWebhookEndpointParamSchema,
     t_GetWebhookEndpointsWebhookEndpointQuerySchema,
-    t_GetWebhookEndpointsWebhookEndpointBodySchema | undefined,
+    void,
     void
   >,
   respond: GetWebhookEndpointsWebhookEndpointResponder,
@@ -16076,8 +15233,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getAccountBodySchema = z.object({}).optional()
-
   const getAccountResponseValidator = responseValidationFactory(
     [["200", s_account]],
     s_error,
@@ -16091,11 +15246,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ctx.query,
         RequestInputType.QueryString,
       ),
-      body: parseRequestInput(
-        getAccountBodySchema,
-        Reflect.get(ctx.request, "body"),
-        RequestInputType.RequestBody,
-      ),
+      body: undefined,
       headers: undefined,
     }
 
@@ -16453,8 +15604,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     starting_after: z.string().optional(),
   })
 
-  const getAccountsBodySchema = z.object({}).optional()
-
   const getAccountsResponseValidator = responseValidationFactory(
     [
       [
@@ -16478,11 +15627,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ctx.query,
         RequestInputType.QueryString,
       ),
-      body: parseRequestInput(
-        getAccountsBodySchema,
-        Reflect.get(ctx.request, "body"),
-        RequestInputType.RequestBody,
-      ),
+      body: undefined,
       headers: undefined,
     }
 
@@ -17231,8 +16376,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     account: z.string().max(5000),
   })
 
-  const deleteAccountsAccountBodySchema = z.object({}).optional()
-
   const deleteAccountsAccountResponseValidator = responseValidationFactory(
     [["200", s_deleted_account]],
     s_error,
@@ -17249,11 +16392,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.RouteParam,
         ),
         query: undefined,
-        body: parseRequestInput(
-          deleteAccountsAccountBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -17302,8 +16441,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getAccountsAccountBodySchema = z.object({}).optional()
-
   const getAccountsAccountResponseValidator = responseValidationFactory(
     [["200", s_account]],
     s_error,
@@ -17324,11 +16461,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getAccountsAccountBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -18140,8 +17273,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     id: z.string(),
   })
 
-  const deleteAccountsAccountBankAccountsIdBodySchema = z.object({}).optional()
-
   const deleteAccountsAccountBankAccountsIdResponseValidator =
     responseValidationFactory([["200", s_deleted_external_account]], s_error)
 
@@ -18156,11 +17287,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.RouteParam,
         ),
         query: undefined,
-        body: parseRequestInput(
-          deleteAccountsAccountBankAccountsIdBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -18213,8 +17340,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getAccountsAccountBankAccountsIdBodySchema = z.object({}).optional()
-
   const getAccountsAccountBankAccountsIdResponseValidator =
     responseValidationFactory([["200", s_external_account]], s_error)
 
@@ -18233,11 +17358,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getAccountsAccountBankAccountsIdBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -18375,8 +17496,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getAccountsAccountCapabilitiesBodySchema = z.object({}).optional()
-
   const getAccountsAccountCapabilitiesResponseValidator =
     responseValidationFactory(
       [
@@ -18408,11 +17527,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getAccountsAccountCapabilitiesBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -18467,10 +17582,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getAccountsAccountCapabilitiesCapabilityBodySchema = z
-    .object({})
-    .optional()
-
   const getAccountsAccountCapabilitiesCapabilityResponseValidator =
     responseValidationFactory([["200", s_capability]], s_error)
 
@@ -18489,11 +17600,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getAccountsAccountCapabilitiesCapabilityBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -18618,8 +17725,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     starting_after: z.string().optional(),
   })
 
-  const getAccountsAccountExternalAccountsBodySchema = z.object({}).optional()
-
   const getAccountsAccountExternalAccountsResponseValidator =
     responseValidationFactory(
       [
@@ -18653,11 +17758,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getAccountsAccountExternalAccountsBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -18800,10 +17901,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     id: z.string(),
   })
 
-  const deleteAccountsAccountExternalAccountsIdBodySchema = z
-    .object({})
-    .optional()
-
   const deleteAccountsAccountExternalAccountsIdResponseValidator =
     responseValidationFactory([["200", s_deleted_external_account]], s_error)
 
@@ -18818,11 +17915,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.RouteParam,
         ),
         query: undefined,
-        body: parseRequestInput(
-          deleteAccountsAccountExternalAccountsIdBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -18875,8 +17968,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getAccountsAccountExternalAccountsIdBodySchema = z.object({}).optional()
-
   const getAccountsAccountExternalAccountsIdResponseValidator =
     responseValidationFactory([["200", s_external_account]], s_error)
 
@@ -18895,11 +17986,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getAccountsAccountExternalAccountsIdBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -19115,8 +18202,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getAccountsAccountPeopleBodySchema = z.object({}).optional()
-
   const getAccountsAccountPeopleResponseValidator = responseValidationFactory(
     [
       [
@@ -19147,11 +18232,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getAccountsAccountPeopleBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -19461,8 +18542,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     person: z.string().max(5000),
   })
 
-  const deleteAccountsAccountPeoplePersonBodySchema = z.object({}).optional()
-
   const deleteAccountsAccountPeoplePersonResponseValidator =
     responseValidationFactory([["200", s_deleted_person]], s_error)
 
@@ -19477,11 +18556,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.RouteParam,
         ),
         query: undefined,
-        body: parseRequestInput(
-          deleteAccountsAccountPeoplePersonBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -19534,8 +18609,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getAccountsAccountPeoplePersonBodySchema = z.object({}).optional()
-
   const getAccountsAccountPeoplePersonResponseValidator =
     responseValidationFactory([["200", s_person]], s_error)
 
@@ -19554,11 +18627,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getAccountsAccountPeoplePersonBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -19883,8 +18952,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getAccountsAccountPersonsBodySchema = z.object({}).optional()
-
   const getAccountsAccountPersonsResponseValidator = responseValidationFactory(
     [
       [
@@ -19915,11 +18982,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getAccountsAccountPersonsBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -20229,8 +19292,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     person: z.string().max(5000),
   })
 
-  const deleteAccountsAccountPersonsPersonBodySchema = z.object({}).optional()
-
   const deleteAccountsAccountPersonsPersonResponseValidator =
     responseValidationFactory([["200", s_deleted_person]], s_error)
 
@@ -20245,11 +19306,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.RouteParam,
         ),
         query: undefined,
-        body: parseRequestInput(
-          deleteAccountsAccountPersonsPersonBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -20302,8 +19359,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getAccountsAccountPersonsPersonBodySchema = z.object({}).optional()
-
   const getAccountsAccountPersonsPersonResponseValidator =
     responseValidationFactory([["200", s_person]], s_error)
 
@@ -20322,11 +19377,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getAccountsAccountPersonsPersonBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -20703,8 +19754,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getApplePayDomainsBodySchema = z.object({}).optional()
-
   const getApplePayDomainsResponseValidator = responseValidationFactory(
     [
       [
@@ -20731,11 +19780,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getApplePayDomainsBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -20837,8 +19882,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     domain: z.string().max(5000),
   })
 
-  const deleteApplePayDomainsDomainBodySchema = z.object({}).optional()
-
   const deleteApplePayDomainsDomainResponseValidator =
     responseValidationFactory([["200", s_deleted_apple_pay_domain]], s_error)
 
@@ -20853,11 +19896,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.RouteParam,
         ),
         query: undefined,
-        body: parseRequestInput(
-          deleteApplePayDomainsDomainBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -20906,8 +19945,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getApplePayDomainsDomainBodySchema = z.object({}).optional()
-
   const getApplePayDomainsDomainResponseValidator = responseValidationFactory(
     [["200", s_apple_pay_domain]],
     s_error,
@@ -20928,11 +19965,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getApplePayDomainsDomainBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -20992,8 +20025,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getApplicationFeesBodySchema = z.object({}).optional()
-
   const getApplicationFeesResponseValidator = responseValidationFactory(
     [
       [
@@ -21020,11 +20051,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getApplicationFeesBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -21079,8 +20106,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getApplicationFeesFeeRefundsIdBodySchema = z.object({}).optional()
-
   const getApplicationFeesFeeRefundsIdResponseValidator =
     responseValidationFactory([["200", s_fee_refund]], s_error)
 
@@ -21099,11 +20124,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getApplicationFeesFeeRefundsIdBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -21216,8 +20237,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getApplicationFeesIdBodySchema = z.object({}).optional()
-
   const getApplicationFeesIdResponseValidator = responseValidationFactory(
     [["200", s_application_fee]],
     s_error,
@@ -21238,11 +20257,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getApplicationFeesIdBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -21360,8 +20375,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getApplicationFeesIdRefundsBodySchema = z.object({}).optional()
-
   const getApplicationFeesIdRefundsResponseValidator =
     responseValidationFactory(
       [
@@ -21393,11 +20406,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getApplicationFeesIdRefundsBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -21520,8 +20529,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getAppsSecretsBodySchema = z.object({}).optional()
-
   const getAppsSecretsResponseValidator = responseValidationFactory(
     [
       [
@@ -21545,11 +20552,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ctx.query,
         RequestInputType.QueryString,
       ),
-      body: parseRequestInput(
-        getAppsSecretsBodySchema,
-        Reflect.get(ctx.request, "body"),
-        RequestInputType.RequestBody,
-      ),
+      body: undefined,
       headers: undefined,
     }
 
@@ -21723,8 +20726,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     }),
   })
 
-  const getAppsSecretsFindBodySchema = z.object({}).optional()
-
   const getAppsSecretsFindResponseValidator = responseValidationFactory(
     [["200", s_apps_secret]],
     s_error,
@@ -21741,11 +20742,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getAppsSecretsFindBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -21790,8 +20787,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getBalanceBodySchema = z.object({}).optional()
-
   const getBalanceResponseValidator = responseValidationFactory(
     [["200", s_balance]],
     s_error,
@@ -21805,11 +20800,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ctx.query,
         RequestInputType.QueryString,
       ),
-      body: parseRequestInput(
-        getBalanceBodySchema,
-        Reflect.get(ctx.request, "body"),
-        RequestInputType.RequestBody,
-      ),
+      body: undefined,
       headers: undefined,
     }
 
@@ -21871,8 +20862,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     type: z.string().max(5000).optional(),
   })
 
-  const getBalanceHistoryBodySchema = z.object({}).optional()
-
   const getBalanceHistoryResponseValidator = responseValidationFactory(
     [
       [
@@ -21899,11 +20888,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ctx.query,
         RequestInputType.QueryString,
       ),
-      body: parseRequestInput(
-        getBalanceHistoryBodySchema,
-        Reflect.get(ctx.request, "body"),
-        RequestInputType.RequestBody,
-      ),
+      body: undefined,
       headers: undefined,
     }
 
@@ -21954,8 +20939,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getBalanceHistoryIdBodySchema = z.object({}).optional()
-
   const getBalanceHistoryIdResponseValidator = responseValidationFactory(
     [["200", s_balance_transaction]],
     s_error,
@@ -21976,11 +20959,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getBalanceHistoryIdBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -22043,8 +21022,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     type: z.string().max(5000).optional(),
   })
 
-  const getBalanceTransactionsBodySchema = z.object({}).optional()
-
   const getBalanceTransactionsResponseValidator = responseValidationFactory(
     [
       [
@@ -22074,11 +21051,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getBalanceTransactionsBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -22132,8 +21105,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getBalanceTransactionsIdBodySchema = z.object({}).optional()
-
   const getBalanceTransactionsIdResponseValidator = responseValidationFactory(
     [["200", s_balance_transaction]],
     s_error,
@@ -22154,11 +21125,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getBalanceTransactionsIdBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -22208,8 +21175,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getBillingAlertsBodySchema = z.object({}).optional()
-
   const getBillingAlertsResponseValidator = responseValidationFactory(
     [
       [
@@ -22233,11 +21198,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ctx.query,
         RequestInputType.QueryString,
       ),
-      body: parseRequestInput(
-        getBillingAlertsBodySchema,
-        Reflect.get(ctx.request, "body"),
-        RequestInputType.RequestBody,
-      ),
+      body: undefined,
       headers: undefined,
     }
 
@@ -22357,8 +21318,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getBillingAlertsIdBodySchema = z.object({}).optional()
-
   const getBillingAlertsIdResponseValidator = responseValidationFactory(
     [["200", s_billing_alert]],
     s_error,
@@ -22379,11 +21338,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getBillingAlertsIdBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -22627,8 +21582,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     }),
   })
 
-  const getBillingCreditBalanceSummaryBodySchema = z.object({}).optional()
-
   const getBillingCreditBalanceSummaryResponseValidator =
     responseValidationFactory(
       [["200", s_billing_credit_balance_summary]],
@@ -22646,11 +21599,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getBillingCreditBalanceSummaryBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -22700,8 +21649,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getBillingCreditBalanceTransactionsBodySchema = z.object({}).optional()
-
   const getBillingCreditBalanceTransactionsResponseValidator =
     responseValidationFactory(
       [
@@ -22732,11 +21679,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getBillingCreditBalanceTransactionsBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -22793,10 +21736,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getBillingCreditBalanceTransactionsIdBodySchema = z
-    .object({})
-    .optional()
-
   const getBillingCreditBalanceTransactionsIdResponseValidator =
     responseValidationFactory(
       [["200", s_billing_credit_balance_transaction]],
@@ -22818,11 +21757,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getBillingCreditBalanceTransactionsIdBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -22876,8 +21811,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getBillingCreditGrantsBodySchema = z.object({}).optional()
-
   const getBillingCreditGrantsResponseValidator = responseValidationFactory(
     [
       [
@@ -22907,11 +21840,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getBillingCreditGrantsBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -23040,8 +21969,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getBillingCreditGrantsIdBodySchema = z.object({}).optional()
-
   const getBillingCreditGrantsIdResponseValidator = responseValidationFactory(
     [["200", s_billing_credit_grant]],
     s_error,
@@ -23062,11 +21989,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getBillingCreditGrantsIdBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -23427,8 +22350,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     status: z.enum(["active", "inactive"]).optional(),
   })
 
-  const getBillingMetersBodySchema = z.object({}).optional()
-
   const getBillingMetersResponseValidator = responseValidationFactory(
     [
       [
@@ -23452,11 +22373,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ctx.query,
         RequestInputType.QueryString,
       ),
-      body: parseRequestInput(
-        getBillingMetersBodySchema,
-        Reflect.get(ctx.request, "body"),
-        RequestInputType.RequestBody,
-      ),
+      body: undefined,
       headers: undefined,
     }
 
@@ -23569,8 +22486,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getBillingMetersIdBodySchema = z.object({}).optional()
-
   const getBillingMetersIdResponseValidator = responseValidationFactory(
     [["200", s_billing_meter]],
     s_error,
@@ -23591,11 +22506,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getBillingMetersIdBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -23778,8 +22689,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     value_grouping_window: z.enum(["day", "hour"]).optional(),
   })
 
-  const getBillingMetersIdEventSummariesBodySchema = z.object({}).optional()
-
   const getBillingMetersIdEventSummariesResponseValidator =
     responseValidationFactory(
       [
@@ -23814,11 +22723,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getBillingMetersIdEventSummariesBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -23935,8 +22840,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getBillingPortalConfigurationsBodySchema = z.object({}).optional()
-
   const getBillingPortalConfigurationsResponseValidator =
     responseValidationFactory(
       [
@@ -23967,11 +22870,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getBillingPortalConfigurationsBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -24184,10 +23083,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getBillingPortalConfigurationsConfigurationBodySchema = z
-    .object({})
-    .optional()
-
   const getBillingPortalConfigurationsConfigurationResponseValidator =
     responseValidationFactory(
       [["200", s_billing_portal_configuration]],
@@ -24209,11 +23104,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getBillingPortalConfigurationsConfigurationBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -24638,8 +23529,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     transfer_group: z.string().max(5000).optional(),
   })
 
-  const getChargesBodySchema = z.object({}).optional()
-
   const getChargesResponseValidator = responseValidationFactory(
     [
       [
@@ -24663,11 +23552,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ctx.query,
         RequestInputType.QueryString,
       ),
-      body: parseRequestInput(
-        getChargesBodySchema,
-        Reflect.get(ctx.request, "body"),
-        RequestInputType.RequestBody,
-      ),
+      body: undefined,
       headers: undefined,
     }
 
@@ -24841,8 +23726,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     query: z.string().max(5000),
   })
 
-  const getChargesSearchBodySchema = z.object({}).optional()
-
   const getChargesSearchResponseValidator = responseValidationFactory(
     [
       [
@@ -24868,11 +23751,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ctx.query,
         RequestInputType.QueryString,
       ),
-      body: parseRequestInput(
-        getChargesSearchBodySchema,
-        Reflect.get(ctx.request, "body"),
-        RequestInputType.RequestBody,
-      ),
+      body: undefined,
       headers: undefined,
     }
 
@@ -24925,8 +23804,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getChargesChargeBodySchema = z.object({}).optional()
-
   const getChargesChargeResponseValidator = responseValidationFactory(
     [["200", s_charge]],
     s_error,
@@ -24944,11 +23821,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ctx.query,
         RequestInputType.QueryString,
       ),
-      body: parseRequestInput(
-        getChargesChargeBodySchema,
-        Reflect.get(ctx.request, "body"),
-        RequestInputType.RequestBody,
-      ),
+      body: undefined,
       headers: undefined,
     }
 
@@ -25156,8 +24029,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getChargesChargeDisputeBodySchema = z.object({}).optional()
-
   const getChargesChargeDisputeResponseValidator = responseValidationFactory(
     [["200", s_dispute]],
     s_error,
@@ -25178,11 +24049,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getChargesChargeDisputeBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -25576,8 +24443,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     starting_after: z.string().optional(),
   })
 
-  const getChargesChargeRefundsBodySchema = z.object({}).optional()
-
   const getChargesChargeRefundsResponseValidator = responseValidationFactory(
     [
       [
@@ -25608,11 +24473,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getChargesChargeRefundsBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -25745,8 +24606,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getChargesChargeRefundsRefundBodySchema = z.object({}).optional()
-
   const getChargesChargeRefundsRefundResponseValidator =
     responseValidationFactory([["200", s_refund]], s_error)
 
@@ -25765,11 +24624,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getChargesChargeRefundsRefundBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -25900,8 +24755,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     subscription: z.string().max(5000).optional(),
   })
 
-  const getCheckoutSessionsBodySchema = z.object({}).optional()
-
   const getCheckoutSessionsResponseValidator = responseValidationFactory(
     [
       [
@@ -25928,11 +24781,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getCheckoutSessionsBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -27148,8 +25997,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getCheckoutSessionsSessionBodySchema = z.object({}).optional()
-
   const getCheckoutSessionsSessionResponseValidator = responseValidationFactory(
     [["200", s_checkout_session]],
     s_error,
@@ -27170,11 +26017,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getCheckoutSessionsSessionBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -27438,8 +26281,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getCheckoutSessionsSessionLineItemsBodySchema = z.object({}).optional()
-
   const getCheckoutSessionsSessionLineItemsResponseValidator =
     responseValidationFactory(
       [
@@ -27471,11 +26312,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getCheckoutSessionsSessionLineItemsBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -27531,8 +26368,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getClimateOrdersBodySchema = z.object({}).optional()
-
   const getClimateOrdersResponseValidator = responseValidationFactory(
     [
       [
@@ -27556,11 +26391,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ctx.query,
         RequestInputType.QueryString,
       ),
-      body: parseRequestInput(
-        getClimateOrdersBodySchema,
-        Reflect.get(ctx.request, "body"),
-        RequestInputType.RequestBody,
-      ),
+      body: undefined,
       headers: undefined,
     }
 
@@ -27671,8 +26502,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getClimateOrdersOrderBodySchema = z.object({}).optional()
-
   const getClimateOrdersOrderResponseValidator = responseValidationFactory(
     [["200", s_climate_order]],
     s_error,
@@ -27693,11 +26522,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getClimateOrdersOrderBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -27882,8 +26707,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getClimateProductsBodySchema = z.object({}).optional()
-
   const getClimateProductsResponseValidator = responseValidationFactory(
     [
       [
@@ -27910,11 +26733,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getClimateProductsBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -27968,8 +26787,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getClimateProductsProductBodySchema = z.object({}).optional()
-
   const getClimateProductsProductResponseValidator = responseValidationFactory(
     [["200", s_climate_product]],
     s_error,
@@ -27990,11 +26807,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getClimateProductsProductBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -28042,8 +26855,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getClimateSuppliersBodySchema = z.object({}).optional()
-
   const getClimateSuppliersResponseValidator = responseValidationFactory(
     [
       [
@@ -28070,11 +26881,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getClimateSuppliersBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -28128,8 +26935,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getClimateSuppliersSupplierBodySchema = z.object({}).optional()
-
   const getClimateSuppliersSupplierResponseValidator =
     responseValidationFactory([["200", s_climate_supplier]], s_error)
 
@@ -28148,11 +26953,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getClimateSuppliersSupplierBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -28201,10 +27002,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getConfirmationTokensConfirmationTokenBodySchema = z
-    .object({})
-    .optional()
-
   const getConfirmationTokensConfirmationTokenResponseValidator =
     responseValidationFactory([["200", s_confirmation_token]], s_error)
 
@@ -28223,11 +27020,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getConfirmationTokensConfirmationTokenBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -28278,8 +27071,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getCountrySpecsBodySchema = z.object({}).optional()
-
   const getCountrySpecsResponseValidator = responseValidationFactory(
     [
       [
@@ -28303,11 +27094,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ctx.query,
         RequestInputType.QueryString,
       ),
-      body: parseRequestInput(
-        getCountrySpecsBodySchema,
-        Reflect.get(ctx.request, "body"),
-        RequestInputType.RequestBody,
-      ),
+      body: undefined,
       headers: undefined,
     }
 
@@ -28360,8 +27147,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getCountrySpecsCountryBodySchema = z.object({}).optional()
-
   const getCountrySpecsCountryResponseValidator = responseValidationFactory(
     [["200", s_country_spec]],
     s_error,
@@ -28382,11 +27167,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getCountrySpecsCountryBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -28445,8 +27226,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getCouponsBodySchema = z.object({}).optional()
-
   const getCouponsResponseValidator = responseValidationFactory(
     [
       [
@@ -28470,11 +27249,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ctx.query,
         RequestInputType.QueryString,
       ),
-      body: parseRequestInput(
-        getCouponsBodySchema,
-        Reflect.get(ctx.request, "body"),
-        RequestInputType.RequestBody,
-      ),
+      body: undefined,
       headers: undefined,
     }
 
@@ -28588,8 +27363,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     coupon: z.string().max(5000),
   })
 
-  const deleteCouponsCouponBodySchema = z.object({}).optional()
-
   const deleteCouponsCouponResponseValidator = responseValidationFactory(
     [["200", s_deleted_coupon]],
     s_error,
@@ -28606,11 +27379,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.RouteParam,
         ),
         query: undefined,
-        body: parseRequestInput(
-          deleteCouponsCouponBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -28657,8 +27426,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getCouponsCouponBodySchema = z.object({}).optional()
-
   const getCouponsCouponResponseValidator = responseValidationFactory(
     [["200", s_coupon]],
     s_error,
@@ -28676,11 +27443,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ctx.query,
         RequestInputType.QueryString,
       ),
-      body: parseRequestInput(
-        getCouponsCouponBodySchema,
-        Reflect.get(ctx.request, "body"),
-        RequestInputType.RequestBody,
-      ),
+      body: undefined,
       headers: undefined,
     }
 
@@ -28805,8 +27568,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getCreditNotesBodySchema = z.object({}).optional()
-
   const getCreditNotesResponseValidator = responseValidationFactory(
     [
       [
@@ -28830,11 +27591,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ctx.query,
         RequestInputType.QueryString,
       ),
-      body: parseRequestInput(
-        getCreditNotesBodySchema,
-        Reflect.get(ctx.request, "body"),
-        RequestInputType.RequestBody,
-      ),
+      body: undefined,
       headers: undefined,
     }
 
@@ -29053,8 +27810,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getCreditNotesPreviewBodySchema = z.object({}).optional()
-
   const getCreditNotesPreviewResponseValidator = responseValidationFactory(
     [["200", s_credit_note]],
     s_error,
@@ -29071,11 +27826,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getCreditNotesPreviewBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -29185,8 +27936,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getCreditNotesPreviewLinesBodySchema = z.object({}).optional()
-
   const getCreditNotesPreviewLinesResponseValidator = responseValidationFactory(
     [
       [
@@ -29213,11 +27962,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getCreditNotesPreviewLinesBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -29274,8 +28019,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getCreditNotesCreditNoteLinesBodySchema = z.object({}).optional()
-
   const getCreditNotesCreditNoteLinesResponseValidator =
     responseValidationFactory(
       [
@@ -29307,11 +28050,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getCreditNotesCreditNoteLinesBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -29363,8 +28102,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getCreditNotesIdBodySchema = z.object({}).optional()
-
   const getCreditNotesIdResponseValidator = responseValidationFactory(
     [["200", s_credit_note]],
     s_error,
@@ -29382,11 +28119,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ctx.query,
         RequestInputType.QueryString,
       ),
-      body: parseRequestInput(
-        getCreditNotesIdBodySchema,
-        Reflect.get(ctx.request, "body"),
-        RequestInputType.RequestBody,
-      ),
+      body: undefined,
       headers: undefined,
     }
 
@@ -29656,8 +28389,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     test_clock: z.string().max(5000).optional(),
   })
 
-  const getCustomersBodySchema = z.object({}).optional()
-
   const getCustomersResponseValidator = responseValidationFactory(
     [
       [
@@ -29681,11 +28412,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ctx.query,
         RequestInputType.QueryString,
       ),
-      body: parseRequestInput(
-        getCustomersBodySchema,
-        Reflect.get(ctx.request, "body"),
-        RequestInputType.RequestBody,
-      ),
+      body: undefined,
       headers: undefined,
     }
 
@@ -29998,8 +28725,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     query: z.string().max(5000),
   })
 
-  const getCustomersSearchBodySchema = z.object({}).optional()
-
   const getCustomersSearchResponseValidator = responseValidationFactory(
     [
       [
@@ -30028,11 +28753,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getCustomersSearchBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -30079,8 +28800,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     customer: z.string().max(5000),
   })
 
-  const deleteCustomersCustomerBodySchema = z.object({}).optional()
-
   const deleteCustomersCustomerResponseValidator = responseValidationFactory(
     [["200", s_deleted_customer]],
     s_error,
@@ -30097,11 +28816,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.RouteParam,
         ),
         query: undefined,
-        body: parseRequestInput(
-          deleteCustomersCustomerBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -30150,8 +28865,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getCustomersCustomerBodySchema = z.object({}).optional()
-
   const getCustomersCustomerResponseValidator = responseValidationFactory(
     [["200", z.union([z.lazy(() => s_customer), s_deleted_customer])]],
     s_error,
@@ -30172,11 +28885,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getCustomersCustomerBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -30420,10 +29129,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getCustomersCustomerBalanceTransactionsBodySchema = z
-    .object({})
-    .optional()
-
   const getCustomersCustomerBalanceTransactionsResponseValidator =
     responseValidationFactory(
       [
@@ -30455,11 +29160,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getCustomersCustomerBalanceTransactionsBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -30588,10 +29289,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
         .optional(),
     })
 
-  const getCustomersCustomerBalanceTransactionsTransactionBodySchema = z
-    .object({})
-    .optional()
-
   const getCustomersCustomerBalanceTransactionsTransactionResponseValidator =
     responseValidationFactory(
       [["200", s_customer_balance_transaction]],
@@ -30613,11 +29310,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getCustomersCustomerBalanceTransactionsTransactionBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -30758,8 +29451,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     starting_after: z.string().optional(),
   })
 
-  const getCustomersCustomerBankAccountsBodySchema = z.object({}).optional()
-
   const getCustomersCustomerBankAccountsResponseValidator =
     responseValidationFactory(
       [
@@ -30791,11 +29482,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getCustomersCustomerBankAccountsBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -31030,8 +29717,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getCustomersCustomerBankAccountsIdBodySchema = z.object({}).optional()
-
   const getCustomersCustomerBankAccountsIdResponseValidator =
     responseValidationFactory([["200", s_bank_account]], s_error)
 
@@ -31050,11 +29735,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getCustomersCustomerBankAccountsIdBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -31287,8 +29968,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     starting_after: z.string().optional(),
   })
 
-  const getCustomersCustomerCardsBodySchema = z.object({}).optional()
-
   const getCustomersCustomerCardsResponseValidator = responseValidationFactory(
     [
       [
@@ -31319,11 +29998,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getCustomersCustomerCardsBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -31554,8 +30229,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getCustomersCustomerCardsIdBodySchema = z.object({}).optional()
-
   const getCustomersCustomerCardsIdResponseValidator =
     responseValidationFactory([["200", s_card]], s_error)
 
@@ -31574,11 +30247,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getCustomersCustomerCardsIdBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -31733,8 +30402,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getCustomersCustomerCashBalanceBodySchema = z.object({}).optional()
-
   const getCustomersCustomerCashBalanceResponseValidator =
     responseValidationFactory([["200", s_cash_balance]], s_error)
 
@@ -31753,11 +30420,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getCustomersCustomerCashBalanceBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -31880,10 +30543,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getCustomersCustomerCashBalanceTransactionsBodySchema = z
-    .object({})
-    .optional()
-
   const getCustomersCustomerCashBalanceTransactionsResponseValidator =
     responseValidationFactory(
       [
@@ -31915,11 +30574,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getCustomersCustomerCashBalanceTransactionsBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -31981,10 +30636,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
         .optional(),
     })
 
-  const getCustomersCustomerCashBalanceTransactionsTransactionBodySchema = z
-    .object({})
-    .optional()
-
   const getCustomersCustomerCashBalanceTransactionsTransactionResponseValidator =
     responseValidationFactory(
       [["200", s_customer_cash_balance_transaction]],
@@ -32006,11 +30657,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getCustomersCustomerCashBalanceTransactionsTransactionBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -32061,8 +30708,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     customer: z.string().max(5000),
   })
 
-  const deleteCustomersCustomerDiscountBodySchema = z.object({}).optional()
-
   const deleteCustomersCustomerDiscountResponseValidator =
     responseValidationFactory([["200", s_deleted_discount]], s_error)
 
@@ -32077,11 +30722,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.RouteParam,
         ),
         query: undefined,
-        body: parseRequestInput(
-          deleteCustomersCustomerDiscountBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -32130,8 +30771,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getCustomersCustomerDiscountBodySchema = z.object({}).optional()
-
   const getCustomersCustomerDiscountResponseValidator =
     responseValidationFactory([["200", s_discount]], s_error)
 
@@ -32150,11 +30789,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getCustomersCustomerDiscountBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -32339,8 +30974,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getCustomersCustomerPaymentMethodsBodySchema = z.object({}).optional()
-
   const getCustomersCustomerPaymentMethodsResponseValidator =
     responseValidationFactory(
       [
@@ -32372,11 +31005,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getCustomersCustomerPaymentMethodsBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -32434,10 +31063,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getCustomersCustomerPaymentMethodsPaymentMethodBodySchema = z
-    .object({})
-    .optional()
-
   const getCustomersCustomerPaymentMethodsPaymentMethodResponseValidator =
     responseValidationFactory([["200", s_payment_method]], s_error)
 
@@ -32456,11 +31081,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getCustomersCustomerPaymentMethodsPaymentMethodBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -32522,8 +31143,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     starting_after: z.string().optional(),
   })
 
-  const getCustomersCustomerSourcesBodySchema = z.object({}).optional()
-
   const getCustomersCustomerSourcesResponseValidator =
     responseValidationFactory(
       [
@@ -32561,11 +31180,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getCustomersCustomerSourcesBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -32794,8 +31409,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getCustomersCustomerSourcesIdBodySchema = z.object({}).optional()
-
   const getCustomersCustomerSourcesIdResponseValidator =
     responseValidationFactory([["200", s_payment_source]], s_error)
 
@@ -32814,11 +31427,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getCustomersCustomerSourcesIdBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -33045,8 +31654,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getCustomersCustomerSubscriptionsBodySchema = z.object({}).optional()
-
   const getCustomersCustomerSubscriptionsResponseValidator =
     responseValidationFactory(
       [
@@ -33078,11 +31685,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getCustomersCustomerSubscriptionsBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -33637,10 +32240,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
         .optional(),
     })
 
-  const getCustomersCustomerSubscriptionsSubscriptionExposedIdBodySchema = z
-    .object({})
-    .optional()
-
   const getCustomersCustomerSubscriptionsSubscriptionExposedIdResponseValidator =
     responseValidationFactory([["200", s_subscription]], s_error)
 
@@ -33659,11 +32258,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getCustomersCustomerSubscriptionsSubscriptionExposedIdBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -34171,9 +32766,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       subscription_exposed_id: z.string().max(5000),
     })
 
-  const deleteCustomersCustomerSubscriptionsSubscriptionExposedIdDiscountBodySchema =
-    z.object({}).optional()
-
   const deleteCustomersCustomerSubscriptionsSubscriptionExposedIdDiscountResponseValidator =
     responseValidationFactory([["200", s_deleted_discount]], s_error)
 
@@ -34188,11 +32780,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.RouteParam,
         ),
         query: undefined,
-        body: parseRequestInput(
-          deleteCustomersCustomerSubscriptionsSubscriptionExposedIdDiscountBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -34253,9 +32841,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
         .optional(),
     })
 
-  const getCustomersCustomerSubscriptionsSubscriptionExposedIdDiscountBodySchema =
-    z.object({}).optional()
-
   const getCustomersCustomerSubscriptionsSubscriptionExposedIdDiscountResponseValidator =
     responseValidationFactory([["200", s_discount]], s_error)
 
@@ -34274,11 +32859,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getCustomersCustomerSubscriptionsSubscriptionExposedIdDiscountBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -34339,8 +32920,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getCustomersCustomerTaxIdsBodySchema = z.object({}).optional()
-
   const getCustomersCustomerTaxIdsResponseValidator = responseValidationFactory(
     [
       [
@@ -34371,11 +32950,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getCustomersCustomerTaxIdsBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -34596,8 +33171,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     id: z.string(),
   })
 
-  const deleteCustomersCustomerTaxIdsIdBodySchema = z.object({}).optional()
-
   const deleteCustomersCustomerTaxIdsIdResponseValidator =
     responseValidationFactory([["200", s_deleted_tax_id]], s_error)
 
@@ -34612,11 +33185,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.RouteParam,
         ),
         query: undefined,
-        body: parseRequestInput(
-          deleteCustomersCustomerTaxIdsIdBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -34666,8 +33235,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getCustomersCustomerTaxIdsIdBodySchema = z.object({}).optional()
-
   const getCustomersCustomerTaxIdsIdResponseValidator =
     responseValidationFactory([["200", s_tax_id]], s_error)
 
@@ -34686,11 +33253,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getCustomersCustomerTaxIdsIdBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -34751,8 +33314,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getDisputesBodySchema = z.object({}).optional()
-
   const getDisputesResponseValidator = responseValidationFactory(
     [
       [
@@ -34776,11 +33337,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ctx.query,
         RequestInputType.QueryString,
       ),
-      body: parseRequestInput(
-        getDisputesBodySchema,
-        Reflect.get(ctx.request, "body"),
-        RequestInputType.RequestBody,
-      ),
+      body: undefined,
       headers: undefined,
     }
 
@@ -34833,8 +33390,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getDisputesDisputeBodySchema = z.object({}).optional()
-
   const getDisputesDisputeResponseValidator = responseValidationFactory(
     [["200", s_dispute]],
     s_error,
@@ -34855,11 +33410,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getDisputesDisputeBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -35179,8 +33730,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getEntitlementsActiveEntitlementsBodySchema = z.object({}).optional()
-
   const getEntitlementsActiveEntitlementsResponseValidator =
     responseValidationFactory(
       [
@@ -35208,11 +33757,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getEntitlementsActiveEntitlementsBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -35269,8 +33814,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getEntitlementsActiveEntitlementsIdBodySchema = z.object({}).optional()
-
   const getEntitlementsActiveEntitlementsIdResponseValidator =
     responseValidationFactory(
       [["200", s_entitlements_active_entitlement]],
@@ -35292,11 +33835,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getEntitlementsActiveEntitlementsIdBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -35349,8 +33888,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getEntitlementsFeaturesBodySchema = z.object({}).optional()
-
   const getEntitlementsFeaturesResponseValidator = responseValidationFactory(
     [
       [
@@ -35380,11 +33917,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getEntitlementsFeaturesBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -35497,8 +34030,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getEntitlementsFeaturesIdBodySchema = z.object({}).optional()
-
   const getEntitlementsFeaturesIdResponseValidator = responseValidationFactory(
     [["200", s_entitlements_feature]],
     s_error,
@@ -35519,11 +34050,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getEntitlementsFeaturesIdBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -35781,8 +34308,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getEventsBodySchema = z.object({}).optional()
-
   const getEventsResponseValidator = responseValidationFactory(
     [
       [
@@ -35806,11 +34331,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ctx.query,
         RequestInputType.QueryString,
       ),
-      body: parseRequestInput(
-        getEventsBodySchema,
-        Reflect.get(ctx.request, "body"),
-        RequestInputType.RequestBody,
-      ),
+      body: undefined,
       headers: undefined,
     }
 
@@ -35861,8 +34382,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getEventsIdBodySchema = z.object({}).optional()
-
   const getEventsIdResponseValidator = responseValidationFactory(
     [["200", s_event]],
     s_error,
@@ -35880,11 +34399,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ctx.query,
         RequestInputType.QueryString,
       ),
-      body: parseRequestInput(
-        getEventsIdBodySchema,
-        Reflect.get(ctx.request, "body"),
-        RequestInputType.RequestBody,
-      ),
+      body: undefined,
       headers: undefined,
     }
 
@@ -35931,8 +34446,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getExchangeRatesBodySchema = z.object({}).optional()
-
   const getExchangeRatesResponseValidator = responseValidationFactory(
     [
       [
@@ -35956,11 +34469,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ctx.query,
         RequestInputType.QueryString,
       ),
-      body: parseRequestInput(
-        getExchangeRatesBodySchema,
-        Reflect.get(ctx.request, "body"),
-        RequestInputType.RequestBody,
-      ),
+      body: undefined,
       headers: undefined,
     }
 
@@ -36013,8 +34522,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getExchangeRatesRateIdBodySchema = z.object({}).optional()
-
   const getExchangeRatesRateIdResponseValidator = responseValidationFactory(
     [["200", s_exchange_rate]],
     s_error,
@@ -36035,11 +34542,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getExchangeRatesRateIdBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -36185,8 +34688,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     starting_after: z.string().optional(),
   })
 
-  const getFileLinksBodySchema = z.object({}).optional()
-
   const getFileLinksResponseValidator = responseValidationFactory(
     [
       [
@@ -36210,11 +34711,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ctx.query,
         RequestInputType.QueryString,
       ),
-      body: parseRequestInput(
-        getFileLinksBodySchema,
-        Reflect.get(ctx.request, "body"),
-        RequestInputType.RequestBody,
-      ),
+      body: undefined,
       headers: undefined,
     }
 
@@ -36320,8 +34817,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getFileLinksLinkBodySchema = z.object({}).optional()
-
   const getFileLinksLinkResponseValidator = responseValidationFactory(
     [["200", s_file_link]],
     s_error,
@@ -36339,11 +34834,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ctx.query,
         RequestInputType.QueryString,
       ),
-      body: parseRequestInput(
-        getFileLinksLinkBodySchema,
-        Reflect.get(ctx.request, "body"),
-        RequestInputType.RequestBody,
-      ),
+      body: undefined,
       headers: undefined,
     }
 
@@ -36490,8 +34981,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getFilesBodySchema = z.object({}).optional()
-
   const getFilesResponseValidator = responseValidationFactory(
     [
       [
@@ -36515,11 +35004,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ctx.query,
         RequestInputType.QueryString,
       ),
-      body: parseRequestInput(
-        getFilesBodySchema,
-        Reflect.get(ctx.request, "body"),
-        RequestInputType.RequestBody,
-      ),
+      body: undefined,
       headers: undefined,
     }
 
@@ -36643,8 +35128,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getFilesFileBodySchema = z.object({}).optional()
-
   const getFilesFileResponseValidator = responseValidationFactory(
     [["200", s_file]],
     s_error,
@@ -36662,11 +35145,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ctx.query,
         RequestInputType.QueryString,
       ),
-      body: parseRequestInput(
-        getFilesFileBodySchema,
-        Reflect.get(ctx.request, "body"),
-        RequestInputType.RequestBody,
-      ),
+      body: undefined,
       headers: undefined,
     }
 
@@ -36720,8 +35199,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getFinancialConnectionsAccountsBodySchema = z.object({}).optional()
-
   const getFinancialConnectionsAccountsResponseValidator =
     responseValidationFactory(
       [
@@ -36752,11 +35229,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getFinancialConnectionsAccountsBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -36810,10 +35283,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getFinancialConnectionsAccountsAccountBodySchema = z
-    .object({})
-    .optional()
-
   const getFinancialConnectionsAccountsAccountResponseValidator =
     responseValidationFactory(
       [["200", s_financial_connections_account]],
@@ -36835,11 +35304,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getFinancialConnectionsAccountsAccountBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -36969,10 +35434,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getFinancialConnectionsAccountsAccountOwnersBodySchema = z
-    .object({})
-    .optional()
-
   const getFinancialConnectionsAccountsAccountOwnersResponseValidator =
     responseValidationFactory(
       [
@@ -37004,11 +35465,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getFinancialConnectionsAccountsAccountOwnersBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -37381,10 +35838,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getFinancialConnectionsSessionsSessionBodySchema = z
-    .object({})
-    .optional()
-
   const getFinancialConnectionsSessionsSessionResponseValidator =
     responseValidationFactory(
       [["200", s_financial_connections_session]],
@@ -37406,11 +35859,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getFinancialConnectionsSessionsSessionBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -37474,8 +35923,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     transaction_refresh: z.object({after: z.string().max(5000)}).optional(),
   })
 
-  const getFinancialConnectionsTransactionsBodySchema = z.object({}).optional()
-
   const getFinancialConnectionsTransactionsResponseValidator =
     responseValidationFactory(
       [
@@ -37506,11 +35953,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getFinancialConnectionsTransactionsBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -37567,10 +36010,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getFinancialConnectionsTransactionsTransactionBodySchema = z
-    .object({})
-    .optional()
-
   const getFinancialConnectionsTransactionsTransactionResponseValidator =
     responseValidationFactory(
       [["200", s_financial_connections_transaction]],
@@ -37592,11 +36031,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getFinancialConnectionsTransactionsTransactionBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -37663,8 +36098,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getForwardingRequestsBodySchema = z.object({}).optional()
-
   const getForwardingRequestsResponseValidator = responseValidationFactory(
     [
       [
@@ -37691,11 +36124,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getForwardingRequestsBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -37827,8 +36256,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getForwardingRequestsIdBodySchema = z.object({}).optional()
-
   const getForwardingRequestsIdResponseValidator = responseValidationFactory(
     [["200", s_forwarding_request]],
     s_error,
@@ -37849,11 +36276,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getForwardingRequestsIdBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -37915,8 +36338,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     verification_session: z.string().max(5000).optional(),
   })
 
-  const getIdentityVerificationReportsBodySchema = z.object({}).optional()
-
   const getIdentityVerificationReportsResponseValidator =
     responseValidationFactory(
       [
@@ -37947,11 +36368,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getIdentityVerificationReportsBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -38005,8 +36422,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getIdentityVerificationReportsReportBodySchema = z.object({}).optional()
-
   const getIdentityVerificationReportsReportResponseValidator =
     responseValidationFactory(
       [["200", s_identity_verification_report]],
@@ -38028,11 +36443,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getIdentityVerificationReportsReportBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -38099,8 +36510,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getIdentityVerificationSessionsBodySchema = z.object({}).optional()
-
   const getIdentityVerificationSessionsResponseValidator =
     responseValidationFactory(
       [
@@ -38131,11 +36540,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getIdentityVerificationSessionsBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -38277,10 +36682,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getIdentityVerificationSessionsSessionBodySchema = z
-    .object({})
-    .optional()
-
   const getIdentityVerificationSessionsSessionResponseValidator =
     responseValidationFactory(
       [["200", s_identity_verification_session]],
@@ -38302,11 +36703,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getIdentityVerificationSessionsSessionBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -38603,8 +37000,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     status: z.enum(["canceled", "open", "paid"]).optional(),
   })
 
-  const getInvoicePaymentsBodySchema = z.object({}).optional()
-
   const getInvoicePaymentsResponseValidator = responseValidationFactory(
     [
       [
@@ -38631,11 +37026,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getInvoicePaymentsBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -38689,8 +37080,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getInvoicePaymentsInvoicePaymentBodySchema = z.object({}).optional()
-
   const getInvoicePaymentsInvoicePaymentResponseValidator =
     responseValidationFactory([["200", s_invoice_payment]], s_error)
 
@@ -38709,11 +37098,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getInvoicePaymentsInvoicePaymentBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -38762,8 +37147,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     status: z.enum(["active", "archived"]).optional(),
   })
 
-  const getInvoiceRenderingTemplatesBodySchema = z.object({}).optional()
-
   const getInvoiceRenderingTemplatesResponseValidator =
     responseValidationFactory(
       [
@@ -38791,11 +37174,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getInvoiceRenderingTemplatesBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -38850,8 +37229,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     version: z.coerce.number().optional(),
   })
 
-  const getInvoiceRenderingTemplatesTemplateBodySchema = z.object({}).optional()
-
   const getInvoiceRenderingTemplatesTemplateResponseValidator =
     responseValidationFactory([["200", s_invoice_rendering_template]], s_error)
 
@@ -38870,11 +37247,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getInvoiceRenderingTemplatesTemplateBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -39080,8 +37453,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getInvoiceitemsBodySchema = z.object({}).optional()
-
   const getInvoiceitemsResponseValidator = responseValidationFactory(
     [
       [
@@ -39105,11 +37476,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ctx.query,
         RequestInputType.QueryString,
       ),
-      body: parseRequestInput(
-        getInvoiceitemsBodySchema,
-        Reflect.get(ctx.request, "body"),
-        RequestInputType.RequestBody,
-      ),
+      body: undefined,
       headers: undefined,
     }
 
@@ -39245,8 +37612,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     invoiceitem: z.string().max(5000),
   })
 
-  const deleteInvoiceitemsInvoiceitemBodySchema = z.object({}).optional()
-
   const deleteInvoiceitemsInvoiceitemResponseValidator =
     responseValidationFactory([["200", s_deleted_invoiceitem]], s_error)
 
@@ -39261,11 +37626,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.RouteParam,
         ),
         query: undefined,
-        body: parseRequestInput(
-          deleteInvoiceitemsInvoiceitemBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -39314,8 +37675,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getInvoiceitemsInvoiceitemBodySchema = z.object({}).optional()
-
   const getInvoiceitemsInvoiceitemResponseValidator = responseValidationFactory(
     [["200", s_invoiceitem]],
     s_error,
@@ -39336,11 +37695,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getInvoiceitemsInvoiceitemBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -39522,8 +37877,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     subscription: z.string().max(5000).optional(),
   })
 
-  const getInvoicesBodySchema = z.object({}).optional()
-
   const getInvoicesResponseValidator = responseValidationFactory(
     [
       [
@@ -39547,11 +37900,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ctx.query,
         RequestInputType.QueryString,
       ),
-      body: parseRequestInput(
-        getInvoicesBodySchema,
-        Reflect.get(ctx.request, "body"),
-        RequestInputType.RequestBody,
-      ),
+      body: undefined,
       headers: undefined,
     }
 
@@ -40529,8 +38878,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     query: z.string().max(5000),
   })
 
-  const getInvoicesSearchBodySchema = z.object({}).optional()
-
   const getInvoicesSearchResponseValidator = responseValidationFactory(
     [
       [
@@ -40556,11 +38903,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ctx.query,
         RequestInputType.QueryString,
       ),
-      body: parseRequestInput(
-        getInvoicesSearchBodySchema,
-        Reflect.get(ctx.request, "body"),
-        RequestInputType.RequestBody,
-      ),
+      body: undefined,
       headers: undefined,
     }
 
@@ -40606,8 +38949,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     invoice: z.string().max(5000),
   })
 
-  const deleteInvoicesInvoiceBodySchema = z.object({}).optional()
-
   const deleteInvoicesInvoiceResponseValidator = responseValidationFactory(
     [["200", s_deleted_invoice]],
     s_error,
@@ -40624,11 +38965,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.RouteParam,
         ),
         query: undefined,
-        body: parseRequestInput(
-          deleteInvoicesInvoiceBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -40677,8 +39014,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getInvoicesInvoiceBodySchema = z.object({}).optional()
-
   const getInvoicesInvoiceResponseValidator = responseValidationFactory(
     [["200", s_invoice]],
     s_error,
@@ -40699,11 +39034,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getInvoicesInvoiceBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -41462,8 +39793,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getInvoicesInvoiceLinesBodySchema = z.object({}).optional()
-
   const getInvoicesInvoiceLinesResponseValidator = responseValidationFactory(
     [
       [
@@ -41494,11 +39823,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getInvoicesInvoiceLinesBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -42257,8 +40582,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     status: z.enum(["closed", "expired", "pending", "reversed"]).optional(),
   })
 
-  const getIssuingAuthorizationsBodySchema = z.object({}).optional()
-
   const getIssuingAuthorizationsResponseValidator = responseValidationFactory(
     [
       [
@@ -42288,11 +40611,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getIssuingAuthorizationsBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -42346,10 +40665,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getIssuingAuthorizationsAuthorizationBodySchema = z
-    .object({})
-    .optional()
-
   const getIssuingAuthorizationsAuthorizationResponseValidator =
     responseValidationFactory([["200", s_issuing_authorization]], s_error)
 
@@ -42368,11 +40683,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getIssuingAuthorizationsAuthorizationBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -42653,8 +40964,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     type: z.enum(["company", "individual"]).optional(),
   })
 
-  const getIssuingCardholdersBodySchema = z.object({}).optional()
-
   const getIssuingCardholdersResponseValidator = responseValidationFactory(
     [
       [
@@ -42684,11 +40993,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getIssuingCardholdersBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -43779,8 +42084,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getIssuingCardholdersCardholderBodySchema = z.object({}).optional()
-
   const getIssuingCardholdersCardholderResponseValidator =
     responseValidationFactory([["200", s_issuing_cardholder]], s_error)
 
@@ -43799,11 +42102,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getIssuingCardholdersCardholderBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -44914,8 +43213,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     type: z.enum(["physical", "virtual"]).optional(),
   })
 
-  const getIssuingCardsBodySchema = z.object({}).optional()
-
   const getIssuingCardsResponseValidator = responseValidationFactory(
     [
       [
@@ -44939,11 +43236,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ctx.query,
         RequestInputType.QueryString,
       ),
-      body: parseRequestInput(
-        getIssuingCardsBodySchema,
-        Reflect.get(ctx.request, "body"),
-        RequestInputType.RequestBody,
-      ),
+      body: undefined,
       headers: undefined,
     }
 
@@ -46014,8 +44307,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getIssuingCardsCardBodySchema = z.object({}).optional()
-
   const getIssuingCardsCardResponseValidator = responseValidationFactory(
     [["200", s_issuing_card]],
     s_error,
@@ -46036,11 +44327,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getIssuingCardsCardBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -47127,8 +45414,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     transaction: z.string().max(5000).optional(),
   })
 
-  const getIssuingDisputesBodySchema = z.object({}).optional()
-
   const getIssuingDisputesResponseValidator = responseValidationFactory(
     [
       [
@@ -47155,11 +45440,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getIssuingDisputesBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -47453,8 +45734,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getIssuingDisputesDisputeBodySchema = z.object({}).optional()
-
   const getIssuingDisputesDisputeResponseValidator = responseValidationFactory(
     [["200", s_issuing_dispute]],
     s_error,
@@ -47475,11 +45754,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getIssuingDisputesDisputeBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -47851,8 +46126,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     status: z.enum(["active", "inactive", "rejected", "review"]).optional(),
   })
 
-  const getIssuingPersonalizationDesignsBodySchema = z.object({}).optional()
-
   const getIssuingPersonalizationDesignsResponseValidator =
     responseValidationFactory(
       [
@@ -47883,11 +46156,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getIssuingPersonalizationDesignsBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -48016,10 +46285,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
         .optional(),
     })
 
-  const getIssuingPersonalizationDesignsPersonalizationDesignBodySchema = z
-    .object({})
-    .optional()
-
   const getIssuingPersonalizationDesignsPersonalizationDesignResponseValidator =
     responseValidationFactory(
       [["200", s_issuing_personalization_design]],
@@ -48041,11 +46306,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getIssuingPersonalizationDesignsPersonalizationDesignBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -48205,8 +46466,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     type: z.enum(["custom", "standard"]).optional(),
   })
 
-  const getIssuingPhysicalBundlesBodySchema = z.object({}).optional()
-
   const getIssuingPhysicalBundlesResponseValidator = responseValidationFactory(
     [
       [
@@ -48236,11 +46495,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getIssuingPhysicalBundlesBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -48294,10 +46549,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getIssuingPhysicalBundlesPhysicalBundleBodySchema = z
-    .object({})
-    .optional()
-
   const getIssuingPhysicalBundlesPhysicalBundleResponseValidator =
     responseValidationFactory([["200", s_issuing_physical_bundle]], s_error)
 
@@ -48316,11 +46567,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getIssuingPhysicalBundlesPhysicalBundleBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -48372,8 +46619,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getIssuingSettlementsSettlementBodySchema = z.object({}).optional()
-
   const getIssuingSettlementsSettlementResponseValidator =
     responseValidationFactory([["200", s_issuing_settlement]], s_error)
 
@@ -48392,11 +46637,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getIssuingSettlementsSettlementBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -48522,8 +46763,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     status: z.enum(["active", "deleted", "requested", "suspended"]).optional(),
   })
 
-  const getIssuingTokensBodySchema = z.object({}).optional()
-
   const getIssuingTokensResponseValidator = responseValidationFactory(
     [
       [
@@ -48547,11 +46786,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ctx.query,
         RequestInputType.QueryString,
       ),
-      body: parseRequestInput(
-        getIssuingTokensBodySchema,
-        Reflect.get(ctx.request, "body"),
-        RequestInputType.RequestBody,
-      ),
+      body: undefined,
       headers: undefined,
     }
 
@@ -48604,8 +46839,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getIssuingTokensTokenBodySchema = z.object({}).optional()
-
   const getIssuingTokensTokenResponseValidator = responseValidationFactory(
     [["200", s_issuing_token]],
     s_error,
@@ -48626,11 +46859,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getIssuingTokensTokenBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -48757,8 +46986,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     type: z.enum(["capture", "refund"]).optional(),
   })
 
-  const getIssuingTransactionsBodySchema = z.object({}).optional()
-
   const getIssuingTransactionsResponseValidator = responseValidationFactory(
     [
       [
@@ -48788,11 +47015,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getIssuingTransactionsBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -48846,8 +47069,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getIssuingTransactionsTransactionBodySchema = z.object({}).optional()
-
   const getIssuingTransactionsTransactionResponseValidator =
     responseValidationFactory([["200", s_issuing_transaction]], s_error)
 
@@ -48866,11 +47087,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getIssuingTransactionsTransactionBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -49074,8 +47291,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getLinkAccountSessionsSessionBodySchema = z.object({}).optional()
-
   const getLinkAccountSessionsSessionResponseValidator =
     responseValidationFactory(
       [["200", s_financial_connections_session]],
@@ -49097,11 +47312,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getLinkAccountSessionsSessionBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -49156,8 +47367,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getLinkedAccountsBodySchema = z.object({}).optional()
-
   const getLinkedAccountsResponseValidator = responseValidationFactory(
     [
       [
@@ -49184,11 +47393,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ctx.query,
         RequestInputType.QueryString,
       ),
-      body: parseRequestInput(
-        getLinkedAccountsBodySchema,
-        Reflect.get(ctx.request, "body"),
-        RequestInputType.RequestBody,
-      ),
+      body: undefined,
       headers: undefined,
     }
 
@@ -49241,8 +47446,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getLinkedAccountsAccountBodySchema = z.object({}).optional()
-
   const getLinkedAccountsAccountResponseValidator = responseValidationFactory(
     [["200", s_financial_connections_account]],
     s_error,
@@ -49263,11 +47466,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getLinkedAccountsAccountBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -49388,8 +47587,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getLinkedAccountsAccountOwnersBodySchema = z.object({}).optional()
-
   const getLinkedAccountsAccountOwnersResponseValidator =
     responseValidationFactory(
       [
@@ -49421,11 +47618,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getLinkedAccountsAccountOwnersBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -49543,8 +47736,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getMandatesMandateBodySchema = z.object({}).optional()
-
   const getMandatesMandateResponseValidator = responseValidationFactory(
     [["200", s_mandate]],
     s_error,
@@ -49565,11 +47756,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getMandatesMandateBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -49629,8 +47816,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getPaymentIntentsBodySchema = z.object({}).optional()
-
   const getPaymentIntentsResponseValidator = responseValidationFactory(
     [
       [
@@ -49654,11 +47839,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ctx.query,
         RequestInputType.QueryString,
       ),
-      body: parseRequestInput(
-        getPaymentIntentsBodySchema,
-        Reflect.get(ctx.request, "body"),
-        RequestInputType.RequestBody,
-      ),
+      body: undefined,
       headers: undefined,
     }
 
@@ -50895,8 +49076,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     query: z.string().max(5000),
   })
 
-  const getPaymentIntentsSearchBodySchema = z.object({}).optional()
-
   const getPaymentIntentsSearchResponseValidator = responseValidationFactory(
     [
       [
@@ -50925,11 +49104,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getPaymentIntentsSearchBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -50986,8 +49161,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getPaymentIntentsIntentBodySchema = z.object({}).optional()
-
   const getPaymentIntentsIntentResponseValidator = responseValidationFactory(
     [["200", s_payment_intent]],
     s_error,
@@ -51008,11 +49181,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getPaymentIntentsIntentBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -53789,8 +51958,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getPaymentLinksBodySchema = z.object({}).optional()
-
   const getPaymentLinksResponseValidator = responseValidationFactory(
     [
       [
@@ -53814,11 +51981,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ctx.query,
         RequestInputType.QueryString,
       ),
-      body: parseRequestInput(
-        getPaymentLinksBodySchema,
-        Reflect.get(ctx.request, "body"),
-        RequestInputType.RequestBody,
-      ),
+      body: undefined,
       headers: undefined,
     }
 
@@ -54435,8 +52598,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getPaymentLinksPaymentLinkBodySchema = z.object({}).optional()
-
   const getPaymentLinksPaymentLinkResponseValidator = responseValidationFactory(
     [["200", s_payment_link]],
     s_error,
@@ -54457,11 +52618,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getPaymentLinksPaymentLinkBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -55080,8 +53237,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getPaymentLinksPaymentLinkLineItemsBodySchema = z.object({}).optional()
-
   const getPaymentLinksPaymentLinkLineItemsResponseValidator =
     responseValidationFactory(
       [
@@ -55113,11 +53268,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getPaymentLinksPaymentLinkLineItemsBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -55174,8 +53325,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getPaymentMethodConfigurationsBodySchema = z.object({}).optional()
-
   const getPaymentMethodConfigurationsResponseValidator =
     responseValidationFactory(
       [
@@ -55206,11 +53355,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getPaymentMethodConfigurationsBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -55689,10 +53834,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getPaymentMethodConfigurationsConfigurationBodySchema = z
-    .object({})
-    .optional()
-
   const getPaymentMethodConfigurationsConfigurationResponseValidator =
     responseValidationFactory(
       [["200", s_payment_method_configuration]],
@@ -55714,11 +53855,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getPaymentMethodConfigurationsConfigurationBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -56217,8 +54354,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getPaymentMethodDomainsBodySchema = z.object({}).optional()
-
   const getPaymentMethodDomainsResponseValidator = responseValidationFactory(
     [
       [
@@ -56248,11 +54383,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getPaymentMethodDomainsBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -56364,10 +54495,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getPaymentMethodDomainsPaymentMethodDomainBodySchema = z
-    .object({})
-    .optional()
-
   const getPaymentMethodDomainsPaymentMethodDomainResponseValidator =
     responseValidationFactory([["200", s_payment_method_domain]], s_error)
 
@@ -56386,11 +54513,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getPaymentMethodDomainsPaymentMethodDomainBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -56637,8 +54760,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getPaymentMethodsBodySchema = z.object({}).optional()
-
   const getPaymentMethodsResponseValidator = responseValidationFactory(
     [
       [
@@ -56662,11 +54783,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ctx.query,
         RequestInputType.QueryString,
       ),
-      body: parseRequestInput(
-        getPaymentMethodsBodySchema,
-        Reflect.get(ctx.request, "body"),
-        RequestInputType.RequestBody,
-      ),
+      body: undefined,
       headers: undefined,
     }
 
@@ -57089,8 +55206,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getPaymentMethodsPaymentMethodBodySchema = z.object({}).optional()
-
   const getPaymentMethodsPaymentMethodResponseValidator =
     responseValidationFactory([["200", s_payment_method]], s_error)
 
@@ -57109,11 +55224,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getPaymentMethodsPaymentMethodBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -57424,8 +55535,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     status: z.string().max(5000).optional(),
   })
 
-  const getPayoutsBodySchema = z.object({}).optional()
-
   const getPayoutsResponseValidator = responseValidationFactory(
     [
       [
@@ -57449,11 +55558,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ctx.query,
         RequestInputType.QueryString,
       ),
-      body: parseRequestInput(
-        getPayoutsBodySchema,
-        Reflect.get(ctx.request, "body"),
-        RequestInputType.RequestBody,
-      ),
+      body: undefined,
       headers: undefined,
     }
 
@@ -57564,8 +55669,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getPayoutsPayoutBodySchema = z.object({}).optional()
-
   const getPayoutsPayoutResponseValidator = responseValidationFactory(
     [["200", s_payout]],
     s_error,
@@ -57583,11 +55686,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ctx.query,
         RequestInputType.QueryString,
       ),
-      body: parseRequestInput(
-        getPayoutsPayoutBodySchema,
-        Reflect.get(ctx.request, "body"),
-        RequestInputType.RequestBody,
-      ),
+      body: undefined,
       headers: undefined,
     }
 
@@ -57839,8 +55938,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getPlansBodySchema = z.object({}).optional()
-
   const getPlansResponseValidator = responseValidationFactory(
     [
       [
@@ -57864,11 +55961,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ctx.query,
         RequestInputType.QueryString,
       ),
-      body: parseRequestInput(
-        getPlansBodySchema,
-        Reflect.get(ctx.request, "body"),
-        RequestInputType.RequestBody,
-      ),
+      body: undefined,
       headers: undefined,
     }
 
@@ -58004,8 +56097,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   const deletePlansPlanParamSchema = z.object({plan: z.string().max(5000)})
 
-  const deletePlansPlanBodySchema = z.object({}).optional()
-
   const deletePlansPlanResponseValidator = responseValidationFactory(
     [["200", s_deleted_plan]],
     s_error,
@@ -58019,11 +56110,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         RequestInputType.RouteParam,
       ),
       query: undefined,
-      body: parseRequestInput(
-        deletePlansPlanBodySchema,
-        Reflect.get(ctx.request, "body"),
-        RequestInputType.RequestBody,
-      ),
+      body: undefined,
       headers: undefined,
     }
 
@@ -58069,8 +56156,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getPlansPlanBodySchema = z.object({}).optional()
-
   const getPlansPlanResponseValidator = responseValidationFactory(
     [["200", s_plan]],
     s_error,
@@ -58088,11 +56173,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ctx.query,
         RequestInputType.QueryString,
       ),
-      body: parseRequestInput(
-        getPlansPlanBodySchema,
-        Reflect.get(ctx.request, "body"),
-        RequestInputType.RequestBody,
-      ),
+      body: undefined,
       headers: undefined,
     }
 
@@ -58232,8 +56313,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     type: z.enum(["one_time", "recurring"]).optional(),
   })
 
-  const getPricesBodySchema = z.object({}).optional()
-
   const getPricesResponseValidator = responseValidationFactory(
     [
       [
@@ -58257,11 +56336,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ctx.query,
         RequestInputType.QueryString,
       ),
-      body: parseRequestInput(
-        getPricesBodySchema,
-        Reflect.get(ctx.request, "body"),
-        RequestInputType.RequestBody,
-      ),
+      body: undefined,
       headers: undefined,
     }
 
@@ -58448,8 +56523,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     query: z.string().max(5000),
   })
 
-  const getPricesSearchBodySchema = z.object({}).optional()
-
   const getPricesSearchResponseValidator = responseValidationFactory(
     [
       [
@@ -58475,11 +56548,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ctx.query,
         RequestInputType.QueryString,
       ),
-      body: parseRequestInput(
-        getPricesSearchBodySchema,
-        Reflect.get(ctx.request, "body"),
-        RequestInputType.RequestBody,
-      ),
+      body: undefined,
       headers: undefined,
     }
 
@@ -58532,8 +56601,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getPricesPriceBodySchema = z.object({}).optional()
-
   const getPricesPriceResponseValidator = responseValidationFactory(
     [["200", s_price]],
     s_error,
@@ -58551,11 +56618,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ctx.query,
         RequestInputType.QueryString,
       ),
-      body: parseRequestInput(
-        getPricesPriceBodySchema,
-        Reflect.get(ctx.request, "body"),
-        RequestInputType.RequestBody,
-      ),
+      body: undefined,
       headers: undefined,
     }
 
@@ -58723,8 +56786,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     url: z.string().max(5000).optional(),
   })
 
-  const getProductsBodySchema = z.object({}).optional()
-
   const getProductsResponseValidator = responseValidationFactory(
     [
       [
@@ -58748,11 +56809,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ctx.query,
         RequestInputType.QueryString,
       ),
-      body: parseRequestInput(
-        getProductsBodySchema,
-        Reflect.get(ctx.request, "body"),
-        RequestInputType.RequestBody,
-      ),
+      body: undefined,
       headers: undefined,
     }
 
@@ -58933,8 +56990,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     query: z.string().max(5000),
   })
 
-  const getProductsSearchBodySchema = z.object({}).optional()
-
   const getProductsSearchResponseValidator = responseValidationFactory(
     [
       [
@@ -58960,11 +57015,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ctx.query,
         RequestInputType.QueryString,
       ),
-      body: parseRequestInput(
-        getProductsSearchBodySchema,
-        Reflect.get(ctx.request, "body"),
-        RequestInputType.RequestBody,
-      ),
+      body: undefined,
       headers: undefined,
     }
 
@@ -59008,8 +57059,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   const deleteProductsIdParamSchema = z.object({id: z.string().max(5000)})
 
-  const deleteProductsIdBodySchema = z.object({}).optional()
-
   const deleteProductsIdResponseValidator = responseValidationFactory(
     [["200", s_deleted_product]],
     s_error,
@@ -59023,11 +57072,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         RequestInputType.RouteParam,
       ),
       query: undefined,
-      body: parseRequestInput(
-        deleteProductsIdBodySchema,
-        Reflect.get(ctx.request, "body"),
-        RequestInputType.RequestBody,
-      ),
+      body: undefined,
       headers: undefined,
     }
 
@@ -59073,8 +57118,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getProductsIdBodySchema = z.object({}).optional()
-
   const getProductsIdResponseValidator = responseValidationFactory(
     [["200", s_product]],
     s_error,
@@ -59092,11 +57135,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ctx.query,
         RequestInputType.QueryString,
       ),
-      body: parseRequestInput(
-        getProductsIdBodySchema,
-        Reflect.get(ctx.request, "body"),
-        RequestInputType.RequestBody,
-      ),
+      body: undefined,
       headers: undefined,
     }
 
@@ -59232,8 +57271,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getProductsProductFeaturesBodySchema = z.object({}).optional()
-
   const getProductsProductFeaturesResponseValidator = responseValidationFactory(
     [
       [
@@ -59264,11 +57301,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getProductsProductFeaturesBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -59377,8 +57410,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     product: z.string().max(5000),
   })
 
-  const deleteProductsProductFeaturesIdBodySchema = z.object({}).optional()
-
   const deleteProductsProductFeaturesIdResponseValidator =
     responseValidationFactory([["200", s_deleted_product_feature]], s_error)
 
@@ -59393,11 +57424,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.RouteParam,
         ),
         query: undefined,
-        body: parseRequestInput(
-          deleteProductsProductFeaturesIdBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -59447,8 +57474,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getProductsProductFeaturesIdBodySchema = z.object({}).optional()
-
   const getProductsProductFeaturesIdResponseValidator =
     responseValidationFactory([["200", s_product_feature]], s_error)
 
@@ -59467,11 +57492,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getProductsProductFeaturesIdBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -59534,8 +57555,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getPromotionCodesBodySchema = z.object({}).optional()
-
   const getPromotionCodesResponseValidator = responseValidationFactory(
     [
       [
@@ -59559,11 +57578,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ctx.query,
         RequestInputType.QueryString,
       ),
-      body: parseRequestInput(
-        getPromotionCodesBodySchema,
-        Reflect.get(ctx.request, "body"),
-        RequestInputType.RequestBody,
-      ),
+      body: undefined,
       headers: undefined,
     }
 
@@ -59689,8 +57704,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getPromotionCodesPromotionCodeBodySchema = z.object({}).optional()
-
   const getPromotionCodesPromotionCodeResponseValidator =
     responseValidationFactory([["200", s_promotion_code]], s_error)
 
@@ -59709,11 +57722,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getPromotionCodesPromotionCodeBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -59837,8 +57846,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     test_clock: z.string().max(5000).optional(),
   })
 
-  const getQuotesBodySchema = z.object({}).optional()
-
   const getQuotesResponseValidator = responseValidationFactory(
     [
       [
@@ -59862,11 +57869,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ctx.query,
         RequestInputType.QueryString,
       ),
-      body: parseRequestInput(
-        getQuotesBodySchema,
-        Reflect.get(ctx.request, "body"),
-        RequestInputType.RequestBody,
-      ),
+      body: undefined,
       headers: undefined,
     }
 
@@ -60100,8 +58103,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getQuotesQuoteBodySchema = z.object({}).optional()
-
   const getQuotesQuoteResponseValidator = responseValidationFactory(
     [["200", s_quote]],
     s_error,
@@ -60119,11 +58120,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ctx.query,
         RequestInputType.QueryString,
       ),
-      body: parseRequestInput(
-        getQuotesQuoteBodySchema,
-        Reflect.get(ctx.request, "body"),
-        RequestInputType.RequestBody,
-      ),
+      body: undefined,
       headers: undefined,
     }
 
@@ -60482,10 +58479,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getQuotesQuoteComputedUpfrontLineItemsBodySchema = z
-    .object({})
-    .optional()
-
   const getQuotesQuoteComputedUpfrontLineItemsResponseValidator =
     responseValidationFactory(
       [
@@ -60517,11 +58510,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getQuotesQuoteComputedUpfrontLineItemsBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -60648,8 +58637,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getQuotesQuoteLineItemsBodySchema = z.object({}).optional()
-
   const getQuotesQuoteLineItemsResponseValidator = responseValidationFactory(
     [
       [
@@ -60680,11 +58667,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getQuotesQuoteLineItemsBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -60736,8 +58719,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getQuotesQuotePdfBodySchema = z.object({}).optional()
-
   const getQuotesQuotePdfResponseValidator = responseValidationFactory(
     [["200", z.string()]],
     s_error,
@@ -60758,11 +58739,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getQuotesQuotePdfBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -60823,8 +58800,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getRadarEarlyFraudWarningsBodySchema = z.object({}).optional()
-
   const getRadarEarlyFraudWarningsResponseValidator = responseValidationFactory(
     [
       [
@@ -60854,11 +58829,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getRadarEarlyFraudWarningsBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -60912,10 +58883,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getRadarEarlyFraudWarningsEarlyFraudWarningBodySchema = z
-    .object({})
-    .optional()
-
   const getRadarEarlyFraudWarningsEarlyFraudWarningResponseValidator =
     responseValidationFactory([["200", s_radar_early_fraud_warning]], s_error)
 
@@ -60934,11 +58901,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getRadarEarlyFraudWarningsEarlyFraudWarningBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -61007,8 +58970,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     value_list: z.string().max(5000),
   })
 
-  const getRadarValueListItemsBodySchema = z.object({}).optional()
-
   const getRadarValueListItemsResponseValidator = responseValidationFactory(
     [
       [
@@ -61038,11 +58999,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getRadarValueListItemsBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -61145,8 +59102,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     item: z.string().max(5000),
   })
 
-  const deleteRadarValueListItemsItemBodySchema = z.object({}).optional()
-
   const deleteRadarValueListItemsItemResponseValidator =
     responseValidationFactory(
       [["200", s_deleted_radar_value_list_item]],
@@ -61164,11 +59119,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.RouteParam,
         ),
         query: undefined,
-        body: parseRequestInput(
-          deleteRadarValueListItemsItemBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -61217,8 +59168,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getRadarValueListItemsItemBodySchema = z.object({}).optional()
-
   const getRadarValueListItemsItemResponseValidator = responseValidationFactory(
     [["200", s_radar_value_list_item]],
     s_error,
@@ -61239,11 +59188,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getRadarValueListItemsItemBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -61304,8 +59249,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getRadarValueListsBodySchema = z.object({}).optional()
-
   const getRadarValueListsResponseValidator = responseValidationFactory(
     [
       [
@@ -61332,11 +59275,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getRadarValueListsBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -61454,8 +59393,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     value_list: z.string().max(5000),
   })
 
-  const deleteRadarValueListsValueListBodySchema = z.object({}).optional()
-
   const deleteRadarValueListsValueListResponseValidator =
     responseValidationFactory([["200", s_deleted_radar_value_list]], s_error)
 
@@ -61470,11 +59407,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.RouteParam,
         ),
         query: undefined,
-        body: parseRequestInput(
-          deleteRadarValueListsValueListBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -61523,8 +59456,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getRadarValueListsValueListBodySchema = z.object({}).optional()
-
   const getRadarValueListsValueListResponseValidator =
     responseValidationFactory([["200", s_radar_value_list]], s_error)
 
@@ -61543,11 +59474,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getRadarValueListsValueListBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -61675,8 +59602,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     starting_after: z.string().optional(),
   })
 
-  const getRefundsBodySchema = z.object({}).optional()
-
   const getRefundsResponseValidator = responseValidationFactory(
     [
       [
@@ -61700,11 +59625,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ctx.query,
         RequestInputType.QueryString,
       ),
-      body: parseRequestInput(
-        getRefundsBodySchema,
-        Reflect.get(ctx.request, "body"),
-        RequestInputType.RequestBody,
-      ),
+      body: undefined,
       headers: undefined,
     }
 
@@ -61822,8 +59743,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getRefundsRefundBodySchema = z.object({}).optional()
-
   const getRefundsRefundResponseValidator = responseValidationFactory(
     [["200", s_refund]],
     s_error,
@@ -61841,11 +59760,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ctx.query,
         RequestInputType.QueryString,
       ),
-      body: parseRequestInput(
-        getRefundsRefundBodySchema,
-        Reflect.get(ctx.request, "body"),
-        RequestInputType.RequestBody,
-      ),
+      body: undefined,
       headers: undefined,
     }
 
@@ -62026,8 +59941,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getReportingReportRunsBodySchema = z.object({}).optional()
-
   const getReportingReportRunsResponseValidator = responseValidationFactory(
     [
       [
@@ -62057,11 +59970,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getReportingReportRunsBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -62825,8 +60734,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getReportingReportRunsReportRunBodySchema = z.object({}).optional()
-
   const getReportingReportRunsReportRunResponseValidator =
     responseValidationFactory([["200", s_reporting_report_run]], s_error)
 
@@ -62845,11 +60752,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getReportingReportRunsReportRunBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -62894,8 +60797,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getReportingReportTypesBodySchema = z.object({}).optional()
-
   const getReportingReportTypesResponseValidator = responseValidationFactory(
     [
       [
@@ -62922,11 +60823,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getReportingReportTypesBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -62980,8 +60877,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getReportingReportTypesReportTypeBodySchema = z.object({}).optional()
-
   const getReportingReportTypesReportTypeResponseValidator =
     responseValidationFactory([["200", s_reporting_report_type]], s_error)
 
@@ -63000,11 +60895,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getReportingReportTypesReportTypeBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -63066,8 +60957,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getReviewsBodySchema = z.object({}).optional()
-
   const getReviewsResponseValidator = responseValidationFactory(
     [
       [
@@ -63091,11 +60980,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ctx.query,
         RequestInputType.QueryString,
       ),
-      body: parseRequestInput(
-        getReviewsBodySchema,
-        Reflect.get(ctx.request, "body"),
-        RequestInputType.RequestBody,
-      ),
+      body: undefined,
       headers: undefined,
     }
 
@@ -63146,8 +61031,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getReviewsReviewBodySchema = z.object({}).optional()
-
   const getReviewsReviewResponseValidator = responseValidationFactory(
     [["200", s_review]],
     s_error,
@@ -63165,11 +61048,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ctx.query,
         RequestInputType.QueryString,
       ),
-      body: parseRequestInput(
-        getReviewsReviewBodySchema,
-        Reflect.get(ctx.request, "body"),
-        RequestInputType.RequestBody,
-      ),
+      body: undefined,
       headers: undefined,
     }
 
@@ -63292,8 +61171,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getSetupAttemptsBodySchema = z.object({}).optional()
-
   const getSetupAttemptsResponseValidator = responseValidationFactory(
     [
       [
@@ -63317,11 +61194,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ctx.query,
         RequestInputType.QueryString,
       ),
-      body: parseRequestInput(
-        getSetupAttemptsBodySchema,
-        Reflect.get(ctx.request, "body"),
-        RequestInputType.RequestBody,
-      ),
+      body: undefined,
       headers: undefined,
     }
 
@@ -63387,8 +61260,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getSetupIntentsBodySchema = z.object({}).optional()
-
   const getSetupIntentsResponseValidator = responseValidationFactory(
     [
       [
@@ -63412,11 +61283,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ctx.query,
         RequestInputType.QueryString,
       ),
-      body: parseRequestInput(
-        getSetupIntentsBodySchema,
-        Reflect.get(ctx.request, "body"),
-        RequestInputType.RequestBody,
-      ),
+      body: undefined,
       headers: undefined,
     }
 
@@ -64109,8 +61976,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getSetupIntentsIntentBodySchema = z.object({}).optional()
-
   const getSetupIntentsIntentResponseValidator = responseValidationFactory(
     [["200", s_setup_intent]],
     s_error,
@@ -64131,11 +61996,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getSetupIntentsIntentBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -65591,8 +63452,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getShippingRatesBodySchema = z.object({}).optional()
-
   const getShippingRatesResponseValidator = responseValidationFactory(
     [
       [
@@ -65616,11 +63475,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ctx.query,
         RequestInputType.QueryString,
       ),
-      body: parseRequestInput(
-        getShippingRatesBodySchema,
-        Reflect.get(ctx.request, "body"),
-        RequestInputType.RequestBody,
-      ),
+      body: undefined,
       headers: undefined,
     }
 
@@ -65762,8 +63617,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getShippingRatesShippingRateTokenBodySchema = z.object({}).optional()
-
   const getShippingRatesShippingRateTokenResponseValidator =
     responseValidationFactory([["200", s_shipping_rate]], s_error)
 
@@ -65782,11 +63635,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getShippingRatesShippingRateTokenBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -65991,8 +63840,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getSigmaScheduledQueryRunsBodySchema = z.object({}).optional()
-
   const getSigmaScheduledQueryRunsResponseValidator = responseValidationFactory(
     [
       [
@@ -66022,11 +63869,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getSigmaScheduledQueryRunsBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -66080,10 +63923,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getSigmaScheduledQueryRunsScheduledQueryRunBodySchema = z
-    .object({})
-    .optional()
-
   const getSigmaScheduledQueryRunsScheduledQueryRunResponseValidator =
     responseValidationFactory([["200", s_scheduled_query_run]], s_error)
 
@@ -66102,11 +63941,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getSigmaScheduledQueryRunsScheduledQueryRunBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -66318,8 +64153,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getSourcesSourceBodySchema = z.object({}).optional()
-
   const getSourcesSourceResponseValidator = responseValidationFactory(
     [["200", s_source]],
     s_error,
@@ -66337,11 +64170,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ctx.query,
         RequestInputType.QueryString,
       ),
-      body: parseRequestInput(
-        getSourcesSourceBodySchema,
-        Reflect.get(ctx.request, "body"),
-        RequestInputType.RequestBody,
-      ),
+      body: undefined,
       headers: undefined,
     }
 
@@ -66536,10 +64365,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
         .optional(),
     })
 
-  const getSourcesSourceMandateNotificationsMandateNotificationBodySchema = z
-    .object({})
-    .optional()
-
   const getSourcesSourceMandateNotificationsMandateNotificationResponseValidator =
     responseValidationFactory([["200", s_source_mandate_notification]], s_error)
 
@@ -66558,11 +64383,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getSourcesSourceMandateNotificationsMandateNotificationBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -66623,8 +64444,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getSourcesSourceSourceTransactionsBodySchema = z.object({}).optional()
-
   const getSourcesSourceSourceTransactionsResponseValidator =
     responseValidationFactory(
       [
@@ -66656,11 +64475,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getSourcesSourceSourceTransactionsBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -66720,10 +64535,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
         .optional(),
     })
 
-  const getSourcesSourceSourceTransactionsSourceTransactionBodySchema = z
-    .object({})
-    .optional()
-
   const getSourcesSourceSourceTransactionsSourceTransactionResponseValidator =
     responseValidationFactory([["200", s_source_transaction]], s_error)
 
@@ -66742,11 +64553,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getSourcesSourceSourceTransactionsSourceTransactionBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -66869,8 +64676,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     subscription: z.string().max(5000),
   })
 
-  const getSubscriptionItemsBodySchema = z.object({}).optional()
-
   const getSubscriptionItemsResponseValidator = responseValidationFactory(
     [
       [
@@ -66900,11 +64705,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getSubscriptionItemsBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -67131,8 +64932,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getSubscriptionItemsItemBodySchema = z.object({}).optional()
-
   const getSubscriptionItemsItemResponseValidator = responseValidationFactory(
     [["200", s_subscription_item]],
     s_error,
@@ -67153,11 +64952,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getSubscriptionItemsItemBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -67366,8 +65161,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getSubscriptionSchedulesBodySchema = z.object({}).optional()
-
   const getSubscriptionSchedulesResponseValidator = responseValidationFactory(
     [
       [
@@ -67397,11 +65190,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getSubscriptionSchedulesBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -67732,8 +65521,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getSubscriptionSchedulesScheduleBodySchema = z.object({}).optional()
-
   const getSubscriptionSchedulesScheduleResponseValidator =
     responseValidationFactory([["200", s_subscription_schedule]], s_error)
 
@@ -67752,11 +65539,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getSubscriptionSchedulesScheduleBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -68280,8 +66063,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     test_clock: z.string().max(5000).optional(),
   })
 
-  const getSubscriptionsBodySchema = z.object({}).optional()
-
   const getSubscriptionsResponseValidator = responseValidationFactory(
     [
       [
@@ -68305,11 +66086,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ctx.query,
         RequestInputType.QueryString,
       ),
-      body: parseRequestInput(
-        getSubscriptionsBodySchema,
-        Reflect.get(ctx.request, "body"),
-        RequestInputType.RequestBody,
-      ),
+      body: undefined,
       headers: undefined,
     }
 
@@ -68773,8 +66550,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     query: z.string().max(5000),
   })
 
-  const getSubscriptionsSearchBodySchema = z.object({}).optional()
-
   const getSubscriptionsSearchResponseValidator = responseValidationFactory(
     [
       [
@@ -68803,11 +66578,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getSubscriptionsSearchBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -68950,10 +66721,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getSubscriptionsSubscriptionExposedIdBodySchema = z
-    .object({})
-    .optional()
-
   const getSubscriptionsSubscriptionExposedIdResponseValidator =
     responseValidationFactory([["200", s_subscription]], s_error)
 
@@ -68972,11 +66739,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getSubscriptionsSubscriptionExposedIdBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -69470,10 +67233,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     subscription_exposed_id: z.string().max(5000),
   })
 
-  const deleteSubscriptionsSubscriptionExposedIdDiscountBodySchema = z
-    .object({})
-    .optional()
-
   const deleteSubscriptionsSubscriptionExposedIdDiscountResponseValidator =
     responseValidationFactory([["200", s_deleted_discount]], s_error)
 
@@ -69488,11 +67247,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.RouteParam,
         ),
         query: undefined,
-        body: parseRequestInput(
-          deleteSubscriptionsSubscriptionExposedIdDiscountBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -69918,8 +67673,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getTaxCalculationsCalculationBodySchema = z.object({}).optional()
-
   const getTaxCalculationsCalculationResponseValidator =
     responseValidationFactory([["200", s_tax_calculation]], s_error)
 
@@ -69938,11 +67691,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getTaxCalculationsCalculationBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -69994,10 +67743,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     starting_after: z.string().max(500).optional(),
   })
 
-  const getTaxCalculationsCalculationLineItemsBodySchema = z
-    .object({})
-    .optional()
-
   const getTaxCalculationsCalculationLineItemsResponseValidator =
     responseValidationFactory(
       [
@@ -70032,11 +67777,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getTaxCalculationsCalculationLineItemsBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -70093,8 +67834,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     status: z.enum(["active", "all", "expired", "scheduled"]).optional(),
   })
 
-  const getTaxRegistrationsBodySchema = z.object({}).optional()
-
   const getTaxRegistrationsResponseValidator = responseValidationFactory(
     [
       [
@@ -70121,11 +67860,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getTaxRegistrationsBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -70618,8 +68353,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getTaxRegistrationsIdBodySchema = z.object({}).optional()
-
   const getTaxRegistrationsIdResponseValidator = responseValidationFactory(
     [["200", s_tax_registration]],
     s_error,
@@ -70640,11 +68373,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getTaxRegistrationsIdBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -70757,8 +68486,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getTaxSettingsBodySchema = z.object({}).optional()
-
   const getTaxSettingsResponseValidator = responseValidationFactory(
     [["200", s_tax_settings]],
     s_error,
@@ -70772,11 +68499,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ctx.query,
         RequestInputType.QueryString,
       ),
-      body: parseRequestInput(
-        getTaxSettingsBodySchema,
-        Reflect.get(ctx.request, "body"),
-        RequestInputType.RequestBody,
-      ),
+      body: undefined,
       headers: undefined,
     }
 
@@ -71036,8 +68759,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getTaxTransactionsTransactionBodySchema = z.object({}).optional()
-
   const getTaxTransactionsTransactionResponseValidator =
     responseValidationFactory([["200", s_tax_transaction]], s_error)
 
@@ -71056,11 +68777,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getTaxTransactionsTransactionBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -71112,10 +68829,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     starting_after: z.string().max(500).optional(),
   })
 
-  const getTaxTransactionsTransactionLineItemsBodySchema = z
-    .object({})
-    .optional()
-
   const getTaxTransactionsTransactionLineItemsResponseValidator =
     responseValidationFactory(
       [
@@ -71150,11 +68863,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getTaxTransactionsTransactionLineItemsBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -71210,8 +68919,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     starting_after: z.string().optional(),
   })
 
-  const getTaxCodesBodySchema = z.object({}).optional()
-
   const getTaxCodesResponseValidator = responseValidationFactory(
     [
       [
@@ -71235,11 +68942,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ctx.query,
         RequestInputType.QueryString,
       ),
-      body: parseRequestInput(
-        getTaxCodesBodySchema,
-        Reflect.get(ctx.request, "body"),
-        RequestInputType.RequestBody,
-      ),
+      body: undefined,
       headers: undefined,
     }
 
@@ -71290,8 +68993,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getTaxCodesIdBodySchema = z.object({}).optional()
-
   const getTaxCodesIdResponseValidator = responseValidationFactory(
     [["200", s_tax_code]],
     s_error,
@@ -71309,11 +69010,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ctx.query,
         RequestInputType.QueryString,
       ),
-      body: parseRequestInput(
-        getTaxCodesIdBodySchema,
-        Reflect.get(ctx.request, "body"),
-        RequestInputType.RequestBody,
-      ),
+      body: undefined,
       headers: undefined,
     }
 
@@ -71367,8 +69064,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getTaxIdsBodySchema = z.object({}).optional()
-
   const getTaxIdsResponseValidator = responseValidationFactory(
     [
       [
@@ -71392,11 +69087,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ctx.query,
         RequestInputType.QueryString,
       ),
-      body: parseRequestInput(
-        getTaxIdsBodySchema,
-        Reflect.get(ctx.request, "body"),
-        RequestInputType.RequestBody,
-      ),
+      body: undefined,
       headers: undefined,
     }
 
@@ -71610,8 +69301,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   const deleteTaxIdsIdParamSchema = z.object({id: z.string().max(5000)})
 
-  const deleteTaxIdsIdBodySchema = z.object({}).optional()
-
   const deleteTaxIdsIdResponseValidator = responseValidationFactory(
     [["200", s_deleted_tax_id]],
     s_error,
@@ -71625,11 +69314,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         RequestInputType.RouteParam,
       ),
       query: undefined,
-      body: parseRequestInput(
-        deleteTaxIdsIdBodySchema,
-        Reflect.get(ctx.request, "body"),
-        RequestInputType.RequestBody,
-      ),
+      body: undefined,
       headers: undefined,
     }
 
@@ -71675,8 +69360,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getTaxIdsIdBodySchema = z.object({}).optional()
-
   const getTaxIdsIdResponseValidator = responseValidationFactory(
     [["200", s_tax_id]],
     s_error,
@@ -71694,11 +69377,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ctx.query,
         RequestInputType.QueryString,
       ),
-      body: parseRequestInput(
-        getTaxIdsIdBodySchema,
-        Reflect.get(ctx.request, "body"),
-        RequestInputType.RequestBody,
-      ),
+      body: undefined,
       headers: undefined,
     }
 
@@ -71758,8 +69437,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getTaxRatesBodySchema = z.object({}).optional()
-
   const getTaxRatesResponseValidator = responseValidationFactory(
     [
       [
@@ -71783,11 +69460,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ctx.query,
         RequestInputType.QueryString,
       ),
-      body: parseRequestInput(
-        getTaxRatesBodySchema,
-        Reflect.get(ctx.request, "body"),
-        RequestInputType.RequestBody,
-      ),
+      body: undefined,
       headers: undefined,
     }
 
@@ -71919,8 +69592,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getTaxRatesTaxRateBodySchema = z.object({}).optional()
-
   const getTaxRatesTaxRateResponseValidator = responseValidationFactory(
     [["200", s_tax_rate]],
     s_error,
@@ -71941,11 +69612,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getTaxRatesTaxRateBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -72085,8 +69752,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getTerminalConfigurationsBodySchema = z.object({}).optional()
-
   const getTerminalConfigurationsResponseValidator = responseValidationFactory(
     [
       [
@@ -72116,11 +69781,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getTerminalConfigurationsBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -72393,10 +70054,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     configuration: z.string().max(5000),
   })
 
-  const deleteTerminalConfigurationsConfigurationBodySchema = z
-    .object({})
-    .optional()
-
   const deleteTerminalConfigurationsConfigurationResponseValidator =
     responseValidationFactory(
       [["200", s_deleted_terminal_configuration]],
@@ -72414,11 +70071,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.RouteParam,
         ),
         query: undefined,
-        body: parseRequestInput(
-          deleteTerminalConfigurationsConfigurationBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -72470,10 +70123,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getTerminalConfigurationsConfigurationBodySchema = z
-    .object({})
-    .optional()
-
   const getTerminalConfigurationsConfigurationResponseValidator =
     responseValidationFactory(
       [
@@ -72503,11 +70152,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getTerminalConfigurationsConfigurationBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -72888,8 +70533,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getTerminalLocationsBodySchema = z.object({}).optional()
-
   const getTerminalLocationsResponseValidator = responseValidationFactory(
     [
       [
@@ -72919,11 +70562,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getTerminalLocationsBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -73035,8 +70674,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     location: z.string().max(5000),
   })
 
-  const deleteTerminalLocationsLocationBodySchema = z.object({}).optional()
-
   const deleteTerminalLocationsLocationResponseValidator =
     responseValidationFactory([["200", s_deleted_terminal_location]], s_error)
 
@@ -73051,11 +70688,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.RouteParam,
         ),
         query: undefined,
-        body: parseRequestInput(
-          deleteTerminalLocationsLocationBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -73104,8 +70737,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getTerminalLocationsLocationBodySchema = z.object({}).optional()
-
   const getTerminalLocationsLocationResponseValidator =
     responseValidationFactory(
       [["200", z.union([s_terminal_location, s_deleted_terminal_location])]],
@@ -73127,11 +70758,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getTerminalLocationsLocationBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -73281,8 +70908,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     status: z.enum(["offline", "online"]).optional(),
   })
 
-  const getTerminalReadersBodySchema = z.object({}).optional()
-
   const getTerminalReadersResponseValidator = responseValidationFactory(
     [
       [
@@ -73309,11 +70934,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getTerminalReadersBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -73418,8 +71039,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     reader: z.string().max(5000),
   })
 
-  const deleteTerminalReadersReaderBodySchema = z.object({}).optional()
-
   const deleteTerminalReadersReaderResponseValidator =
     responseValidationFactory([["200", s_deleted_terminal_reader]], s_error)
 
@@ -73434,11 +71053,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.RouteParam,
         ),
         query: undefined,
-        body: parseRequestInput(
-          deleteTerminalReadersReaderBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -73487,8 +71102,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getTerminalReadersReaderBodySchema = z.object({}).optional()
-
   const getTerminalReadersReaderResponseValidator = responseValidationFactory(
     [
       [
@@ -73514,11 +71127,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getTerminalReadersReaderBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -77909,8 +75518,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getTestHelpersTestClocksBodySchema = z.object({}).optional()
-
   const getTestHelpersTestClocksResponseValidator = responseValidationFactory(
     [
       [
@@ -77940,11 +75547,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getTestHelpersTestClocksBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -78047,8 +75650,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     test_clock: z.string().max(5000),
   })
 
-  const deleteTestHelpersTestClocksTestClockBodySchema = z.object({}).optional()
-
   const deleteTestHelpersTestClocksTestClockResponseValidator =
     responseValidationFactory(
       [["200", s_deleted_test_helpers_test_clock]],
@@ -78066,11 +75667,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.RouteParam,
         ),
         query: undefined,
-        body: parseRequestInput(
-          deleteTestHelpersTestClocksTestClockBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -78122,8 +75719,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getTestHelpersTestClocksTestClockBodySchema = z.object({}).optional()
-
   const getTestHelpersTestClocksTestClockResponseValidator =
     responseValidationFactory([["200", s_test_helpers_test_clock]], s_error)
 
@@ -78142,11 +75737,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getTestHelpersTestClocksTestClockBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -79792,8 +77383,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getTokensTokenBodySchema = z.object({}).optional()
-
   const getTokensTokenResponseValidator = responseValidationFactory(
     [["200", s_token]],
     s_error,
@@ -79811,11 +77400,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ctx.query,
         RequestInputType.QueryString,
       ),
-      body: parseRequestInput(
-        getTokensTokenBodySchema,
-        Reflect.get(ctx.request, "body"),
-        RequestInputType.RequestBody,
-      ),
+      body: undefined,
       headers: undefined,
     }
 
@@ -79885,8 +77470,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     status: z.enum(["canceled", "failed", "pending", "succeeded"]).optional(),
   })
 
-  const getTopupsBodySchema = z.object({}).optional()
-
   const getTopupsResponseValidator = responseValidationFactory(
     [
       [
@@ -79910,11 +77493,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ctx.query,
         RequestInputType.QueryString,
       ),
-      body: parseRequestInput(
-        getTopupsBodySchema,
-        Reflect.get(ctx.request, "body"),
-        RequestInputType.RequestBody,
-      ),
+      body: undefined,
       headers: undefined,
     }
 
@@ -80024,8 +77603,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getTopupsTopupBodySchema = z.object({}).optional()
-
   const getTopupsTopupResponseValidator = responseValidationFactory(
     [["200", s_topup]],
     s_error,
@@ -80043,11 +77620,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ctx.query,
         RequestInputType.QueryString,
       ),
-      body: parseRequestInput(
-        getTopupsTopupBodySchema,
-        Reflect.get(ctx.request, "body"),
-        RequestInputType.RequestBody,
-      ),
+      body: undefined,
       headers: undefined,
     }
 
@@ -80233,8 +77806,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     transfer_group: z.string().max(5000).optional(),
   })
 
-  const getTransfersBodySchema = z.object({}).optional()
-
   const getTransfersResponseValidator = responseValidationFactory(
     [
       [
@@ -80258,11 +77829,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ctx.query,
         RequestInputType.QueryString,
       ),
-      body: parseRequestInput(
-        getTransfersBodySchema,
-        Reflect.get(ctx.request, "body"),
-        RequestInputType.RequestBody,
-      ),
+      body: undefined,
       headers: undefined,
     }
 
@@ -80378,8 +77945,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getTransfersIdReversalsBodySchema = z.object({}).optional()
-
   const getTransfersIdReversalsResponseValidator = responseValidationFactory(
     [
       [
@@ -80410,11 +77975,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getTransfersIdReversalsBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -80538,8 +78099,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getTransfersTransferBodySchema = z.object({}).optional()
-
   const getTransfersTransferResponseValidator = responseValidationFactory(
     [["200", s_transfer]],
     s_error,
@@ -80560,11 +78119,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getTransfersTransferBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -80682,8 +78237,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getTransfersTransferReversalsIdBodySchema = z.object({}).optional()
-
   const getTransfersTransferReversalsIdResponseValidator =
     responseValidationFactory([["200", s_transfer_reversal]], s_error)
 
@@ -80702,11 +78255,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getTransfersTransferReversalsIdBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -80823,8 +78372,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     status: z.enum(["canceled", "posted", "processing"]).optional(),
   })
 
-  const getTreasuryCreditReversalsBodySchema = z.object({}).optional()
-
   const getTreasuryCreditReversalsResponseValidator = responseValidationFactory(
     [
       [
@@ -80851,11 +78398,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getTreasuryCreditReversalsBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -80965,10 +78508,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getTreasuryCreditReversalsCreditReversalBodySchema = z
-    .object({})
-    .optional()
-
   const getTreasuryCreditReversalsCreditReversalResponseValidator =
     responseValidationFactory([["200", s_treasury_credit_reversal]], s_error)
 
@@ -80987,11 +78526,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getTreasuryCreditReversalsCreditReversalBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -81046,8 +78581,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     status: z.enum(["canceled", "completed", "processing"]).optional(),
   })
 
-  const getTreasuryDebitReversalsBodySchema = z.object({}).optional()
-
   const getTreasuryDebitReversalsResponseValidator = responseValidationFactory(
     [
       [
@@ -81074,11 +78607,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getTreasuryDebitReversalsBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -81190,10 +78719,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getTreasuryDebitReversalsDebitReversalBodySchema = z
-    .object({})
-    .optional()
-
   const getTreasuryDebitReversalsDebitReversalResponseValidator =
     responseValidationFactory([["200", s_treasury_debit_reversal]], s_error)
 
@@ -81212,11 +78737,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getTreasuryDebitReversalsDebitReversalBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -81279,8 +78800,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     status: z.enum(["closed", "open"]).optional(),
   })
 
-  const getTreasuryFinancialAccountsBodySchema = z.object({}).optional()
-
   const getTreasuryFinancialAccountsResponseValidator =
     responseValidationFactory(
       [
@@ -81311,11 +78830,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getTreasuryFinancialAccountsBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -81461,10 +78976,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getTreasuryFinancialAccountsFinancialAccountBodySchema = z
-    .object({})
-    .optional()
-
   const getTreasuryFinancialAccountsFinancialAccountResponseValidator =
     responseValidationFactory([["200", s_treasury_financial_account]], s_error)
 
@@ -81483,11 +78994,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getTreasuryFinancialAccountsFinancialAccountBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -81743,10 +79250,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
         .optional(),
     })
 
-  const getTreasuryFinancialAccountsFinancialAccountFeaturesBodySchema = z
-    .object({})
-    .optional()
-
   const getTreasuryFinancialAccountsFinancialAccountFeaturesResponseValidator =
     responseValidationFactory(
       [["200", s_treasury_financial_account_features]],
@@ -81768,11 +79271,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getTreasuryFinancialAccountsFinancialAccountFeaturesBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -81933,8 +79432,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getTreasuryInboundTransfersBodySchema = z.object({}).optional()
-
   const getTreasuryInboundTransfersResponseValidator =
     responseValidationFactory(
       [
@@ -81962,11 +79459,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getTreasuryInboundTransfersBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -82081,8 +79574,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getTreasuryInboundTransfersIdBodySchema = z.object({}).optional()
-
   const getTreasuryInboundTransfersIdResponseValidator =
     responseValidationFactory([["200", s_treasury_inbound_transfer]], s_error)
 
@@ -82101,11 +79592,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getTreasuryInboundTransfersIdBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -82240,8 +79727,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getTreasuryOutboundPaymentsBodySchema = z.object({}).optional()
-
   const getTreasuryOutboundPaymentsResponseValidator =
     responseValidationFactory(
       [
@@ -82272,11 +79757,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getTreasuryOutboundPaymentsBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -82441,8 +79922,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getTreasuryOutboundPaymentsIdBodySchema = z.object({}).optional()
-
   const getTreasuryOutboundPaymentsIdResponseValidator =
     responseValidationFactory([["200", s_treasury_outbound_payment]], s_error)
 
@@ -82461,11 +79940,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getTreasuryOutboundPaymentsIdBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -82582,8 +80057,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getTreasuryOutboundTransfersBodySchema = z.object({}).optional()
-
   const getTreasuryOutboundTransfersResponseValidator =
     responseValidationFactory(
       [
@@ -82611,11 +80084,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getTreasuryOutboundTransfersBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -82746,10 +80215,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getTreasuryOutboundTransfersOutboundTransferBodySchema = z
-    .object({})
-    .optional()
-
   const getTreasuryOutboundTransfersOutboundTransferResponseValidator =
     responseValidationFactory([["200", s_treasury_outbound_transfer]], s_error)
 
@@ -82768,11 +80233,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getTreasuryOutboundTransfersOutboundTransferBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -82911,8 +80372,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     status: z.enum(["failed", "succeeded"]).optional(),
   })
 
-  const getTreasuryReceivedCreditsBodySchema = z.object({}).optional()
-
   const getTreasuryReceivedCreditsResponseValidator = responseValidationFactory(
     [
       [
@@ -82939,11 +80398,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getTreasuryReceivedCreditsBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -82997,8 +80452,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getTreasuryReceivedCreditsIdBodySchema = z.object({}).optional()
-
   const getTreasuryReceivedCreditsIdResponseValidator =
     responseValidationFactory([["200", s_treasury_received_credit]], s_error)
 
@@ -83017,11 +80470,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getTreasuryReceivedCreditsIdBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -83071,8 +80520,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     status: z.enum(["failed", "succeeded"]).optional(),
   })
 
-  const getTreasuryReceivedDebitsBodySchema = z.object({}).optional()
-
   const getTreasuryReceivedDebitsResponseValidator = responseValidationFactory(
     [
       [
@@ -83099,11 +80546,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getTreasuryReceivedDebitsBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -83157,8 +80600,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getTreasuryReceivedDebitsIdBodySchema = z.object({}).optional()
-
   const getTreasuryReceivedDebitsIdResponseValidator =
     responseValidationFactory([["200", s_treasury_received_debit]], s_error)
 
@@ -83177,11 +80618,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getTreasuryReceivedDebitsIdBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -83254,8 +80691,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     transaction: z.string().max(5000).optional(),
   })
 
-  const getTreasuryTransactionEntriesBodySchema = z.object({}).optional()
-
   const getTreasuryTransactionEntriesResponseValidator =
     responseValidationFactory(
       [
@@ -83286,11 +80721,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getTreasuryTransactionEntriesBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -83344,8 +80775,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getTreasuryTransactionEntriesIdBodySchema = z.object({}).optional()
-
   const getTreasuryTransactionEntriesIdResponseValidator =
     responseValidationFactory([["200", s_treasury_transaction_entry]], s_error)
 
@@ -83364,11 +80793,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getTreasuryTransactionEntriesIdBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -83445,8 +80870,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getTreasuryTransactionsBodySchema = z.object({}).optional()
-
   const getTreasuryTransactionsResponseValidator = responseValidationFactory(
     [
       [
@@ -83473,11 +80896,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getTreasuryTransactionsBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -83531,8 +80950,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getTreasuryTransactionsIdBodySchema = z.object({}).optional()
-
   const getTreasuryTransactionsIdResponseValidator = responseValidationFactory(
     [["200", s_treasury_transaction]],
     s_error,
@@ -83553,11 +80970,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getTreasuryTransactionsIdBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -83605,8 +81018,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     starting_after: z.string().max(5000).optional(),
   })
 
-  const getWebhookEndpointsBodySchema = z.object({}).optional()
-
   const getWebhookEndpointsResponseValidator = responseValidationFactory(
     [
       [
@@ -83633,11 +81044,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getWebhookEndpointsBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -84106,10 +81513,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
     webhook_endpoint: z.string().max(5000),
   })
 
-  const deleteWebhookEndpointsWebhookEndpointBodySchema = z
-    .object({})
-    .optional()
-
   const deleteWebhookEndpointsWebhookEndpointResponseValidator =
     responseValidationFactory([["200", s_deleted_webhook_endpoint]], s_error)
 
@@ -84124,11 +81527,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.RouteParam,
         ),
         query: undefined,
-        body: parseRequestInput(
-          deleteWebhookEndpointsWebhookEndpointBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 
@@ -84180,8 +81579,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
-  const getWebhookEndpointsWebhookEndpointBodySchema = z.object({}).optional()
-
   const getWebhookEndpointsWebhookEndpointResponseValidator =
     responseValidationFactory([["200", s_webhook_endpoint]], s_error)
 
@@ -84200,11 +81597,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ctx.query,
           RequestInputType.QueryString,
         ),
-        body: parseRequestInput(
-          getWebhookEndpointsWebhookEndpointBodySchema,
-          Reflect.get(ctx.request, "body"),
-          RequestInputType.RequestBody,
-        ),
+        body: undefined,
         headers: undefined,
       }
 

--- a/integration-tests/typescript-koa/src/generated/stripe.yaml/models.ts
+++ b/integration-tests/typescript-koa/src/generated/stripe.yaml/models.ts
@@ -14197,53 +14197,37 @@ export type t_webhook_endpoint = {
   url: string
 }
 
-export type t_DeleteAccountsAccountBodySchema = EmptyObject
-
 export type t_DeleteAccountsAccountParamSchema = {
   account: string
 }
-
-export type t_DeleteAccountsAccountBankAccountsIdBodySchema = EmptyObject
 
 export type t_DeleteAccountsAccountBankAccountsIdParamSchema = {
   account: string
   id: string
 }
 
-export type t_DeleteAccountsAccountExternalAccountsIdBodySchema = EmptyObject
-
 export type t_DeleteAccountsAccountExternalAccountsIdParamSchema = {
   account: string
   id: string
 }
-
-export type t_DeleteAccountsAccountPeoplePersonBodySchema = EmptyObject
 
 export type t_DeleteAccountsAccountPeoplePersonParamSchema = {
   account: string
   person: string
 }
 
-export type t_DeleteAccountsAccountPersonsPersonBodySchema = EmptyObject
-
 export type t_DeleteAccountsAccountPersonsPersonParamSchema = {
   account: string
   person: string
 }
 
-export type t_DeleteApplePayDomainsDomainBodySchema = EmptyObject
-
 export type t_DeleteApplePayDomainsDomainParamSchema = {
   domain: string
 }
 
-export type t_DeleteCouponsCouponBodySchema = EmptyObject
-
 export type t_DeleteCouponsCouponParamSchema = {
   coupon: string
 }
-
-export type t_DeleteCustomersCustomerBodySchema = EmptyObject
 
 export type t_DeleteCustomersCustomerParamSchema = {
   customer: string
@@ -14266,8 +14250,6 @@ export type t_DeleteCustomersCustomerCardsIdParamSchema = {
   customer: string
   id: string
 }
-
-export type t_DeleteCustomersCustomerDiscountBodySchema = EmptyObject
 
 export type t_DeleteCustomersCustomerDiscountParamSchema = {
   customer: string
@@ -14295,16 +14277,11 @@ export type t_DeleteCustomersCustomerSubscriptionsSubscriptionExposedIdParamSche
     subscription_exposed_id: string
   }
 
-export type t_DeleteCustomersCustomerSubscriptionsSubscriptionExposedIdDiscountBodySchema =
-  EmptyObject
-
 export type t_DeleteCustomersCustomerSubscriptionsSubscriptionExposedIdDiscountParamSchema =
   {
     customer: string
     subscription_exposed_id: string
   }
-
-export type t_DeleteCustomersCustomerTaxIdsIdBodySchema = EmptyObject
 
 export type t_DeleteCustomersCustomerTaxIdsIdParamSchema = {
   customer: string
@@ -14319,44 +14296,30 @@ export type t_DeleteEphemeralKeysKeyParamSchema = {
   key: string
 }
 
-export type t_DeleteInvoiceitemsInvoiceitemBodySchema = EmptyObject
-
 export type t_DeleteInvoiceitemsInvoiceitemParamSchema = {
   invoiceitem: string
 }
-
-export type t_DeleteInvoicesInvoiceBodySchema = EmptyObject
 
 export type t_DeleteInvoicesInvoiceParamSchema = {
   invoice: string
 }
 
-export type t_DeletePlansPlanBodySchema = EmptyObject
-
 export type t_DeletePlansPlanParamSchema = {
   plan: string
 }
 
-export type t_DeleteProductsIdBodySchema = EmptyObject
-
 export type t_DeleteProductsIdParamSchema = {
   id: string
 }
-
-export type t_DeleteProductsProductFeaturesIdBodySchema = EmptyObject
 
 export type t_DeleteProductsProductFeaturesIdParamSchema = {
   id: string
   product: string
 }
 
-export type t_DeleteRadarValueListItemsItemBodySchema = EmptyObject
-
 export type t_DeleteRadarValueListItemsItemParamSchema = {
   item: string
 }
-
-export type t_DeleteRadarValueListsValueListBodySchema = EmptyObject
 
 export type t_DeleteRadarValueListsValueListParamSchema = {
   value_list: string
@@ -14395,56 +14358,37 @@ export type t_DeleteSubscriptionsSubscriptionExposedIdParamSchema = {
   subscription_exposed_id: string
 }
 
-export type t_DeleteSubscriptionsSubscriptionExposedIdDiscountBodySchema =
-  EmptyObject
-
 export type t_DeleteSubscriptionsSubscriptionExposedIdDiscountParamSchema = {
   subscription_exposed_id: string
 }
-
-export type t_DeleteTaxIdsIdBodySchema = EmptyObject
 
 export type t_DeleteTaxIdsIdParamSchema = {
   id: string
 }
 
-export type t_DeleteTerminalConfigurationsConfigurationBodySchema = EmptyObject
-
 export type t_DeleteTerminalConfigurationsConfigurationParamSchema = {
   configuration: string
 }
-
-export type t_DeleteTerminalLocationsLocationBodySchema = EmptyObject
 
 export type t_DeleteTerminalLocationsLocationParamSchema = {
   location: string
 }
 
-export type t_DeleteTerminalReadersReaderBodySchema = EmptyObject
-
 export type t_DeleteTerminalReadersReaderParamSchema = {
   reader: string
 }
-
-export type t_DeleteTestHelpersTestClocksTestClockBodySchema = EmptyObject
 
 export type t_DeleteTestHelpersTestClocksTestClockParamSchema = {
   test_clock: string
 }
 
-export type t_DeleteWebhookEndpointsWebhookEndpointBodySchema = EmptyObject
-
 export type t_DeleteWebhookEndpointsWebhookEndpointParamSchema = {
   webhook_endpoint: string
 }
 
-export type t_GetAccountBodySchema = EmptyObject
-
 export type t_GetAccountQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetAccountsBodySchema = EmptyObject
 
 export type t_GetAccountsQuerySchema = {
   created?:
@@ -14461,8 +14405,6 @@ export type t_GetAccountsQuerySchema = {
   starting_after?: string
 }
 
-export type t_GetAccountsAccountBodySchema = EmptyObject
-
 export type t_GetAccountsAccountParamSchema = {
   account: string
 }
@@ -14470,8 +14412,6 @@ export type t_GetAccountsAccountParamSchema = {
 export type t_GetAccountsAccountQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetAccountsAccountBankAccountsIdBodySchema = EmptyObject
 
 export type t_GetAccountsAccountBankAccountsIdParamSchema = {
   account: string
@@ -14482,8 +14422,6 @@ export type t_GetAccountsAccountBankAccountsIdQuerySchema = {
   expand?: string[]
 }
 
-export type t_GetAccountsAccountCapabilitiesBodySchema = EmptyObject
-
 export type t_GetAccountsAccountCapabilitiesParamSchema = {
   account: string
 }
@@ -14491,8 +14429,6 @@ export type t_GetAccountsAccountCapabilitiesParamSchema = {
 export type t_GetAccountsAccountCapabilitiesQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetAccountsAccountCapabilitiesCapabilityBodySchema = EmptyObject
 
 export type t_GetAccountsAccountCapabilitiesCapabilityParamSchema = {
   account: string
@@ -14502,8 +14438,6 @@ export type t_GetAccountsAccountCapabilitiesCapabilityParamSchema = {
 export type t_GetAccountsAccountCapabilitiesCapabilityQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetAccountsAccountExternalAccountsBodySchema = EmptyObject
 
 export type t_GetAccountsAccountExternalAccountsParamSchema = {
   account: string
@@ -14517,8 +14451,6 @@ export type t_GetAccountsAccountExternalAccountsQuerySchema = {
   starting_after?: string
 }
 
-export type t_GetAccountsAccountExternalAccountsIdBodySchema = EmptyObject
-
 export type t_GetAccountsAccountExternalAccountsIdParamSchema = {
   account: string
   id: string
@@ -14527,8 +14459,6 @@ export type t_GetAccountsAccountExternalAccountsIdParamSchema = {
 export type t_GetAccountsAccountExternalAccountsIdQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetAccountsAccountPeopleBodySchema = EmptyObject
 
 export type t_GetAccountsAccountPeopleParamSchema = {
   account: string
@@ -14549,8 +14479,6 @@ export type t_GetAccountsAccountPeopleQuerySchema = {
   starting_after?: string
 }
 
-export type t_GetAccountsAccountPeoplePersonBodySchema = EmptyObject
-
 export type t_GetAccountsAccountPeoplePersonParamSchema = {
   account: string
   person: string
@@ -14559,8 +14487,6 @@ export type t_GetAccountsAccountPeoplePersonParamSchema = {
 export type t_GetAccountsAccountPeoplePersonQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetAccountsAccountPersonsBodySchema = EmptyObject
 
 export type t_GetAccountsAccountPersonsParamSchema = {
   account: string
@@ -14581,8 +14507,6 @@ export type t_GetAccountsAccountPersonsQuerySchema = {
   starting_after?: string
 }
 
-export type t_GetAccountsAccountPersonsPersonBodySchema = EmptyObject
-
 export type t_GetAccountsAccountPersonsPersonParamSchema = {
   account: string
   person: string
@@ -14592,8 +14516,6 @@ export type t_GetAccountsAccountPersonsPersonQuerySchema = {
   expand?: string[]
 }
 
-export type t_GetApplePayDomainsBodySchema = EmptyObject
-
 export type t_GetApplePayDomainsQuerySchema = {
   domain_name?: string
   ending_before?: string
@@ -14602,8 +14524,6 @@ export type t_GetApplePayDomainsQuerySchema = {
   starting_after?: string
 }
 
-export type t_GetApplePayDomainsDomainBodySchema = EmptyObject
-
 export type t_GetApplePayDomainsDomainParamSchema = {
   domain: string
 }
@@ -14611,8 +14531,6 @@ export type t_GetApplePayDomainsDomainParamSchema = {
 export type t_GetApplePayDomainsDomainQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetApplicationFeesBodySchema = EmptyObject
 
 export type t_GetApplicationFeesQuerySchema = {
   charge?: string
@@ -14630,8 +14548,6 @@ export type t_GetApplicationFeesQuerySchema = {
   starting_after?: string
 }
 
-export type t_GetApplicationFeesFeeRefundsIdBodySchema = EmptyObject
-
 export type t_GetApplicationFeesFeeRefundsIdParamSchema = {
   fee: string
   id: string
@@ -14641,8 +14557,6 @@ export type t_GetApplicationFeesFeeRefundsIdQuerySchema = {
   expand?: string[]
 }
 
-export type t_GetApplicationFeesIdBodySchema = EmptyObject
-
 export type t_GetApplicationFeesIdParamSchema = {
   id: string
 }
@@ -14650,8 +14564,6 @@ export type t_GetApplicationFeesIdParamSchema = {
 export type t_GetApplicationFeesIdQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetApplicationFeesIdRefundsBodySchema = EmptyObject
 
 export type t_GetApplicationFeesIdRefundsParamSchema = {
   id: string
@@ -14664,8 +14576,6 @@ export type t_GetApplicationFeesIdRefundsQuerySchema = {
   starting_after?: string
 }
 
-export type t_GetAppsSecretsBodySchema = EmptyObject
-
 export type t_GetAppsSecretsQuerySchema = {
   ending_before?: string
   expand?: string[]
@@ -14677,8 +14587,6 @@ export type t_GetAppsSecretsQuerySchema = {
   starting_after?: string
 }
 
-export type t_GetAppsSecretsFindBodySchema = EmptyObject
-
 export type t_GetAppsSecretsFindQuerySchema = {
   expand?: string[]
   name: string
@@ -14688,13 +14596,9 @@ export type t_GetAppsSecretsFindQuerySchema = {
   }
 }
 
-export type t_GetBalanceBodySchema = EmptyObject
-
 export type t_GetBalanceQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetBalanceHistoryBodySchema = EmptyObject
 
 export type t_GetBalanceHistoryQuerySchema = {
   created?:
@@ -14715,8 +14619,6 @@ export type t_GetBalanceHistoryQuerySchema = {
   type?: string
 }
 
-export type t_GetBalanceHistoryIdBodySchema = EmptyObject
-
 export type t_GetBalanceHistoryIdParamSchema = {
   id: string
 }
@@ -14724,8 +14626,6 @@ export type t_GetBalanceHistoryIdParamSchema = {
 export type t_GetBalanceHistoryIdQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetBalanceTransactionsBodySchema = EmptyObject
 
 export type t_GetBalanceTransactionsQuerySchema = {
   created?:
@@ -14746,8 +14646,6 @@ export type t_GetBalanceTransactionsQuerySchema = {
   type?: string
 }
 
-export type t_GetBalanceTransactionsIdBodySchema = EmptyObject
-
 export type t_GetBalanceTransactionsIdParamSchema = {
   id: string
 }
@@ -14755,8 +14653,6 @@ export type t_GetBalanceTransactionsIdParamSchema = {
 export type t_GetBalanceTransactionsIdQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetBillingAlertsBodySchema = EmptyObject
 
 export type t_GetBillingAlertsQuerySchema = {
   alert_type?: "usage_threshold"
@@ -14767,8 +14663,6 @@ export type t_GetBillingAlertsQuerySchema = {
   starting_after?: string
 }
 
-export type t_GetBillingAlertsIdBodySchema = EmptyObject
-
 export type t_GetBillingAlertsIdParamSchema = {
   id: string
 }
@@ -14776,8 +14670,6 @@ export type t_GetBillingAlertsIdParamSchema = {
 export type t_GetBillingAlertsIdQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetBillingCreditBalanceSummaryBodySchema = EmptyObject
 
 export type t_GetBillingCreditBalanceSummaryQuerySchema = {
   customer: string
@@ -14794,8 +14686,6 @@ export type t_GetBillingCreditBalanceSummaryQuerySchema = {
   }
 }
 
-export type t_GetBillingCreditBalanceTransactionsBodySchema = EmptyObject
-
 export type t_GetBillingCreditBalanceTransactionsQuerySchema = {
   credit_grant?: string
   customer: string
@@ -14805,8 +14695,6 @@ export type t_GetBillingCreditBalanceTransactionsQuerySchema = {
   starting_after?: string
 }
 
-export type t_GetBillingCreditBalanceTransactionsIdBodySchema = EmptyObject
-
 export type t_GetBillingCreditBalanceTransactionsIdParamSchema = {
   id: string
 }
@@ -14814,8 +14702,6 @@ export type t_GetBillingCreditBalanceTransactionsIdParamSchema = {
 export type t_GetBillingCreditBalanceTransactionsIdQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetBillingCreditGrantsBodySchema = EmptyObject
 
 export type t_GetBillingCreditGrantsQuerySchema = {
   customer?: string
@@ -14825,8 +14711,6 @@ export type t_GetBillingCreditGrantsQuerySchema = {
   starting_after?: string
 }
 
-export type t_GetBillingCreditGrantsIdBodySchema = EmptyObject
-
 export type t_GetBillingCreditGrantsIdParamSchema = {
   id: string
 }
@@ -14834,8 +14718,6 @@ export type t_GetBillingCreditGrantsIdParamSchema = {
 export type t_GetBillingCreditGrantsIdQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetBillingMetersBodySchema = EmptyObject
 
 export type t_GetBillingMetersQuerySchema = {
   ending_before?: string
@@ -14845,8 +14727,6 @@ export type t_GetBillingMetersQuerySchema = {
   status?: "active" | "inactive"
 }
 
-export type t_GetBillingMetersIdBodySchema = EmptyObject
-
 export type t_GetBillingMetersIdParamSchema = {
   id: string
 }
@@ -14854,8 +14734,6 @@ export type t_GetBillingMetersIdParamSchema = {
 export type t_GetBillingMetersIdQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetBillingMetersIdEventSummariesBodySchema = EmptyObject
 
 export type t_GetBillingMetersIdEventSummariesParamSchema = {
   id: string
@@ -14872,8 +14750,6 @@ export type t_GetBillingMetersIdEventSummariesQuerySchema = {
   value_grouping_window?: "day" | "hour"
 }
 
-export type t_GetBillingPortalConfigurationsBodySchema = EmptyObject
-
 export type t_GetBillingPortalConfigurationsQuerySchema = {
   active?: boolean
   ending_before?: string
@@ -14883,9 +14759,6 @@ export type t_GetBillingPortalConfigurationsQuerySchema = {
   starting_after?: string
 }
 
-export type t_GetBillingPortalConfigurationsConfigurationBodySchema =
-  EmptyObject
-
 export type t_GetBillingPortalConfigurationsConfigurationParamSchema = {
   configuration: string
 }
@@ -14893,8 +14766,6 @@ export type t_GetBillingPortalConfigurationsConfigurationParamSchema = {
 export type t_GetBillingPortalConfigurationsConfigurationQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetChargesBodySchema = EmptyObject
 
 export type t_GetChargesQuerySchema = {
   created?:
@@ -14914,8 +14785,6 @@ export type t_GetChargesQuerySchema = {
   transfer_group?: string
 }
 
-export type t_GetChargesChargeBodySchema = EmptyObject
-
 export type t_GetChargesChargeParamSchema = {
   charge: string
 }
@@ -14924,8 +14793,6 @@ export type t_GetChargesChargeQuerySchema = {
   expand?: string[]
 }
 
-export type t_GetChargesChargeDisputeBodySchema = EmptyObject
-
 export type t_GetChargesChargeDisputeParamSchema = {
   charge: string
 }
@@ -14933,8 +14800,6 @@ export type t_GetChargesChargeDisputeParamSchema = {
 export type t_GetChargesChargeDisputeQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetChargesChargeRefundsBodySchema = EmptyObject
 
 export type t_GetChargesChargeRefundsParamSchema = {
   charge: string
@@ -14947,8 +14812,6 @@ export type t_GetChargesChargeRefundsQuerySchema = {
   starting_after?: string
 }
 
-export type t_GetChargesChargeRefundsRefundBodySchema = EmptyObject
-
 export type t_GetChargesChargeRefundsRefundParamSchema = {
   charge: string
   refund: string
@@ -14958,16 +14821,12 @@ export type t_GetChargesChargeRefundsRefundQuerySchema = {
   expand?: string[]
 }
 
-export type t_GetChargesSearchBodySchema = EmptyObject
-
 export type t_GetChargesSearchQuerySchema = {
   expand?: string[]
   limit?: number
   page?: string
   query: string
 }
-
-export type t_GetCheckoutSessionsBodySchema = EmptyObject
 
 export type t_GetCheckoutSessionsQuerySchema = {
   created?:
@@ -14992,8 +14851,6 @@ export type t_GetCheckoutSessionsQuerySchema = {
   subscription?: string
 }
 
-export type t_GetCheckoutSessionsSessionBodySchema = EmptyObject
-
 export type t_GetCheckoutSessionsSessionParamSchema = {
   session: string
 }
@@ -15001,8 +14858,6 @@ export type t_GetCheckoutSessionsSessionParamSchema = {
 export type t_GetCheckoutSessionsSessionQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetCheckoutSessionsSessionLineItemsBodySchema = EmptyObject
 
 export type t_GetCheckoutSessionsSessionLineItemsParamSchema = {
   session: string
@@ -15015,16 +14870,12 @@ export type t_GetCheckoutSessionsSessionLineItemsQuerySchema = {
   starting_after?: string
 }
 
-export type t_GetClimateOrdersBodySchema = EmptyObject
-
 export type t_GetClimateOrdersQuerySchema = {
   ending_before?: string
   expand?: string[]
   limit?: number
   starting_after?: string
 }
-
-export type t_GetClimateOrdersOrderBodySchema = EmptyObject
 
 export type t_GetClimateOrdersOrderParamSchema = {
   order: string
@@ -15034,16 +14885,12 @@ export type t_GetClimateOrdersOrderQuerySchema = {
   expand?: string[]
 }
 
-export type t_GetClimateProductsBodySchema = EmptyObject
-
 export type t_GetClimateProductsQuerySchema = {
   ending_before?: string
   expand?: string[]
   limit?: number
   starting_after?: string
 }
-
-export type t_GetClimateProductsProductBodySchema = EmptyObject
 
 export type t_GetClimateProductsProductParamSchema = {
   product: string
@@ -15053,16 +14900,12 @@ export type t_GetClimateProductsProductQuerySchema = {
   expand?: string[]
 }
 
-export type t_GetClimateSuppliersBodySchema = EmptyObject
-
 export type t_GetClimateSuppliersQuerySchema = {
   ending_before?: string
   expand?: string[]
   limit?: number
   starting_after?: string
 }
-
-export type t_GetClimateSuppliersSupplierBodySchema = EmptyObject
 
 export type t_GetClimateSuppliersSupplierParamSchema = {
   supplier: string
@@ -15072,8 +14915,6 @@ export type t_GetClimateSuppliersSupplierQuerySchema = {
   expand?: string[]
 }
 
-export type t_GetConfirmationTokensConfirmationTokenBodySchema = EmptyObject
-
 export type t_GetConfirmationTokensConfirmationTokenParamSchema = {
   confirmation_token: string
 }
@@ -15082,16 +14923,12 @@ export type t_GetConfirmationTokensConfirmationTokenQuerySchema = {
   expand?: string[]
 }
 
-export type t_GetCountrySpecsBodySchema = EmptyObject
-
 export type t_GetCountrySpecsQuerySchema = {
   ending_before?: string
   expand?: string[]
   limit?: number
   starting_after?: string
 }
-
-export type t_GetCountrySpecsCountryBodySchema = EmptyObject
 
 export type t_GetCountrySpecsCountryParamSchema = {
   country: string
@@ -15100,8 +14937,6 @@ export type t_GetCountrySpecsCountryParamSchema = {
 export type t_GetCountrySpecsCountryQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetCouponsBodySchema = EmptyObject
 
 export type t_GetCouponsQuerySchema = {
   created?:
@@ -15118,8 +14953,6 @@ export type t_GetCouponsQuerySchema = {
   starting_after?: string
 }
 
-export type t_GetCouponsCouponBodySchema = EmptyObject
-
 export type t_GetCouponsCouponParamSchema = {
   coupon: string
 }
@@ -15127,8 +14960,6 @@ export type t_GetCouponsCouponParamSchema = {
 export type t_GetCouponsCouponQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetCreditNotesBodySchema = EmptyObject
 
 export type t_GetCreditNotesQuerySchema = {
   created?:
@@ -15147,8 +14978,6 @@ export type t_GetCreditNotesQuerySchema = {
   starting_after?: string
 }
 
-export type t_GetCreditNotesCreditNoteLinesBodySchema = EmptyObject
-
 export type t_GetCreditNotesCreditNoteLinesParamSchema = {
   credit_note: string
 }
@@ -15160,8 +14989,6 @@ export type t_GetCreditNotesCreditNoteLinesQuerySchema = {
   starting_after?: string
 }
 
-export type t_GetCreditNotesIdBodySchema = EmptyObject
-
 export type t_GetCreditNotesIdParamSchema = {
   id: string
 }
@@ -15169,8 +14996,6 @@ export type t_GetCreditNotesIdParamSchema = {
 export type t_GetCreditNotesIdQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetCreditNotesPreviewBodySchema = EmptyObject
 
 export type t_GetCreditNotesPreviewQuerySchema = {
   amount?: number
@@ -15215,8 +15040,6 @@ export type t_GetCreditNotesPreviewQuerySchema = {
     shipping_rate?: string
   }
 }
-
-export type t_GetCreditNotesPreviewLinesBodySchema = EmptyObject
 
 export type t_GetCreditNotesPreviewLinesQuerySchema = {
   amount?: number
@@ -15265,8 +15088,6 @@ export type t_GetCreditNotesPreviewLinesQuerySchema = {
   starting_after?: string
 }
 
-export type t_GetCustomersBodySchema = EmptyObject
-
 export type t_GetCustomersQuerySchema = {
   created?:
     | {
@@ -15284,8 +15105,6 @@ export type t_GetCustomersQuerySchema = {
   test_clock?: string
 }
 
-export type t_GetCustomersCustomerBodySchema = EmptyObject
-
 export type t_GetCustomersCustomerParamSchema = {
   customer: string
 }
@@ -15293,8 +15112,6 @@ export type t_GetCustomersCustomerParamSchema = {
 export type t_GetCustomersCustomerQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetCustomersCustomerBalanceTransactionsBodySchema = EmptyObject
 
 export type t_GetCustomersCustomerBalanceTransactionsParamSchema = {
   customer: string
@@ -15307,9 +15124,6 @@ export type t_GetCustomersCustomerBalanceTransactionsQuerySchema = {
   starting_after?: string
 }
 
-export type t_GetCustomersCustomerBalanceTransactionsTransactionBodySchema =
-  EmptyObject
-
 export type t_GetCustomersCustomerBalanceTransactionsTransactionParamSchema = {
   customer: string
   transaction: string
@@ -15318,8 +15132,6 @@ export type t_GetCustomersCustomerBalanceTransactionsTransactionParamSchema = {
 export type t_GetCustomersCustomerBalanceTransactionsTransactionQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetCustomersCustomerBankAccountsBodySchema = EmptyObject
 
 export type t_GetCustomersCustomerBankAccountsParamSchema = {
   customer: string
@@ -15332,8 +15144,6 @@ export type t_GetCustomersCustomerBankAccountsQuerySchema = {
   starting_after?: string
 }
 
-export type t_GetCustomersCustomerBankAccountsIdBodySchema = EmptyObject
-
 export type t_GetCustomersCustomerBankAccountsIdParamSchema = {
   customer: string
   id: string
@@ -15342,8 +15152,6 @@ export type t_GetCustomersCustomerBankAccountsIdParamSchema = {
 export type t_GetCustomersCustomerBankAccountsIdQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetCustomersCustomerCardsBodySchema = EmptyObject
 
 export type t_GetCustomersCustomerCardsParamSchema = {
   customer: string
@@ -15356,8 +15164,6 @@ export type t_GetCustomersCustomerCardsQuerySchema = {
   starting_after?: string
 }
 
-export type t_GetCustomersCustomerCardsIdBodySchema = EmptyObject
-
 export type t_GetCustomersCustomerCardsIdParamSchema = {
   customer: string
   id: string
@@ -15367,8 +15173,6 @@ export type t_GetCustomersCustomerCardsIdQuerySchema = {
   expand?: string[]
 }
 
-export type t_GetCustomersCustomerCashBalanceBodySchema = EmptyObject
-
 export type t_GetCustomersCustomerCashBalanceParamSchema = {
   customer: string
 }
@@ -15376,9 +15180,6 @@ export type t_GetCustomersCustomerCashBalanceParamSchema = {
 export type t_GetCustomersCustomerCashBalanceQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetCustomersCustomerCashBalanceTransactionsBodySchema =
-  EmptyObject
 
 export type t_GetCustomersCustomerCashBalanceTransactionsParamSchema = {
   customer: string
@@ -15391,9 +15192,6 @@ export type t_GetCustomersCustomerCashBalanceTransactionsQuerySchema = {
   starting_after?: string
 }
 
-export type t_GetCustomersCustomerCashBalanceTransactionsTransactionBodySchema =
-  EmptyObject
-
 export type t_GetCustomersCustomerCashBalanceTransactionsTransactionParamSchema =
   {
     customer: string
@@ -15405,8 +15203,6 @@ export type t_GetCustomersCustomerCashBalanceTransactionsTransactionQuerySchema 
     expand?: string[]
   }
 
-export type t_GetCustomersCustomerDiscountBodySchema = EmptyObject
-
 export type t_GetCustomersCustomerDiscountParamSchema = {
   customer: string
 }
@@ -15414,8 +15210,6 @@ export type t_GetCustomersCustomerDiscountParamSchema = {
 export type t_GetCustomersCustomerDiscountQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetCustomersCustomerPaymentMethodsBodySchema = EmptyObject
 
 export type t_GetCustomersCustomerPaymentMethodsParamSchema = {
   customer: string
@@ -15478,9 +15272,6 @@ export type t_GetCustomersCustomerPaymentMethodsQuerySchema = {
     | "zip"
 }
 
-export type t_GetCustomersCustomerPaymentMethodsPaymentMethodBodySchema =
-  EmptyObject
-
 export type t_GetCustomersCustomerPaymentMethodsPaymentMethodParamSchema = {
   customer: string
   payment_method: string
@@ -15489,8 +15280,6 @@ export type t_GetCustomersCustomerPaymentMethodsPaymentMethodParamSchema = {
 export type t_GetCustomersCustomerPaymentMethodsPaymentMethodQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetCustomersCustomerSourcesBodySchema = EmptyObject
 
 export type t_GetCustomersCustomerSourcesParamSchema = {
   customer: string
@@ -15504,8 +15293,6 @@ export type t_GetCustomersCustomerSourcesQuerySchema = {
   starting_after?: string
 }
 
-export type t_GetCustomersCustomerSourcesIdBodySchema = EmptyObject
-
 export type t_GetCustomersCustomerSourcesIdParamSchema = {
   customer: string
   id: string
@@ -15514,8 +15301,6 @@ export type t_GetCustomersCustomerSourcesIdParamSchema = {
 export type t_GetCustomersCustomerSourcesIdQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetCustomersCustomerSubscriptionsBodySchema = EmptyObject
 
 export type t_GetCustomersCustomerSubscriptionsParamSchema = {
   customer: string
@@ -15528,9 +15313,6 @@ export type t_GetCustomersCustomerSubscriptionsQuerySchema = {
   starting_after?: string
 }
 
-export type t_GetCustomersCustomerSubscriptionsSubscriptionExposedIdBodySchema =
-  EmptyObject
-
 export type t_GetCustomersCustomerSubscriptionsSubscriptionExposedIdParamSchema =
   {
     customer: string
@@ -15541,9 +15323,6 @@ export type t_GetCustomersCustomerSubscriptionsSubscriptionExposedIdQuerySchema 
   {
     expand?: string[]
   }
-
-export type t_GetCustomersCustomerSubscriptionsSubscriptionExposedIdDiscountBodySchema =
-  EmptyObject
 
 export type t_GetCustomersCustomerSubscriptionsSubscriptionExposedIdDiscountParamSchema =
   {
@@ -15556,8 +15335,6 @@ export type t_GetCustomersCustomerSubscriptionsSubscriptionExposedIdDiscountQuer
     expand?: string[]
   }
 
-export type t_GetCustomersCustomerTaxIdsBodySchema = EmptyObject
-
 export type t_GetCustomersCustomerTaxIdsParamSchema = {
   customer: string
 }
@@ -15569,8 +15346,6 @@ export type t_GetCustomersCustomerTaxIdsQuerySchema = {
   starting_after?: string
 }
 
-export type t_GetCustomersCustomerTaxIdsIdBodySchema = EmptyObject
-
 export type t_GetCustomersCustomerTaxIdsIdParamSchema = {
   customer: string
   id: string
@@ -15580,16 +15355,12 @@ export type t_GetCustomersCustomerTaxIdsIdQuerySchema = {
   expand?: string[]
 }
 
-export type t_GetCustomersSearchBodySchema = EmptyObject
-
 export type t_GetCustomersSearchQuerySchema = {
   expand?: string[]
   limit?: number
   page?: string
   query: string
 }
-
-export type t_GetDisputesBodySchema = EmptyObject
 
 export type t_GetDisputesQuerySchema = {
   charge?: string
@@ -15608,8 +15379,6 @@ export type t_GetDisputesQuerySchema = {
   starting_after?: string
 }
 
-export type t_GetDisputesDisputeBodySchema = EmptyObject
-
 export type t_GetDisputesDisputeParamSchema = {
   dispute: string
 }
@@ -15617,8 +15386,6 @@ export type t_GetDisputesDisputeParamSchema = {
 export type t_GetDisputesDisputeQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetEntitlementsActiveEntitlementsBodySchema = EmptyObject
 
 export type t_GetEntitlementsActiveEntitlementsQuerySchema = {
   customer: string
@@ -15628,8 +15395,6 @@ export type t_GetEntitlementsActiveEntitlementsQuerySchema = {
   starting_after?: string
 }
 
-export type t_GetEntitlementsActiveEntitlementsIdBodySchema = EmptyObject
-
 export type t_GetEntitlementsActiveEntitlementsIdParamSchema = {
   id: string
 }
@@ -15637,8 +15402,6 @@ export type t_GetEntitlementsActiveEntitlementsIdParamSchema = {
 export type t_GetEntitlementsActiveEntitlementsIdQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetEntitlementsFeaturesBodySchema = EmptyObject
 
 export type t_GetEntitlementsFeaturesQuerySchema = {
   archived?: boolean
@@ -15649,8 +15412,6 @@ export type t_GetEntitlementsFeaturesQuerySchema = {
   starting_after?: string
 }
 
-export type t_GetEntitlementsFeaturesIdBodySchema = EmptyObject
-
 export type t_GetEntitlementsFeaturesIdParamSchema = {
   id: string
 }
@@ -15658,8 +15419,6 @@ export type t_GetEntitlementsFeaturesIdParamSchema = {
 export type t_GetEntitlementsFeaturesIdQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetEventsBodySchema = EmptyObject
 
 export type t_GetEventsQuerySchema = {
   created?:
@@ -15679,8 +15438,6 @@ export type t_GetEventsQuerySchema = {
   types?: string[]
 }
 
-export type t_GetEventsIdBodySchema = EmptyObject
-
 export type t_GetEventsIdParamSchema = {
   id: string
 }
@@ -15689,16 +15446,12 @@ export type t_GetEventsIdQuerySchema = {
   expand?: string[]
 }
 
-export type t_GetExchangeRatesBodySchema = EmptyObject
-
 export type t_GetExchangeRatesQuerySchema = {
   ending_before?: string
   expand?: string[]
   limit?: number
   starting_after?: string
 }
-
-export type t_GetExchangeRatesRateIdBodySchema = EmptyObject
 
 export type t_GetExchangeRatesRateIdParamSchema = {
   rate_id: string
@@ -15707,8 +15460,6 @@ export type t_GetExchangeRatesRateIdParamSchema = {
 export type t_GetExchangeRatesRateIdQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetFileLinksBodySchema = EmptyObject
 
 export type t_GetFileLinksQuerySchema = {
   created?:
@@ -15727,8 +15478,6 @@ export type t_GetFileLinksQuerySchema = {
   starting_after?: string
 }
 
-export type t_GetFileLinksLinkBodySchema = EmptyObject
-
 export type t_GetFileLinksLinkParamSchema = {
   link: string
 }
@@ -15736,8 +15485,6 @@ export type t_GetFileLinksLinkParamSchema = {
 export type t_GetFileLinksLinkQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetFilesBodySchema = EmptyObject
 
 export type t_GetFilesQuerySchema = {
   created?:
@@ -15772,8 +15519,6 @@ export type t_GetFilesQuerySchema = {
   starting_after?: string
 }
 
-export type t_GetFilesFileBodySchema = EmptyObject
-
 export type t_GetFilesFileParamSchema = {
   file: string
 }
@@ -15781,8 +15526,6 @@ export type t_GetFilesFileParamSchema = {
 export type t_GetFilesFileQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetFinancialConnectionsAccountsBodySchema = EmptyObject
 
 export type t_GetFinancialConnectionsAccountsQuerySchema = {
   account_holder?: {
@@ -15796,8 +15539,6 @@ export type t_GetFinancialConnectionsAccountsQuerySchema = {
   starting_after?: string
 }
 
-export type t_GetFinancialConnectionsAccountsAccountBodySchema = EmptyObject
-
 export type t_GetFinancialConnectionsAccountsAccountParamSchema = {
   account: string
 }
@@ -15805,9 +15546,6 @@ export type t_GetFinancialConnectionsAccountsAccountParamSchema = {
 export type t_GetFinancialConnectionsAccountsAccountQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetFinancialConnectionsAccountsAccountOwnersBodySchema =
-  EmptyObject
 
 export type t_GetFinancialConnectionsAccountsAccountOwnersParamSchema = {
   account: string
@@ -15821,8 +15559,6 @@ export type t_GetFinancialConnectionsAccountsAccountOwnersQuerySchema = {
   starting_after?: string
 }
 
-export type t_GetFinancialConnectionsSessionsSessionBodySchema = EmptyObject
-
 export type t_GetFinancialConnectionsSessionsSessionParamSchema = {
   session: string
 }
@@ -15830,8 +15566,6 @@ export type t_GetFinancialConnectionsSessionsSessionParamSchema = {
 export type t_GetFinancialConnectionsSessionsSessionQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetFinancialConnectionsTransactionsBodySchema = EmptyObject
 
 export type t_GetFinancialConnectionsTransactionsQuerySchema = {
   account: string
@@ -15852,9 +15586,6 @@ export type t_GetFinancialConnectionsTransactionsQuerySchema = {
   }
 }
 
-export type t_GetFinancialConnectionsTransactionsTransactionBodySchema =
-  EmptyObject
-
 export type t_GetFinancialConnectionsTransactionsTransactionParamSchema = {
   transaction: string
 }
@@ -15862,8 +15593,6 @@ export type t_GetFinancialConnectionsTransactionsTransactionParamSchema = {
 export type t_GetFinancialConnectionsTransactionsTransactionQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetForwardingRequestsBodySchema = EmptyObject
 
 export type t_GetForwardingRequestsQuerySchema = {
   created?: {
@@ -15878,8 +15607,6 @@ export type t_GetForwardingRequestsQuerySchema = {
   starting_after?: string
 }
 
-export type t_GetForwardingRequestsIdBodySchema = EmptyObject
-
 export type t_GetForwardingRequestsIdParamSchema = {
   id: string
 }
@@ -15887,8 +15614,6 @@ export type t_GetForwardingRequestsIdParamSchema = {
 export type t_GetForwardingRequestsIdQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetIdentityVerificationReportsBodySchema = EmptyObject
 
 export type t_GetIdentityVerificationReportsQuerySchema = {
   client_reference_id?: string
@@ -15908,8 +15633,6 @@ export type t_GetIdentityVerificationReportsQuerySchema = {
   verification_session?: string
 }
 
-export type t_GetIdentityVerificationReportsReportBodySchema = EmptyObject
-
 export type t_GetIdentityVerificationReportsReportParamSchema = {
   report: string
 }
@@ -15917,8 +15640,6 @@ export type t_GetIdentityVerificationReportsReportParamSchema = {
 export type t_GetIdentityVerificationReportsReportQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetIdentityVerificationSessionsBodySchema = EmptyObject
 
 export type t_GetIdentityVerificationSessionsQuerySchema = {
   client_reference_id?: string
@@ -15938,8 +15659,6 @@ export type t_GetIdentityVerificationSessionsQuerySchema = {
   status?: "canceled" | "processing" | "requires_input" | "verified"
 }
 
-export type t_GetIdentityVerificationSessionsSessionBodySchema = EmptyObject
-
 export type t_GetIdentityVerificationSessionsSessionParamSchema = {
   session: string
 }
@@ -15947,8 +15666,6 @@ export type t_GetIdentityVerificationSessionsSessionParamSchema = {
 export type t_GetIdentityVerificationSessionsSessionQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetInvoicePaymentsBodySchema = EmptyObject
 
 export type t_GetInvoicePaymentsQuerySchema = {
   ending_before?: string
@@ -15963,8 +15680,6 @@ export type t_GetInvoicePaymentsQuerySchema = {
   status?: "canceled" | "open" | "paid"
 }
 
-export type t_GetInvoicePaymentsInvoicePaymentBodySchema = EmptyObject
-
 export type t_GetInvoicePaymentsInvoicePaymentParamSchema = {
   invoice_payment: string
 }
@@ -15972,8 +15687,6 @@ export type t_GetInvoicePaymentsInvoicePaymentParamSchema = {
 export type t_GetInvoicePaymentsInvoicePaymentQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetInvoiceRenderingTemplatesBodySchema = EmptyObject
 
 export type t_GetInvoiceRenderingTemplatesQuerySchema = {
   ending_before?: string
@@ -15983,8 +15696,6 @@ export type t_GetInvoiceRenderingTemplatesQuerySchema = {
   status?: "active" | "archived"
 }
 
-export type t_GetInvoiceRenderingTemplatesTemplateBodySchema = EmptyObject
-
 export type t_GetInvoiceRenderingTemplatesTemplateParamSchema = {
   template: string
 }
@@ -15993,8 +15704,6 @@ export type t_GetInvoiceRenderingTemplatesTemplateQuerySchema = {
   expand?: string[]
   version?: number
 }
-
-export type t_GetInvoiceitemsBodySchema = EmptyObject
 
 export type t_GetInvoiceitemsQuerySchema = {
   created?:
@@ -16014,8 +15723,6 @@ export type t_GetInvoiceitemsQuerySchema = {
   starting_after?: string
 }
 
-export type t_GetInvoiceitemsInvoiceitemBodySchema = EmptyObject
-
 export type t_GetInvoiceitemsInvoiceitemParamSchema = {
   invoiceitem: string
 }
@@ -16023,8 +15730,6 @@ export type t_GetInvoiceitemsInvoiceitemParamSchema = {
 export type t_GetInvoiceitemsInvoiceitemQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetInvoicesBodySchema = EmptyObject
 
 export type t_GetInvoicesQuerySchema = {
   collection_method?: "charge_automatically" | "send_invoice"
@@ -16053,8 +15758,6 @@ export type t_GetInvoicesQuerySchema = {
   subscription?: string
 }
 
-export type t_GetInvoicesInvoiceBodySchema = EmptyObject
-
 export type t_GetInvoicesInvoiceParamSchema = {
   invoice: string
 }
@@ -16062,8 +15765,6 @@ export type t_GetInvoicesInvoiceParamSchema = {
 export type t_GetInvoicesInvoiceQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetInvoicesInvoiceLinesBodySchema = EmptyObject
 
 export type t_GetInvoicesInvoiceLinesParamSchema = {
   invoice: string
@@ -16076,16 +15777,12 @@ export type t_GetInvoicesInvoiceLinesQuerySchema = {
   starting_after?: string
 }
 
-export type t_GetInvoicesSearchBodySchema = EmptyObject
-
 export type t_GetInvoicesSearchQuerySchema = {
   expand?: string[]
   limit?: number
   page?: string
   query: string
 }
-
-export type t_GetIssuingAuthorizationsBodySchema = EmptyObject
 
 export type t_GetIssuingAuthorizationsQuerySchema = {
   card?: string
@@ -16105,8 +15802,6 @@ export type t_GetIssuingAuthorizationsQuerySchema = {
   status?: "closed" | "expired" | "pending" | "reversed"
 }
 
-export type t_GetIssuingAuthorizationsAuthorizationBodySchema = EmptyObject
-
 export type t_GetIssuingAuthorizationsAuthorizationParamSchema = {
   authorization: string
 }
@@ -16114,8 +15809,6 @@ export type t_GetIssuingAuthorizationsAuthorizationParamSchema = {
 export type t_GetIssuingAuthorizationsAuthorizationQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetIssuingCardholdersBodySchema = EmptyObject
 
 export type t_GetIssuingCardholdersQuerySchema = {
   created?:
@@ -16136,8 +15829,6 @@ export type t_GetIssuingCardholdersQuerySchema = {
   type?: "company" | "individual"
 }
 
-export type t_GetIssuingCardholdersCardholderBodySchema = EmptyObject
-
 export type t_GetIssuingCardholdersCardholderParamSchema = {
   cardholder: string
 }
@@ -16145,8 +15836,6 @@ export type t_GetIssuingCardholdersCardholderParamSchema = {
 export type t_GetIssuingCardholdersCardholderQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetIssuingCardsBodySchema = EmptyObject
 
 export type t_GetIssuingCardsQuerySchema = {
   cardholder?: string
@@ -16170,8 +15859,6 @@ export type t_GetIssuingCardsQuerySchema = {
   type?: "physical" | "virtual"
 }
 
-export type t_GetIssuingCardsCardBodySchema = EmptyObject
-
 export type t_GetIssuingCardsCardParamSchema = {
   card: string
 }
@@ -16179,8 +15866,6 @@ export type t_GetIssuingCardsCardParamSchema = {
 export type t_GetIssuingCardsCardQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetIssuingDisputesBodySchema = EmptyObject
 
 export type t_GetIssuingDisputesQuerySchema = {
   created?:
@@ -16199,8 +15884,6 @@ export type t_GetIssuingDisputesQuerySchema = {
   transaction?: string
 }
 
-export type t_GetIssuingDisputesDisputeBodySchema = EmptyObject
-
 export type t_GetIssuingDisputesDisputeParamSchema = {
   dispute: string
 }
@@ -16208,8 +15891,6 @@ export type t_GetIssuingDisputesDisputeParamSchema = {
 export type t_GetIssuingDisputesDisputeQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetIssuingPersonalizationDesignsBodySchema = EmptyObject
 
 export type t_GetIssuingPersonalizationDesignsQuerySchema = {
   ending_before?: string
@@ -16224,9 +15905,6 @@ export type t_GetIssuingPersonalizationDesignsQuerySchema = {
   status?: "active" | "inactive" | "rejected" | "review"
 }
 
-export type t_GetIssuingPersonalizationDesignsPersonalizationDesignBodySchema =
-  EmptyObject
-
 export type t_GetIssuingPersonalizationDesignsPersonalizationDesignParamSchema =
   {
     personalization_design: string
@@ -16237,8 +15915,6 @@ export type t_GetIssuingPersonalizationDesignsPersonalizationDesignQuerySchema =
     expand?: string[]
   }
 
-export type t_GetIssuingPhysicalBundlesBodySchema = EmptyObject
-
 export type t_GetIssuingPhysicalBundlesQuerySchema = {
   ending_before?: string
   expand?: string[]
@@ -16248,8 +15924,6 @@ export type t_GetIssuingPhysicalBundlesQuerySchema = {
   type?: "custom" | "standard"
 }
 
-export type t_GetIssuingPhysicalBundlesPhysicalBundleBodySchema = EmptyObject
-
 export type t_GetIssuingPhysicalBundlesPhysicalBundleParamSchema = {
   physical_bundle: string
 }
@@ -16258,8 +15932,6 @@ export type t_GetIssuingPhysicalBundlesPhysicalBundleQuerySchema = {
   expand?: string[]
 }
 
-export type t_GetIssuingSettlementsSettlementBodySchema = EmptyObject
-
 export type t_GetIssuingSettlementsSettlementParamSchema = {
   settlement: string
 }
@@ -16267,8 +15939,6 @@ export type t_GetIssuingSettlementsSettlementParamSchema = {
 export type t_GetIssuingSettlementsSettlementQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetIssuingTokensBodySchema = EmptyObject
 
 export type t_GetIssuingTokensQuerySchema = {
   card: string
@@ -16287,8 +15957,6 @@ export type t_GetIssuingTokensQuerySchema = {
   status?: "active" | "deleted" | "requested" | "suspended"
 }
 
-export type t_GetIssuingTokensTokenBodySchema = EmptyObject
-
 export type t_GetIssuingTokensTokenParamSchema = {
   token: string
 }
@@ -16296,8 +15964,6 @@ export type t_GetIssuingTokensTokenParamSchema = {
 export type t_GetIssuingTokensTokenQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetIssuingTransactionsBodySchema = EmptyObject
 
 export type t_GetIssuingTransactionsQuerySchema = {
   card?: string
@@ -16317,8 +15983,6 @@ export type t_GetIssuingTransactionsQuerySchema = {
   type?: "capture" | "refund"
 }
 
-export type t_GetIssuingTransactionsTransactionBodySchema = EmptyObject
-
 export type t_GetIssuingTransactionsTransactionParamSchema = {
   transaction: string
 }
@@ -16327,8 +15991,6 @@ export type t_GetIssuingTransactionsTransactionQuerySchema = {
   expand?: string[]
 }
 
-export type t_GetLinkAccountSessionsSessionBodySchema = EmptyObject
-
 export type t_GetLinkAccountSessionsSessionParamSchema = {
   session: string
 }
@@ -16336,8 +15998,6 @@ export type t_GetLinkAccountSessionsSessionParamSchema = {
 export type t_GetLinkAccountSessionsSessionQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetLinkedAccountsBodySchema = EmptyObject
 
 export type t_GetLinkedAccountsQuerySchema = {
   account_holder?: {
@@ -16351,8 +16011,6 @@ export type t_GetLinkedAccountsQuerySchema = {
   starting_after?: string
 }
 
-export type t_GetLinkedAccountsAccountBodySchema = EmptyObject
-
 export type t_GetLinkedAccountsAccountParamSchema = {
   account: string
 }
@@ -16360,8 +16018,6 @@ export type t_GetLinkedAccountsAccountParamSchema = {
 export type t_GetLinkedAccountsAccountQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetLinkedAccountsAccountOwnersBodySchema = EmptyObject
 
 export type t_GetLinkedAccountsAccountOwnersParamSchema = {
   account: string
@@ -16375,8 +16031,6 @@ export type t_GetLinkedAccountsAccountOwnersQuerySchema = {
   starting_after?: string
 }
 
-export type t_GetMandatesMandateBodySchema = EmptyObject
-
 export type t_GetMandatesMandateParamSchema = {
   mandate: string
 }
@@ -16384,8 +16038,6 @@ export type t_GetMandatesMandateParamSchema = {
 export type t_GetMandatesMandateQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetPaymentIntentsBodySchema = EmptyObject
 
 export type t_GetPaymentIntentsQuerySchema = {
   created?:
@@ -16403,8 +16055,6 @@ export type t_GetPaymentIntentsQuerySchema = {
   starting_after?: string
 }
 
-export type t_GetPaymentIntentsIntentBodySchema = EmptyObject
-
 export type t_GetPaymentIntentsIntentParamSchema = {
   intent: string
 }
@@ -16414,16 +16064,12 @@ export type t_GetPaymentIntentsIntentQuerySchema = {
   expand?: string[]
 }
 
-export type t_GetPaymentIntentsSearchBodySchema = EmptyObject
-
 export type t_GetPaymentIntentsSearchQuerySchema = {
   expand?: string[]
   limit?: number
   page?: string
   query: string
 }
-
-export type t_GetPaymentLinksBodySchema = EmptyObject
 
 export type t_GetPaymentLinksQuerySchema = {
   active?: boolean
@@ -16433,8 +16079,6 @@ export type t_GetPaymentLinksQuerySchema = {
   starting_after?: string
 }
 
-export type t_GetPaymentLinksPaymentLinkBodySchema = EmptyObject
-
 export type t_GetPaymentLinksPaymentLinkParamSchema = {
   payment_link: string
 }
@@ -16442,8 +16086,6 @@ export type t_GetPaymentLinksPaymentLinkParamSchema = {
 export type t_GetPaymentLinksPaymentLinkQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetPaymentLinksPaymentLinkLineItemsBodySchema = EmptyObject
 
 export type t_GetPaymentLinksPaymentLinkLineItemsParamSchema = {
   payment_link: string
@@ -16456,8 +16098,6 @@ export type t_GetPaymentLinksPaymentLinkLineItemsQuerySchema = {
   starting_after?: string
 }
 
-export type t_GetPaymentMethodConfigurationsBodySchema = EmptyObject
-
 export type t_GetPaymentMethodConfigurationsQuerySchema = {
   application?: string | ""
   ending_before?: string
@@ -16466,9 +16106,6 @@ export type t_GetPaymentMethodConfigurationsQuerySchema = {
   starting_after?: string
 }
 
-export type t_GetPaymentMethodConfigurationsConfigurationBodySchema =
-  EmptyObject
-
 export type t_GetPaymentMethodConfigurationsConfigurationParamSchema = {
   configuration: string
 }
@@ -16476,8 +16113,6 @@ export type t_GetPaymentMethodConfigurationsConfigurationParamSchema = {
 export type t_GetPaymentMethodConfigurationsConfigurationQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetPaymentMethodDomainsBodySchema = EmptyObject
 
 export type t_GetPaymentMethodDomainsQuerySchema = {
   domain_name?: string
@@ -16488,8 +16123,6 @@ export type t_GetPaymentMethodDomainsQuerySchema = {
   starting_after?: string
 }
 
-export type t_GetPaymentMethodDomainsPaymentMethodDomainBodySchema = EmptyObject
-
 export type t_GetPaymentMethodDomainsPaymentMethodDomainParamSchema = {
   payment_method_domain: string
 }
@@ -16497,8 +16130,6 @@ export type t_GetPaymentMethodDomainsPaymentMethodDomainParamSchema = {
 export type t_GetPaymentMethodDomainsPaymentMethodDomainQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetPaymentMethodsBodySchema = EmptyObject
 
 export type t_GetPaymentMethodsQuerySchema = {
   customer?: string
@@ -16557,8 +16188,6 @@ export type t_GetPaymentMethodsQuerySchema = {
     | "zip"
 }
 
-export type t_GetPaymentMethodsPaymentMethodBodySchema = EmptyObject
-
 export type t_GetPaymentMethodsPaymentMethodParamSchema = {
   payment_method: string
 }
@@ -16566,8 +16195,6 @@ export type t_GetPaymentMethodsPaymentMethodParamSchema = {
 export type t_GetPaymentMethodsPaymentMethodQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetPayoutsBodySchema = EmptyObject
 
 export type t_GetPayoutsQuerySchema = {
   arrival_date?:
@@ -16594,8 +16221,6 @@ export type t_GetPayoutsQuerySchema = {
   status?: string
 }
 
-export type t_GetPayoutsPayoutBodySchema = EmptyObject
-
 export type t_GetPayoutsPayoutParamSchema = {
   payout: string
 }
@@ -16603,8 +16228,6 @@ export type t_GetPayoutsPayoutParamSchema = {
 export type t_GetPayoutsPayoutQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetPlansBodySchema = EmptyObject
 
 export type t_GetPlansQuerySchema = {
   active?: boolean
@@ -16623,8 +16246,6 @@ export type t_GetPlansQuerySchema = {
   starting_after?: string
 }
 
-export type t_GetPlansPlanBodySchema = EmptyObject
-
 export type t_GetPlansPlanParamSchema = {
   plan: string
 }
@@ -16632,8 +16253,6 @@ export type t_GetPlansPlanParamSchema = {
 export type t_GetPlansPlanQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetPricesBodySchema = EmptyObject
 
 export type t_GetPricesQuerySchema = {
   active?: boolean
@@ -16660,8 +16279,6 @@ export type t_GetPricesQuerySchema = {
   type?: "one_time" | "recurring"
 }
 
-export type t_GetPricesPriceBodySchema = EmptyObject
-
 export type t_GetPricesPriceParamSchema = {
   price: string
 }
@@ -16670,16 +16287,12 @@ export type t_GetPricesPriceQuerySchema = {
   expand?: string[]
 }
 
-export type t_GetPricesSearchBodySchema = EmptyObject
-
 export type t_GetPricesSearchQuerySchema = {
   expand?: string[]
   limit?: number
   page?: string
   query: string
 }
-
-export type t_GetProductsBodySchema = EmptyObject
 
 export type t_GetProductsQuerySchema = {
   active?: boolean
@@ -16700,8 +16313,6 @@ export type t_GetProductsQuerySchema = {
   url?: string
 }
 
-export type t_GetProductsIdBodySchema = EmptyObject
-
 export type t_GetProductsIdParamSchema = {
   id: string
 }
@@ -16709,8 +16320,6 @@ export type t_GetProductsIdParamSchema = {
 export type t_GetProductsIdQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetProductsProductFeaturesBodySchema = EmptyObject
 
 export type t_GetProductsProductFeaturesParamSchema = {
   product: string
@@ -16723,8 +16332,6 @@ export type t_GetProductsProductFeaturesQuerySchema = {
   starting_after?: string
 }
 
-export type t_GetProductsProductFeaturesIdBodySchema = EmptyObject
-
 export type t_GetProductsProductFeaturesIdParamSchema = {
   id: string
   product: string
@@ -16734,16 +16341,12 @@ export type t_GetProductsProductFeaturesIdQuerySchema = {
   expand?: string[]
 }
 
-export type t_GetProductsSearchBodySchema = EmptyObject
-
 export type t_GetProductsSearchQuerySchema = {
   expand?: string[]
   limit?: number
   page?: string
   query: string
 }
-
-export type t_GetPromotionCodesBodySchema = EmptyObject
 
 export type t_GetPromotionCodesQuerySchema = {
   active?: boolean
@@ -16764,8 +16367,6 @@ export type t_GetPromotionCodesQuerySchema = {
   starting_after?: string
 }
 
-export type t_GetPromotionCodesPromotionCodeBodySchema = EmptyObject
-
 export type t_GetPromotionCodesPromotionCodeParamSchema = {
   promotion_code: string
 }
@@ -16773,8 +16374,6 @@ export type t_GetPromotionCodesPromotionCodeParamSchema = {
 export type t_GetPromotionCodesPromotionCodeQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetQuotesBodySchema = EmptyObject
 
 export type t_GetQuotesQuerySchema = {
   customer?: string
@@ -16786,8 +16385,6 @@ export type t_GetQuotesQuerySchema = {
   test_clock?: string
 }
 
-export type t_GetQuotesQuoteBodySchema = EmptyObject
-
 export type t_GetQuotesQuoteParamSchema = {
   quote: string
 }
@@ -16795,8 +16392,6 @@ export type t_GetQuotesQuoteParamSchema = {
 export type t_GetQuotesQuoteQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetQuotesQuoteComputedUpfrontLineItemsBodySchema = EmptyObject
 
 export type t_GetQuotesQuoteComputedUpfrontLineItemsParamSchema = {
   quote: string
@@ -16809,8 +16404,6 @@ export type t_GetQuotesQuoteComputedUpfrontLineItemsQuerySchema = {
   starting_after?: string
 }
 
-export type t_GetQuotesQuoteLineItemsBodySchema = EmptyObject
-
 export type t_GetQuotesQuoteLineItemsParamSchema = {
   quote: string
 }
@@ -16822,8 +16415,6 @@ export type t_GetQuotesQuoteLineItemsQuerySchema = {
   starting_after?: string
 }
 
-export type t_GetQuotesQuotePdfBodySchema = EmptyObject
-
 export type t_GetQuotesQuotePdfParamSchema = {
   quote: string
 }
@@ -16831,8 +16422,6 @@ export type t_GetQuotesQuotePdfParamSchema = {
 export type t_GetQuotesQuotePdfQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetRadarEarlyFraudWarningsBodySchema = EmptyObject
 
 export type t_GetRadarEarlyFraudWarningsQuerySchema = {
   charge?: string
@@ -16851,9 +16440,6 @@ export type t_GetRadarEarlyFraudWarningsQuerySchema = {
   starting_after?: string
 }
 
-export type t_GetRadarEarlyFraudWarningsEarlyFraudWarningBodySchema =
-  EmptyObject
-
 export type t_GetRadarEarlyFraudWarningsEarlyFraudWarningParamSchema = {
   early_fraud_warning: string
 }
@@ -16861,8 +16447,6 @@ export type t_GetRadarEarlyFraudWarningsEarlyFraudWarningParamSchema = {
 export type t_GetRadarEarlyFraudWarningsEarlyFraudWarningQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetRadarValueListItemsBodySchema = EmptyObject
 
 export type t_GetRadarValueListItemsQuerySchema = {
   created?:
@@ -16881,8 +16465,6 @@ export type t_GetRadarValueListItemsQuerySchema = {
   value_list: string
 }
 
-export type t_GetRadarValueListItemsItemBodySchema = EmptyObject
-
 export type t_GetRadarValueListItemsItemParamSchema = {
   item: string
 }
@@ -16890,8 +16472,6 @@ export type t_GetRadarValueListItemsItemParamSchema = {
 export type t_GetRadarValueListItemsItemQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetRadarValueListsBodySchema = EmptyObject
 
 export type t_GetRadarValueListsQuerySchema = {
   alias?: string
@@ -16910,8 +16490,6 @@ export type t_GetRadarValueListsQuerySchema = {
   starting_after?: string
 }
 
-export type t_GetRadarValueListsValueListBodySchema = EmptyObject
-
 export type t_GetRadarValueListsValueListParamSchema = {
   value_list: string
 }
@@ -16919,8 +16497,6 @@ export type t_GetRadarValueListsValueListParamSchema = {
 export type t_GetRadarValueListsValueListQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetRefundsBodySchema = EmptyObject
 
 export type t_GetRefundsQuerySchema = {
   charge?: string
@@ -16939,8 +16515,6 @@ export type t_GetRefundsQuerySchema = {
   starting_after?: string
 }
 
-export type t_GetRefundsRefundBodySchema = EmptyObject
-
 export type t_GetRefundsRefundParamSchema = {
   refund: string
 }
@@ -16948,8 +16522,6 @@ export type t_GetRefundsRefundParamSchema = {
 export type t_GetRefundsRefundQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetReportingReportRunsBodySchema = EmptyObject
 
 export type t_GetReportingReportRunsQuerySchema = {
   created?:
@@ -16966,8 +16538,6 @@ export type t_GetReportingReportRunsQuerySchema = {
   starting_after?: string
 }
 
-export type t_GetReportingReportRunsReportRunBodySchema = EmptyObject
-
 export type t_GetReportingReportRunsReportRunParamSchema = {
   report_run: string
 }
@@ -16976,13 +16546,9 @@ export type t_GetReportingReportRunsReportRunQuerySchema = {
   expand?: string[]
 }
 
-export type t_GetReportingReportTypesBodySchema = EmptyObject
-
 export type t_GetReportingReportTypesQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetReportingReportTypesReportTypeBodySchema = EmptyObject
 
 export type t_GetReportingReportTypesReportTypeParamSchema = {
   report_type: string
@@ -16991,8 +16557,6 @@ export type t_GetReportingReportTypesReportTypeParamSchema = {
 export type t_GetReportingReportTypesReportTypeQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetReviewsBodySchema = EmptyObject
 
 export type t_GetReviewsQuerySchema = {
   created?:
@@ -17009,8 +16573,6 @@ export type t_GetReviewsQuerySchema = {
   starting_after?: string
 }
 
-export type t_GetReviewsReviewBodySchema = EmptyObject
-
 export type t_GetReviewsReviewParamSchema = {
   review: string
 }
@@ -17018,8 +16580,6 @@ export type t_GetReviewsReviewParamSchema = {
 export type t_GetReviewsReviewQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetSetupAttemptsBodySchema = EmptyObject
 
 export type t_GetSetupAttemptsQuerySchema = {
   created?:
@@ -17036,8 +16596,6 @@ export type t_GetSetupAttemptsQuerySchema = {
   setup_intent: string
   starting_after?: string
 }
-
-export type t_GetSetupIntentsBodySchema = EmptyObject
 
 export type t_GetSetupIntentsQuerySchema = {
   attach_to_self?: boolean
@@ -17057,8 +16615,6 @@ export type t_GetSetupIntentsQuerySchema = {
   starting_after?: string
 }
 
-export type t_GetSetupIntentsIntentBodySchema = EmptyObject
-
 export type t_GetSetupIntentsIntentParamSchema = {
   intent: string
 }
@@ -17067,8 +16623,6 @@ export type t_GetSetupIntentsIntentQuerySchema = {
   client_secret?: string
   expand?: string[]
 }
-
-export type t_GetShippingRatesBodySchema = EmptyObject
 
 export type t_GetShippingRatesQuerySchema = {
   active?: boolean
@@ -17087,8 +16641,6 @@ export type t_GetShippingRatesQuerySchema = {
   starting_after?: string
 }
 
-export type t_GetShippingRatesShippingRateTokenBodySchema = EmptyObject
-
 export type t_GetShippingRatesShippingRateTokenParamSchema = {
   shipping_rate_token: string
 }
@@ -17097,17 +16649,12 @@ export type t_GetShippingRatesShippingRateTokenQuerySchema = {
   expand?: string[]
 }
 
-export type t_GetSigmaScheduledQueryRunsBodySchema = EmptyObject
-
 export type t_GetSigmaScheduledQueryRunsQuerySchema = {
   ending_before?: string
   expand?: string[]
   limit?: number
   starting_after?: string
 }
-
-export type t_GetSigmaScheduledQueryRunsScheduledQueryRunBodySchema =
-  EmptyObject
 
 export type t_GetSigmaScheduledQueryRunsScheduledQueryRunParamSchema = {
   scheduled_query_run: string
@@ -17117,8 +16664,6 @@ export type t_GetSigmaScheduledQueryRunsScheduledQueryRunQuerySchema = {
   expand?: string[]
 }
 
-export type t_GetSourcesSourceBodySchema = EmptyObject
-
 export type t_GetSourcesSourceParamSchema = {
   source: string
 }
@@ -17127,9 +16672,6 @@ export type t_GetSourcesSourceQuerySchema = {
   client_secret?: string
   expand?: string[]
 }
-
-export type t_GetSourcesSourceMandateNotificationsMandateNotificationBodySchema =
-  EmptyObject
 
 export type t_GetSourcesSourceMandateNotificationsMandateNotificationParamSchema =
   {
@@ -17142,8 +16684,6 @@ export type t_GetSourcesSourceMandateNotificationsMandateNotificationQuerySchema
     expand?: string[]
   }
 
-export type t_GetSourcesSourceSourceTransactionsBodySchema = EmptyObject
-
 export type t_GetSourcesSourceSourceTransactionsParamSchema = {
   source: string
 }
@@ -17155,9 +16695,6 @@ export type t_GetSourcesSourceSourceTransactionsQuerySchema = {
   starting_after?: string
 }
 
-export type t_GetSourcesSourceSourceTransactionsSourceTransactionBodySchema =
-  EmptyObject
-
 export type t_GetSourcesSourceSourceTransactionsSourceTransactionParamSchema = {
   source: string
   source_transaction: string
@@ -17167,8 +16704,6 @@ export type t_GetSourcesSourceSourceTransactionsSourceTransactionQuerySchema = {
   expand?: string[]
 }
 
-export type t_GetSubscriptionItemsBodySchema = EmptyObject
-
 export type t_GetSubscriptionItemsQuerySchema = {
   ending_before?: string
   expand?: string[]
@@ -17177,8 +16712,6 @@ export type t_GetSubscriptionItemsQuerySchema = {
   subscription: string
 }
 
-export type t_GetSubscriptionItemsItemBodySchema = EmptyObject
-
 export type t_GetSubscriptionItemsItemParamSchema = {
   item: string
 }
@@ -17186,8 +16719,6 @@ export type t_GetSubscriptionItemsItemParamSchema = {
 export type t_GetSubscriptionItemsItemQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetSubscriptionSchedulesBodySchema = EmptyObject
 
 export type t_GetSubscriptionSchedulesQuerySchema = {
   canceled_at?:
@@ -17230,8 +16761,6 @@ export type t_GetSubscriptionSchedulesQuerySchema = {
   starting_after?: string
 }
 
-export type t_GetSubscriptionSchedulesScheduleBodySchema = EmptyObject
-
 export type t_GetSubscriptionSchedulesScheduleParamSchema = {
   schedule: string
 }
@@ -17239,8 +16768,6 @@ export type t_GetSubscriptionSchedulesScheduleParamSchema = {
 export type t_GetSubscriptionSchedulesScheduleQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetSubscriptionsBodySchema = EmptyObject
 
 export type t_GetSubscriptionsQuerySchema = {
   automatic_tax?: {
@@ -17291,16 +16818,12 @@ export type t_GetSubscriptionsQuerySchema = {
   test_clock?: string
 }
 
-export type t_GetSubscriptionsSearchBodySchema = EmptyObject
-
 export type t_GetSubscriptionsSearchQuerySchema = {
   expand?: string[]
   limit?: number
   page?: string
   query: string
 }
-
-export type t_GetSubscriptionsSubscriptionExposedIdBodySchema = EmptyObject
 
 export type t_GetSubscriptionsSubscriptionExposedIdParamSchema = {
   subscription_exposed_id: string
@@ -17310,8 +16833,6 @@ export type t_GetSubscriptionsSubscriptionExposedIdQuerySchema = {
   expand?: string[]
 }
 
-export type t_GetTaxCalculationsCalculationBodySchema = EmptyObject
-
 export type t_GetTaxCalculationsCalculationParamSchema = {
   calculation: string
 }
@@ -17319,8 +16840,6 @@ export type t_GetTaxCalculationsCalculationParamSchema = {
 export type t_GetTaxCalculationsCalculationQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetTaxCalculationsCalculationLineItemsBodySchema = EmptyObject
 
 export type t_GetTaxCalculationsCalculationLineItemsParamSchema = {
   calculation: string
@@ -17333,16 +16852,12 @@ export type t_GetTaxCalculationsCalculationLineItemsQuerySchema = {
   starting_after?: string
 }
 
-export type t_GetTaxCodesBodySchema = EmptyObject
-
 export type t_GetTaxCodesQuerySchema = {
   ending_before?: string
   expand?: string[]
   limit?: number
   starting_after?: string
 }
-
-export type t_GetTaxCodesIdBodySchema = EmptyObject
 
 export type t_GetTaxCodesIdParamSchema = {
   id: string
@@ -17351,8 +16866,6 @@ export type t_GetTaxCodesIdParamSchema = {
 export type t_GetTaxCodesIdQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetTaxIdsBodySchema = EmptyObject
 
 export type t_GetTaxIdsQuerySchema = {
   ending_before?: string
@@ -17366,8 +16879,6 @@ export type t_GetTaxIdsQuerySchema = {
   starting_after?: string
 }
 
-export type t_GetTaxIdsIdBodySchema = EmptyObject
-
 export type t_GetTaxIdsIdParamSchema = {
   id: string
 }
@@ -17375,8 +16886,6 @@ export type t_GetTaxIdsIdParamSchema = {
 export type t_GetTaxIdsIdQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetTaxRatesBodySchema = EmptyObject
 
 export type t_GetTaxRatesQuerySchema = {
   active?: boolean
@@ -17395,8 +16904,6 @@ export type t_GetTaxRatesQuerySchema = {
   starting_after?: string
 }
 
-export type t_GetTaxRatesTaxRateBodySchema = EmptyObject
-
 export type t_GetTaxRatesTaxRateParamSchema = {
   tax_rate: string
 }
@@ -17404,8 +16911,6 @@ export type t_GetTaxRatesTaxRateParamSchema = {
 export type t_GetTaxRatesTaxRateQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetTaxRegistrationsBodySchema = EmptyObject
 
 export type t_GetTaxRegistrationsQuerySchema = {
   ending_before?: string
@@ -17415,8 +16920,6 @@ export type t_GetTaxRegistrationsQuerySchema = {
   status?: "active" | "all" | "expired" | "scheduled"
 }
 
-export type t_GetTaxRegistrationsIdBodySchema = EmptyObject
-
 export type t_GetTaxRegistrationsIdParamSchema = {
   id: string
 }
@@ -17425,13 +16928,9 @@ export type t_GetTaxRegistrationsIdQuerySchema = {
   expand?: string[]
 }
 
-export type t_GetTaxSettingsBodySchema = EmptyObject
-
 export type t_GetTaxSettingsQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetTaxTransactionsTransactionBodySchema = EmptyObject
 
 export type t_GetTaxTransactionsTransactionParamSchema = {
   transaction: string
@@ -17440,8 +16939,6 @@ export type t_GetTaxTransactionsTransactionParamSchema = {
 export type t_GetTaxTransactionsTransactionQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetTaxTransactionsTransactionLineItemsBodySchema = EmptyObject
 
 export type t_GetTaxTransactionsTransactionLineItemsParamSchema = {
   transaction: string
@@ -17454,8 +16951,6 @@ export type t_GetTaxTransactionsTransactionLineItemsQuerySchema = {
   starting_after?: string
 }
 
-export type t_GetTerminalConfigurationsBodySchema = EmptyObject
-
 export type t_GetTerminalConfigurationsQuerySchema = {
   ending_before?: string
   expand?: string[]
@@ -17463,8 +16958,6 @@ export type t_GetTerminalConfigurationsQuerySchema = {
   limit?: number
   starting_after?: string
 }
-
-export type t_GetTerminalConfigurationsConfigurationBodySchema = EmptyObject
 
 export type t_GetTerminalConfigurationsConfigurationParamSchema = {
   configuration: string
@@ -17474,16 +16967,12 @@ export type t_GetTerminalConfigurationsConfigurationQuerySchema = {
   expand?: string[]
 }
 
-export type t_GetTerminalLocationsBodySchema = EmptyObject
-
 export type t_GetTerminalLocationsQuerySchema = {
   ending_before?: string
   expand?: string[]
   limit?: number
   starting_after?: string
 }
-
-export type t_GetTerminalLocationsLocationBodySchema = EmptyObject
 
 export type t_GetTerminalLocationsLocationParamSchema = {
   location: string
@@ -17492,8 +16981,6 @@ export type t_GetTerminalLocationsLocationParamSchema = {
 export type t_GetTerminalLocationsLocationQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetTerminalReadersBodySchema = EmptyObject
 
 export type t_GetTerminalReadersQuerySchema = {
   device_type?:
@@ -17515,8 +17002,6 @@ export type t_GetTerminalReadersQuerySchema = {
   status?: "offline" | "online"
 }
 
-export type t_GetTerminalReadersReaderBodySchema = EmptyObject
-
 export type t_GetTerminalReadersReaderParamSchema = {
   reader: string
 }
@@ -17525,16 +17010,12 @@ export type t_GetTerminalReadersReaderQuerySchema = {
   expand?: string[]
 }
 
-export type t_GetTestHelpersTestClocksBodySchema = EmptyObject
-
 export type t_GetTestHelpersTestClocksQuerySchema = {
   ending_before?: string
   expand?: string[]
   limit?: number
   starting_after?: string
 }
-
-export type t_GetTestHelpersTestClocksTestClockBodySchema = EmptyObject
 
 export type t_GetTestHelpersTestClocksTestClockParamSchema = {
   test_clock: string
@@ -17544,8 +17025,6 @@ export type t_GetTestHelpersTestClocksTestClockQuerySchema = {
   expand?: string[]
 }
 
-export type t_GetTokensTokenBodySchema = EmptyObject
-
 export type t_GetTokensTokenParamSchema = {
   token: string
 }
@@ -17553,8 +17032,6 @@ export type t_GetTokensTokenParamSchema = {
 export type t_GetTokensTokenQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetTopupsBodySchema = EmptyObject
 
 export type t_GetTopupsQuerySchema = {
   amount?:
@@ -17580,8 +17057,6 @@ export type t_GetTopupsQuerySchema = {
   status?: "canceled" | "failed" | "pending" | "succeeded"
 }
 
-export type t_GetTopupsTopupBodySchema = EmptyObject
-
 export type t_GetTopupsTopupParamSchema = {
   topup: string
 }
@@ -17589,8 +17064,6 @@ export type t_GetTopupsTopupParamSchema = {
 export type t_GetTopupsTopupQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetTransfersBodySchema = EmptyObject
 
 export type t_GetTransfersQuerySchema = {
   created?:
@@ -17609,8 +17082,6 @@ export type t_GetTransfersQuerySchema = {
   transfer_group?: string
 }
 
-export type t_GetTransfersIdReversalsBodySchema = EmptyObject
-
 export type t_GetTransfersIdReversalsParamSchema = {
   id: string
 }
@@ -17622,8 +17093,6 @@ export type t_GetTransfersIdReversalsQuerySchema = {
   starting_after?: string
 }
 
-export type t_GetTransfersTransferBodySchema = EmptyObject
-
 export type t_GetTransfersTransferParamSchema = {
   transfer: string
 }
@@ -17631,8 +17100,6 @@ export type t_GetTransfersTransferParamSchema = {
 export type t_GetTransfersTransferQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetTransfersTransferReversalsIdBodySchema = EmptyObject
 
 export type t_GetTransfersTransferReversalsIdParamSchema = {
   id: string
@@ -17642,8 +17109,6 @@ export type t_GetTransfersTransferReversalsIdParamSchema = {
 export type t_GetTransfersTransferReversalsIdQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetTreasuryCreditReversalsBodySchema = EmptyObject
 
 export type t_GetTreasuryCreditReversalsQuerySchema = {
   ending_before?: string
@@ -17655,8 +17120,6 @@ export type t_GetTreasuryCreditReversalsQuerySchema = {
   status?: "canceled" | "posted" | "processing"
 }
 
-export type t_GetTreasuryCreditReversalsCreditReversalBodySchema = EmptyObject
-
 export type t_GetTreasuryCreditReversalsCreditReversalParamSchema = {
   credit_reversal: string
 }
@@ -17664,8 +17127,6 @@ export type t_GetTreasuryCreditReversalsCreditReversalParamSchema = {
 export type t_GetTreasuryCreditReversalsCreditReversalQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetTreasuryDebitReversalsBodySchema = EmptyObject
 
 export type t_GetTreasuryDebitReversalsQuerySchema = {
   ending_before?: string
@@ -17678,8 +17139,6 @@ export type t_GetTreasuryDebitReversalsQuerySchema = {
   status?: "canceled" | "completed" | "processing"
 }
 
-export type t_GetTreasuryDebitReversalsDebitReversalBodySchema = EmptyObject
-
 export type t_GetTreasuryDebitReversalsDebitReversalParamSchema = {
   debit_reversal: string
 }
@@ -17687,8 +17146,6 @@ export type t_GetTreasuryDebitReversalsDebitReversalParamSchema = {
 export type t_GetTreasuryDebitReversalsDebitReversalQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetTreasuryFinancialAccountsBodySchema = EmptyObject
 
 export type t_GetTreasuryFinancialAccountsQuerySchema = {
   created?:
@@ -17706,9 +17163,6 @@ export type t_GetTreasuryFinancialAccountsQuerySchema = {
   status?: "closed" | "open"
 }
 
-export type t_GetTreasuryFinancialAccountsFinancialAccountBodySchema =
-  EmptyObject
-
 export type t_GetTreasuryFinancialAccountsFinancialAccountParamSchema = {
   financial_account: string
 }
@@ -17716,9 +17170,6 @@ export type t_GetTreasuryFinancialAccountsFinancialAccountParamSchema = {
 export type t_GetTreasuryFinancialAccountsFinancialAccountQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetTreasuryFinancialAccountsFinancialAccountFeaturesBodySchema =
-  EmptyObject
 
 export type t_GetTreasuryFinancialAccountsFinancialAccountFeaturesParamSchema =
   {
@@ -17730,8 +17181,6 @@ export type t_GetTreasuryFinancialAccountsFinancialAccountFeaturesQuerySchema =
     expand?: string[]
   }
 
-export type t_GetTreasuryInboundTransfersBodySchema = EmptyObject
-
 export type t_GetTreasuryInboundTransfersQuerySchema = {
   ending_before?: string
   expand?: string[]
@@ -17741,8 +17190,6 @@ export type t_GetTreasuryInboundTransfersQuerySchema = {
   status?: "canceled" | "failed" | "processing" | "succeeded"
 }
 
-export type t_GetTreasuryInboundTransfersIdBodySchema = EmptyObject
-
 export type t_GetTreasuryInboundTransfersIdParamSchema = {
   id: string
 }
@@ -17750,8 +17197,6 @@ export type t_GetTreasuryInboundTransfersIdParamSchema = {
 export type t_GetTreasuryInboundTransfersIdQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetTreasuryOutboundPaymentsBodySchema = EmptyObject
 
 export type t_GetTreasuryOutboundPaymentsQuerySchema = {
   created?:
@@ -17771,8 +17216,6 @@ export type t_GetTreasuryOutboundPaymentsQuerySchema = {
   status?: "canceled" | "failed" | "posted" | "processing" | "returned"
 }
 
-export type t_GetTreasuryOutboundPaymentsIdBodySchema = EmptyObject
-
 export type t_GetTreasuryOutboundPaymentsIdParamSchema = {
   id: string
 }
@@ -17780,8 +17223,6 @@ export type t_GetTreasuryOutboundPaymentsIdParamSchema = {
 export type t_GetTreasuryOutboundPaymentsIdQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetTreasuryOutboundTransfersBodySchema = EmptyObject
 
 export type t_GetTreasuryOutboundTransfersQuerySchema = {
   ending_before?: string
@@ -17792,9 +17233,6 @@ export type t_GetTreasuryOutboundTransfersQuerySchema = {
   status?: "canceled" | "failed" | "posted" | "processing" | "returned"
 }
 
-export type t_GetTreasuryOutboundTransfersOutboundTransferBodySchema =
-  EmptyObject
-
 export type t_GetTreasuryOutboundTransfersOutboundTransferParamSchema = {
   outbound_transfer: string
 }
@@ -17802,8 +17240,6 @@ export type t_GetTreasuryOutboundTransfersOutboundTransferParamSchema = {
 export type t_GetTreasuryOutboundTransfersOutboundTransferQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetTreasuryReceivedCreditsBodySchema = EmptyObject
 
 export type t_GetTreasuryReceivedCreditsQuerySchema = {
   ending_before?: string
@@ -17822,8 +17258,6 @@ export type t_GetTreasuryReceivedCreditsQuerySchema = {
   status?: "failed" | "succeeded"
 }
 
-export type t_GetTreasuryReceivedCreditsIdBodySchema = EmptyObject
-
 export type t_GetTreasuryReceivedCreditsIdParamSchema = {
   id: string
 }
@@ -17831,8 +17265,6 @@ export type t_GetTreasuryReceivedCreditsIdParamSchema = {
 export type t_GetTreasuryReceivedCreditsIdQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetTreasuryReceivedDebitsBodySchema = EmptyObject
 
 export type t_GetTreasuryReceivedDebitsQuerySchema = {
   ending_before?: string
@@ -17843,8 +17275,6 @@ export type t_GetTreasuryReceivedDebitsQuerySchema = {
   status?: "failed" | "succeeded"
 }
 
-export type t_GetTreasuryReceivedDebitsIdBodySchema = EmptyObject
-
 export type t_GetTreasuryReceivedDebitsIdParamSchema = {
   id: string
 }
@@ -17852,8 +17282,6 @@ export type t_GetTreasuryReceivedDebitsIdParamSchema = {
 export type t_GetTreasuryReceivedDebitsIdQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetTreasuryTransactionEntriesBodySchema = EmptyObject
 
 export type t_GetTreasuryTransactionEntriesQuerySchema = {
   created?:
@@ -17881,8 +17309,6 @@ export type t_GetTreasuryTransactionEntriesQuerySchema = {
   transaction?: string
 }
 
-export type t_GetTreasuryTransactionEntriesIdBodySchema = EmptyObject
-
 export type t_GetTreasuryTransactionEntriesIdParamSchema = {
   id: string
 }
@@ -17890,8 +17316,6 @@ export type t_GetTreasuryTransactionEntriesIdParamSchema = {
 export type t_GetTreasuryTransactionEntriesIdQuerySchema = {
   expand?: string[]
 }
-
-export type t_GetTreasuryTransactionsBodySchema = EmptyObject
 
 export type t_GetTreasuryTransactionsQuerySchema = {
   created?:
@@ -17921,8 +17345,6 @@ export type t_GetTreasuryTransactionsQuerySchema = {
   }
 }
 
-export type t_GetTreasuryTransactionsIdBodySchema = EmptyObject
-
 export type t_GetTreasuryTransactionsIdParamSchema = {
   id: string
 }
@@ -17931,16 +17353,12 @@ export type t_GetTreasuryTransactionsIdQuerySchema = {
   expand?: string[]
 }
 
-export type t_GetWebhookEndpointsBodySchema = EmptyObject
-
 export type t_GetWebhookEndpointsQuerySchema = {
   ending_before?: string
   expand?: string[]
   limit?: number
   starting_after?: string
 }
-
-export type t_GetWebhookEndpointsWebhookEndpointBodySchema = EmptyObject
 
 export type t_GetWebhookEndpointsWebhookEndpointParamSchema = {
   webhook_endpoint: string

--- a/packages/openapi-code-generator/src/typescript/client/client-operation-builder.ts
+++ b/packages/openapi-code-generator/src/typescript/client/client-operation-builder.ts
@@ -1,4 +1,5 @@
 import {generationLib} from "../../core/generation-lib"
+import {logger} from "../../core/logger"
 import type {
   IROperation,
   IRParameter,
@@ -99,7 +100,17 @@ export class ClientOperationBuilder {
     requestBodyParameter?: IRParameter
     requestBodyContentType?: string
   } {
-    return requestBodyAsParameter(this.operation)
+    const result = requestBodyAsParameter(this.operation)
+    const schema = result.requestBodyParameter?.schema
+
+    if (schema && this.models.isEmptyObject(schema)) {
+      logger.warn(
+        `[${this.route}]: skipping requestBody parameter that resolves to EmptyObject`,
+      )
+      return {}
+    }
+
+    return result
   }
 
   queryString(): string {

--- a/packages/openapi-code-generator/src/typescript/common/type-builder.ts
+++ b/packages/openapi-code-generator/src/typescript/common/type-builder.ts
@@ -233,11 +233,9 @@ export class TypeBuilder implements ICompilable {
             ? `[key: string]: ${union(additionalPropertiesType, "undefined")}`
             : ""
 
-          const emptyObject =
-            schemaObject.additionalProperties === false &&
-            properties.length === 0
-              ? this.addStaticType("EmptyObject")
-              : ""
+          const emptyObject = this.isEmptyObject(schemaObject)
+            ? this.addStaticType("EmptyObject")
+            : ""
 
           properties.push(additionalProperties)
 
@@ -262,5 +260,18 @@ export class TypeBuilder implements ICompilable {
 
   toCompilationUnit(): CompilationUnit {
     return new CompilationUnit(this.filename, this.imports, this.toString())
+  }
+
+  isEmptyObject(schemaObject: MaybeIRModel) {
+    const dereferenced = this.input.schema(schemaObject)
+
+    return (
+      dereferenced.type === "object" &&
+      dereferenced.allOf.length === 0 &&
+      dereferenced.anyOf.length === 0 &&
+      dereferenced.oneOf.length === 0 &&
+      dereferenced.additionalProperties === false &&
+      Object.keys(dereferenced.properties).length === 0
+    )
   }
 }

--- a/packages/openapi-code-generator/src/typescript/server/server-operation-builder.ts
+++ b/packages/openapi-code-generator/src/typescript/server/server-operation-builder.ts
@@ -1,4 +1,5 @@
 import type {Input} from "../../core/input"
+import {logger} from "../../core/logger"
 import type {
   IRModelObject,
   IROperation,
@@ -265,7 +266,9 @@ export class ServerOperationBuilder {
 
   private requestBodyParameter(schemaSymbolName: string): Parameters["body"] {
     const {requestBodyParameter} = requestBodyAsParameter(this.operation)
+
     const isRequired = Boolean(requestBodyParameter?.required)
+
     const schema = requestBodyParameter
       ? this.schemaBuilder.fromModel(
           requestBodyParameter.schema,
@@ -273,6 +276,17 @@ export class ServerOperationBuilder {
           true,
         )
       : undefined
+
+    if (
+      requestBodyParameter &&
+      this.types.isEmptyObject(requestBodyParameter.schema)
+    ) {
+      logger.warn(
+        `[${this.route}]: skipping requestBody parameter that resolves to EmptyObject`,
+      )
+      return {type: "void", schema: undefined, isRequired: false}
+    }
+
     let type = "void"
 
     if (schema && requestBodyParameter) {


### PR DESCRIPTION
whilst implementing better support for non-JSON content-types, I realized that the stripe api defines a bunch of meaningless requests bodies on their `GET` / `DELETE` requests that look like this:

```yaml
requestBody:
        content:
          application/x-www-form-urlencoded:
            encoding: {}
            schema:
              additionalProperties: false
              properties: {}
              type: object
        required: false
```

which is basically an `object` with no `properties` and no `additionalProperties` allowed.

I'd probably have just ignored this, but the combination of this with `application/x-www-form-urlencoded` meant it complicated adding support for encoding bodies using `URLSearchParams`

I've raised https://github.com/stripe/openapi/issues/170 but for now lets just skip these and log a warning.