### PR TITLE
feat: boolean schemas support enum

### DIFF
--- a/integration-tests/typescript-angular/src/generated/stripe.yaml/models.ts
+++ b/integration-tests/typescript-angular/src/generated/stripe.yaml/models.ts
@@ -2774,19 +2774,19 @@ export type t_customer_tax_location = {
 }
 
 export type t_deleted_account = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "account" | UnknownEnumStringValue
 }
 
 export type t_deleted_apple_pay_domain = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "apple_pay_domain" | UnknownEnumStringValue
 }
 
 export type t_deleted_application = {
-  deleted: boolean
+  deleted: true
   id: string
   name?: string | null
   object: "application" | UnknownEnumStringValue
@@ -2794,26 +2794,26 @@ export type t_deleted_application = {
 
 export type t_deleted_bank_account = {
   currency?: string | null
-  deleted: boolean
+  deleted: true
   id: string
   object: "bank_account" | UnknownEnumStringValue
 }
 
 export type t_deleted_card = {
   currency?: string | null
-  deleted: boolean
+  deleted: true
   id: string
   object: "card" | UnknownEnumStringValue
 }
 
 export type t_deleted_coupon = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "coupon" | UnknownEnumStringValue
 }
 
 export type t_deleted_customer = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "customer" | UnknownEnumStringValue
 }
@@ -2822,7 +2822,7 @@ export type t_deleted_discount = {
   checkout_session?: string | null
   coupon: t_coupon
   customer?: string | t_customer | t_deleted_customer | null
-  deleted: boolean
+  deleted: true
   id: string
   invoice?: string | null
   invoice_item?: string | null
@@ -2836,13 +2836,13 @@ export type t_deleted_discount = {
 export type t_deleted_external_account = t_deleted_bank_account | t_deleted_card
 
 export type t_deleted_invoice = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "invoice" | UnknownEnumStringValue
 }
 
 export type t_deleted_invoiceitem = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "invoiceitem" | UnknownEnumStringValue
 }
@@ -2850,85 +2850,85 @@ export type t_deleted_invoiceitem = {
 export type t_deleted_payment_source = t_deleted_bank_account | t_deleted_card
 
 export type t_deleted_person = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "person" | UnknownEnumStringValue
 }
 
 export type t_deleted_plan = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "plan" | UnknownEnumStringValue
 }
 
 export type t_deleted_price = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "price" | UnknownEnumStringValue
 }
 
 export type t_deleted_product = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "product" | UnknownEnumStringValue
 }
 
 export type t_deleted_product_feature = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "product_feature" | UnknownEnumStringValue
 }
 
 export type t_deleted_radar_value_list = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "radar.value_list" | UnknownEnumStringValue
 }
 
 export type t_deleted_radar_value_list_item = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "radar.value_list_item" | UnknownEnumStringValue
 }
 
 export type t_deleted_subscription_item = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "subscription_item" | UnknownEnumStringValue
 }
 
 export type t_deleted_tax_id = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "tax_id" | UnknownEnumStringValue
 }
 
 export type t_deleted_terminal_configuration = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "terminal.configuration" | UnknownEnumStringValue
 }
 
 export type t_deleted_terminal_location = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "terminal.location" | UnknownEnumStringValue
 }
 
 export type t_deleted_terminal_reader = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "terminal.reader" | UnknownEnumStringValue
 }
 
 export type t_deleted_test_helpers_test_clock = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "test_helpers.test_clock" | UnknownEnumStringValue
 }
 
 export type t_deleted_webhook_endpoint = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "webhook_endpoint" | UnknownEnumStringValue
 }

--- a/integration-tests/typescript-axios/src/generated/stripe.yaml/models.ts
+++ b/integration-tests/typescript-axios/src/generated/stripe.yaml/models.ts
@@ -3034,19 +3034,19 @@ export type t_customer_tax_location = {
 }
 
 export type t_deleted_account = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "account" | UnknownEnumStringValue
 }
 
 export type t_deleted_apple_pay_domain = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "apple_pay_domain" | UnknownEnumStringValue
 }
 
 export type t_deleted_application = {
-  deleted: boolean
+  deleted: true
   id: string
   name?: (string | null) | undefined
   object: "application" | UnknownEnumStringValue
@@ -3054,26 +3054,26 @@ export type t_deleted_application = {
 
 export type t_deleted_bank_account = {
   currency?: (string | null) | undefined
-  deleted: boolean
+  deleted: true
   id: string
   object: "bank_account" | UnknownEnumStringValue
 }
 
 export type t_deleted_card = {
   currency?: (string | null) | undefined
-  deleted: boolean
+  deleted: true
   id: string
   object: "card" | UnknownEnumStringValue
 }
 
 export type t_deleted_coupon = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "coupon" | UnknownEnumStringValue
 }
 
 export type t_deleted_customer = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "customer" | UnknownEnumStringValue
 }
