### PR TITLE
docs: fix example commands

### DIFF
--- a/packages/documentation/src/app/getting-started/quick-start/page.mdx
+++ b/packages/documentation/src/app/getting-started/quick-start/page.mdx
@@ -26,8 +26,8 @@ You can check the version we develop and test against [here](https://github.com/
       {<h3>Install dependencies</h3>}
       First install the CLI and the required runtime packages to your project:
       ```sh npm2yarn
-      npm i --dev @nahkies/openapi-code-generator
-      npm i @nahkies/typescript-fetch-runtime
+      npm i --save-dev @nahkies/openapi-code-generator
+      npm i --save @nahkies/typescript-fetch-runtime
       ```
 
       You could also run the cli through `npx`, or install it globally if you prefer, but it's recommended to pin its
@@ -38,7 +38,7 @@ You can check the version we develop and test against [here](https://github.com/
 
       You can provide either a local file path or url for the input file.
       ```sh npm2yarn
-      npm run openapi-code-generator \
+      npm exec -- openapi-code-generator \
       --input ./openapi.yaml \ # or https://example.com/openapi.{json,yaml}
       --output ./src/generated/clients/some-service \
       --template typescript-fetch
@@ -56,8 +56,8 @@ You can check the version we develop and test against [here](https://github.com/
       {<h3>Install dependencies</h3>}
       First install the CLI and the required runtime packages to your project:
       ```sh npm2yarn
-      npm i --dev @nahkies/openapi-code-generator
-      npm i axios @nahkies/typescript-axios-runtime
+      npm i --save-dev @nahkies/openapi-code-generator
+      npm i --save axios @nahkies/typescript-axios-runtime
       ```
 
       You could also run the cli through `npx`, or install it globally if you prefer, but it's recommended to pin its
@@ -68,7 +68,7 @@ You can check the version we develop and test against [here](https://github.com/
 
       You can provide either a local file path or url for the input file.
       ```sh npm2yarn
-      npm run openapi-code-generator \
+      npm exec -- openapi-code-generator \
       --input ./openapi.yaml \ # or https://example.com/openapi.{json,yaml}
       --output ./src/generated/clients/some-service \
       --template typescript-axios
@@ -87,8 +87,8 @@ You can check the version we develop and test against [here](https://github.com/
       {<h3>Install dependencies</h3>}
       First install the CLI and the required runtime packages to your project:
       ```sh npm2yarn
-      npm i --dev @nahkies/openapi-code-generator @types/koa @types/koa__router
-      npm i @nahkies/typescript-koa-runtime @koa/cors @koa/router koa koa-body zod
+      npm i --save-dev @nahkies/openapi-code-generator @types/koa @types/koa__router
+      npm i --save @nahkies/typescript-koa-runtime @koa/cors @koa/router koa koa-body zod
       ```
 
       You could also run the cli through `npx`, or install it globally if you prefer, but it's recommended to pin its
@@ -99,7 +99,7 @@ You can check the version we develop and test against [here](https://github.com/
       {<h3>Run generation</h3>}
       This will generate the server router and validation logic to `./src/generated`
       ```sh npm2yarn
-      npm run openapi-code-generator \
+      npm exec -- openapi-code-generator \
       --input ./openapi.yaml \ # or https://example.com/openapi.{json,yaml}
       --output ./src/generated \
       --template typescript-koa
@@ -120,8 +120,8 @@ You can check the version we develop and test against [here](https://github.com/
       {<h3>Install dependencies</h3>}
       First install the CLI and the required runtime packages to your project:
       ```sh npm2yarn
-      npm i --dev @nahkies/openapi-code-generator @types/express
-      npm i @nahkies/typescript-express-runtime express zod
+      npm i --save-dev @nahkies/openapi-code-generator @types/express
+      npm i --save @nahkies/typescript-express-runtime express zod
       ```
 
       You could also run the cli through `npx`, or install it globally if you prefer, but it's recommended to pin its
@@ -132,7 +132,7 @@ You can check the version we develop and test against [here](https://github.com/
       {<h3>Run generation</h3>}
       This will generate the server router and validation logic to `./src/generated`
       ```sh npm2yarn
-      npm run openapi-code-generator \
+      npm exec -- openapi-code-generator \
       --input ./openapi.yaml \ # or https://example.com/openapi.{json,yaml}
       --output ./src/generated \
       --template typescript-express
@@ -152,7 +152,7 @@ You can check the version we develop and test against [here](https://github.com/
 ## CLI options
 See the [cli reference](../reference/cli-options) for the full range of supported options, or try
 ```sh npm2yarn
-npm run openapi-code-generator --help
+npm exec -- openapi-code-generator --help
 ```
 
 ## Typespec specifications
@@ -160,7 +160,7 @@ If you want to use [typespec](https://typespec.io/) instead of [openapi3](https:
 as your input specifications, additionally install the typespec compiler and supporting packages.
 
 ```sh npm2yarn
-npm i --dev @typespec/compiler @typespec/http @typespec/openapi @typespec/openapi3 @typespec/versioning
+npm i --save-dev @typespec/compiler @typespec/http @typespec/openapi @typespec/openapi3 @typespec/versioning
 ```
 
 Depending on how your `typespec` specification is written, you may need to install additional packages such
@@ -168,7 +168,7 @@ as `@typespec/rest`.
 
 You can then generate like so:
 ```sh npm2yarn
-npm run openapi-code-generator \
+npm exec -- openapi-code-generator \
   --input ./some-service.tsp \ # or https://example.com/some-service.tsp
   --input-type=typespec \
   --output ./src/generated/clients/some-service \

--- a/packages/documentation/src/app/guides/client-templates/typescript-angular/page.mdx
+++ b/packages/documentation/src/app/guides/client-templates/typescript-angular/page.mdx
@@ -21,7 +21,7 @@ See [integration-tests/typescript-angular](https://github.com/mnahkies/openapi-c
 ### Install dependencies
 First install the CLI to your project:
 ```sh npm2yarn
-npm i --dev @nahkies/openapi-code-generator
+npm i --save-dev @nahkies/openapi-code-generator
 ```
 
 See also [quick start](../../getting-started/quick-start) guide
@@ -32,7 +32,7 @@ See also [quick start](../../getting-started/quick-start) guide
 
   <Tabs.Tab>
     ```sh npm2yarn
-    npm run openapi-code-generator \
+    npm exec -- openapi-code-generator \
       --input ./openapi.yaml \
       --input-type openapi3 \
       --output ./src/app/clients/some-service \
@@ -42,7 +42,7 @@ See also [quick start](../../getting-started/quick-start) guide
   </Tabs.Tab>
   <Tabs.Tab>
     ```sh npm2yarn
-    npm run openapi-code-generator \
+    npm exec -- openapi-code-generator \
       --input ./typespec.tsp \
       --input-type typespec \
       --output ./src/app/clients/some-service \

--- a/packages/documentation/src/app/guides/client-templates/typescript-axios/page.mdx
+++ b/packages/documentation/src/app/guides/client-templates/typescript-axios/page.mdx
@@ -22,8 +22,8 @@ See [integration-tests/typescript-axios](https://github.com/mnahkies/openapi-cod
 ### Install dependencies
 First install the CLI and the required runtime packages to your project:
 ```sh npm2yarn
-npm i --dev @nahkies/openapi-code-generator
-npm i axios @nahkies/typescript-axios-runtime
+npm i --save-dev @nahkies/openapi-code-generator
+npm i --save axios @nahkies/typescript-axios-runtime
 ```
 
 See also [quick start](../../getting-started/quick-start) guide
@@ -38,7 +38,7 @@ See also [quick start](../../getting-started/quick-start) guide
 
   <Tabs.Tab>
     ```sh npm2yarn
-    npm run openapi-code-generator \
+    npm exec -- openapi-code-generator \
       --input ./openapi.yaml \
       --input-type openapi3 \
       --output ./src/clients/some-service \
@@ -48,7 +48,7 @@ See also [quick start](../../getting-started/quick-start) guide
   </Tabs.Tab>
   <Tabs.Tab>
     ```sh npm2yarn
-    npm run openapi-code-generator \
+    npm exec -- openapi-code-generator \
       --input ./typespec.tsp \
       --input-type typespec \
       --output ./src/clients/some-service \

--- a/packages/documentation/src/app/guides/client-templates/typescript-fetch/page.mdx
+++ b/packages/documentation/src/app/guides/client-templates/typescript-fetch/page.mdx
@@ -22,8 +22,8 @@ Dependencies:
 ### Install dependencies
 First install the CLI and the required runtime packages to your project:
 ```sh npm2yarn
-npm i --dev @nahkies/openapi-code-generator
-npm i @nahkies/typescript-fetch-runtime
+npm i --save-dev @nahkies/openapi-code-generator
+npm i --save @nahkies/typescript-fetch-runtime
 ```
 
 See also [quick start](../../getting-started/quick-start) guide
@@ -43,7 +43,7 @@ See also [quick start](../../getting-started/quick-start) guide
 
   <Tabs.Tab>
     ```sh npm2yarn
-    npm run openapi-code-generator \
+    npm exec -- openapi-code-generator \
       --input ./openapi.yaml \
       --input-type openapi3 \
       --output ./src/clients/some-service \
@@ -54,7 +54,7 @@ See also [quick start](../../getting-started/quick-start) guide
 
   <Tabs.Tab>
     ```sh npm2yarn
-    npm run openapi-code-generator \
+    npm exec -- openapi-code-generator \
       --input ./typespec.tsp \
       --input-type typespec \
       --output ./src/clients/some-service \

--- a/packages/documentation/src/app/guides/server-templates/typescript-express/page.mdx
+++ b/packages/documentation/src/app/guides/server-templates/typescript-express/page.mdx
@@ -18,8 +18,8 @@ See [integration-tests/typescript-express](https://github.com/mnahkies/openapi-c
 ### Install dependencies
 First install the CLI and the required runtime packages to your project:
 ```sh npm2yarn
-npm i --dev @nahkies/openapi-code-generator @types/express
-npm i @nahkies/typescript-express-runtime express zod
+npm i --save-dev @nahkies/openapi-code-generator @types/express
+npm i --save @nahkies/typescript-express-runtime express zod
 ```
 
 See also [quick start](../../getting-started/quick-start) guide
@@ -29,7 +29,7 @@ See also [quick start](../../getting-started/quick-start) guide
 
   <Tabs.Tab>
     ```sh npm2yarn
-    npm run openapi-code-generator \
+    npm exec -- openapi-code-generator \
       --input ./openapi.yaml \
       --input-type openapi3 \
       --output ./src/generated \
@@ -39,7 +39,7 @@ See also [quick start](../../getting-started/quick-start) guide
   </Tabs.Tab>
   <Tabs.Tab>
     ```sh npm2yarn
-    npm run openapi-code-generator \
+    npm exec -- openapi-code-generator \
       --input ./typespec.tsp \
       --input-type typespec \
       --output ./src/generated \

--- a/packages/documentation/src/app/guides/server-templates/typescript-koa/page.mdx
+++ b/packages/documentation/src/app/guides/server-templates/typescript-koa/page.mdx
@@ -19,8 +19,8 @@ See [integration-tests/typescript-koa](https://github.com/mnahkies/openapi-code-
 ### Install dependencies
 First install the CLI and the required runtime packages to your project:
 ```sh npm2yarn
-npm i --dev @nahkies/openapi-code-generator @types/koa @types/koa__router
-npm i @nahkies/typescript-koa-runtime @koa/cors @koa/router koa koa-body zod
+npm i --save-dev @nahkies/openapi-code-generator @types/koa @types/koa__router
+npm i --save @nahkies/typescript-koa-runtime @koa/cors @koa/router koa koa-body zod
 ```
 
 See also [quick start](../../getting-started/quick-start) guide
@@ -30,7 +30,7 @@ See also [quick start](../../getting-started/quick-start) guide
 
   <Tabs.Tab>
     ```sh npm2yarn
-    npm run openapi-code-generator \
+    npm exec -- openapi-code-generator \
       --input ./openapi.yaml \
       --input-type openapi3 \
       --output ./src \
@@ -40,7 +40,7 @@ See also [quick start](../../getting-started/quick-start) guide
   </Tabs.Tab>
   <Tabs.Tab>
     ```sh npm2yarn
-    npm run openapi-code-generator \
+    npm exec -- openapi-code-generator \
       --input ./typespec.tsp \
       --input-type typespec \
       --output ./src \


### PR DESCRIPTION
corrects the example commands in `npm2yarn` blocks to use the `npm` format, such that it renders the right thing for all package managers :facepalm: 