### PR TITLE
fix: remove an instance of double normalization

### DIFF
--- a/packages/openapi-code-generator/src/core/input.ts
+++ b/packages/openapi-code-generator/src/core/input.ts
@@ -88,8 +88,10 @@ export class Input {
 
     return Object.fromEntries(
       Object.entries(schemas).map(([name, maybeSchema]) => {
-        // TODO: double normalization?
-        return [name, this.schema(this.schemaNormalizer.normalize(maybeSchema))]
+        const schema = this.schemaNormalizer.normalize(
+          this.loader.schema(maybeSchema),
+        )
+        return [name, schema]
       }),
     )
   }

--- a/packages/openapi-code-generator/src/typescript/server/server-operation-builder.ts
+++ b/packages/openapi-code-generator/src/typescript/server/server-operation-builder.ts
@@ -274,6 +274,7 @@ export class ServerOperationBuilder {
     )
 
     const isRequired = Boolean(requestBody?.parameter?.required)
+    const isSupported = Boolean(requestBody?.isSupported)
 
     const schema = requestBody?.parameter
       ? this.schemaBuilder.fromModel(
@@ -312,7 +313,7 @@ export class ServerOperationBuilder {
     }
 
     return {
-      isSupported: Boolean(requestBody?.isSupported),
+      isSupported,
       contentType: requestBody?.contentType,
       schema,
       type,

--- a/packages/openapi-code-generator/src/typescript/server/typescript-express/typescript-express-router-builder.ts
+++ b/packages/openapi-code-generator/src/typescript/server/typescript-express/typescript-express-router-builder.ts
@@ -94,14 +94,17 @@ export class ExpressRouterBuilder extends AbstractRouterBuilder {
     if (params.path.schema) {
       statements.push(constStatement(symbols.paramSchema, params.path.schema))
     }
+
     if (params.query.schema) {
       statements.push(constStatement(symbols.querySchema, params.query.schema))
     }
+
     if (params.header.schema) {
       statements.push(
         constStatement(symbols.requestHeaderSchema, params.header.schema),
       )
     }
+
     if (params.body.schema) {
       if (!params.body.isSupported) {
         statements.push(

--- a/packages/openapi-code-generator/src/typescript/server/typescript-koa/typescript-koa-router-builder.ts
+++ b/packages/openapi-code-generator/src/typescript/server/typescript-koa/typescript-koa-router-builder.ts
@@ -91,14 +91,17 @@ export class KoaRouterBuilder extends AbstractRouterBuilder {
     if (params.path.schema) {
       statements.push(constStatement(symbols.paramSchema, params.path.schema))
     }
+
     if (params.query.schema) {
       statements.push(constStatement(symbols.querySchema, params.query.schema))
     }
+
     if (params.header.schema) {
       statements.push(
         constStatement(symbols.requestHeaderSchema, params.header.schema),
       )
     }
+
     if (params.body.schema) {
       if (!params.body.isSupported) {
         statements.push(


### PR DESCRIPTION
wasn't causing issues yet, but will do once `IRModel` is no longer compatible with `Schema`, split from #386 