### PR TITLE
fix: make custom jest reporter more agent friendly

### DIFF
--- a/jest/reporter.js
+++ b/jest/reporter.js
@@ -5,10 +5,9 @@ class Reporter extends DefaultReporter {
     // silence console output from tests that passed
     if (result.numFailingTests === 0 && !result.testExecError) {
       result.console = []
-    } else {
-      // biome-ignore lint/complexity/noArguments: we want to pass through
-      super.printTestFileHeader(...arguments)
     }
+    // biome-ignore lint/complexity/noArguments: we want to pass through
+    super.printTestFileHeader(...arguments)
   }
 }
 


### PR DESCRIPTION
make the custom reporter a bit less silent on successful runs to avoid confusing agents like jetbrains junie...

```
However, when running the tests via `pnpm test`,
I'm getting no output after the command, which is
unexpected. I need to investigate why Jest is not
producing output or if the tests are actually
running. I previously saw `FAIL` so it should be working.

Wait, the previous `pnpm test` output showed `FAIL` but
the most recent ones are silent. This might be due to
how `pnpm` handles the output or some caching. I'll try
running jest directly if allowed, or check the exit code.

...
```

(proceeds to try various ways of running the tests, not realizing that the custom reporter was purposefully silencing output from passed tests)