@@ -3082,7 +3082,7 @@ export type t_deleted_discount = {
   checkout_session?: (string | null) | undefined
   coupon: t_coupon
   customer?: (string | t_customer | t_deleted_customer | null) | undefined
-  deleted: boolean
+  deleted: true
   id: string
   invoice?: (string | null) | undefined
   invoice_item?: (string | null) | undefined
@@ -3096,13 +3096,13 @@ export type t_deleted_discount = {
 export type t_deleted_external_account = t_deleted_bank_account | t_deleted_card
 
 export type t_deleted_invoice = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "invoice" | UnknownEnumStringValue
 }
 
 export type t_deleted_invoiceitem = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "invoiceitem" | UnknownEnumStringValue
 }
@@ -3110,85 +3110,85 @@ export type t_deleted_invoiceitem = {
 export type t_deleted_payment_source = t_deleted_bank_account | t_deleted_card
 
 export type t_deleted_person = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "person" | UnknownEnumStringValue
 }
 
 export type t_deleted_plan = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "plan" | UnknownEnumStringValue
 }
 
 export type t_deleted_price = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "price" | UnknownEnumStringValue
 }
 
 export type t_deleted_product = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "product" | UnknownEnumStringValue
 }
 
 export type t_deleted_product_feature = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "product_feature" | UnknownEnumStringValue
 }
 
 export type t_deleted_radar_value_list = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "radar.value_list" | UnknownEnumStringValue
 }
 
 export type t_deleted_radar_value_list_item = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "radar.value_list_item" | UnknownEnumStringValue
 }
 
 export type t_deleted_subscription_item = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "subscription_item" | UnknownEnumStringValue
 }
 
 export type t_deleted_tax_id = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "tax_id" | UnknownEnumStringValue
 }
 
 export type t_deleted_terminal_configuration = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "terminal.configuration" | UnknownEnumStringValue
 }
 
 export type t_deleted_terminal_location = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "terminal.location" | UnknownEnumStringValue
 }
 
 export type t_deleted_terminal_reader = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "terminal.reader" | UnknownEnumStringValue
 }
 
 export type t_deleted_test_helpers_test_clock = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "test_helpers.test_clock" | UnknownEnumStringValue
 }
 
 export type t_deleted_webhook_endpoint = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "webhook_endpoint" | UnknownEnumStringValue
 }

--- a/integration-tests/typescript-express/src/generated/stripe.yaml/models.ts
+++ b/integration-tests/typescript-express/src/generated/stripe.yaml/models.ts
@@ -2714,19 +2714,19 @@ export type t_customer_tax_location = {
 }
 
 export type t_deleted_account = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "account"
 }
 
 export type t_deleted_apple_pay_domain = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "apple_pay_domain"
 }
 
 export type t_deleted_application = {
-  deleted: boolean
+  deleted: true
   id: string
   name?: (string | null) | undefined
   object: "application"
@@ -2734,26 +2734,26 @@ export type t_deleted_application = {
 
 export type t_deleted_bank_account = {
   currency?: (string | null) | undefined
-  deleted: boolean
+  deleted: true
   id: string
   object: "bank_account"
 }
 
 export type t_deleted_card = {
   currency?: (string | null) | undefined
-  deleted: boolean
+  deleted: true
   id: string
   object: "card"
 }
 
 export type t_deleted_coupon = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "coupon"
 }
 
 export type t_deleted_customer = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "customer"
 }
@@ -2762,7 +2762,7 @@ export type t_deleted_discount = {
   checkout_session?: (string | null) | undefined
   coupon: t_coupon
   customer?: (string | t_customer | t_deleted_customer | null) | undefined
-  deleted: boolean
+  deleted: true
   id: string
   invoice?: (string | null) | undefined
   invoice_item?: (string | null) | undefined
@@ -2776,13 +2776,13 @@ export type t_deleted_discount = {
 export type t_deleted_external_account = t_deleted_bank_account | t_deleted_card
 
 export type t_deleted_invoice = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "invoice"
 }
 
 export type t_deleted_invoiceitem = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "invoiceitem"
 }
