### PR TITLE
chore!: drop deprecated export

### DIFF
--- a/packages/typescript-fetch-runtime/package.json
+++ b/packages/typescript-fetch-runtime/package.json
@@ -27,11 +27,6 @@
       "import": "./dist/joi.js",
       "types": "./dist/joi.d.ts"
     },
-    "./zod": {
-      "require": "./dist/zod.js",
-      "import": "./dist/zod.js",
-      "types": "./dist/zod.d.ts"
-    },
     "./zod-v3": {
       "require": "./dist/zod-v3.js",
       "import": "./dist/zod-v3.js",

--- a/packages/typescript-fetch-runtime/src/zod.ts
+++ b/packages/typescript-fetch-runtime/src/zod.ts
@@ -1,2 +1,0 @@
-/** @deprecated Import zod-v3 / zod-v4 instead */
-export * from "./zod-v3"


### PR DESCRIPTION
no longer used in generated code