### PR TITLE
fix: use schema types rather than ir

### DIFF
--- a/packages/openapi-code-generator/src/typescript/common/schema-builders/joi-schema-builder.spec.ts
+++ b/packages/openapi-code-generator/src/typescript/common/schema-builders/joi-schema-builder.spec.ts
@@ -1,19 +1,19 @@
 import vm from "node:vm"
 import {describe, expect, it} from "@jest/globals"
 import type {
-  IRModelArray,
-  IRModelBoolean,
-  IRModelNumeric,
-  IRModelObject,
-  IRModelString,
-} from "../../../core/openapi-types-normalized"
+  SchemaArray,
+  SchemaBoolean,
+  SchemaNumber,
+  SchemaObject,
+  SchemaString,
+} from "../../../core/openapi-types"
 import {testVersions} from "../../../test/input.test-utils"
 import type {SchemaBuilderConfig} from "./abstract-schema-builder"
 import {
-  irModelNumber,
-  irModelObject,
-  irModelString,
   schemaBuilderTestHarness,
+  schemaNumber,
+  schemaObject,
+  schemaString,
 } from "./schema-builder.test-utils"
 
 describe.each(testVersions)(
@@ -408,7 +408,7 @@ describe.each(testVersions)(
     })
 
     describe("numbers", () => {
-      const base: IRModelNumeric = {
+      const base: SchemaNumber = {
         nullable: false,
         readOnly: false,
         type: "number",
@@ -642,7 +642,7 @@ describe.each(testVersions)(
     })
 
     describe("strings", () => {
-      const base: IRModelString = {
+      const base: SchemaString = {
         nullable: false,
         readOnly: false,
         type: "string",
@@ -876,7 +876,7 @@ describe.each(testVersions)(
     })
 
     describe("booleans", () => {
-      const base: IRModelBoolean = {
+      const base: SchemaBoolean = {
         nullable: false,
         readOnly: false,
         type: "boolean",
@@ -978,7 +978,7 @@ describe.each(testVersions)(
     })
 
     describe("arrays", () => {
-      const base: IRModelArray = {
+      const base: SchemaArray = {
         nullable: false,
         readOnly: false,
         type: "array",
@@ -1061,7 +1061,7 @@ describe.each(testVersions)(
       it("supports minItems / maxItems / uniqueItems", async () => {
         const {code, execute} = await getActualFromModel({
           ...base,
-          items: {type: "number", nullable: false, readOnly: false},
+          items: schemaNumber(),
           minItems: 1,
           maxItems: 3,
           uniqueItems: true,
@@ -1111,7 +1111,7 @@ describe.each(testVersions)(
     })
 
     describe("objects", () => {
-      const base: IRModelObject = {
+      const base: SchemaObject = {
         type: "object",
         allOf: [],
         anyOf: [],
@@ -1203,8 +1203,8 @@ describe.each(testVersions)(
     describe("unions", () => {
       it("can union a string and number", async () => {
         const {code, execute} = await getActualFromModel(
-          irModelObject({
-            anyOf: [irModelString(), irModelNumber()],
+          schemaObject({
+            anyOf: [schemaString(), schemaNumber()],
           }),
         )
 
@@ -1222,17 +1222,17 @@ describe.each(testVersions)(
 
       it("can union an intersected object and string", async () => {
         const {code, execute} = await getActualFromModel(
-          irModelObject({
+          schemaObject({
             anyOf: [
-              irModelString(),
-              irModelObject({
+              schemaString(),
+              schemaObject({
                 allOf: [
-                  irModelObject({
-                    properties: {foo: irModelString()},
+                  schemaObject({
+                    properties: {foo: schemaString()},
                     required: ["foo"],
                   }),
-                  irModelObject({
-                    properties: {bar: irModelString()},
+                  schemaObject({
+                    properties: {bar: schemaString()},
                     required: ["bar"],
                   }),
                 ],
@@ -1275,14 +1275,14 @@ describe.each(testVersions)(
     describe("intersections", () => {
       it("can intersect objects", async () => {
         const {code, execute} = await getActualFromModel(
-          irModelObject({
+          schemaObject({
             allOf: [
-              irModelObject({
-                properties: {foo: irModelString()},
+              schemaObject({
+                properties: {foo: schemaString()},
                 required: ["foo"],
               }),
-              irModelObject({
-                properties: {bar: irModelString()},
+              schemaObject({
+                properties: {bar: schemaString()},
                 required: ["bar"],
               }),
             ],
@@ -1315,22 +1315,22 @@ describe.each(testVersions)(
       // TODO: https://github.com/hapijs/joi/issues/3057
       it.skip("can intersect unions", async () => {
         const {code, execute} = await getActualFromModel(
-          irModelObject({
+          schemaObject({
             allOf: [
-              irModelObject({
+              schemaObject({
                 oneOf: [
-                  irModelObject({
-                    properties: {foo: irModelString()},
+                  schemaObject({
+                    properties: {foo: schemaString()},
                     required: ["foo"],
                   }),
-                  irModelObject({
-                    properties: {bar: irModelString()},
+                  schemaObject({
+                    properties: {bar: schemaString()},
                     required: ["bar"],
                   }),
                 ],
               }),
-              irModelObject({
-                properties: {id: irModelString()},
+              schemaObject({
+                properties: {id: schemaString()},
                 required: ["id"],
               }),
             ],
@@ -1377,7 +1377,7 @@ describe.each(testVersions)(
 
     describe("unspecified schemas when allowAny: true", () => {
       const config: SchemaBuilderConfig = {allowAny: true}
-      const base: IRModelObject = {
+      const base: SchemaObject = {
         type: "object",
         allOf: [],
         anyOf: [],
@@ -1482,7 +1482,7 @@ describe.each(testVersions)(
 
     describe("unspecified schemas when allowAny: false", () => {
       const config: SchemaBuilderConfig = {allowAny: false}
-      const base: IRModelObject = {
+      const base: SchemaObject = {
         type: "object",
         allOf: [],
         anyOf: [],

--- a/packages/openapi-code-generator/src/typescript/common/schema-builders/schema-builder.test-utils.ts
+++ b/packages/openapi-code-generator/src/typescript/common/schema-builders/schema-builder.test-utils.ts
@@ -1,12 +1,13 @@
 import ts from "typescript"
 import type {Input} from "../../../core/input"
 import type {
-  IRModel,
-  IRModelNumeric,
-  IRModelObject,
-  IRModelString,
-  MaybeIRModel,
-} from "../../../core/openapi-types-normalized"
+  Reference,
+  Schema,
+  SchemaNumber,
+  SchemaObject,
+  SchemaString,
+} from "../../../core/openapi-types"
+import {isRef} from "../../../core/openapi-utils"
 import {
   type OpenApiVersion,
   unitTestInput,
@@ -23,11 +24,11 @@ export function schemaBuilderTestHarness(
   executeParseSchema: (code: string, input?: unknown) => Promise<unknown>,
 ) {
   async function getActualFromModel(
-    model: IRModel,
+    schema: Schema,
     config: SchemaBuilderConfig = {allowAny: false},
   ) {
     const {input} = await unitTestInput(version)
-    return getResult(input, model, true, config)
+    return getResult(input, schema, true, config)
   }
 
   async function getActual(
@@ -40,7 +41,7 @@ export function schemaBuilderTestHarness(
 
   async function getResult(
     input: Input,
-    maybeModel: MaybeIRModel,
+    maybeSchema: Schema | Reference,
     required: boolean,
     config: SchemaBuilderConfig,
   ) {
@@ -66,7 +67,10 @@ export function schemaBuilderTestHarness(
 
     const schema = schemaBuilder
       .withImports(imports)
-      .fromModel(maybeModel, required)
+      .fromModel(
+        isRef(maybeSchema) ? maybeSchema : input.schema(maybeSchema),
+        required,
+      )
 
     const code = (
       await formatter.format(
@@ -117,9 +121,9 @@ export function schemaBuilderTestHarness(
   }
 }
 
-export function irModelObject(
-  partial: Partial<IRModelObject> = {},
-): IRModelObject {
+export function schemaObject(
+  partial: Partial<SchemaObject> = {},
+): SchemaObject {
   return {
     type: "object",
     allOf: [],
@@ -134,9 +138,9 @@ export function irModelObject(
   }
 }
 
-export function irModelString(
-  partial: Partial<IRModelString> = {},
-): IRModelString {
+export function schemaString(
+  partial: Partial<SchemaString> = {},
+): SchemaString {
   return {
     type: "string",
     nullable: false,
@@ -145,9 +149,9 @@ export function irModelString(
   }
 }
 
-export function irModelNumber(
-  partial: Partial<IRModelNumeric> = {},
-): IRModelNumeric {
+export function schemaNumber(
+  partial: Partial<SchemaNumber> = {},
+): SchemaNumber {
   return {
     type: "number",
     nullable: false,

--- a/packages/openapi-code-generator/src/typescript/common/schema-builders/zod-v3-schema-builder.spec.ts
+++ b/packages/openapi-code-generator/src/typescript/common/schema-builders/zod-v3-schema-builder.spec.ts
@@ -1,20 +1,20 @@
 import * as vm from "node:vm"
 import {describe, expect, it} from "@jest/globals"
 import type {
-  IRModelArray,
-  IRModelBoolean,
-  IRModelNumeric,
-  IRModelObject,
-  IRModelString,
-} from "../../../core/openapi-types-normalized"
+  SchemaArray,
+  SchemaBoolean,
+  SchemaNumber,
+  SchemaObject,
+  SchemaString,
+} from "../../../core/openapi-types"
 import {isDefined} from "../../../core/utils"
 import {testVersions} from "../../../test/input.test-utils"
 import type {SchemaBuilderConfig} from "./abstract-schema-builder"
 import {
-  irModelNumber,
-  irModelObject,
-  irModelString,
   schemaBuilderTestHarness,
+  schemaNumber,
+  schemaObject,
+  schemaString,
 } from "./schema-builder.test-utils"
 import {staticSchemas} from "./zod-v3-schema-builder"
 
@@ -326,7 +326,7 @@ describe.each(testVersions)(
     })
 
     describe("numbers", () => {
-      const base: IRModelNumeric = {
+      const base: SchemaNumber = {
         nullable: false,
         readOnly: false,
         type: "number",
@@ -563,7 +563,7 @@ describe.each(testVersions)(
     })
 
     describe("strings", () => {
-      const base: IRModelString = {
+      const base: SchemaString = {
         nullable: false,
         readOnly: false,
         type: "string",
@@ -818,7 +818,7 @@ describe.each(testVersions)(
         })()`)
       }
 
-      const base: IRModelBoolean = {
+      const base: SchemaBoolean = {
         nullable: false,
         readOnly: false,
         type: "boolean",
@@ -1034,7 +1034,7 @@ describe.each(testVersions)(
     })
 
     describe("arrays", () => {
-      const base: IRModelArray = {
+      const base: SchemaArray = {
         nullable: false,
         readOnly: false,
         type: "array",
@@ -1121,7 +1121,7 @@ describe.each(testVersions)(
       it("supports minItems / maxItems / uniqueItems", async () => {
         const {code, execute} = await getActualFromModel({
           ...base,
-          items: {type: "number", nullable: false, readOnly: false},
+          items: schemaNumber(),
           minItems: 1,
           maxItems: 3,
           uniqueItems: true,
@@ -1177,7 +1177,7 @@ describe.each(testVersions)(
     })
 
     describe("objects", () => {
-      const base: IRModelObject = {
+      const base: SchemaObject = {
         type: "object",
         allOf: [],
         anyOf: [],
@@ -1275,8 +1275,8 @@ describe.each(testVersions)(
     describe("unions", () => {
       it("can union a string and number", async () => {
         const {code, execute} = await getActualFromModel(
-          irModelObject({
-            anyOf: [irModelString(), irModelNumber()],
+          schemaObject({
+            anyOf: [schemaString(), schemaNumber()],
           }),
         )
 
@@ -1291,17 +1291,17 @@ describe.each(testVersions)(
 
       it("can union an intersected object and string", async () => {
         const {code, execute} = await getActualFromModel(
-          irModelObject({
+          schemaObject({
             anyOf: [
-              irModelString(),
-              irModelObject({
+              schemaString(),
+              schemaObject({
                 allOf: [
-                  irModelObject({
-                    properties: {foo: irModelString()},
+                  schemaObject({
+                    properties: {foo: schemaString()},
                     required: ["foo"],
                   }),
-                  irModelObject({
-                    properties: {bar: irModelString()},
+                  schemaObject({
+                    properties: {bar: schemaString()},
                     required: ["bar"],
                   }),
                 ],
@@ -1329,14 +1329,14 @@ describe.each(testVersions)(
     describe("intersections", () => {
       it("can intersect objects", async () => {
         const {code, execute} = await getActualFromModel(
-          irModelObject({
+          schemaObject({
             allOf: [
-              irModelObject({
-                properties: {foo: irModelString()},
+              schemaObject({
+                properties: {foo: schemaString()},
                 required: ["foo"],
               }),
-              irModelObject({
-                properties: {bar: irModelString()},
+              schemaObject({
+                properties: {bar: schemaString()},
                 required: ["bar"],
               }),
             ],
@@ -1356,22 +1356,22 @@ describe.each(testVersions)(
 
       it("can intersect unions", async () => {
         const {code, execute} = await getActualFromModel(
-          irModelObject({
+          schemaObject({
             allOf: [
-              irModelObject({
+              schemaObject({
                 oneOf: [
-                  irModelObject({
-                    properties: {foo: irModelString()},
+                  schemaObject({
+                    properties: {foo: schemaString()},
                     required: ["foo"],
                   }),
-                  irModelObject({
-                    properties: {bar: irModelString()},
+                  schemaObject({
+                    properties: {bar: schemaString()},
                     required: ["bar"],
                   }),
                 ],
               }),
-              irModelObject({
-                properties: {id: irModelString()},
+              schemaObject({
+                properties: {id: schemaString()},
                 required: ["id"],
               }),
             ],
@@ -1399,7 +1399,7 @@ describe.each(testVersions)(
 
     describe("unspecified schemas when allowAny: true", () => {
       const config: SchemaBuilderConfig = {allowAny: true}
-      const base: IRModelObject = {
+      const base: SchemaObject = {
         type: "object",
         allOf: [],
         anyOf: [],
@@ -1497,7 +1497,7 @@ describe.each(testVersions)(
 
     describe("unspecified schemas when allowAny: false", () => {
       const config: SchemaBuilderConfig = {allowAny: false}
-      const base: IRModelObject = {
+      const base: SchemaObject = {
         type: "object",
         allOf: [],
         anyOf: [],

--- a/packages/openapi-code-generator/src/typescript/common/schema-builders/zod-v4-schema-builder.spec.ts
+++ b/packages/openapi-code-generator/src/typescript/common/schema-builders/zod-v4-schema-builder.spec.ts
@@ -1,20 +1,20 @@
 import * as vm from "node:vm"
 import {describe, expect, it} from "@jest/globals"
 import type {
-  IRModelArray,
-  IRModelBoolean,
-  IRModelNumeric,
-  IRModelObject,
-  IRModelString,
-} from "../../../core/openapi-types-normalized"
+  SchemaArray,
+  SchemaBoolean,
+  SchemaNumber,
+  SchemaObject,
+  SchemaString,
+} from "../../../core/openapi-types"
 import {isDefined} from "../../../core/utils"
 import {testVersions} from "../../../test/input.test-utils"
 import type {SchemaBuilderConfig} from "./abstract-schema-builder"
 import {
-  irModelNumber,
-  irModelObject,
-  irModelString,
   schemaBuilderTestHarness,
+  schemaNumber,
+  schemaObject,
+  schemaString,
 } from "./schema-builder.test-utils"
 import {staticSchemas} from "./zod-v4-schema-builder"
 
@@ -330,7 +330,7 @@ describe.each(testVersions)(
     })
 
     describe("numbers", () => {
-      const base: IRModelNumeric = {
+      const base: SchemaNumber = {
         nullable: false,
         readOnly: false,
         type: "number",
@@ -569,7 +569,7 @@ describe.each(testVersions)(
     })
 
     describe("strings", () => {
-      const base: IRModelString = {
+      const base: SchemaString = {
         nullable: false,
         readOnly: false,
         type: "string",
@@ -828,7 +828,7 @@ describe.each(testVersions)(
         })()`)
       }
 
-      const base: IRModelBoolean = {
+      const base: SchemaBoolean = {
         nullable: false,
         readOnly: false,
         type: "boolean",
@@ -1044,7 +1044,7 @@ describe.each(testVersions)(
     })
 
     describe("arrays", () => {
-      const base: IRModelArray = {
+      const base: SchemaArray = {
         nullable: false,
         readOnly: false,
         type: "array",
@@ -1131,7 +1131,7 @@ describe.each(testVersions)(
       it("supports minItems / maxItems / uniqueItems", async () => {
         const {code, execute} = await getActualFromModel({
           ...base,
-          items: {type: "number", nullable: false, readOnly: false},
+          items: schemaNumber(),
           minItems: 1,
           maxItems: 3,
           uniqueItems: true,
@@ -1187,7 +1187,7 @@ describe.each(testVersions)(
     })
 
     describe("objects", () => {
-      const base: IRModelObject = {
+      const base: SchemaObject = {
         type: "object",
         allOf: [],
         anyOf: [],
@@ -1287,8 +1287,8 @@ describe.each(testVersions)(
     describe("unions", () => {
       it("can union a string and number", async () => {
         const {code, execute} = await getActualFromModel(
-          irModelObject({
-            anyOf: [irModelString(), irModelNumber()],
+          schemaObject({
+            anyOf: [schemaString(), schemaNumber()],
           }),
         )
 
@@ -1305,17 +1305,17 @@ describe.each(testVersions)(
 
       it("can union an intersected object and string", async () => {
         const {code, execute} = await getActualFromModel(
-          irModelObject({
+          schemaObject({
             anyOf: [
-              irModelString(),
-              irModelObject({
+              schemaString(),
+              schemaObject({
                 allOf: [
-                  irModelObject({
-                    properties: {foo: irModelString()},
+                  schemaObject({
+                    properties: {foo: schemaString()},
                     required: ["foo"],
                   }),
-                  irModelObject({
-                    properties: {bar: irModelString()},
+                  schemaObject({
+                    properties: {bar: schemaString()},
                     required: ["bar"],
                   }),
                 ],
@@ -1346,14 +1346,14 @@ describe.each(testVersions)(
     describe("intersections", () => {
       it("can intersect objects", async () => {
         const {code, execute} = await getActualFromModel(
-          irModelObject({
+          schemaObject({
             allOf: [
-              irModelObject({
-                properties: {foo: irModelString()},
+              schemaObject({
+                properties: {foo: schemaString()},
                 required: ["foo"],
               }),
-              irModelObject({
-                properties: {bar: irModelString()},
+              schemaObject({
+                properties: {bar: schemaString()},
                 required: ["bar"],
               }),
             ],
@@ -1375,22 +1375,22 @@ describe.each(testVersions)(
 
       it("can intersect unions", async () => {
         const {code, execute} = await getActualFromModel(
-          irModelObject({
+          schemaObject({
             allOf: [
-              irModelObject({
+              schemaObject({
                 oneOf: [
-                  irModelObject({
-                    properties: {foo: irModelString()},
+                  schemaObject({
+                    properties: {foo: schemaString()},
                     required: ["foo"],
                   }),
-                  irModelObject({
-                    properties: {bar: irModelString()},
+                  schemaObject({
+                    properties: {bar: schemaString()},
                     required: ["bar"],
                   }),
                 ],
               }),
-              irModelObject({
-                properties: {id: irModelString()},
+              schemaObject({
+                properties: {id: schemaString()},
                 required: ["id"],
               }),
             ],
@@ -1420,7 +1420,7 @@ describe.each(testVersions)(
 
     describe("unspecified schemas when allowAny: true", () => {
       const config: SchemaBuilderConfig = {allowAny: true}
-      const base: IRModelObject = {
+      const base: SchemaObject = {
         type: "object",
         allOf: [],
         anyOf: [],
@@ -1520,7 +1520,7 @@ describe.each(testVersions)(
 
     describe("unspecified schemas when allowAny: false", () => {
       const config: SchemaBuilderConfig = {allowAny: false}
-      const base: IRModelObject = {
+      const base: SchemaObject = {
         type: "object",
         allOf: [],
         anyOf: [],


### PR DESCRIPTION
as written, these tests are using `Schema` types not normalized `IRModel` types for the input.

this needs correcting before `Schema` and `IRModel` begin to diverge, split from #386 