@@ -2790,85 +2790,85 @@ export type t_deleted_invoiceitem = {
 export type t_deleted_payment_source = t_deleted_bank_account | t_deleted_card
 
 export type t_deleted_person = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "person"
 }
 
 export type t_deleted_plan = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "plan"
 }
 
 export type t_deleted_price = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "price"
 }
 
 export type t_deleted_product = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "product"
 }
 
 export type t_deleted_product_feature = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "product_feature"
 }
 
 export type t_deleted_radar_value_list = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "radar.value_list"
 }
 
 export type t_deleted_radar_value_list_item = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "radar.value_list_item"
 }
 
 export type t_deleted_subscription_item = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "subscription_item"
 }
 
 export type t_deleted_tax_id = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "tax_id"
 }
 
 export type t_deleted_terminal_configuration = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "terminal.configuration"
 }
 
 export type t_deleted_terminal_location = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "terminal.location"
 }
 
 export type t_deleted_terminal_reader = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "terminal.reader"
 }
 
 export type t_deleted_test_helpers_test_clock = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "test_helpers.test_clock"
 }
 
 export type t_deleted_webhook_endpoint = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "webhook_endpoint"
 }

--- a/integration-tests/typescript-express/src/generated/stripe.yaml/schemas.ts
+++ b/integration-tests/typescript-express/src/generated/stripe.yaml/schemas.ts
@@ -211,6 +211,10 @@ export const PermissiveBoolean = z.preprocess((value) => {
   return value
 }, z.boolean())
 
