### PR TITLE
refactor: avoid dependency on concrete schema builders

### DIFF
--- a/packages/openapi-code-generator/src/typescript/client/typescript-fetch/typescript-fetch-client-builder.ts
+++ b/packages/openapi-code-generator/src/typescript/client/typescript-fetch/typescript-fetch-client-builder.ts
@@ -1,7 +1,5 @@
 import {isDefined} from "../../../core/utils"
 import type {ImportBuilder} from "../../common/import-builder"
-import {JoiBuilder} from "../../common/schema-builders/joi-schema-builder"
-import {ZodBuilder} from "../../common/schema-builders/zod-schema-builder"
 import {union} from "../../common/type-utils"
 import {
   asyncMethod,
@@ -40,15 +38,27 @@ export class TypescriptFetchClientBuilder extends AbstractClientBuilder {
         "StatusCode",
       )
 
+    const schemaBuilderType = this.schemaBuilder.type
+
     if (this.config.enableRuntimeResponseValidation) {
-      if (this.schemaBuilder instanceof ZodBuilder) {
-        imports
-          .from("@nahkies/typescript-fetch-runtime/zod")
-          .add("responseValidationFactory")
-      } else if (this.schemaBuilder instanceof JoiBuilder) {
-        imports
-          .from("@nahkies/typescript-fetch-runtime/joi")
-          .add("responseValidationFactory")
+      switch (schemaBuilderType) {
+        case "joi": {
+          imports
+            .from("@nahkies/typescript-fetch-runtime/joi")
+            .add("responseValidationFactory")
+          break
+        }
+        case "zod": {
+          imports
+            .from("@nahkies/typescript-fetch-runtime/zod")
+            .add("responseValidationFactory")
+          break
+        }
+        default: {
+          throw new Error(
+            `unsupported schema builder type '${schemaBuilderType satisfies never}'`,
+          )
+        }
       }
     }
   }

--- a/packages/openapi-code-generator/src/typescript/common/schema-builders/abstract-schema-builder.ts
+++ b/packages/openapi-code-generator/src/typescript/common/schema-builders/abstract-schema-builder.ts
@@ -20,6 +20,7 @@ import {hasSingleElement} from "../../../core/utils"
 import {CompilationUnit, type ICompilable} from "../compilation-units"
 import {ImportBuilder} from "../import-builder"
 import {buildExport, type ExportDefinition} from "../typescript-common"
+import type {SchemaBuilderType} from "./schema-builder"
 
 export type SchemaBuilderConfig = {
   allowAny: boolean
@@ -30,6 +31,8 @@ export abstract class AbstractSchemaBuilder<
   StaticSchemas extends {[key: string]: string},
 > implements ICompilable
 {
+  public abstract readonly type: SchemaBuilderType
+
   private readonly graph: DependencyGraph
 
   protected readonly schemaBuilderImports = new ImportBuilder()

--- a/packages/openapi-code-generator/src/typescript/common/schema-builders/joi-schema-builder.ts
+++ b/packages/openapi-code-generator/src/typescript/common/schema-builders/joi-schema-builder.ts
@@ -27,6 +27,8 @@ export class JoiBuilder extends AbstractSchemaBuilder<
   JoiBuilder,
   StaticSchemas
 > {
+  readonly type = "joi"
+
   static async fromInput(
     filename: string,
     input: Input,

--- a/packages/openapi-code-generator/src/typescript/common/schema-builders/zod-schema-builder.ts
+++ b/packages/openapi-code-generator/src/typescript/common/schema-builders/zod-schema-builder.ts
@@ -45,6 +45,8 @@ export class ZodBuilder extends AbstractSchemaBuilder<
   ZodBuilder,
   StaticSchemas
 > {
+  readonly type = "zod"
+
   static async fromInput(
     filename: string,
     input: Input,

--- a/packages/openapi-code-generator/src/typescript/server/typescript-express/typescript-express-router-builder.ts
+++ b/packages/openapi-code-generator/src/typescript/server/typescript-express/typescript-express-router-builder.ts
@@ -2,9 +2,7 @@ import type {Input} from "../../../core/input"
 import {titleCase} from "../../../core/utils"
 import type {ServerImplementationMethod} from "../../../templates.types"
 import type {ImportBuilder} from "../../common/import-builder"
-import {JoiBuilder} from "../../common/schema-builders/joi-schema-builder"
 import type {SchemaBuilder} from "../../common/schema-builders/schema-builder"
-import {ZodBuilder} from "../../common/schema-builders/zod-schema-builder"
 import type {TypeBuilder} from "../../common/type-builder"
 import {constStatement, object} from "../../common/type-utils"
 import {buildExport} from "../../common/typescript-common"
@@ -58,14 +56,28 @@ export class ExpressRouterBuilder extends AbstractRouterBuilder {
       .from("@nahkies/typescript-express-runtime/errors")
       .add("ExpressRuntimeError", "RequestInputType")
 
-    if (this.schemaBuilder instanceof ZodBuilder) {
-      this.imports
-        .from("@nahkies/typescript-express-runtime/zod")
-        .add("parseRequestInput", "responseValidationFactory")
-    } else if (this.schemaBuilder instanceof JoiBuilder) {
-      this.imports
-        .from("@nahkies/typescript-express-runtime/joi")
-        .add("parseRequestInput", "responseValidationFactory")
+    const schemaBuilderType = this.schemaBuilder.type
+
+    switch (schemaBuilderType) {
+      case "joi": {
+        this.imports
+          .from("@nahkies/typescript-express-runtime/joi")
+          .add("parseRequestInput", "responseValidationFactory")
+        break
+      }
+
+      case "zod": {
+        this.imports
+          .from("@nahkies/typescript-express-runtime/zod")
+          .add("parseRequestInput", "responseValidationFactory")
+        break
+      }
+
+      default: {
+        throw new Error(
+          `unsupported schema builder type '${schemaBuilderType satisfies never}'`,
+        )
+      }
     }
   }
 

--- a/packages/openapi-code-generator/src/typescript/server/typescript-koa/typescript-koa-router-builder.ts
+++ b/packages/openapi-code-generator/src/typescript/server/typescript-koa/typescript-koa-router-builder.ts
@@ -2,9 +2,7 @@ import type {Input} from "../../../core/input"
 import {isDefined, titleCase} from "../../../core/utils"
 import type {ServerImplementationMethod} from "../../../templates.types"
 import type {ImportBuilder} from "../../common/import-builder"
-import {JoiBuilder} from "../../common/schema-builders/joi-schema-builder"
 import type {SchemaBuilder} from "../../common/schema-builders/schema-builder"
-import {ZodBuilder} from "../../common/schema-builders/zod-schema-builder"
 import type {TypeBuilder} from "../../common/type-builder"
 import {constStatement, object} from "../../common/type-utils"
 import {buildExport} from "../../common/typescript-common"
@@ -59,14 +57,28 @@ export class KoaRouterBuilder extends AbstractRouterBuilder {
     this.imports.addModule("KoaRouter", "@koa/router")
     this.imports.from("@koa/router").add("RouterContext")
 
-    if (this.schemaBuilder instanceof ZodBuilder) {
-      this.imports
-        .from("@nahkies/typescript-koa-runtime/zod")
-        .add("parseRequestInput", "responseValidationFactory")
-    } else if (this.schemaBuilder instanceof JoiBuilder) {
-      this.imports
-        .from("@nahkies/typescript-koa-runtime/joi")
-        .add("parseRequestInput", "responseValidationFactory")
+    const schemaBuilderType = this.schemaBuilder.type
+
+    switch (schemaBuilderType) {
+      case "joi": {
+        this.imports
+          .from("@nahkies/typescript-koa-runtime/joi")
+          .add("parseRequestInput", "responseValidationFactory")
+        break
+      }
+
+      case "zod": {
+        this.imports
+          .from("@nahkies/typescript-koa-runtime/zod")
+          .add("parseRequestInput", "responseValidationFactory")
+        break
+      }
+
+      default: {
+        throw new Error(
+          `unsupported schema builder type '${schemaBuilderType satisfies never}'`,
+        )
+      }
     }
   }
 


### PR DESCRIPTION
split from #366, refactors such that the templates don't have a direct dependency on the concrete schema builders, and adds an exhaustiveness check to flag when a new builder hasn't been registered with a template.