### PR TITLE
fix: use nodejs built-in sourcemap support

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "lint-staged": "^16.1.2",
     "markdown-toc": "^1.2.0",
     "prettier": "^3.6.2",
-    "source-map-support": "^0.5.21",
     "typescript": "~5.9.3"
   },
   "workspaces": [

--- a/packages/openapi-code-generator/package.json
+++ b/packages/openapi-code-generator/package.json
@@ -57,7 +57,6 @@
     "js-yaml": "^4.1.0",
     "json5": "^2.2.3",
     "lodash": "^4.17.21",
-    "source-map-support": "^0.5.21",
     "strip-json-comments": "^5.0.2",
     "tslib": "^2.8.1",
     "typescript": "~5.9.3",

--- a/packages/openapi-code-generator/src/cli.ts
+++ b/packages/openapi-code-generator/src/cli.ts
@@ -1,6 +1,11 @@
 #!/usr/bin/env node
 
-import "source-map-support/register"
+import * as nodeModule from "node:module"
+
+// note: support added in v22.14.0
+if (Reflect.has(nodeModule, "setSourceMapsSupport")) {
+  nodeModule.setSourceMapsSupport(true)
+}
 
 import path from "node:path"
 import {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,9 +73,6 @@ importers:
       prettier:
         specifier: ^3.6.2
         version: 3.6.2
-      source-map-support:
-        specifier: ^0.5.21
-        version: 0.5.21
       typescript:
         specifier: ~5.9.3
         version: 5.9.3
@@ -419,9 +416,6 @@ importers:
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
-      source-map-support:
-        specifier: ^0.5.21
-        version: 0.5.21
       strip-json-comments:
         specifier: ^5.0.2
         version: 5.0.2


### PR DESCRIPTION
no need for a dependency anymore, use https://nodejs.org/docs/latest-v24.x/api/module.html#modulesetsourcemapssupportenabled-options