+export const PermissiveLiteralTrue = z.preprocess((value) => {
+  return PermissiveBoolean.parse(value)
+}, z.literal(true))
+
 export const s_account_annual_revenue = z.object({
   amount: z.coerce.number().nullable().optional(),
   currency: z.string().nullable().optional(),
@@ -987,19 +991,19 @@ export const s_customer_tax_location = z.object({
 })
 
 export const s_deleted_account = z.object({
-  deleted: PermissiveBoolean,
+  deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
   object: z.enum(["account"]),
 })
 
 export const s_deleted_apple_pay_domain = z.object({
-  deleted: PermissiveBoolean,
+  deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
   object: z.enum(["apple_pay_domain"]),
 })
 
 export const s_deleted_application = z.object({
-  deleted: PermissiveBoolean,
+  deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
   name: z.string().max(5000).nullable().optional(),
   object: z.enum(["application"]),
@@ -1007,122 +1011,122 @@ export const s_deleted_application = z.object({
 
 export const s_deleted_bank_account = z.object({
   currency: z.string().max(5000).nullable().optional(),
-  deleted: PermissiveBoolean,
+  deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
   object: z.enum(["bank_account"]),
 })
 
 export const s_deleted_card = z.object({
   currency: z.string().max(5000).nullable().optional(),
-  deleted: PermissiveBoolean,
+  deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
   object: z.enum(["card"]),
 })
 
 export const s_deleted_coupon = z.object({
-  deleted: PermissiveBoolean,
+  deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
   object: z.enum(["coupon"]),
 })
 
 export const s_deleted_customer = z.object({
-  deleted: PermissiveBoolean,
+  deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
   object: z.enum(["customer"]),
 })
 
 export const s_deleted_invoice = z.object({
-  deleted: PermissiveBoolean,
+  deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
   object: z.enum(["invoice"]),
 })
 
 export const s_deleted_invoiceitem = z.object({
-  deleted: PermissiveBoolean,
+  deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
   object: z.enum(["invoiceitem"]),
 })
 
 export const s_deleted_person = z.object({
-  deleted: PermissiveBoolean,
+  deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
   object: z.enum(["person"]),
 })
 
 export const s_deleted_plan = z.object({
-  deleted: PermissiveBoolean,
+  deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
   object: z.enum(["plan"]),
 })
 
 export const s_deleted_price = z.object({
-  deleted: PermissiveBoolean,
+  deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
   object: z.enum(["price"]),
 })
 
 export const s_deleted_product = z.object({
-  deleted: PermissiveBoolean,
+  deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
   object: z.enum(["product"]),
 })
 
 export const s_deleted_product_feature = z.object({
-  deleted: PermissiveBoolean,
+  deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
   object: z.enum(["product_feature"]),
 })
 
 export const s_deleted_radar_value_list = z.object({
-  deleted: PermissiveBoolean,
+  deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
   object: z.enum(["radar.value_list"]),
 })
 
 export const s_deleted_radar_value_list_item = z.object({
-  deleted: PermissiveBoolean,
+  deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
   object: z.enum(["radar.value_list_item"]),
 })
 
 export const s_deleted_subscription_item = z.object({
-  deleted: PermissiveBoolean,
+  deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
   object: z.enum(["subscription_item"]),
 })
 
 export const s_deleted_tax_id = z.object({
-  deleted: PermissiveBoolean,
+  deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
   object: z.enum(["tax_id"]),
 })
 
 export const s_deleted_terminal_configuration = z.object({
-  deleted: PermissiveBoolean,
+  deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
   object: z.enum(["terminal.configuration"]),
 })
 
 export const s_deleted_terminal_location = z.object({
-  deleted: PermissiveBoolean,
+  deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
   object: z.enum(["terminal.location"]),
 })
 
 export const s_deleted_terminal_reader = z.object({
-  deleted: PermissiveBoolean,
+  deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
   object: z.enum(["terminal.reader"]),
 })
 
 export const s_deleted_test_helpers_test_clock = z.object({
-  deleted: PermissiveBoolean,
+  deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
   object: z.enum(["test_helpers.test_clock"]),
 })
 
 export const s_deleted_webhook_endpoint = z.object({
-  deleted: PermissiveBoolean,
+  deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
   object: z.enum(["webhook_endpoint"]),
 })
@@ -12767,7 +12771,7 @@ export const s_deleted_discount: z.ZodType<
     .union([z.string().max(5000), z.lazy(() => s_customer), s_deleted_customer])
     .nullable()
     .optional(),
-  deleted: PermissiveBoolean,
+  deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
   invoice: z.string().max(5000).nullable().optional(),
   invoice_item: z.string().max(5000).nullable().optional(),

--- a/integration-tests/typescript-fetch/src/generated/stripe.yaml/models.ts
+++ b/integration-tests/typescript-fetch/src/generated/stripe.yaml/models.ts
@@ -2774,19 +2774,19 @@ export type t_customer_tax_location = {
 }
 
 export type t_deleted_account = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "account" | UnknownEnumStringValue
 }
 
 export type t_deleted_apple_pay_domain = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "apple_pay_domain" | UnknownEnumStringValue
 }
 
 export type t_deleted_application = {
-  deleted: boolean
+  deleted: true
   id: string
   name?: string | null
   object: "application" | UnknownEnumStringValue
@@ -2794,26 +2794,26 @@ export type t_deleted_application = {
 
 export type t_deleted_bank_account = {
   currency?: string | null
-  deleted: boolean
+  deleted: true
   id: string
   object: "bank_account" | UnknownEnumStringValue
 }
 
 export type t_deleted_card = {
   currency?: string | null
-  deleted: boolean
+  deleted: true
   id: string
   object: "card" | UnknownEnumStringValue
 }
 
 export type t_deleted_coupon = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "coupon" | UnknownEnumStringValue
 }
 
 export type t_deleted_customer = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "customer" | UnknownEnumStringValue
 }
@@ -2822,7 +2822,7 @@ export type t_deleted_discount = {
   checkout_session?: string | null
   coupon: t_coupon
   customer?: string | t_customer | t_deleted_customer | null
-  deleted: boolean
+  deleted: true
   id: string
   invoice?: string | null
   invoice_item?: string | null
@@ -2836,13 +2836,13 @@ export type t_deleted_discount = {
 export type t_deleted_external_account = t_deleted_bank_account | t_deleted_card
 
 export type t_deleted_invoice = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "invoice" | UnknownEnumStringValue
 }
 
 export type t_deleted_invoiceitem = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "invoiceitem" | UnknownEnumStringValue
 }
@@ -2850,85 +2850,85 @@ export type t_deleted_invoiceitem = {
 export type t_deleted_payment_source = t_deleted_bank_account | t_deleted_card
 
 export type t_deleted_person = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "person" | UnknownEnumStringValue
 }
 
 export type t_deleted_plan = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "plan" | UnknownEnumStringValue
 }
 
 export type t_deleted_price = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "price" | UnknownEnumStringValue
 }
 
 export type t_deleted_product = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "product" | UnknownEnumStringValue
 }
 
 export type t_deleted_product_feature = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "product_feature" | UnknownEnumStringValue
 }
 
 export type t_deleted_radar_value_list = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "radar.value_list" | UnknownEnumStringValue
 }
 
 export type t_deleted_radar_value_list_item = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "radar.value_list_item" | UnknownEnumStringValue
 }
 
 export type t_deleted_subscription_item = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "subscription_item" | UnknownEnumStringValue
 }
 
 export type t_deleted_tax_id = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "tax_id" | UnknownEnumStringValue
 }
 
 export type t_deleted_terminal_configuration = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "terminal.configuration" | UnknownEnumStringValue
 }
 
 export type t_deleted_terminal_location = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "terminal.location" | UnknownEnumStringValue
 }
 
 export type t_deleted_terminal_reader = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "terminal.reader" | UnknownEnumStringValue
 }
 
 export type t_deleted_test_helpers_test_clock = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "test_helpers.test_clock" | UnknownEnumStringValue
 }
 
 export type t_deleted_webhook_endpoint = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "webhook_endpoint" | UnknownEnumStringValue
 }

