### PR TITLE
fix: consistently use json5

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,11 +55,11 @@
     "commander": "^14.0.1",
     "husky": "^9.1.7",
     "jest": "^30.2.0",
+    "json5": "^2.2.3",
     "lerna": "^8.2.3",
     "lint-staged": "^16.2.4",
     "markdown-toc": "^1.2.0",
     "prettier": "^3.6.2",
-    "strip-json-comments": "^5.0.3",
     "typescript": "^5.9.3"
   },
   "workspaces": [

--- a/packages/openapi-code-generator/package.json
+++ b/packages/openapi-code-generator/package.json
@@ -67,7 +67,6 @@
     "js-yaml": "^4.1.0",
     "json5": "^2.2.3",
     "lodash": "^4.17.21",
-    "strip-json-comments": "^5.0.3",
     "tslib": "^2.8.1",
     "typescript": "^5.9.3",
     "zod": "^3.25.74"

--- a/packages/openapi-code-generator/src/core/loaders/typescript-formatter-config.loader.ts
+++ b/packages/openapi-code-generator/src/core/loaders/typescript-formatter-config.loader.ts
@@ -1,4 +1,5 @@
 import path from "node:path"
+import json5 from "json5"
 import type {IFsAdaptor} from "../file-system/fs-adaptor"
 import {logger} from "../logger"
 
@@ -22,11 +23,9 @@ export async function loadTypescriptFormatterConfig(
   if (biomeConfigFile) {
     const rawConfig = await fsAdaptor.readFile(biomeConfigFile)
 
-    const stripJsonComments = (await import("strip-json-comments")).default
-
     return {
       type: "biome",
-      config: JSON.parse(stripJsonComments(rawConfig)),
+      config: json5.parse(rawConfig),
     }
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,6 +61,9 @@ importers:
       jest:
         specifier: ^30.2.0
         version: 30.2.0(@types/node@22.16.5)
+      json5:
+        specifier: ^2.2.3
+        version: 2.2.3
       lerna:
         specifier: ^8.2.3
         version: 8.2.3(@swc/core@1.13.5(@swc/helpers@0.5.17))(encoding@0.1.13)
@@ -73,9 +76,6 @@ importers:
       prettier:
         specifier: ^3.6.2
         version: 3.6.2
-      strip-json-comments:
-        specifier: ^5.0.3
-        version: 5.0.3
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -419,9 +419,6 @@ importers:
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
-      strip-json-comments:
-        specifier: ^5.0.3
-        version: 5.0.3
       tslib:
         specifier: ^2.8.1
         version: 2.8.1
@@ -9142,10 +9139,6 @@ packages:
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
-
-  strip-json-comments@5.0.3:
-    resolution: {integrity: sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==}
-    engines: {node: '>=14.16'}
 
   strip-outer@1.0.1:
     resolution: {integrity: sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==}
@@ -20211,8 +20204,6 @@ snapshots:
       min-indent: 1.0.1
 
   strip-json-comments@3.1.1: {}
-
-  strip-json-comments@5.0.3: {}
 
   strip-outer@1.0.1:
     dependencies:

--- a/scripts/generate-ajv-validator.js
+++ b/scripts/generate-ajv-validator.js
@@ -8,7 +8,7 @@ const Ajv2020 = require("ajv/dist/2020")
 const standaloneCode = require("ajv/dist/standalone").default
 const addFormats = require("ajv-formats")
 const {Biome, Distribution} = require("@biomejs/js-api")
-const stripJsonComments = require("strip-json-comments").default
+const json5 = require("json5")
 
 const openapi30Path = path.join(
   __dirname,
@@ -47,10 +47,8 @@ const writeOutput = async (filepath, moduleCode) => {
     path.resolve(path.join(__dirname, "..")),
   )
 
-  const biomeConfig = JSON.parse(
-    stripJsonComments(
-      await fs.readFile(path.join(__dirname, "../biome.jsonc"), "utf-8"),
-    ),
+  const biomeConfig = json5.parse(
+    await fs.readFile(path.join(__dirname, "../biome.jsonc"), "utf-8"),
   )
   biome.applyConfiguration(projectKey, biomeConfig)
 


### PR DESCRIPTION
we already use `json5` to parse JSON - no need for `strip-json-comments` as JSON5 supports comments.