### PR TITLE
fix: tsconfig loading when no compilerOptions

### DIFF
--- a/packages/openapi-code-generator/src/core/file-system/fs-adaptor.ts
+++ b/packages/openapi-code-generator/src/core/file-system/fs-adaptor.ts
@@ -8,4 +8,6 @@ export interface IFsAdaptor {
   existsSync(path: string): boolean
 
   mkDir(path: string, recursive: boolean): Promise<void>
+
+  resolve(request: string, fromDir: string): string
 }

--- a/packages/openapi-code-generator/src/core/file-system/node-fs-adaptor.ts
+++ b/packages/openapi-code-generator/src/core/file-system/node-fs-adaptor.ts
@@ -1,5 +1,4 @@
 import {existsSync} from "node:fs"
-
 import fs from "node:fs/promises"
 import type {IFsAdaptor} from "./fs-adaptor"
 
@@ -34,5 +33,9 @@ export class NodeFsAdaptor implements IFsAdaptor {
 
   async mkDir(path: string, recursive = true) {
     await fs.mkdir(path, {recursive})
+  }
+
+  resolve(request: string, fromDir: string): string {
+    return require.resolve(request, {paths: [fromDir]})
   }
 }

--- a/packages/openapi-code-generator/src/core/file-system/web-fs-adaptor.ts
+++ b/packages/openapi-code-generator/src/core/file-system/web-fs-adaptor.ts
@@ -1,3 +1,4 @@
+import pathModule from "node:path"
 import type {IFsAdaptor} from "./fs-adaptor"
 
 export class WebFsAdaptor implements IFsAdaptor {
@@ -29,5 +30,9 @@ export class WebFsAdaptor implements IFsAdaptor {
 
   async mkDir() {
     /*noop*/
+  }
+
+  resolve(request: string, fromDir: string): string {
+    return pathModule.normalize(pathModule.resolve(fromDir, request))
   }
 }

--- a/packages/openapi-code-generator/src/core/loaders/tsconfig.loader.spec.ts
+++ b/packages/openapi-code-generator/src/core/loaders/tsconfig.loader.spec.ts
@@ -1,0 +1,101 @@
+import {describe, expect, it} from "@jest/globals"
+import {WebFsAdaptor} from "../file-system/web-fs-adaptor"
+import {loadTsConfigCompilerOptions} from "./tsconfig.loader"
+
+function fsAdaptor(files: Record<string, string>) {
+  return new WebFsAdaptor(new Map(Object.entries(files)))
+}
+
+describe("core/loaders/tsconfig.loader", () => {
+  it("returns defaults when no tsconfig.json is found", async () => {
+    const fs = fsAdaptor({})
+
+    const actual = await loadTsConfigCompilerOptions(
+      "/virtual/workspace/src",
+      fs,
+    )
+
+    expect(actual).toEqual({
+      exactOptionalPropertyTypes: false,
+      rewriteRelativeImportExtensions: false,
+    })
+  })
+
+  it("parses tsconfig.json without compilerOptions and applies defaults", async () => {
+    const fs = fsAdaptor({
+      "/virtual/workspace/tsconfig.json": "{}",
+    })
+
+    const actual = await loadTsConfigCompilerOptions("/virtual/workspace", fs)
+
+    expect(actual).toEqual({
+      exactOptionalPropertyTypes: false,
+      rewriteRelativeImportExtensions: false,
+    })
+  })
+
+  it("reads and returns specified compilerOptions overriding defaults", async () => {
+    const fs = fsAdaptor({
+      "/virtual/ws/tsconfig.json": JSON.stringify({
+        compilerOptions: {
+          exactOptionalPropertyTypes: true,
+        },
+      }),
+    })
+
+    const actual = await loadTsConfigCompilerOptions(
+      "/virtual/ws/packages/pkg",
+      fs,
+    )
+
+    expect(actual).toEqual({
+      exactOptionalPropertyTypes: true,
+      rewriteRelativeImportExtensions: false,
+    })
+  })
+
+  it("supports both options when set", async () => {
+    const fs = fsAdaptor({
+      "/v/tsconfig.json": JSON.stringify({
+        compilerOptions: {
+          exactOptionalPropertyTypes: true,
+          rewriteRelativeImportExtensions: true,
+        },
+      }),
+    })
+
+    const actual = await loadTsConfigCompilerOptions("/v/src", fs)
+
+    expect(actual).toEqual({
+      exactOptionalPropertyTypes: true,
+      rewriteRelativeImportExtensions: true,
+    })
+  })
+
+  it("merges compilerOptions from an extends chain", async () => {
+    const basePath = "/virt/base/tsconfig.base.json"
+    const childPath = "/virt/proj/tsconfig.json"
+
+    const fs = fsAdaptor({
+      [basePath]: JSON.stringify({
+        compilerOptions: {
+          exactOptionalPropertyTypes: true,
+          rewriteRelativeImportExtensions: false,
+        },
+      }),
+      [childPath]: JSON.stringify({
+        extends: "./../base/tsconfig.base.json",
+        compilerOptions: {
+          rewriteRelativeImportExtensions: true,
+        },
+      }),
+    })
+
+    const actual = await loadTsConfigCompilerOptions("/virt/proj/src", fs)
+
+    expect(actual).toEqual({
+      exactOptionalPropertyTypes: true,
+      rewriteRelativeImportExtensions: true,
+    })
+  })
+})

--- a/packages/openapi-code-generator/src/core/loaders/tsconfig.loader.ts
+++ b/packages/openapi-code-generator/src/core/loaders/tsconfig.loader.ts
@@ -27,7 +27,9 @@ export async function loadTsConfigCompilerOptions(
     const path = ts.findConfigFile(searchPath, (it) => fsAdaptor.existsSync(it))
 
     if (path) {
-      return (await loadTsConfig(path, fsAdaptor)).compilerOptions
+      const compilerOptions = (await loadTsConfig(path, fsAdaptor))
+        .compilerOptions
+      return {...defaults, ...compilerOptions}
     }
 
     logger.warn(`no tsconfig.json found for ${searchPath}, using defaults`, {
@@ -59,7 +61,7 @@ async function loadTsConfig(
       ? [config.extends]
       : (config.extends ?? [])
     )
-      .map((it) => require.resolve(it, {paths: [path.dirname(configPath)]}))
+      .map((it) => fsAdaptor.resolve(it, path.dirname(configPath)))
       .map((it) => loadTsConfig(it, fsAdaptor)),
   )
 

--- a/packages/openapi-code-generator/src/core/schemas/tsconfig.schema.ts
+++ b/packages/openapi-code-generator/src/core/schemas/tsconfig.schema.ts
@@ -38,5 +38,7 @@ export const tsconfigSchema = z.object({
       rewriteRelativeImportExtensions: z.boolean(),
       verbatimModuleSyntax: z.boolean(),
     })
-    .partial(),
+    .partial()
+    .optional()
+    .default({}),
 })


### PR DESCRIPTION
previously the zod schema would refuse to parse a `tsconfig.json` if it didn't define any `compilerOptions`.

This was problematic when configurations extend each other, as you might have intermediate configuration files that don't define this.