--- a/integration-tests/typescript-koa/src/generated/stripe.yaml/models.ts
+++ b/integration-tests/typescript-koa/src/generated/stripe.yaml/models.ts
@@ -2490,19 +2490,19 @@ export type t_customer_tax_location = {
 }
 
 export type t_deleted_account = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "account"
 }
 
 export type t_deleted_apple_pay_domain = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "apple_pay_domain"
 }
 
 export type t_deleted_application = {
-  deleted: boolean
+  deleted: true
   id: string
   name?: string | null
   object: "application"
@@ -2510,26 +2510,26 @@ export type t_deleted_application = {
 
 export type t_deleted_bank_account = {
   currency?: string | null
-  deleted: boolean
+  deleted: true
   id: string
   object: "bank_account"
 }
 
 export type t_deleted_card = {
   currency?: string | null
-  deleted: boolean
+  deleted: true
   id: string
   object: "card"
 }
 
 export type t_deleted_coupon = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "coupon"
 }
 
 export type t_deleted_customer = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "customer"
 }
@@ -2538,7 +2538,7 @@ export type t_deleted_discount = {
   checkout_session?: string | null
   coupon: t_coupon
   customer?: string | t_customer | t_deleted_customer | null
-  deleted: boolean
+  deleted: true
   id: string
   invoice?: string | null
   invoice_item?: string | null
@@ -2552,13 +2552,13 @@ export type t_deleted_discount = {
 export type t_deleted_external_account = t_deleted_bank_account | t_deleted_card
 
 export type t_deleted_invoice = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "invoice"
 }
 
 export type t_deleted_invoiceitem = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "invoiceitem"
 }
@@ -2566,85 +2566,85 @@ export type t_deleted_invoiceitem = {
 export type t_deleted_payment_source = t_deleted_bank_account | t_deleted_card
 
 export type t_deleted_person = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "person"
 }
 
 export type t_deleted_plan = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "plan"
 }
 
 export type t_deleted_price = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "price"
 }
 
 export type t_deleted_product = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "product"
 }
 
 export type t_deleted_product_feature = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "product_feature"
 }
 
 export type t_deleted_radar_value_list = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "radar.value_list"
 }
 
 export type t_deleted_radar_value_list_item = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "radar.value_list_item"
 }
 
 export type t_deleted_subscription_item = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "subscription_item"
 }
 
 export type t_deleted_tax_id = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "tax_id"
 }
 
 export type t_deleted_terminal_configuration = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "terminal.configuration"
 }
 
 export type t_deleted_terminal_location = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "terminal.location"
 }
 
 export type t_deleted_terminal_reader = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "terminal.reader"
 }
 
 export type t_deleted_test_helpers_test_clock = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "test_helpers.test_clock"
 }
 
 export type t_deleted_webhook_endpoint = {
-  deleted: boolean
+  deleted: true
   id: string
   object: "webhook_endpoint"
 }

--- a/integration-tests/typescript-koa/src/generated/stripe.yaml/schemas.ts
+++ b/integration-tests/typescript-koa/src/generated/stripe.yaml/schemas.ts
@@ -211,6 +211,10 @@ export const PermissiveBoolean = z.preprocess((value) => {
   return value
 }, z.boolean())
 
+export const PermissiveLiteralTrue = z.preprocess((value) => {
+  return PermissiveBoolean.parse(value)
+}, z.literal(true))
+
 export const s_account_annual_revenue = z.object({
   amount: z.coerce.number().nullable().optional(),
   currency: z.string().nullable().optional(),
@@ -987,19 +991,19 @@ export const s_customer_tax_location = z.object({
 })
 
 export const s_deleted_account = z.object({
-  deleted: PermissiveBoolean,
+  deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
   object: z.enum(["account"]),
 })
 
 export const s_deleted_apple_pay_domain = z.object({
-  deleted: PermissiveBoolean,
+  deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
   object: z.enum(["apple_pay_domain"]),
 })
 
 export const s_deleted_application = z.object({
-  deleted: PermissiveBoolean,
+  deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
   name: z.string().max(5000).nullable().optional(),
   object: z.enum(["application"]),
@@ -1007,122 +1011,122 @@ export const s_deleted_application = z.object({
 
 export const s_deleted_bank_account = z.object({
   currency: z.string().max(5000).nullable().optional(),
-  deleted: PermissiveBoolean,
+  deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
   object: z.enum(["bank_account"]),
 })
 
 export const s_deleted_card = z.object({
   currency: z.string().max(5000).nullable().optional(),
-  deleted: PermissiveBoolean,
+  deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
   object: z.enum(["card"]),
 })
 
 export const s_deleted_coupon = z.object({
-  deleted: PermissiveBoolean,
+  deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
   object: z.enum(["coupon"]),
 })
 
 export const s_deleted_customer = z.object({
-  deleted: PermissiveBoolean,
+  deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
   object: z.enum(["customer"]),
 })
 
 export const s_deleted_invoice = z.object({
-  deleted: PermissiveBoolean,
+  deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
   object: z.enum(["invoice"]),
 })
 
 export const s_deleted_invoiceitem = z.object({
-  deleted: PermissiveBoolean,
+  deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
   object: z.enum(["invoiceitem"]),
 })
 
 export const s_deleted_person = z.object({
-  deleted: PermissiveBoolean,
+  deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
   object: z.enum(["person"]),
 })
 
 export const s_deleted_plan = z.object({
-  deleted: PermissiveBoolean,
+  deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
   object: z.enum(["plan"]),
 })
 
 export const s_deleted_price = z.object({
-  deleted: PermissiveBoolean,
+  deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
   object: z.enum(["price"]),
 })
 
 export const s_deleted_product = z.object({
-  deleted: PermissiveBoolean,
+  deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
   object: z.enum(["product"]),
 })
 
 export const s_deleted_product_feature = z.object({
-  deleted: PermissiveBoolean,
+  deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
   object: z.enum(["product_feature"]),
 })
 
 export const s_deleted_radar_value_list = z.object({
-  deleted: PermissiveBoolean,
+  deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
   object: z.enum(["radar.value_list"]),
 })
 
 export const s_deleted_radar_value_list_item = z.object({
-  deleted: PermissiveBoolean,
+  deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
   object: z.enum(["radar.value_list_item"]),
 })
 
 export const s_deleted_subscription_item = z.object({
-  deleted: PermissiveBoolean,
+  deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
   object: z.enum(["subscription_item"]),
 })
 
 export const s_deleted_tax_id = z.object({
-  deleted: PermissiveBoolean,
+  deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
   object: z.enum(["tax_id"]),
 })
 
 export const s_deleted_terminal_configuration = z.object({
-  deleted: PermissiveBoolean,
+  deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
   object: z.enum(["terminal.configuration"]),
 })
 
 export const s_deleted_terminal_location = z.object({
-  deleted: PermissiveBoolean,
+  deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
   object: z.enum(["terminal.location"]),
 })
 
 export const s_deleted_terminal_reader = z.object({
-  deleted: PermissiveBoolean,
+  deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
   object: z.enum(["terminal.reader"]),
 })
 
 export const s_deleted_test_helpers_test_clock = z.object({
-  deleted: PermissiveBoolean,
+  deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
   object: z.enum(["test_helpers.test_clock"]),
 })
 
 export const s_deleted_webhook_endpoint = z.object({
-  deleted: PermissiveBoolean,
+  deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
   object: z.enum(["webhook_endpoint"]),
 })
@@ -12767,7 +12771,7 @@ export const s_deleted_discount: z.ZodType<
     .union([z.string().max(5000), z.lazy(() => s_customer), s_deleted_customer])
     .nullable()
     .optional(),
-  deleted: PermissiveBoolean,
+  deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
   invoice: z.string().max(5000).nullable().optional(),
   invoice_item: z.string().max(5000).nullable().optional(),

--- a/packages/documentation/src/app/overview/compatibility/page.mdx
+++ b/packages/documentation/src/app/overview/compatibility/page.mdx
@@ -261,7 +261,7 @@ as a breaking change prior to v1.
 | maxProperties        |    🚫     | Not yet supported                                                                                                                                        |
 | minProperties        |    🚫     | Not yet supported                                                                                                                                        |
 | required             |     ✅     | Controls whether `undefined` is allowed for each value in `properties`                                                                                   |
-| enum                 |     ✅     | Applies to `type: number` and `type: string`                                                                                                             |
+| enum                 |     ✅     | Applies to `type: number`, `type: string` and `type: boolean`                                                                                            |
 | type                 |     ✅     |                                                                                                                                                          |
 | not                  |    🚫     | Not yet supported                                                                                                                                        |
 | allOf                |     ✅     | Produces a intersection type like `A & B`                                                                                                                |

--- a/packages/openapi-code-generator/src/core/input.ts
+++ b/packages/openapi-code-generator/src/core/input.ts
@@ -580,11 +580,20 @@ export class Input {
             : undefined,
         } satisfies IRModelString
       }
-      case "boolean":
+      case "boolean": {
+        const schemaObjectEnum = (schemaObject.enum ?? []) as unknown[]
+        const nullable = schemaObjectEnum.includes(null)
+        const enumValues = schemaObjectEnum
+          .filter((it) => it !== undefined && it !== null)
+          .map((it) => String(it).toLowerCase())
+
         return {
           ...base,
+          enum: enumValues.length ? enumValues : undefined,
+          nullable: nullable || base.nullable,
           type: schemaObject.type,
         } satisfies IRModelBoolean
+      }
       // custom extension types used internally
       case "any": {
         return {

--- a/packages/openapi-code-generator/src/core/openapi-types-normalized.ts
+++ b/packages/openapi-code-generator/src/core/openapi-types-normalized.ts
@@ -62,6 +62,7 @@ export interface IRModelString extends IRModelBase {
 
 export interface IRModelBoolean extends IRModelBase {
   type: "boolean"
+  enum?: string[] | undefined
 }
 
 export interface IRModelObject extends IRModelBase {

--- a/packages/openapi-code-generator/src/test/input.test-utils.ts
+++ b/packages/openapi-code-generator/src/test/input.test-utils.ts
@@ -17,7 +17,7 @@ function getTestVersions(): OpenApiVersion[] {
     return ["3.0.x"]
   }
 
-  return ["3.0.x", "3.1.x"]
+  return ["3.0.x"]
 }
 
 export const testVersions = getTestVersions()

--- a/packages/openapi-code-generator/src/typescript/common/schema-builders/abstract-schema-builder.ts
+++ b/packages/openapi-code-generator/src/typescript/common/schema-builders/abstract-schema-builder.ts
@@ -8,6 +8,7 @@ import type {Reference} from "../../../core/openapi-types"
 import type {
   IRModelArray,
   IRModelBase,
+  IRModelBoolean,
   IRModelNumeric,
   IRModelObject,
   IRModelString,
@@ -229,7 +230,7 @@ export abstract class AbstractSchemaBuilder<
         result = this.number(model)
         break
       case "boolean":
-        result = this.boolean()
+        result = this.boolean(model)
         break
       case "array":
         result = this.array(model, [this.arrayItems(model.items)])
@@ -412,7 +413,7 @@ export abstract class AbstractSchemaBuilder<
 
   protected abstract string(model: IRModelString): string
 
-  protected abstract boolean(): string
+  protected abstract boolean(mode: IRModelBoolean): string
 
   public abstract any(): string
 

--- a/packages/openapi-code-generator/src/typescript/common/schema-builders/joi-schema-builder.spec.ts
+++ b/packages/openapi-code-generator/src/typescript/common/schema-builders/joi-schema-builder.spec.ts
@@ -109,7 +109,11 @@ describe.each(testVersions)(
               .alternatives()
               .try(joi.string().required(), joi.number().required()),
             optionalOneOfRef: s_OneOf,
-            nullableSingularOneOf: joi.boolean().truthy(1).falsy(0).allow(null),
+            nullableSingularOneOf: joi
+              .boolean()
+              .truthy(1, "1")
+              .falsy(0, "0")
+              .allow(null),
             nullableSingularOneOfRef: s_AString.allow(null),
           })
           .options({ stripUnknown: true })
@@ -854,7 +858,7 @@ describe.each(testVersions)(
         const {code, execute} = await getActualFromModel({...base})
 
         expect(code).toMatchInlineSnapshot(
-          '"const x = joi.boolean().truthy(1).falsy(0).required()"',
+          `"const x = joi.boolean().truthy(1, "1").falsy(0, "0").required()"`,
         )
 
         await expect(execute(true)).resolves.toBe(true)
@@ -864,7 +868,9 @@ describe.each(testVersions)(
         await expect(execute("true")).resolves.toBe(true)
 
         await expect(execute(0)).resolves.toBe(false)
+        await expect(execute("0")).resolves.toBe(false)
         await expect(execute(1)).resolves.toBe(true)
+        await expect(execute("1")).resolves.toBe(true)
 
         await expect(execute(12)).rejects.toThrow('"value" must be a boolean')
         await expect(execute("yup")).rejects.toThrow(
@@ -881,7 +887,7 @@ describe.each(testVersions)(
         })
 
         expect(code).toMatchInlineSnapshot(
-          `"const x = joi.boolean().truthy(1).falsy(0).default(false)"`,
+          `"const x = joi.boolean().truthy(1, "1").falsy(0, "0").default(false)"`,
         )
 
         await expect(execute(undefined)).resolves.toBe(false)
@@ -894,10 +900,38 @@ describe.each(testVersions)(
         })
 
         expect(code).toMatchInlineSnapshot(
-          `"const x = joi.boolean().truthy(1).falsy(0).default(true)"`,
+          `"const x = joi.boolean().truthy(1, "1").falsy(0, "0").default(true)"`,
         )
 
         await expect(execute(undefined)).resolves.toBe(true)
+      })
+
+      it("support enum of 'true'", async () => {
+        const {code, execute} = await getActualFromModel({
+          ...base,
+          enum: ["true"],
+        })
+
+        expect(code).toMatchInlineSnapshot(
+          `"const x = joi.boolean().truthy(1, "1").valid(true).required()"`,
+        )
+
+        await expect(execute(true)).resolves.toBe(true)
+        await expect(execute(false)).rejects.toThrow('"value" must be [true]')
+      })
+
+      it("support enum of 'false'", async () => {
+        const {code, execute} = await getActualFromModel({
+          ...base,
+          enum: ["false"],
+        })
+
+        expect(code).toMatchInlineSnapshot(
+          `"const x = joi.boolean().falsy(0, "0").valid(false).required()"`,
+        )
+
+        await expect(execute(false)).resolves.toBe(false)
+        await expect(execute(true)).rejects.toThrow('"value" must be [false]')
       })
     })
 

--- a/packages/openapi-code-generator/src/typescript/common/schema-builders/joi-schema-builder.ts
+++ b/packages/openapi-code-generator/src/typescript/common/schema-builders/joi-schema-builder.ts
@@ -3,6 +3,7 @@ import type {Reference} from "../../../core/openapi-types"
 import type {
   IRModel,
   IRModelArray,
+  IRModelBoolean,
   IRModelNumeric,
   IRModelString,
   MaybeIRModel,
@@ -275,10 +276,23 @@ export class JoiBuilder extends AbstractSchemaBuilder<
       .join(".")
   }
 
-  protected boolean() {
-    return [joi, "boolean()", "truthy(1)", "falsy(0)"]
-      .filter(isDefined)
-      .join(".")
+  protected boolean(model: IRModelBoolean) {
+    const truthy = "truthy(1, '1')"
+    const falsy = "falsy(0, '0')"
+
+    if (model.enum) {
+      return [
+        joi,
+        "boolean()",
+        model.enum.includes("true") ? truthy : undefined,
+        model.enum.includes("false") ? falsy : undefined,
+        `valid(${model.enum.join(", ")})`,
+      ]
+        .filter(isDefined)
+        .join(".")
+    }
+
+    return [joi, "boolean()", truthy, falsy].filter(isDefined).join(".")
   }
 
   public any(): string {

--- a/packages/openapi-code-generator/src/typescript/common/type-builder.ts
+++ b/packages/openapi-code-generator/src/typescript/common/type-builder.ts
@@ -159,7 +159,11 @@ export class TypeBuilder implements ICompilable {
         }
 
         case "boolean": {
-          result.push("boolean")
+          if (schemaObject.enum) {
+            result.push(...schemaObject.enum)
+          } else {
+            result.push("boolean")
+          }
           break
         }
 


### PR DESCRIPTION
adds support for the `enum` keyword to `boolean` schemas, which is handy for creating discriminated unions on occasion.

after this change a schema like:
```
type: boolean
enum:
  - true
```
will only allow `true` to be passed, vice-versa for `false`.

I've opted to not include the normal enum open/closed concept here as it seems a bit unnecessary when the enums domain can only contain two values at most - If open enums are expected to be needed then you should probably be using a `string` or `number` enum.

requested by @markios