### PR TITLE
fix(fetch): type narrowing with default response types

### DIFF
--- a/e2e/openapi.yaml
+++ b/e2e/openapi.yaml
@@ -277,6 +277,35 @@ paths:
       responses:
         500:
           description: Internal Server Error
+  /responses/default:
+    get:
+      tags:
+        - validation
+      parameters:
+        - name: status
+          in: query
+          schema:
+            type: string
+            enum: [200,500]
+      responses:
+        200:
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
   /responses/empty:
     get:
       tags:

--- a/e2e/src/generated/client/axios/client.ts
+++ b/e2e/src/generated/client/axios/client.ts
@@ -17,6 +17,7 @@ import type {
   t_GetParamsMixedQuery200Response,
   t_GetParamsSimpleQuery200Response,
   t_GetParamsUnexplodedObjectQuery200Response,
+  t_GetResponsesDefault200Response,
   t_PostValidationOptionalBody200Response,
   t_PostValidationOptionalBodyRequestBody,
   t_ProductOrder,
@@ -31,6 +32,7 @@ import {
   s_GetParamsMixedQuery200Response,
   s_GetParamsSimpleQuery200Response,
   s_GetParamsUnexplodedObjectQuery200Response,
+  s_GetResponsesDefault200Response,
   s_PostValidationOptionalBody200Response,
   s_ProductOrder,
   s_RandomNumber,
@@ -367,6 +369,28 @@ export class E2ETestClient extends AbstractAxiosClient {
       ...opts,
       headers,
     })
+  }
+
+  async getResponsesDefault(
+    p: {
+      status?: "200" | "500" | UnknownEnumStringValue
+    } = {},
+    timeout?: number,
+    opts: AxiosRequestConfig = {},
+  ): Promise<AxiosResponse<t_GetResponsesDefault200Response>> {
+    const url = `/responses/default`
+    const headers = this._headers({Accept: "application/json"}, opts.headers)
+    const query = this._query({status: p["status"]})
+
+    const res = await this._request({
+      url: url + query,
+      method: "GET",
+      ...(timeout ? {timeout} : {}),
+      ...opts,
+      headers,
+    })
+
+    return {...res, data: s_GetResponsesDefault200Response.parse(res.data)}
   }
 
   async getResponsesEmpty(

--- a/e2e/src/generated/client/axios/models.ts
+++ b/e2e/src/generated/client/axios/models.ts
@@ -71,6 +71,14 @@ export type t_GetParamsUnexplodedObjectQuery200Response = {
   }
 }
 
+export type t_GetResponsesDefault200Response = {
+  id?: string | undefined
+}
+
+export type t_GetResponsesDefaultdefaultResponse = {
+  error?: string | undefined
+}
+
 export type t_PostValidationOptionalBody200Response = {
   id?: string | undefined
 }

--- a/e2e/src/generated/client/axios/schemas.ts
+++ b/e2e/src/generated/client/axios/schemas.ts
@@ -68,3 +68,11 @@ export const s_GetParamsMixedQuery200Response = z.object({
 export const s_PostValidationOptionalBody200Response = z.object({
   id: z.string().optional(),
 })
+
+export const s_GetResponsesDefault200Response = z.object({
+  id: z.string().optional(),
+})
+
+export const s_GetResponsesDefaultdefaultResponse = z.object({
+  error: z.string().optional(),
+})

--- a/e2e/src/generated/client/fetch/client.ts
+++ b/e2e/src/generated/client/fetch/client.ts
@@ -7,6 +7,7 @@ import {
   type AbstractFetchClientConfig,
   type Res,
   type Server,
+  type StatusCode,
 } from "@nahkies/typescript-fetch-runtime/main"
 import {responseValidationFactory} from "@nahkies/typescript-fetch-runtime/zod-v4"
 import {z} from "zod/v4"
@@ -18,6 +19,8 @@ import type {
   t_GetParamsMixedQuery200Response,
   t_GetParamsSimpleQuery200Response,
   t_GetParamsUnexplodedObjectQuery200Response,
+  t_GetResponsesDefault200Response,
+  t_GetResponsesDefaultdefaultResponse,
   t_PostValidationOptionalBody200Response,
   t_PostValidationOptionalBodyRequestBody,
   t_ProductOrder,
@@ -32,6 +35,8 @@ import {
   s_GetParamsMixedQuery200Response,
   s_GetParamsSimpleQuery200Response,
   s_GetParamsUnexplodedObjectQuery200Response,
+  s_GetResponsesDefault200Response,
+  s_GetResponsesDefaultdefaultResponse,
   s_PostValidationOptionalBody200Response,
   s_ProductOrder,
   s_RandomNumber,
@@ -351,6 +356,32 @@ export class E2ETestClient extends AbstractFetchClient {
     const res = this._fetch(url, {method: "GET", ...opts, headers}, timeout)
 
     return responseValidationFactory([["500", z.any()]], undefined)(res)
+  }
+
+  async getResponsesDefault(
+    p: {
+      status?: "200" | "500" | UnknownEnumStringValue
+    } = {},
+    timeout?: number,
+    opts: RequestInit = {},
+  ): Promise<
+    | Res<200, t_GetResponsesDefault200Response>
+    | Res<StatusCode, t_GetResponsesDefaultdefaultResponse>
+  > {
+    const url = this.basePath + `/responses/default`
+    const headers = this._headers({Accept: "application/json"}, opts.headers)
+    const query = this._query({status: p["status"]})
+
+    const res = this._fetch(
+      url + query,
+      {method: "GET", ...opts, headers},
+      timeout,
+    )
+
+    return responseValidationFactory(
+      [["200", s_GetResponsesDefault200Response]],
+      s_GetResponsesDefaultdefaultResponse,
+    )(res)
   }
 
   async getResponsesEmpty(

--- a/e2e/src/generated/client/fetch/client.ts
+++ b/e2e/src/generated/client/fetch/client.ts
@@ -366,7 +366,7 @@ export class E2ETestClient extends AbstractFetchClient {
     opts: RequestInit = {},
   ): Promise<
     | Res<200, t_GetResponsesDefault200Response>
-    | Res<StatusCode, t_GetResponsesDefaultdefaultResponse>
+    | Res<Exclude<StatusCode, 200>, t_GetResponsesDefaultdefaultResponse>
   > {
     const url = this.basePath + `/responses/default`
     const headers = this._headers({Accept: "application/json"}, opts.headers)

--- a/e2e/src/generated/client/fetch/models.ts
+++ b/e2e/src/generated/client/fetch/models.ts
@@ -71,6 +71,14 @@ export type t_GetParamsUnexplodedObjectQuery200Response = {
   }
 }
 
+export type t_GetResponsesDefault200Response = {
+  id?: string | undefined
+}
+
+export type t_GetResponsesDefaultdefaultResponse = {
+  error?: string | undefined
+}
+
 export type t_PostValidationOptionalBody200Response = {
   id?: string | undefined
 }

--- a/e2e/src/generated/client/fetch/schemas.ts
+++ b/e2e/src/generated/client/fetch/schemas.ts
@@ -68,3 +68,11 @@ export const s_GetParamsMixedQuery200Response = z.object({
 export const s_PostValidationOptionalBody200Response = z.object({
   id: z.string().optional(),
 })
+
+export const s_GetResponsesDefault200Response = z.object({
+  id: z.string().optional(),
+})
+
+export const s_GetResponsesDefaultdefaultResponse = z.object({
+  error: z.string().optional(),
+})

--- a/e2e/src/generated/server/express/models.ts
+++ b/e2e/src/generated/server/express/models.ts
@@ -95,6 +95,18 @@ export type t_GetParamsUnexplodedObjectQueryQuerySchema = {
   }
 }
 
+export type t_GetResponsesDefault200Response = {
+  id?: string | undefined
+}
+
+export type t_GetResponsesDefaultQuerySchema = {
+  status?: ("200" | "500") | undefined
+}
+
+export type t_GetResponsesDefaultdefaultResponse = {
+  error?: string | undefined
+}
+
 export type t_GetValidationNumbersRandomNumberQuerySchema = {
   forbidden?: number[] | undefined
   max?: number | undefined

--- a/e2e/src/generated/server/express/routes/validation.ts
+++ b/e2e/src/generated/server/express/routes/validation.ts
@@ -20,6 +20,9 @@ import {type NextFunction, type Request, type Response, Router} from "express"
 import {z} from "zod/v4"
 import type {
   t_Enumerations,
+  t_GetResponsesDefault200Response,
+  t_GetResponsesDefaultdefaultResponse,
+  t_GetResponsesDefaultQuerySchema,
   t_GetValidationNumbersRandomNumberQuerySchema,
   t_PostValidationOptionalBody200Response,
   t_PostValidationOptionalBodyRequestBody,
@@ -27,6 +30,8 @@ import type {
 } from "../models.ts"
 import {
   s_Enumerations,
+  s_GetResponsesDefault200Response,
+  s_GetResponsesDefaultdefaultResponse,
   s_PostValidationOptionalBody200Response,
   s_PostValidationOptionalBodyRequestBody,
   s_RandomNumber,
@@ -91,6 +96,21 @@ export type GetResponses500 = (
   next: NextFunction,
 ) => Promise<ExpressRuntimeResponse<unknown> | typeof SkipResponse>
 
+export type GetResponsesDefaultResponder = {
+  with200(): ExpressRuntimeResponse<t_GetResponsesDefault200Response>
+  withDefault(
+    status: StatusCode,
+  ): ExpressRuntimeResponse<t_GetResponsesDefaultdefaultResponse>
+} & ExpressRuntimeResponder
+
+export type GetResponsesDefault = (
+  params: Params<void, t_GetResponsesDefaultQuerySchema, void, void>,
+  respond: GetResponsesDefaultResponder,
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => Promise<ExpressRuntimeResponse<unknown> | typeof SkipResponse>
+
 export type GetResponsesEmptyResponder = {
   with204(): ExpressRuntimeResponse<void>
 } & ExpressRuntimeResponder
@@ -108,6 +128,7 @@ export type ValidationImplementation = {
   postValidationEnums: PostValidationEnums
   postValidationOptionalBody: PostValidationOptionalBody
   getResponses500: GetResponses500
+  getResponsesDefault: GetResponsesDefault
   getResponsesEmpty: GetResponsesEmpty
 }
 
@@ -294,6 +315,57 @@ export function createValidationRouter(
           .getResponses500(input, responder, req, res, next)
           .catch(handleImplementationError)
           .then(handleResponse(res, getResponses500ResponseBodyValidator))
+      } catch (error) {
+        next(error)
+      }
+    },
+  )
+
+  const getResponsesDefaultQuerySchema = z.object({
+    status: z.enum(["200", "500"]).optional(),
+  })
+
+  const getResponsesDefaultResponseBodyValidator = responseValidationFactory(
+    [["200", s_GetResponsesDefault200Response]],
+    s_GetResponsesDefaultdefaultResponse,
+  )
+
+  // getResponsesDefault
+  router.get(
+    `/responses/default`,
+    async (req: Request, res: Response, next: NextFunction) => {
+      try {
+        const input = {
+          params: undefined,
+          query: parseRequestInput(
+            getResponsesDefaultQuerySchema,
+            req.query,
+            RequestInputType.QueryString,
+          ),
+          body: undefined,
+          headers: undefined,
+        }
+
+        const responder = {
+          with200() {
+            return new ExpressRuntimeResponse<t_GetResponsesDefault200Response>(
+              200,
+            )
+          },
+          withDefault(status: StatusCode) {
+            return new ExpressRuntimeResponse<t_GetResponsesDefaultdefaultResponse>(
+              status,
+            )
+          },
+          withStatus(status: StatusCode) {
+            return new ExpressRuntimeResponse(status)
+          },
+        }
+
+        await implementation
+          .getResponsesDefault(input, responder, req, res, next)
+          .catch(handleImplementationError)
+          .then(handleResponse(res, getResponsesDefaultResponseBodyValidator))
       } catch (error) {
         next(error)
       }

--- a/e2e/src/generated/server/express/schemas.ts
+++ b/e2e/src/generated/server/express/schemas.ts
@@ -72,3 +72,11 @@ export const s_PostValidationOptionalBodyRequestBody = z.object({
 export const s_PostValidationOptionalBody200Response = z.object({
   id: z.string().optional(),
 })
+
+export const s_GetResponsesDefault200Response = z.object({
+  id: z.string().optional(),
+})
+
+export const s_GetResponsesDefaultdefaultResponse = z.object({
+  error: z.string().optional(),
+})

--- a/e2e/src/generated/server/koa/models.ts
+++ b/e2e/src/generated/server/koa/models.ts
@@ -95,6 +95,18 @@ export type t_GetParamsUnexplodedObjectQueryQuerySchema = {
   }
 }
 
+export type t_GetResponsesDefault200Response = {
+  id?: string | undefined
+}
+
+export type t_GetResponsesDefaultQuerySchema = {
+  status?: ("200" | "500") | undefined
+}
+
+export type t_GetResponsesDefaultdefaultResponse = {
+  error?: string | undefined
+}
+
 export type t_GetValidationNumbersRandomNumberQuerySchema = {
   forbidden?: number[] | undefined
   max?: number | undefined

--- a/e2e/src/generated/server/koa/routes/validation.ts
+++ b/e2e/src/generated/server/koa/routes/validation.ts
@@ -22,6 +22,9 @@ import type {Next} from "koa"
 import {z} from "zod/v4"
 import type {
   t_Enumerations,
+  t_GetResponsesDefault200Response,
+  t_GetResponsesDefaultdefaultResponse,
+  t_GetResponsesDefaultQuerySchema,
   t_GetValidationNumbersRandomNumberQuerySchema,
   t_PostValidationOptionalBody200Response,
   t_PostValidationOptionalBodyRequestBody,
@@ -29,6 +32,8 @@ import type {
 } from "../models.ts"
 import {
   s_Enumerations,
+  s_GetResponsesDefault200Response,
+  s_GetResponsesDefaultdefaultResponse,
   s_PostValidationOptionalBody200Response,
   s_PostValidationOptionalBodyRequestBody,
   s_RandomNumber,
@@ -98,6 +103,25 @@ export type GetResponses500 = (
   next: Next,
 ) => Promise<KoaRuntimeResponse<unknown> | Res<500, void> | typeof SkipResponse>
 
+export type GetResponsesDefaultResponder = {
+  with200(): KoaRuntimeResponse<t_GetResponsesDefault200Response>
+  withDefault(
+    status: StatusCode,
+  ): KoaRuntimeResponse<t_GetResponsesDefaultdefaultResponse>
+} & KoaRuntimeResponder
+
+export type GetResponsesDefault = (
+  params: Params<void, t_GetResponsesDefaultQuerySchema, void, void>,
+  respond: GetResponsesDefaultResponder,
+  ctx: RouterContext,
+  next: Next,
+) => Promise<
+  | KoaRuntimeResponse<unknown>
+  | Res<200, t_GetResponsesDefault200Response>
+  | Res<StatusCode, t_GetResponsesDefaultdefaultResponse>
+  | typeof SkipResponse
+>
+
 export type GetResponsesEmptyResponder = {
   with204(): KoaRuntimeResponse<void>
 } & KoaRuntimeResponder
@@ -114,6 +138,7 @@ export type ValidationImplementation = {
   postValidationEnums: PostValidationEnums
   postValidationOptionalBody: PostValidationOptionalBody
   getResponses500: GetResponses500
+  getResponsesDefault: GetResponsesDefault
   getResponsesEmpty: GetResponsesEmpty
 }
 
@@ -281,6 +306,47 @@ export function createValidationRouter(
       .getResponses500(input, responder, ctx, next)
       .catch(handleImplementationError)
       .then(handleResponse(ctx, next, getResponses500ResponseValidator))
+  })
+
+  const getResponsesDefaultQuerySchema = z.object({
+    status: z.enum(["200", "500"]).optional(),
+  })
+
+  const getResponsesDefaultResponseValidator = responseValidationFactory(
+    [["200", s_GetResponsesDefault200Response]],
+    s_GetResponsesDefaultdefaultResponse,
+  )
+
+  router.get("getResponsesDefault", "/responses/default", async (ctx, next) => {
+    const input = {
+      params: undefined,
+      query: parseRequestInput(
+        getResponsesDefaultQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
+      body: undefined,
+      headers: undefined,
+    }
+
+    const responder = {
+      with200() {
+        return new KoaRuntimeResponse<t_GetResponsesDefault200Response>(200)
+      },
+      withDefault(status: StatusCode) {
+        return new KoaRuntimeResponse<t_GetResponsesDefaultdefaultResponse>(
+          status,
+        )
+      },
+      withStatus(status: StatusCode) {
+        return new KoaRuntimeResponse(status)
+      },
+    }
+
+    await implementation
+      .getResponsesDefault(input, responder, ctx, next)
+      .catch(handleImplementationError)
+      .then(handleResponse(ctx, next, getResponsesDefaultResponseValidator))
   })
 
   const getResponsesEmptyResponseValidator = responseValidationFactory(

--- a/e2e/src/generated/server/koa/schemas.ts
+++ b/e2e/src/generated/server/koa/schemas.ts
@@ -72,3 +72,11 @@ export const s_PostValidationOptionalBodyRequestBody = z.object({
 export const s_PostValidationOptionalBody200Response = z.object({
   id: z.string().optional(),
 })
+
+export const s_GetResponsesDefault200Response = z.object({
+  id: z.string().optional(),
+})
+
+export const s_GetResponsesDefaultdefaultResponse = z.object({
+  error: z.string().optional(),
+})

--- a/e2e/src/index.axios.spec.ts
+++ b/e2e/src/index.axios.spec.ts
@@ -372,6 +372,29 @@ describe.each(
     })
   })
 
+  describe("GET /responses/default", () => {
+    it("returns {id: string} for 200", async () => {
+      const {status, data} = await client.getResponsesDefault({status: "200"})
+
+      expect(status).toBe(200)
+      expect(data.id).toBe("123")
+    })
+
+    it("returns {error: string} for other status codes", async () => {
+      const err = await client.getResponsesDefault({status: "500"}).then(
+        () => {
+          throw new Error("expected request to fail")
+        },
+        (err: AxiosError) => err,
+      )
+
+      expect(err.status).toBe(500)
+      expect(err.response?.data).toStrictEqual({
+        error: "something went wrong",
+      })
+    })
+  })
+
   describe("GET /responses/500", () => {
     it("returns response from error middleware", async () => {
       const err = await client.getResponses500().then(

--- a/e2e/src/index.fetch.spec.ts
+++ b/e2e/src/index.fetch.spec.ts
@@ -379,6 +379,32 @@ describe.each(
     })
   })
 
+  describe("GET /responses/default", () => {
+    it("returns {id: string} for 200", async () => {
+      const res = await client.getResponsesDefault({status: "200"})
+
+      expect(res.status).toBe(200)
+
+      if (res.status === 200) {
+        const body = await res.json()
+
+        expect(body.id).toBe("123")
+      }
+    })
+
+    it("returns {error: string} for other status codes", async () => {
+      const res = await client.getResponsesDefault({status: "500"})
+
+      expect(res.status).toBe(500)
+
+      if (res.status !== 200) {
+        const body = await res.json()
+
+        expect(body.error).toBe("something went wrong")
+      }
+    })
+  })
+
   describe("GET /responses/500", () => {
     it("returns response from error middleware", async () => {
       const res = await client.getResponses500()

--- a/e2e/src/routes/express/validation.ts
+++ b/e2e/src/routes/express/validation.ts
@@ -1,6 +1,7 @@
 import {
   createRouter,
   type GetResponses500,
+  type GetResponsesDefault,
   type GetResponsesEmpty,
   type GetValidationNumbersRandomNumber,
   type PostValidationEnums,
@@ -52,6 +53,17 @@ const getResponsesEmpty: GetResponsesEmpty = async (_, respond) => {
   return respond.with204()
 }
 
+const getResponsesDefault: GetResponsesDefault = async ({query}, respond) => {
+  const status = query.status ?? "200"
+  if (status === "200") {
+    return respond.with200().body({id: "123"})
+  } else if (status === "500") {
+    return respond.withDefault(500).body({error: "something went wrong"})
+  }
+
+  throw new Error("unreachable")
+}
+
 const getResponses500: GetResponses500 = async () => {
   throw new Error("something went wrong")
 }
@@ -62,6 +74,7 @@ export function createValidationRouter() {
     postValidationOptionalBody,
     getValidationNumbersRandomNumber,
     getResponsesEmpty,
+    getResponsesDefault,
     getResponses500,
   })
 }

--- a/e2e/src/routes/koa/validation.ts
+++ b/e2e/src/routes/koa/validation.ts
@@ -1,6 +1,7 @@
 import {
   createRouter,
   type GetResponses500,
+  type GetResponsesDefault,
   type GetResponsesEmpty,
   type GetValidationNumbersRandomNumber,
   type PostValidationEnums,
@@ -54,6 +55,17 @@ const getResponsesEmpty: GetResponsesEmpty = async (_, respond, ctx) => {
   return respond.with204()
 }
 
+const getResponsesDefault: GetResponsesDefault = async ({query}, respond) => {
+  const status = query.status ?? "200"
+  if (status === "200") {
+    return respond.with200().body({id: "123"})
+  } else if (status === "500") {
+    return respond.withDefault(500).body({error: "something went wrong"})
+  }
+
+  throw new Error("unreachable")
+}
+
 const getResponses500: GetResponses500 = async () => {
   throw new Error("something went wrong")
 }
@@ -64,6 +76,7 @@ export function createValidationRouter() {
     postValidationOptionalBody,
     getValidationNumbersRandomNumber,
     getResponsesEmpty,
+    getResponsesDefault,
     getResponses500,
   })
 }

--- a/integration-tests/typescript-fetch/src/generated/azure-core-data-plane-service.tsp/client.ts
+++ b/integration-tests/typescript-fetch/src/generated/azure-core-data-plane-service.tsp/client.ts
@@ -72,7 +72,7 @@ export class ContosoWidgetManager extends AbstractFetchClient {
           statusString: string
         }
       >
-    | Res<StatusCode, t_Azure_Core_Foundations_ErrorResponse>
+    | Res<Exclude<StatusCode, 200>, t_Azure_Core_Foundations_ErrorResponse>
   > {
     const url = this.basePath + `/service-status`
     const headers = this._headers(
@@ -110,7 +110,7 @@ export class ContosoWidgetManager extends AbstractFetchClient {
             status: t_Azure_Core_Foundations_OperationState
           }
       >
-    | Res<StatusCode, t_Azure_Core_Foundations_ErrorResponse>
+    | Res<Exclude<StatusCode, 200>, t_Azure_Core_Foundations_ErrorResponse>
   > {
     const url =
       this.basePath +
@@ -139,7 +139,10 @@ export class ContosoWidgetManager extends AbstractFetchClient {
   ): Promise<
     | Res<200, t_Widget>
     | Res<201, t_Widget>
-    | Res<StatusCode, t_Azure_Core_Foundations_ErrorResponse>
+    | Res<
+        Exclude<StatusCode, 200 | 201>,
+        t_Azure_Core_Foundations_ErrorResponse
+      >
   > {
     const url = this.basePath + `/widgets/${p["widgetName"]}`
     const headers = this._headers(
@@ -179,7 +182,8 @@ export class ContosoWidgetManager extends AbstractFetchClient {
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<
-    Res<200, t_Widget> | Res<StatusCode, t_Azure_Core_Foundations_ErrorResponse>
+    | Res<200, t_Widget>
+    | Res<Exclude<StatusCode, 200>, t_Azure_Core_Foundations_ErrorResponse>
   > {
     const url = this.basePath + `/widgets/${p["widgetName"]}`
     const headers = this._headers(
@@ -221,7 +225,7 @@ export class ContosoWidgetManager extends AbstractFetchClient {
           status: t_Azure_Core_Foundations_OperationState
         }
       >
-    | Res<StatusCode, t_Azure_Core_Foundations_ErrorResponse>
+    | Res<Exclude<StatusCode, 202>, t_Azure_Core_Foundations_ErrorResponse>
   > {
     const url = this.basePath + `/widgets/${p["widgetName"]}`
     const headers = this._headers(
@@ -259,7 +263,7 @@ export class ContosoWidgetManager extends AbstractFetchClient {
     opts: RequestInit = {},
   ): Promise<
     | Res<200, t_PagedWidget>
-    | Res<StatusCode, t_Azure_Core_Foundations_ErrorResponse>
+    | Res<Exclude<StatusCode, 200>, t_Azure_Core_Foundations_ErrorResponse>
   > {
     const url = this.basePath + `/widgets`
     const headers = this._headers(
@@ -302,7 +306,7 @@ export class ContosoWidgetManager extends AbstractFetchClient {
     opts: RequestInit = {},
   ): Promise<
     | Res<200, t_WidgetAnalytics>
-    | Res<StatusCode, t_Azure_Core_Foundations_ErrorResponse>
+    | Res<Exclude<StatusCode, 200>, t_Azure_Core_Foundations_ErrorResponse>
   > {
     const url = this.basePath + `/widgets/${p["widgetName"]}/analytics/current`
     const headers = this._headers(
@@ -339,7 +343,10 @@ export class ContosoWidgetManager extends AbstractFetchClient {
   ): Promise<
     | Res<200, t_WidgetAnalytics>
     | Res<201, t_WidgetAnalytics>
-    | Res<StatusCode, t_Azure_Core_Foundations_ErrorResponse>
+    | Res<
+        Exclude<StatusCode, 200 | 201>,
+        t_Azure_Core_Foundations_ErrorResponse
+      >
   > {
     const url = this.basePath + `/widgets/${p["widgetName"]}/analytics/current`
     const headers = this._headers(
@@ -384,7 +391,7 @@ export class ContosoWidgetManager extends AbstractFetchClient {
           status: t_Azure_Core_Foundations_OperationState
         }
       >
-    | Res<StatusCode, t_Azure_Core_Foundations_ErrorResponse>
+    | Res<Exclude<StatusCode, 200>, t_Azure_Core_Foundations_ErrorResponse>
   > {
     const url =
       this.basePath + `/widgets/${p["widgetId"]}/repairs/${p["operationId"]}`
@@ -421,7 +428,7 @@ export class ContosoWidgetManager extends AbstractFetchClient {
           status: t_Azure_Core_Foundations_OperationState
         }
       >
-    | Res<StatusCode, t_Azure_Core_Foundations_ErrorResponse>
+    | Res<Exclude<StatusCode, 202>, t_Azure_Core_Foundations_ErrorResponse>
   > {
     const url = this.basePath + `/widgets/${p["widgetName"]}:scheduleRepairs`
     const headers = this._headers(
@@ -463,7 +470,7 @@ export class ContosoWidgetManager extends AbstractFetchClient {
           status: t_Azure_Core_Foundations_OperationState
         }
       >
-    | Res<StatusCode, t_Azure_Core_Foundations_ErrorResponse>
+    | Res<Exclude<StatusCode, 200>, t_Azure_Core_Foundations_ErrorResponse>
   > {
     const url =
       this.basePath +
@@ -490,7 +497,8 @@ export class ContosoWidgetManager extends AbstractFetchClient {
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<
-    Res<201, void> | Res<StatusCode, t_Azure_Core_Foundations_ErrorResponse>
+    | Res<201, void>
+    | Res<Exclude<StatusCode, 201>, t_Azure_Core_Foundations_ErrorResponse>
   > {
     const url = this.basePath + `/widgets/${p["widgetName"]}/parts`
     const headers = this._headers(
@@ -527,7 +535,7 @@ export class ContosoWidgetManager extends AbstractFetchClient {
     opts: RequestInit = {},
   ): Promise<
     | Res<200, t_PagedWidgetPart>
-    | Res<StatusCode, t_Azure_Core_Foundations_ErrorResponse>
+    | Res<Exclude<StatusCode, 200>, t_Azure_Core_Foundations_ErrorResponse>
   > {
     const url = this.basePath + `/widgets/${p["widgetName"]}/parts`
     const headers = this._headers(
@@ -557,7 +565,7 @@ export class ContosoWidgetManager extends AbstractFetchClient {
     opts: RequestInit = {},
   ): Promise<
     | Res<200, t_WidgetPart>
-    | Res<StatusCode, t_Azure_Core_Foundations_ErrorResponse>
+    | Res<Exclude<StatusCode, 200>, t_Azure_Core_Foundations_ErrorResponse>
   > {
     const url =
       this.basePath + `/widgets/${p["widgetName"]}/parts/${p["widgetPartName"]}`
@@ -593,7 +601,8 @@ export class ContosoWidgetManager extends AbstractFetchClient {
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<
-    Res<204, void> | Res<StatusCode, t_Azure_Core_Foundations_ErrorResponse>
+    | Res<204, void>
+    | Res<Exclude<StatusCode, 204>, t_Azure_Core_Foundations_ErrorResponse>
   > {
     const url =
       this.basePath + `/widgets/${p["widgetName"]}/parts/${p["widgetPartName"]}`
@@ -639,7 +648,7 @@ export class ContosoWidgetManager extends AbstractFetchClient {
           status: t_Azure_Core_Foundations_OperationState
         }
       >
-    | Res<StatusCode, t_Azure_Core_Foundations_ErrorResponse>
+    | Res<Exclude<StatusCode, 202>, t_Azure_Core_Foundations_ErrorResponse>
   > {
     const url = this.basePath + `/widgets/${p["widgetName"]}/parts:reorderParts`
     const headers = this._headers(
@@ -680,7 +689,7 @@ export class ContosoWidgetManager extends AbstractFetchClient {
           status: t_Azure_Core_Foundations_OperationState
         }
       >
-    | Res<StatusCode, t_Azure_Core_Foundations_ErrorResponse>
+    | Res<Exclude<StatusCode, 200>, t_Azure_Core_Foundations_ErrorResponse>
   > {
     const url =
       this.basePath +
@@ -709,7 +718,10 @@ export class ContosoWidgetManager extends AbstractFetchClient {
   ): Promise<
     | Res<200, t_Manufacturer>
     | Res<201, t_Manufacturer>
-    | Res<StatusCode, t_Azure_Core_Foundations_ErrorResponse>
+    | Res<
+        Exclude<StatusCode, 200 | 201>,
+        t_Azure_Core_Foundations_ErrorResponse
+      >
   > {
     const url = this.basePath + `/manufacturers/${p["manufacturerId"]}`
     const headers = this._headers(
@@ -750,7 +762,7 @@ export class ContosoWidgetManager extends AbstractFetchClient {
     opts: RequestInit = {},
   ): Promise<
     | Res<200, t_Manufacturer>
-    | Res<StatusCode, t_Azure_Core_Foundations_ErrorResponse>
+    | Res<Exclude<StatusCode, 200>, t_Azure_Core_Foundations_ErrorResponse>
   > {
     const url = this.basePath + `/manufacturers/${p["manufacturerId"]}`
     const headers = this._headers(
@@ -792,7 +804,7 @@ export class ContosoWidgetManager extends AbstractFetchClient {
           status: t_Azure_Core_Foundations_OperationState
         }
       >
-    | Res<StatusCode, t_Azure_Core_Foundations_ErrorResponse>
+    | Res<Exclude<StatusCode, 202>, t_Azure_Core_Foundations_ErrorResponse>
   > {
     const url = this.basePath + `/manufacturers/${p["manufacturerId"]}`
     const headers = this._headers(
@@ -826,7 +838,7 @@ export class ContosoWidgetManager extends AbstractFetchClient {
     opts: RequestInit = {},
   ): Promise<
     | Res<200, t_PagedManufacturer>
-    | Res<StatusCode, t_Azure_Core_Foundations_ErrorResponse>
+    | Res<Exclude<StatusCode, 200>, t_Azure_Core_Foundations_ErrorResponse>
   > {
     const url = this.basePath + `/manufacturers`
     const headers = this._headers(

--- a/integration-tests/typescript-fetch/src/generated/azure-resource-manager.tsp/client.ts
+++ b/integration-tests/typescript-fetch/src/generated/azure-resource-manager.tsp/client.ts
@@ -60,7 +60,10 @@ export class ContosoProviderHubClient extends AbstractFetchClient {
     opts: RequestInit = {},
   ): Promise<
     | Res<200, t_OperationListResult>
-    | Res<StatusCode, t_Azure_ResourceManager_CommonTypes_ErrorResponse>
+    | Res<
+        Exclude<StatusCode, 200>,
+        t_Azure_ResourceManager_CommonTypes_ErrorResponse
+      >
   > {
     const url =
       this.basePath + `/providers/Microsoft.ContosoProviderHub/operations`
@@ -81,7 +84,10 @@ export class ContosoProviderHubClient extends AbstractFetchClient {
     opts: RequestInit = {},
   ): Promise<
     | Res<200, t_Employee>
-    | Res<StatusCode, t_Azure_ResourceManager_CommonTypes_ErrorResponse>
+    | Res<
+        Exclude<StatusCode, 200>,
+        t_Azure_ResourceManager_CommonTypes_ErrorResponse
+      >
   > {
     const url =
       this.basePath +
@@ -105,7 +111,10 @@ export class ContosoProviderHubClient extends AbstractFetchClient {
   ): Promise<
     | Res<200, t_Employee>
     | Res<201, t_Employee>
-    | Res<StatusCode, t_Azure_ResourceManager_CommonTypes_ErrorResponse>
+    | Res<
+        Exclude<StatusCode, 200 | 201>,
+        t_Azure_ResourceManager_CommonTypes_ErrorResponse
+      >
   > {
     const url =
       this.basePath +
@@ -136,7 +145,10 @@ export class ContosoProviderHubClient extends AbstractFetchClient {
     opts: RequestInit = {},
   ): Promise<
     | Res<200, t_Employee>
-    | Res<StatusCode, t_Azure_ResourceManager_CommonTypes_ErrorResponse>
+    | Res<
+        Exclude<StatusCode, 200>,
+        t_Azure_ResourceManager_CommonTypes_ErrorResponse
+      >
   > {
     const url =
       this.basePath +
@@ -167,7 +179,10 @@ export class ContosoProviderHubClient extends AbstractFetchClient {
   ): Promise<
     | Res<202, void>
     | Res<204, void>
-    | Res<StatusCode, t_Azure_ResourceManager_CommonTypes_ErrorResponse>
+    | Res<
+        Exclude<StatusCode, 202 | 204>,
+        t_Azure_ResourceManager_CommonTypes_ErrorResponse
+      >
   > {
     const url =
       this.basePath +
@@ -194,7 +209,10 @@ export class ContosoProviderHubClient extends AbstractFetchClient {
   ): Promise<
     | Res<204, void>
     | Res<404, void>
-    | Res<StatusCode, t_Azure_ResourceManager_CommonTypes_ErrorResponse>
+    | Res<
+        Exclude<StatusCode, 204 | 404>,
+        t_Azure_ResourceManager_CommonTypes_ErrorResponse
+      >
   > {
     const url =
       this.basePath +
@@ -215,7 +233,10 @@ export class ContosoProviderHubClient extends AbstractFetchClient {
     opts: RequestInit = {},
   ): Promise<
     | Res<200, t_EmployeeListResult>
-    | Res<StatusCode, t_Azure_ResourceManager_CommonTypes_ErrorResponse>
+    | Res<
+        Exclude<StatusCode, 200>,
+        t_Azure_ResourceManager_CommonTypes_ErrorResponse
+      >
   > {
     const url =
       this.basePath +
@@ -235,7 +256,10 @@ export class ContosoProviderHubClient extends AbstractFetchClient {
     opts: RequestInit = {},
   ): Promise<
     | Res<200, t_EmployeeListResult>
-    | Res<StatusCode, t_Azure_ResourceManager_CommonTypes_ErrorResponse>
+    | Res<
+        Exclude<StatusCode, 200>,
+        t_Azure_ResourceManager_CommonTypes_ErrorResponse
+      >
   > {
     const url =
       this.basePath +
@@ -258,7 +282,10 @@ export class ContosoProviderHubClient extends AbstractFetchClient {
     opts: RequestInit = {},
   ): Promise<
     | Res<200, t_MoveResponse>
-    | Res<StatusCode, t_Azure_ResourceManager_CommonTypes_ErrorResponse>
+    | Res<
+        Exclude<StatusCode, 200>,
+        t_Azure_ResourceManager_CommonTypes_ErrorResponse
+      >
   > {
     const url =
       this.basePath +

--- a/integration-tests/typescript-fetch/src/generated/petstore-expanded.yaml/client.ts
+++ b/integration-tests/typescript-fetch/src/generated/petstore-expanded.yaml/client.ts
@@ -49,7 +49,7 @@ export class SwaggerPetstore extends AbstractFetchClient {
     } = {},
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_Pet[]> | Res<StatusCode, t_Error>> {
+  ): Promise<Res<200, t_Pet[]> | Res<Exclude<StatusCode, 200>, t_Error>> {
     const url = this.basePath + `/pets`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
     const query = this._query(
@@ -71,7 +71,7 @@ export class SwaggerPetstore extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_Pet> | Res<StatusCode, t_Error>> {
+  ): Promise<Res<200, t_Pet> | Res<Exclude<StatusCode, 200>, t_Error>> {
     const url = this.basePath + `/pets`
     const headers = this._headers(
       {Accept: "application/json", "Content-Type": "application/json"},
@@ -88,7 +88,7 @@ export class SwaggerPetstore extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_Pet> | Res<StatusCode, t_Error>> {
+  ): Promise<Res<200, t_Pet> | Res<Exclude<StatusCode, 200>, t_Error>> {
     const url = this.basePath + `/pets/${p["id"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
 
@@ -101,7 +101,7 @@ export class SwaggerPetstore extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<204, void> | Res<StatusCode, t_Error>> {
+  ): Promise<Res<204, void> | Res<Exclude<StatusCode, 204>, t_Error>> {
     const url = this.basePath + `/pets/${p["id"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
 

--- a/integration-tests/typescript-fetch/src/generated/stripe.yaml/client.ts
+++ b/integration-tests/typescript-fetch/src/generated/stripe.yaml/client.ts
@@ -531,7 +531,7 @@ export class StripeApi extends AbstractFetchClient {
     } = {},
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_account> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_account> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/account`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
     const query = this._query(
@@ -553,7 +553,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_account_link> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_account_link> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/account_links`
     const headers = this._headers(
       {
@@ -576,7 +578,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_account_session> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_account_session> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/account_sessions`
     const headers = this._headers(
       {
@@ -620,7 +624,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/accounts`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -653,7 +657,7 @@ export class StripeApi extends AbstractFetchClient {
     } = {},
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_account> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_account> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/accounts`
     const headers = this._headers(
       {
@@ -692,7 +696,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_deleted_account> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_deleted_account> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/accounts/${p["account"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
 
@@ -706,7 +712,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_account> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_account> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/accounts/${p["account"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
     const query = this._query(
@@ -729,7 +735,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_account> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_account> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/accounts/${p["account"]}`
     const headers = this._headers(
       {
@@ -767,7 +773,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_external_account> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_external_account> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/accounts/${p["account"]}/bank_accounts`
     const headers = this._headers(
       {
@@ -798,7 +806,10 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_deleted_external_account> | Res<StatusCode, t_error>> {
+  ): Promise<
+    | Res<200, t_deleted_external_account>
+    | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url =
       this.basePath + `/v1/accounts/${p["account"]}/bank_accounts/${p["id"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -814,7 +825,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_external_account> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_external_account> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url =
       this.basePath + `/v1/accounts/${p["account"]}/bank_accounts/${p["id"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -839,7 +852,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_external_account> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_external_account> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url =
       this.basePath + `/v1/accounts/${p["account"]}/bank_accounts/${p["id"]}`
     const headers = this._headers(
@@ -881,7 +896,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/accounts/${p["account"]}/capabilities`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -906,7 +921,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_capability> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_capability> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url =
       this.basePath +
       `/v1/accounts/${p["account"]}/capabilities/${p["capability"]}`
@@ -932,7 +947,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_capability> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_capability> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url =
       this.basePath +
       `/v1/accounts/${p["account"]}/capabilities/${p["capability"]}`
@@ -977,7 +992,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/accounts/${p["account"]}/external_accounts`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -1007,7 +1022,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_external_account> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_external_account> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/accounts/${p["account"]}/external_accounts`
     const headers = this._headers(
       {
@@ -1038,7 +1055,10 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_deleted_external_account> | Res<StatusCode, t_error>> {
+  ): Promise<
+    | Res<200, t_deleted_external_account>
+    | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url =
       this.basePath +
       `/v1/accounts/${p["account"]}/external_accounts/${p["id"]}`
@@ -1055,7 +1075,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_external_account> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_external_account> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url =
       this.basePath +
       `/v1/accounts/${p["account"]}/external_accounts/${p["id"]}`
@@ -1081,7 +1103,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_external_account> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_external_account> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url =
       this.basePath +
       `/v1/accounts/${p["account"]}/external_accounts/${p["id"]}`
@@ -1114,7 +1138,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_login_link> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_login_link> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/accounts/${p["account"]}/login_links`
     const headers = this._headers(
       {
@@ -1164,7 +1188,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/accounts/${p["account"]}/people`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -1198,7 +1222,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_person> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_person> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/accounts/${p["account"]}/people`
     const headers = this._headers(
       {
@@ -1239,7 +1263,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_deleted_person> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_deleted_person> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url =
       this.basePath + `/v1/accounts/${p["account"]}/people/${p["person"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -1255,7 +1281,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_person> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_person> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url =
       this.basePath + `/v1/accounts/${p["account"]}/people/${p["person"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -1280,7 +1306,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_person> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_person> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url =
       this.basePath + `/v1/accounts/${p["account"]}/people/${p["person"]}`
     const headers = this._headers(
@@ -1343,7 +1369,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/accounts/${p["account"]}/persons`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -1377,7 +1403,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_person> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_person> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/accounts/${p["account"]}/persons`
     const headers = this._headers(
       {
@@ -1418,7 +1444,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_deleted_person> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_deleted_person> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url =
       this.basePath + `/v1/accounts/${p["account"]}/persons/${p["person"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -1434,7 +1462,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_person> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_person> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url =
       this.basePath + `/v1/accounts/${p["account"]}/persons/${p["person"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -1459,7 +1487,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_person> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_person> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url =
       this.basePath + `/v1/accounts/${p["account"]}/persons/${p["person"]}`
     const headers = this._headers(
@@ -1501,7 +1529,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_account> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_account> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/accounts/${p["account"]}/reject`
     const headers = this._headers(
       {
@@ -1537,7 +1565,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/apple_pay/domains`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -1566,7 +1594,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_apple_pay_domain> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_apple_pay_domain> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/apple_pay/domains`
     const headers = this._headers(
       {
@@ -1588,7 +1618,10 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_deleted_apple_pay_domain> | Res<StatusCode, t_error>> {
+  ): Promise<
+    | Res<200, t_deleted_apple_pay_domain>
+    | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/apple_pay/domains/${p["domain"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
 
@@ -1602,7 +1635,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_apple_pay_domain> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_apple_pay_domain> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/apple_pay/domains/${p["domain"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
     const query = this._query(
@@ -1646,7 +1681,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/application_fees`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -1682,7 +1717,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_fee_refund> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_fee_refund> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url =
       this.basePath + `/v1/application_fees/${p["fee"]}/refunds/${p["id"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -1707,7 +1742,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_fee_refund> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_fee_refund> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url =
       this.basePath + `/v1/application_fees/${p["fee"]}/refunds/${p["id"]}`
     const headers = this._headers(
@@ -1738,7 +1773,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_application_fee> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_application_fee> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/application_fees/${p["id"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
     const query = this._query(
@@ -1761,7 +1798,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_application_fee> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_application_fee> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/application_fees/${p["id"]}/refund`
     const headers = this._headers(
       {
@@ -1803,7 +1842,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/application_fees/${p["id"]}/refunds`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -1832,7 +1871,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_fee_refund> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_fee_refund> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/application_fees/${p["id"]}/refunds`
     const headers = this._headers(
       {
@@ -1878,7 +1917,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/apps/secrets`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -1911,7 +1950,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_apps_secret> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_apps_secret> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/apps/secrets`
     const headers = this._headers(
       {
@@ -1934,7 +1973,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_apps_secret> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_apps_secret> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/apps/secrets/delete`
     const headers = this._headers(
       {
@@ -1962,7 +2001,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_apps_secret> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_apps_secret> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/apps/secrets/find`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
     const query = this._query(
@@ -1988,7 +2027,7 @@ export class StripeApi extends AbstractFetchClient {
     } = {},
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_balance> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_balance> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/balance`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
     const query = this._query(
@@ -2035,7 +2074,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/balance/history`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -2073,7 +2112,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_balance_transaction> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_balance_transaction> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/balance/history/${p["id"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
     const query = this._query(
@@ -2120,7 +2161,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/balance_transactions`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -2158,7 +2199,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_balance_transaction> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_balance_transaction> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/balance_transactions/${p["id"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
     const query = this._query(
@@ -2195,7 +2238,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/billing/alerts`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -2225,7 +2268,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_billing_alert> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_billing_alert> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/billing/alerts`
     const headers = this._headers(
       {
@@ -2249,7 +2294,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_billing_alert> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_billing_alert> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/billing/alerts/${p["id"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
     const query = this._query(
@@ -2272,7 +2319,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_billing_alert> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_billing_alert> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/billing/alerts/${p["id"]}/activate`
     const headers = this._headers(
       {
@@ -2301,7 +2350,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_billing_alert> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_billing_alert> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/billing/alerts/${p["id"]}/archive`
     const headers = this._headers(
       {
@@ -2330,7 +2381,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_billing_alert> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_billing_alert> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/billing/alerts/${p["id"]}/deactivate`
     const headers = this._headers(
       {
@@ -2370,7 +2423,8 @@ export class StripeApi extends AbstractFetchClient {
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<
-    Res<200, t_billing_credit_balance_summary> | Res<StatusCode, t_error>
+    | Res<200, t_billing_credit_balance_summary>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/billing/credit_balance_summary`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -2412,7 +2466,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/billing/credit_balance_transactions`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -2444,7 +2498,8 @@ export class StripeApi extends AbstractFetchClient {
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<
-    Res<200, t_billing_credit_balance_transaction> | Res<StatusCode, t_error>
+    | Res<200, t_billing_credit_balance_transaction>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url =
       this.basePath + `/v1/billing/credit_balance_transactions/${p["id"]}`
@@ -2482,7 +2537,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/billing/credit_grants`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -2511,7 +2566,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_billing_credit_grant> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_billing_credit_grant> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/billing/credit_grants`
     const headers = this._headers(
       {
@@ -2537,7 +2594,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_billing_credit_grant> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_billing_credit_grant> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/billing/credit_grants/${p["id"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
     const query = this._query(
@@ -2560,7 +2619,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_billing_credit_grant> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_billing_credit_grant> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/billing/credit_grants/${p["id"]}`
     const headers = this._headers(
       {
@@ -2591,7 +2652,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_billing_credit_grant> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_billing_credit_grant> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/billing/credit_grants/${p["id"]}/expire`
     const headers = this._headers(
       {
@@ -2620,7 +2683,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_billing_credit_grant> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_billing_credit_grant> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/billing/credit_grants/${p["id"]}/void`
     const headers = this._headers(
       {
@@ -2649,7 +2714,8 @@ export class StripeApi extends AbstractFetchClient {
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<
-    Res<200, t_billing_meter_event_adjustment> | Res<StatusCode, t_error>
+    | Res<200, t_billing_meter_event_adjustment>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/billing/meter_event_adjustments`
     const headers = this._headers(
@@ -2673,7 +2739,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_billing_meter_event> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_billing_meter_event> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/billing/meter_events`
     const headers = this._headers(
       {
@@ -2710,7 +2778,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/billing/meters`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -2739,7 +2807,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_billing_meter> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_billing_meter> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/billing/meters`
     const headers = this._headers(
       {
@@ -2765,7 +2835,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_billing_meter> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_billing_meter> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/billing/meters/${p["id"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
     const query = this._query(
@@ -2788,7 +2860,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_billing_meter> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_billing_meter> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/billing/meters/${p["id"]}`
     const headers = this._headers(
       {
@@ -2817,7 +2891,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_billing_meter> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_billing_meter> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/billing/meters/${p["id"]}/deactivate`
     const headers = this._headers(
       {
@@ -2863,7 +2939,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/billing/meters/${p["id"]}/event_summaries`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -2896,7 +2972,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_billing_meter> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_billing_meter> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/billing/meters/${p["id"]}/reactivate`
     const headers = this._headers(
       {
@@ -2939,7 +3017,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/billing_portal/configurations`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -2970,7 +3048,8 @@ export class StripeApi extends AbstractFetchClient {
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<
-    Res<200, t_billing_portal_configuration> | Res<StatusCode, t_error>
+    | Res<200, t_billing_portal_configuration>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/billing_portal/configurations`
     const headers = this._headers(
@@ -3000,7 +3079,8 @@ export class StripeApi extends AbstractFetchClient {
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<
-    Res<200, t_billing_portal_configuration> | Res<StatusCode, t_error>
+    | Res<200, t_billing_portal_configuration>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url =
       this.basePath + `/v1/billing_portal/configurations/${p["configuration"]}`
@@ -3026,7 +3106,8 @@ export class StripeApi extends AbstractFetchClient {
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<
-    Res<200, t_billing_portal_configuration> | Res<StatusCode, t_error>
+    | Res<200, t_billing_portal_configuration>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url =
       this.basePath + `/v1/billing_portal/configurations/${p["configuration"]}`
@@ -3061,7 +3142,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_billing_portal_session> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_billing_portal_session> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/billing_portal/sessions`
     const headers = this._headers(
       {
@@ -3108,7 +3191,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/charges`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -3144,7 +3227,7 @@ export class StripeApi extends AbstractFetchClient {
     } = {},
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_charge> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_charge> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/charges`
     const headers = this._headers(
       {
@@ -3193,7 +3276,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/charges/search`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -3222,7 +3305,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_charge> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_charge> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/charges/${p["charge"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
     const query = this._query(
@@ -3245,7 +3328,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_charge> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_charge> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/charges/${p["charge"]}`
     const headers = this._headers(
       {
@@ -3277,7 +3360,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_charge> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_charge> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/charges/${p["charge"]}/capture`
     const headers = this._headers(
       {
@@ -3307,7 +3390,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_dispute> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_dispute> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/charges/${p["charge"]}/dispute`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
     const query = this._query(
@@ -3330,7 +3413,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_dispute> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_dispute> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/charges/${p["charge"]}/dispute`
     const headers = this._headers(
       {
@@ -3361,7 +3444,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_dispute> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_dispute> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/charges/${p["charge"]}/dispute/close`
     const headers = this._headers(
       {
@@ -3390,7 +3473,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_charge> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_charge> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/charges/${p["charge"]}/refund`
     const headers = this._headers(
       {
@@ -3433,7 +3516,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/charges/${p["charge"]}/refunds`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -3462,7 +3545,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_refund> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_refund> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/charges/${p["charge"]}/refunds`
     const headers = this._headers(
       {
@@ -3493,7 +3576,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_refund> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_refund> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url =
       this.basePath + `/v1/charges/${p["charge"]}/refunds/${p["refund"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -3518,7 +3601,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_refund> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_refund> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url =
       this.basePath + `/v1/charges/${p["charge"]}/refunds/${p["refund"]}`
     const headers = this._headers(
@@ -3577,7 +3660,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/checkout/sessions`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -3620,7 +3703,9 @@ export class StripeApi extends AbstractFetchClient {
     } = {},
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_checkout_session> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_checkout_session> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/checkout/sessions`
     const headers = this._headers(
       {
@@ -3674,7 +3759,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_checkout_session> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_checkout_session> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/checkout/sessions/${p["session"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
     const query = this._query(
@@ -3697,7 +3784,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_checkout_session> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_checkout_session> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/checkout/sessions/${p["session"]}`
     const headers = this._headers(
       {
@@ -3729,7 +3818,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_checkout_session> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_checkout_session> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/checkout/sessions/${p["session"]}/expire`
     const headers = this._headers(
       {
@@ -3771,7 +3862,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url =
       this.basePath + `/v1/checkout/sessions/${p["session"]}/line_items`
@@ -3813,7 +3904,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/climate/orders`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -3841,7 +3932,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_climate_order> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_climate_order> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/climate/orders`
     const headers = this._headers(
       {
@@ -3866,7 +3959,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_climate_order> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_climate_order> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/climate/orders/${p["order"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
     const query = this._query(
@@ -3889,7 +3984,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_climate_order> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_climate_order> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/climate/orders/${p["order"]}`
     const headers = this._headers(
       {
@@ -3920,7 +4017,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_climate_order> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_climate_order> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/climate/orders/${p["order"]}/cancel`
     const headers = this._headers(
       {
@@ -3961,7 +4060,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/climate/products`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -3990,7 +4089,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_climate_product> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_climate_product> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/climate/products/${p["product"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
     const query = this._query(
@@ -4025,7 +4126,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/climate/suppliers`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -4054,7 +4155,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_climate_supplier> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_climate_supplier> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/climate/suppliers/${p["supplier"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
     const query = this._query(
@@ -4077,7 +4180,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_confirmation_token> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_confirmation_token> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url =
       this.basePath + `/v1/confirmation_tokens/${p["confirmationToken"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -4113,7 +4218,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/country_specs`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -4142,7 +4247,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_country_spec> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_country_spec> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/country_specs/${p["country"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
     const query = this._query(
@@ -4185,7 +4292,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/coupons`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -4218,7 +4325,7 @@ export class StripeApi extends AbstractFetchClient {
     } = {},
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_coupon> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_coupon> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/coupons`
     const headers = this._headers(
       {
@@ -4249,7 +4356,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_deleted_coupon> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_deleted_coupon> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/coupons/${p["coupon"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
 
@@ -4263,7 +4372,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_coupon> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_coupon> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/coupons/${p["coupon"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
     const query = this._query(
@@ -4286,7 +4395,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_coupon> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_coupon> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/coupons/${p["coupon"]}`
     const headers = this._headers(
       {
@@ -4339,7 +4448,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/credit_notes`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -4374,7 +4483,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_credit_note> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_credit_note> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/credit_notes`
     const headers = this._headers(
       {
@@ -4440,7 +4549,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_credit_note> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_credit_note> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/credit_notes/preview`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
     const query = this._query(
@@ -4546,7 +4655,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/credit_notes/preview/lines`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -4617,7 +4726,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/credit_notes/${p["creditNote"]}/lines`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -4646,7 +4755,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_credit_note> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_credit_note> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/credit_notes/${p["id"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
     const query = this._query(
@@ -4669,7 +4778,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_credit_note> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_credit_note> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/credit_notes/${p["id"]}`
     const headers = this._headers(
       {
@@ -4699,7 +4808,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_credit_note> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_credit_note> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/credit_notes/${p["id"]}/void`
     const headers = this._headers(
       {
@@ -4727,7 +4836,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_customer_session> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_customer_session> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/customer_sessions`
     const headers = this._headers(
       {
@@ -4773,7 +4884,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/customers`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -4808,7 +4919,7 @@ export class StripeApi extends AbstractFetchClient {
     } = {},
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_customer> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_customer> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/customers`
     const headers = this._headers(
       {
@@ -4859,7 +4970,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/customers/search`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -4887,7 +4998,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_deleted_customer> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_deleted_customer> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/customers/${p["customer"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
 
@@ -4902,7 +5015,8 @@ export class StripeApi extends AbstractFetchClient {
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<
-    Res<200, t_customer | t_deleted_customer> | Res<StatusCode, t_error>
+    | Res<200, t_customer | t_deleted_customer>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/customers/${p["customer"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -4926,7 +5040,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_customer> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_customer> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/customers/${p["customer"]}`
     const headers = this._headers(
       {
@@ -4977,7 +5091,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url =
       this.basePath + `/v1/customers/${p["customer"]}/balance_transactions`
@@ -5008,7 +5122,8 @@ export class StripeApi extends AbstractFetchClient {
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<
-    Res<200, t_customer_balance_transaction> | Res<StatusCode, t_error>
+    | Res<200, t_customer_balance_transaction>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url =
       this.basePath + `/v1/customers/${p["customer"]}/balance_transactions`
@@ -5036,7 +5151,8 @@ export class StripeApi extends AbstractFetchClient {
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<
-    Res<200, t_customer_balance_transaction> | Res<StatusCode, t_error>
+    | Res<200, t_customer_balance_transaction>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url =
       this.basePath +
@@ -5064,7 +5180,8 @@ export class StripeApi extends AbstractFetchClient {
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<
-    Res<200, t_customer_balance_transaction> | Res<StatusCode, t_error>
+    | Res<200, t_customer_balance_transaction>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url =
       this.basePath +
@@ -5110,7 +5227,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/customers/${p["customer"]}/bank_accounts`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -5139,7 +5256,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_payment_source> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_payment_source> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/customers/${p["customer"]}/bank_accounts`
     const headers = this._headers(
       {
@@ -5174,7 +5293,7 @@ export class StripeApi extends AbstractFetchClient {
     opts: RequestInit = {},
   ): Promise<
     | Res<200, t_payment_source | t_deleted_payment_source>
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url =
       this.basePath + `/v1/customers/${p["customer"]}/bank_accounts/${p["id"]}`
@@ -5206,7 +5325,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_bank_account> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_bank_account> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url =
       this.basePath + `/v1/customers/${p["customer"]}/bank_accounts/${p["id"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -5232,7 +5353,8 @@ export class StripeApi extends AbstractFetchClient {
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<
-    Res<200, t_card | t_bank_account | t_source> | Res<StatusCode, t_error>
+    | Res<200, t_card | t_bank_account | t_source>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url =
       this.basePath + `/v1/customers/${p["customer"]}/bank_accounts/${p["id"]}`
@@ -5266,7 +5388,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_bank_account> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_bank_account> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url =
       this.basePath +
       `/v1/customers/${p["customer"]}/bank_accounts/${p["id"]}/verify`
@@ -5311,7 +5435,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/customers/${p["customer"]}/cards`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -5340,7 +5464,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_payment_source> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_payment_source> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/customers/${p["customer"]}/cards`
     const headers = this._headers(
       {
@@ -5375,7 +5501,7 @@ export class StripeApi extends AbstractFetchClient {
     opts: RequestInit = {},
   ): Promise<
     | Res<200, t_payment_source | t_deleted_payment_source>
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url =
       this.basePath + `/v1/customers/${p["customer"]}/cards/${p["id"]}`
@@ -5407,7 +5533,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_card> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_card> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url =
       this.basePath + `/v1/customers/${p["customer"]}/cards/${p["id"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -5433,7 +5559,8 @@ export class StripeApi extends AbstractFetchClient {
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<
-    Res<200, t_card | t_bank_account | t_source> | Res<StatusCode, t_error>
+    | Res<200, t_card | t_bank_account | t_source>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url =
       this.basePath + `/v1/customers/${p["customer"]}/cards/${p["id"]}`
@@ -5466,7 +5593,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_cash_balance> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_cash_balance> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/customers/${p["customer"]}/cash_balance`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
     const query = this._query(
@@ -5489,7 +5618,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_cash_balance> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_cash_balance> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/customers/${p["customer"]}/cash_balance`
     const headers = this._headers(
       {
@@ -5532,7 +5663,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url =
       this.basePath + `/v1/customers/${p["customer"]}/cash_balance_transactions`
@@ -5564,7 +5695,8 @@ export class StripeApi extends AbstractFetchClient {
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<
-    Res<200, t_customer_cash_balance_transaction> | Res<StatusCode, t_error>
+    | Res<200, t_customer_cash_balance_transaction>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url =
       this.basePath +
@@ -5589,7 +5721,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_deleted_discount> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_deleted_discount> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/customers/${p["customer"]}/discount`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
 
@@ -5603,7 +5737,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_discount> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_discount> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/customers/${p["customer"]}/discount`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
     const query = this._query(
@@ -5626,7 +5760,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_funding_instructions> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_funding_instructions> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url =
       this.basePath + `/v1/customers/${p["customer"]}/funding_instructions`
     const headers = this._headers(
@@ -5719,7 +5855,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/customers/${p["customer"]}/payment_methods`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -5751,7 +5887,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_payment_method> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_payment_method> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url =
       this.basePath +
       `/v1/customers/${p["customer"]}/payment_methods/${p["paymentMethod"]}`
@@ -5790,7 +5928,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/customers/${p["customer"]}/sources`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -5820,7 +5958,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_payment_source> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_payment_source> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/customers/${p["customer"]}/sources`
     const headers = this._headers(
       {
@@ -5855,7 +5995,7 @@ export class StripeApi extends AbstractFetchClient {
     opts: RequestInit = {},
   ): Promise<
     | Res<200, t_payment_source | t_deleted_payment_source>
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url =
       this.basePath + `/v1/customers/${p["customer"]}/sources/${p["id"]}`
@@ -5887,7 +6027,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_payment_source> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_payment_source> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url =
       this.basePath + `/v1/customers/${p["customer"]}/sources/${p["id"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -5913,7 +6055,8 @@ export class StripeApi extends AbstractFetchClient {
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<
-    Res<200, t_card | t_bank_account | t_source> | Res<StatusCode, t_error>
+    | Res<200, t_card | t_bank_account | t_source>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url =
       this.basePath + `/v1/customers/${p["customer"]}/sources/${p["id"]}`
@@ -5947,7 +6090,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_bank_account> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_bank_account> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url =
       this.basePath + `/v1/customers/${p["customer"]}/sources/${p["id"]}/verify`
     const headers = this._headers(
@@ -5991,7 +6136,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/customers/${p["customer"]}/subscriptions`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -6020,7 +6165,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_subscription> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_subscription> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/customers/${p["customer"]}/subscriptions`
     const headers = this._headers(
       {
@@ -6065,7 +6212,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_subscription> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_subscription> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url =
       this.basePath +
       `/v1/customers/${p["customer"]}/subscriptions/${p["subscriptionExposedId"]}`
@@ -6097,7 +6246,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_subscription> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_subscription> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url =
       this.basePath +
       `/v1/customers/${p["customer"]}/subscriptions/${p["subscriptionExposedId"]}`
@@ -6123,7 +6274,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_subscription> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_subscription> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url =
       this.basePath +
       `/v1/customers/${p["customer"]}/subscriptions/${p["subscriptionExposedId"]}`
@@ -6172,7 +6325,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_deleted_discount> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_deleted_discount> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url =
       this.basePath +
       `/v1/customers/${p["customer"]}/subscriptions/${p["subscriptionExposedId"]}/discount`
@@ -6189,7 +6344,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_discount> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_discount> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url =
       this.basePath +
       `/v1/customers/${p["customer"]}/subscriptions/${p["subscriptionExposedId"]}/discount`
@@ -6227,7 +6382,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/customers/${p["customer"]}/tax_ids`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -6256,7 +6411,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_tax_id> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_tax_id> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/customers/${p["customer"]}/tax_ids`
     const headers = this._headers(
       {
@@ -6279,7 +6434,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_deleted_tax_id> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_deleted_tax_id> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url =
       this.basePath + `/v1/customers/${p["customer"]}/tax_ids/${p["id"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -6295,7 +6452,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_tax_id> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_tax_id> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url =
       this.basePath + `/v1/customers/${p["customer"]}/tax_ids/${p["id"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -6341,7 +6498,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/disputes`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -6377,7 +6534,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_dispute> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_dispute> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/disputes/${p["dispute"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
     const query = this._query(
@@ -6400,7 +6557,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_dispute> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_dispute> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/disputes/${p["dispute"]}`
     const headers = this._headers(
       {
@@ -6431,7 +6588,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_dispute> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_dispute> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/disputes/${p["dispute"]}/close`
     const headers = this._headers(
       {
@@ -6473,7 +6630,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/entitlements/active_entitlements`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -6504,7 +6661,8 @@ export class StripeApi extends AbstractFetchClient {
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<
-    Res<200, t_entitlements_active_entitlement> | Res<StatusCode, t_error>
+    | Res<200, t_entitlements_active_entitlement>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url =
       this.basePath + `/v1/entitlements/active_entitlements/${p["id"]}`
@@ -6543,7 +6701,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/entitlements/features`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -6573,7 +6731,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_entitlements_feature> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_entitlements_feature> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/entitlements/features`
     const headers = this._headers(
       {
@@ -6597,7 +6757,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_entitlements_feature> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_entitlements_feature> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/entitlements/features/${p["id"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
     const query = this._query(
@@ -6620,7 +6782,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_entitlements_feature> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_entitlements_feature> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/entitlements/features/${p["id"]}`
     const headers = this._headers(
       {
@@ -6649,7 +6813,9 @@ export class StripeApi extends AbstractFetchClient {
     } = {},
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_ephemeral_key> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_ephemeral_key> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/ephemeral_keys`
     const headers = this._headers(
       {
@@ -6678,7 +6844,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_ephemeral_key> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_ephemeral_key> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/ephemeral_keys/${p["key"]}`
     const headers = this._headers(
       {
@@ -6730,7 +6898,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/events`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -6771,7 +6939,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_event> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_event> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/events/${p["id"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
     const query = this._query(
@@ -6806,7 +6974,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/exchange_rates`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -6835,7 +7003,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_exchange_rate> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_exchange_rate> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/exchange_rates/${p["rateId"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
     const query = this._query(
@@ -6858,7 +7028,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_external_account> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_external_account> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/external_accounts/${p["id"]}`
     const headers = this._headers(
       {
@@ -6911,7 +7083,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/file_links`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -6946,7 +7118,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_file_link> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_file_link> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/file_links`
     const headers = this._headers(
       {
@@ -6970,7 +7142,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_file_link> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_file_link> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/file_links/${p["link"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
     const query = this._query(
@@ -6993,7 +7165,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_file_link> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_file_link> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/file_links/${p["link"]}`
     const headers = this._headers(
       {
@@ -7063,7 +7235,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/files`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -7100,7 +7272,7 @@ export class StripeApi extends AbstractFetchClient {
       | string = StripeApiServers.operations.postFiles().build(),
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_file> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_file> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = basePath + `/v1/files`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
 
@@ -7123,7 +7295,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_file> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_file> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/files/${p["file"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
     const query = this._query(
@@ -7163,7 +7335,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/financial_connections/accounts`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -7199,7 +7371,8 @@ export class StripeApi extends AbstractFetchClient {
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<
-    Res<200, t_financial_connections_account> | Res<StatusCode, t_error>
+    | Res<200, t_financial_connections_account>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url =
       this.basePath + `/v1/financial_connections/accounts/${p["account"]}`
@@ -7225,7 +7398,8 @@ export class StripeApi extends AbstractFetchClient {
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<
-    Res<200, t_financial_connections_account> | Res<StatusCode, t_error>
+    | Res<200, t_financial_connections_account>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url =
       this.basePath +
@@ -7271,7 +7445,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url =
       this.basePath +
@@ -7304,7 +7478,8 @@ export class StripeApi extends AbstractFetchClient {
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<
-    Res<200, t_financial_connections_account> | Res<StatusCode, t_error>
+    | Res<200, t_financial_connections_account>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url =
       this.basePath +
@@ -7332,7 +7507,8 @@ export class StripeApi extends AbstractFetchClient {
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<
-    Res<200, t_financial_connections_account> | Res<StatusCode, t_error>
+    | Res<200, t_financial_connections_account>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url =
       this.basePath +
@@ -7360,7 +7536,8 @@ export class StripeApi extends AbstractFetchClient {
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<
-    Res<200, t_financial_connections_account> | Res<StatusCode, t_error>
+    | Res<200, t_financial_connections_account>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url =
       this.basePath +
@@ -7387,7 +7564,8 @@ export class StripeApi extends AbstractFetchClient {
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<
-    Res<200, t_financial_connections_session> | Res<StatusCode, t_error>
+    | Res<200, t_financial_connections_session>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/financial_connections/sessions`
     const headers = this._headers(
@@ -7416,7 +7594,8 @@ export class StripeApi extends AbstractFetchClient {
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<
-    Res<200, t_financial_connections_session> | Res<StatusCode, t_error>
+    | Res<200, t_financial_connections_session>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url =
       this.basePath + `/v1/financial_connections/sessions/${p["session"]}`
@@ -7465,7 +7644,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/financial_connections/transactions`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -7506,7 +7685,8 @@ export class StripeApi extends AbstractFetchClient {
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<
-    Res<200, t_financial_connections_transaction> | Res<StatusCode, t_error>
+    | Res<200, t_financial_connections_transaction>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url =
       this.basePath +
@@ -7550,7 +7730,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/forwarding/requests`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -7583,7 +7763,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_forwarding_request> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_forwarding_request> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/forwarding/requests`
     const headers = this._headers(
       {
@@ -7609,7 +7791,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_forwarding_request> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_forwarding_request> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/forwarding/requests/${p["id"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
     const query = this._query(
@@ -7655,7 +7839,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/identity/verification_reports`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -7693,7 +7877,8 @@ export class StripeApi extends AbstractFetchClient {
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<
-    Res<200, t_identity_verification_report> | Res<StatusCode, t_error>
+    | Res<200, t_identity_verification_report>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url =
       this.basePath + `/v1/identity/verification_reports/${p["report"]}`
@@ -7746,7 +7931,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/identity/verification_sessions`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -7783,7 +7968,8 @@ export class StripeApi extends AbstractFetchClient {
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<
-    Res<200, t_identity_verification_session> | Res<StatusCode, t_error>
+    | Res<200, t_identity_verification_session>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/identity/verification_sessions`
     const headers = this._headers(
@@ -7818,7 +8004,8 @@ export class StripeApi extends AbstractFetchClient {
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<
-    Res<200, t_identity_verification_session> | Res<StatusCode, t_error>
+    | Res<200, t_identity_verification_session>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url =
       this.basePath + `/v1/identity/verification_sessions/${p["session"]}`
@@ -7844,7 +8031,8 @@ export class StripeApi extends AbstractFetchClient {
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<
-    Res<200, t_identity_verification_session> | Res<StatusCode, t_error>
+    | Res<200, t_identity_verification_session>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url =
       this.basePath + `/v1/identity/verification_sessions/${p["session"]}`
@@ -7879,7 +8067,8 @@ export class StripeApi extends AbstractFetchClient {
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<
-    Res<200, t_identity_verification_session> | Res<StatusCode, t_error>
+    | Res<200, t_identity_verification_session>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url =
       this.basePath +
@@ -7912,7 +8101,8 @@ export class StripeApi extends AbstractFetchClient {
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<
-    Res<200, t_identity_verification_session> | Res<StatusCode, t_error>
+    | Res<200, t_identity_verification_session>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url =
       this.basePath +
@@ -7962,7 +8152,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/invoice_payments`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -7998,7 +8188,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_invoice_payment> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_invoice_payment> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/invoice_payments/${p["invoicePayment"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
     const query = this._query(
@@ -8034,7 +8226,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/invoice_rendering_templates`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -8066,7 +8258,8 @@ export class StripeApi extends AbstractFetchClient {
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<
-    Res<200, t_invoice_rendering_template> | Res<StatusCode, t_error>
+    | Res<200, t_invoice_rendering_template>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url =
       this.basePath + `/v1/invoice_rendering_templates/${p["template"]}`
@@ -8092,7 +8285,8 @@ export class StripeApi extends AbstractFetchClient {
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<
-    Res<200, t_invoice_rendering_template> | Res<StatusCode, t_error>
+    | Res<200, t_invoice_rendering_template>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url =
       this.basePath + `/v1/invoice_rendering_templates/${p["template"]}/archive`
@@ -8124,7 +8318,8 @@ export class StripeApi extends AbstractFetchClient {
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<
-    Res<200, t_invoice_rendering_template> | Res<StatusCode, t_error>
+    | Res<200, t_invoice_rendering_template>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url =
       this.basePath +
@@ -8179,7 +8374,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/invoiceitems`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -8215,7 +8410,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_invoiceitem> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_invoiceitem> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/invoiceitems`
     const headers = this._headers(
       {
@@ -8244,7 +8439,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_deleted_invoiceitem> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_deleted_invoiceitem> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/invoiceitems/${p["invoiceitem"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
 
@@ -8258,7 +8455,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_invoiceitem> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_invoiceitem> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/invoiceitems/${p["invoiceitem"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
     const query = this._query(
@@ -8281,7 +8478,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_invoiceitem> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_invoiceitem> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/invoiceitems/${p["invoiceitem"]}`
     const headers = this._headers(
       {
@@ -8358,7 +8555,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/invoices`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -8400,7 +8597,7 @@ export class StripeApi extends AbstractFetchClient {
     } = {},
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_invoice> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_invoice> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/invoices`
     const headers = this._headers(
       {
@@ -8441,7 +8638,7 @@ export class StripeApi extends AbstractFetchClient {
     } = {},
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_invoice> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_invoice> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/invoices/create_preview`
     const headers = this._headers(
       {
@@ -8492,7 +8689,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/invoices/search`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -8520,7 +8717,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_deleted_invoice> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_deleted_invoice> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/invoices/${p["invoice"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
 
@@ -8534,7 +8733,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_invoice> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_invoice> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/invoices/${p["invoice"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
     const query = this._query(
@@ -8557,7 +8756,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_invoice> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_invoice> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/invoices/${p["invoice"]}`
     const headers = this._headers(
       {
@@ -8602,7 +8801,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_invoice> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_invoice> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/invoices/${p["invoice"]}/add_lines`
     const headers = this._headers(
       {
@@ -8627,7 +8826,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_invoice> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_invoice> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/invoices/${p["invoice"]}/attach_payment`
     const headers = this._headers(
       {
@@ -8656,7 +8855,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_invoice> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_invoice> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/invoices/${p["invoice"]}/finalize`
     const headers = this._headers(
       {
@@ -8698,7 +8897,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/invoices/${p["invoice"]}/lines`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -8728,7 +8927,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_line_item> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_line_item> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url =
       this.basePath + `/v1/invoices/${p["invoice"]}/lines/${p["lineItemId"]}`
     const headers = this._headers(
@@ -8765,7 +8964,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_invoice> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_invoice> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url =
       this.basePath + `/v1/invoices/${p["invoice"]}/mark_uncollectible`
     const headers = this._headers(
@@ -8795,7 +8994,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_invoice> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_invoice> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/invoices/${p["invoice"]}/pay`
     const headers = this._headers(
       {
@@ -8825,7 +9024,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_invoice> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_invoice> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/invoices/${p["invoice"]}/remove_lines`
     const headers = this._headers(
       {
@@ -8850,7 +9049,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_invoice> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_invoice> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/invoices/${p["invoice"]}/send`
     const headers = this._headers(
       {
@@ -8879,7 +9078,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_invoice> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_invoice> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/invoices/${p["invoice"]}/update_lines`
     const headers = this._headers(
       {
@@ -8904,7 +9103,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_invoice> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_invoice> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/invoices/${p["invoice"]}/void`
     const headers = this._headers(
       {
@@ -8961,7 +9160,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/issuing/authorizations`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -8998,7 +9197,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_issuing_authorization> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_issuing_authorization> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url =
       this.basePath + `/v1/issuing/authorizations/${p["authorization"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -9022,7 +9223,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_issuing_authorization> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_issuing_authorization> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url =
       this.basePath + `/v1/issuing/authorizations/${p["authorization"]}`
     const headers = this._headers(
@@ -9053,7 +9256,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_issuing_authorization> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_issuing_authorization> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url =
       this.basePath + `/v1/issuing/authorizations/${p["authorization"]}/approve`
     const headers = this._headers(
@@ -9084,7 +9289,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_issuing_authorization> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_issuing_authorization> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url =
       this.basePath + `/v1/issuing/authorizations/${p["authorization"]}/decline`
     const headers = this._headers(
@@ -9139,7 +9346,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/issuing/cardholders`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -9176,7 +9383,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_issuing_cardholder> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_issuing_cardholder> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/issuing/cardholders`
     const headers = this._headers(
       {
@@ -9205,7 +9414,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_issuing_cardholder> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_issuing_cardholder> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/issuing/cardholders/${p["cardholder"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
     const query = this._query(
@@ -9228,7 +9439,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_issuing_cardholder> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_issuing_cardholder> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/issuing/cardholders/${p["cardholder"]}`
     const headers = this._headers(
       {
@@ -9290,7 +9503,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/issuing/cards`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -9330,7 +9543,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_issuing_card> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_issuing_card> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/issuing/cards`
     const headers = this._headers(
       {
@@ -9358,7 +9573,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_issuing_card> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_issuing_card> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/issuing/cards/${p["card"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
     const query = this._query(
@@ -9381,7 +9598,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_issuing_card> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_issuing_card> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/issuing/cards/${p["card"]}`
     const headers = this._headers(
       {
@@ -9442,7 +9661,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/issuing/disputes`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -9477,7 +9696,9 @@ export class StripeApi extends AbstractFetchClient {
     } = {},
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_issuing_dispute> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_issuing_dispute> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/issuing/disputes`
     const headers = this._headers(
       {
@@ -9509,7 +9730,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_issuing_dispute> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_issuing_dispute> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/issuing/disputes/${p["dispute"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
     const query = this._query(
@@ -9532,7 +9755,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_issuing_dispute> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_issuing_dispute> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/issuing/disputes/${p["dispute"]}`
     const headers = this._headers(
       {
@@ -9563,7 +9788,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_issuing_dispute> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_issuing_dispute> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/issuing/disputes/${p["dispute"]}/submit`
     const headers = this._headers(
       {
@@ -9616,7 +9843,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/issuing/personalization_designs`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -9656,7 +9883,8 @@ export class StripeApi extends AbstractFetchClient {
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<
-    Res<200, t_issuing_personalization_design> | Res<StatusCode, t_error>
+    | Res<200, t_issuing_personalization_design>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/issuing/personalization_designs`
     const headers = this._headers(
@@ -9684,7 +9912,8 @@ export class StripeApi extends AbstractFetchClient {
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<
-    Res<200, t_issuing_personalization_design> | Res<StatusCode, t_error>
+    | Res<200, t_issuing_personalization_design>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url =
       this.basePath +
@@ -9711,7 +9940,8 @@ export class StripeApi extends AbstractFetchClient {
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<
-    Res<200, t_issuing_personalization_design> | Res<StatusCode, t_error>
+    | Res<200, t_issuing_personalization_design>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url =
       this.basePath +
@@ -9763,7 +9993,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/issuing/physical_bundles`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -9794,7 +10024,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_issuing_physical_bundle> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_issuing_physical_bundle> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url =
       this.basePath + `/v1/issuing/physical_bundles/${p["physicalBundle"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -9818,7 +10050,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_issuing_settlement> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_issuing_settlement> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/issuing/settlements/${p["settlement"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
     const query = this._query(
@@ -9841,7 +10075,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_issuing_settlement> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_issuing_settlement> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/issuing/settlements/${p["settlement"]}`
     const headers = this._headers(
       {
@@ -9898,7 +10134,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/issuing/tokens`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -9934,7 +10170,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_issuing_token> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_issuing_token> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/issuing/tokens/${p["token"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
     const query = this._query(
@@ -9957,7 +10195,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_issuing_token> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_issuing_token> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/issuing/tokens/${p["token"]}`
     const headers = this._headers(
       {
@@ -10003,7 +10243,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/issuing/transactions`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -10040,7 +10280,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_issuing_transaction> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_issuing_transaction> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/issuing/transactions/${p["transaction"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
     const query = this._query(
@@ -10063,7 +10305,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_issuing_transaction> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_issuing_transaction> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/issuing/transactions/${p["transaction"]}`
     const headers = this._headers(
       {
@@ -10093,7 +10337,8 @@ export class StripeApi extends AbstractFetchClient {
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<
-    Res<200, t_financial_connections_session> | Res<StatusCode, t_error>
+    | Res<200, t_financial_connections_session>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/link_account_sessions`
     const headers = this._headers(
@@ -10122,7 +10367,8 @@ export class StripeApi extends AbstractFetchClient {
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<
-    Res<200, t_financial_connections_session> | Res<StatusCode, t_error>
+    | Res<200, t_financial_connections_session>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/link_account_sessions/${p["session"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -10163,7 +10409,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/linked_accounts`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -10199,7 +10445,8 @@ export class StripeApi extends AbstractFetchClient {
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<
-    Res<200, t_financial_connections_account> | Res<StatusCode, t_error>
+    | Res<200, t_financial_connections_account>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/linked_accounts/${p["account"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -10224,7 +10471,8 @@ export class StripeApi extends AbstractFetchClient {
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<
-    Res<200, t_financial_connections_account> | Res<StatusCode, t_error>
+    | Res<200, t_financial_connections_account>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/linked_accounts/${p["account"]}/disconnect`
     const headers = this._headers(
@@ -10268,7 +10516,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/linked_accounts/${p["account"]}/owners`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -10299,7 +10547,8 @@ export class StripeApi extends AbstractFetchClient {
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<
-    Res<200, t_financial_connections_account> | Res<StatusCode, t_error>
+    | Res<200, t_financial_connections_account>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/linked_accounts/${p["account"]}/refresh`
     const headers = this._headers(
@@ -10324,7 +10573,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_mandate> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_mandate> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/mandates/${p["mandate"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
     const query = this._query(
@@ -10368,7 +10617,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/payment_intents`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -10402,7 +10651,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_payment_intent> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_payment_intent> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/payment_intents`
     const headers = this._headers(
       {
@@ -10449,7 +10700,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/payment_intents/search`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -10479,7 +10730,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_payment_intent> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_payment_intent> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/payment_intents/${p["intent"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
     const query = this._query(
@@ -10502,7 +10755,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_payment_intent> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_payment_intent> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/payment_intents/${p["intent"]}`
     const headers = this._headers(
       {
@@ -10539,7 +10794,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_payment_intent> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_payment_intent> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url =
       this.basePath +
       `/v1/payment_intents/${p["intent"]}/apply_customer_balance`
@@ -10570,7 +10827,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_payment_intent> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_payment_intent> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/payment_intents/${p["intent"]}/cancel`
     const headers = this._headers(
       {
@@ -10599,7 +10858,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_payment_intent> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_payment_intent> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/payment_intents/${p["intent"]}/capture`
     const headers = this._headers(
       {
@@ -10630,7 +10891,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_payment_intent> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_payment_intent> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/payment_intents/${p["intent"]}/confirm`
     const headers = this._headers(
       {
@@ -10667,7 +10930,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_payment_intent> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_payment_intent> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url =
       this.basePath +
       `/v1/payment_intents/${p["intent"]}/increment_authorization`
@@ -10694,7 +10959,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_payment_intent> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_payment_intent> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url =
       this.basePath + `/v1/payment_intents/${p["intent"]}/verify_microdeposits`
     const headers = this._headers(
@@ -10738,7 +11005,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/payment_links`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -10767,7 +11034,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_payment_link> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_payment_link> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/payment_links`
     const headers = this._headers(
       {
@@ -10808,7 +11077,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_payment_link> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_payment_link> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/payment_links/${p["paymentLink"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
     const query = this._query(
@@ -10831,7 +11102,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_payment_link> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_payment_link> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/payment_links/${p["paymentLink"]}`
     const headers = this._headers(
       {
@@ -10888,7 +11161,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url =
       this.basePath + `/v1/payment_links/${p["paymentLink"]}/line_items`
@@ -10931,7 +11204,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/payment_method_configurations`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -10965,7 +11238,8 @@ export class StripeApi extends AbstractFetchClient {
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<
-    Res<200, t_payment_method_configuration> | Res<StatusCode, t_error>
+    | Res<200, t_payment_method_configuration>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/payment_method_configurations`
     const headers = this._headers(
@@ -11048,7 +11322,8 @@ export class StripeApi extends AbstractFetchClient {
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<
-    Res<200, t_payment_method_configuration> | Res<StatusCode, t_error>
+    | Res<200, t_payment_method_configuration>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url =
       this.basePath + `/v1/payment_method_configurations/${p["configuration"]}`
@@ -11074,7 +11349,8 @@ export class StripeApi extends AbstractFetchClient {
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<
-    Res<200, t_payment_method_configuration> | Res<StatusCode, t_error>
+    | Res<200, t_payment_method_configuration>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url =
       this.basePath + `/v1/payment_method_configurations/${p["configuration"]}`
@@ -11171,7 +11447,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/payment_method_domains`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -11201,7 +11477,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_payment_method_domain> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_payment_method_domain> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/payment_method_domains`
     const headers = this._headers(
       {
@@ -11224,7 +11502,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_payment_method_domain> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_payment_method_domain> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url =
       this.basePath + `/v1/payment_method_domains/${p["paymentMethodDomain"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -11248,7 +11528,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_payment_method_domain> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_payment_method_domain> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url =
       this.basePath + `/v1/payment_method_domains/${p["paymentMethodDomain"]}`
     const headers = this._headers(
@@ -11278,7 +11560,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_payment_method_domain> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_payment_method_domain> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url =
       this.basePath +
       `/v1/payment_method_domains/${p["paymentMethodDomain"]}/validate`
@@ -11372,7 +11656,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/payment_methods`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -11402,7 +11686,9 @@ export class StripeApi extends AbstractFetchClient {
     } = {},
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_payment_method> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_payment_method> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/payment_methods`
     const headers = this._headers(
       {
@@ -11483,7 +11769,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_payment_method> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_payment_method> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/payment_methods/${p["paymentMethod"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
     const query = this._query(
@@ -11506,7 +11794,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_payment_method> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_payment_method> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/payment_methods/${p["paymentMethod"]}`
     const headers = this._headers(
       {
@@ -11541,7 +11831,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_payment_method> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_payment_method> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url =
       this.basePath + `/v1/payment_methods/${p["paymentMethod"]}/attach`
     const headers = this._headers(
@@ -11565,7 +11857,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_payment_method> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_payment_method> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url =
       this.basePath + `/v1/payment_methods/${p["paymentMethod"]}/detach`
     const headers = this._headers(
@@ -11625,7 +11919,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/payouts`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -11665,7 +11959,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_payout> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_payout> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/payouts`
     const headers = this._headers(
       {
@@ -11689,7 +11983,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_payout> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_payout> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/payouts/${p["payout"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
     const query = this._query(
@@ -11712,7 +12006,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_payout> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_payout> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/payouts/${p["payout"]}`
     const headers = this._headers(
       {
@@ -11742,7 +12036,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_payout> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_payout> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/payouts/${p["payout"]}/cancel`
     const headers = this._headers(
       {
@@ -11771,7 +12065,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_payout> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_payout> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/payouts/${p["payout"]}/reverse`
     const headers = this._headers(
       {
@@ -11823,7 +12117,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/plans`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -11858,7 +12152,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_plan> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_plan> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/plans`
     const headers = this._headers(
       {
@@ -11884,7 +12178,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_deleted_plan> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_deleted_plan> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/plans/${p["plan"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
 
@@ -11898,7 +12194,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_plan> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_plan> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/plans/${p["plan"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
     const query = this._query(
@@ -11921,7 +12217,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_plan> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_plan> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/plans/${p["plan"]}`
     const headers = this._headers(
       {
@@ -11981,7 +12277,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/prices`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -12028,7 +12324,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_price> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_price> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/prices`
     const headers = this._headers(
       {
@@ -12072,7 +12368,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/prices/search`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -12101,7 +12397,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_price> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_price> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/prices/${p["price"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
     const query = this._query(
@@ -12124,7 +12420,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_price> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_price> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/prices/${p["price"]}`
     const headers = this._headers(
       {
@@ -12179,7 +12475,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/products`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -12220,7 +12516,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_product> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_product> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/products`
     const headers = this._headers(
       {
@@ -12262,7 +12558,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/products/search`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -12290,7 +12586,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_deleted_product> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_deleted_product> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/products/${p["id"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
 
@@ -12304,7 +12602,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_product> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_product> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/products/${p["id"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
     const query = this._query(
@@ -12327,7 +12625,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_product> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_product> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/products/${p["id"]}`
     const headers = this._headers(
       {
@@ -12377,7 +12675,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/products/${p["product"]}/features`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -12406,7 +12704,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_product_feature> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_product_feature> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/products/${p["product"]}/features`
     const headers = this._headers(
       {
@@ -12429,7 +12729,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_deleted_product_feature> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_deleted_product_feature> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url =
       this.basePath + `/v1/products/${p["product"]}/features/${p["id"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -12445,7 +12747,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_product_feature> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_product_feature> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url =
       this.basePath + `/v1/products/${p["product"]}/features/${p["id"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -12493,7 +12797,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/promotion_codes`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -12530,7 +12834,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_promotion_code> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_promotion_code> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/promotion_codes`
     const headers = this._headers(
       {
@@ -12555,7 +12861,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_promotion_code> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_promotion_code> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/promotion_codes/${p["promotionCode"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
     const query = this._query(
@@ -12578,7 +12886,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_promotion_code> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_promotion_code> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/promotion_codes/${p["promotionCode"]}`
     const headers = this._headers(
       {
@@ -12629,7 +12939,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/quotes`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -12660,7 +12970,7 @@ export class StripeApi extends AbstractFetchClient {
     } = {},
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_quote> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_quote> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/quotes`
     const headers = this._headers(
       {
@@ -12704,7 +13014,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_quote> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_quote> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/quotes/${p["quote"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
     const query = this._query(
@@ -12727,7 +13037,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_quote> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_quote> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/quotes/${p["quote"]}`
     const headers = this._headers(
       {
@@ -12770,7 +13080,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_quote> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_quote> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/quotes/${p["quote"]}/accept`
     const headers = this._headers(
       {
@@ -12799,7 +13109,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_quote> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_quote> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/quotes/${p["quote"]}/cancel`
     const headers = this._headers(
       {
@@ -12841,7 +13151,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url =
       this.basePath + `/v1/quotes/${p["quote"]}/computed_upfront_line_items`
@@ -12871,7 +13181,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_quote> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_quote> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/quotes/${p["quote"]}/finalize`
     const headers = this._headers(
       {
@@ -12913,7 +13223,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/quotes/${p["quote"]}/line_items`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -12945,7 +13255,7 @@ export class StripeApi extends AbstractFetchClient {
       | string = StripeApiServers.operations.getQuotesQuotePdf().build(),
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, Blob> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, Blob> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = basePath + `/v1/quotes/${p["quote"]}/pdf`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
     const query = this._query(
@@ -12990,7 +13300,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/radar/early_fraud_warnings`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -13026,7 +13336,10 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_radar_early_fraud_warning> | Res<StatusCode, t_error>> {
+  ): Promise<
+    | Res<200, t_radar_early_fraud_warning>
+    | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url =
       this.basePath + `/v1/radar/early_fraud_warnings/${p["earlyFraudWarning"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -13072,7 +13385,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/radar/value_list_items`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -13107,7 +13420,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_radar_value_list_item> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_radar_value_list_item> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/radar/value_list_items`
     const headers = this._headers(
       {
@@ -13130,7 +13445,8 @@ export class StripeApi extends AbstractFetchClient {
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<
-    Res<200, t_deleted_radar_value_list_item> | Res<StatusCode, t_error>
+    | Res<200, t_deleted_radar_value_list_item>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/radar/value_list_items/${p["item"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -13145,7 +13461,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_radar_value_list_item> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_radar_value_list_item> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/radar/value_list_items/${p["item"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
     const query = this._query(
@@ -13190,7 +13508,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/radar/value_lists`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -13225,7 +13543,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_radar_value_list> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_radar_value_list> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/radar/value_lists`
     const headers = this._headers(
       {
@@ -13248,7 +13568,10 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_deleted_radar_value_list> | Res<StatusCode, t_error>> {
+  ): Promise<
+    | Res<200, t_deleted_radar_value_list>
+    | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/radar/value_lists/${p["valueList"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
 
@@ -13262,7 +13585,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_radar_value_list> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_radar_value_list> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/radar/value_lists/${p["valueList"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
     const query = this._query(
@@ -13285,7 +13610,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_radar_value_list> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_radar_value_list> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/radar/value_lists/${p["valueList"]}`
     const headers = this._headers(
       {
@@ -13337,7 +13664,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/refunds`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -13372,7 +13699,7 @@ export class StripeApi extends AbstractFetchClient {
     } = {},
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_refund> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_refund> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/refunds`
     const headers = this._headers(
       {
@@ -13402,7 +13729,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_refund> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_refund> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/refunds/${p["refund"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
     const query = this._query(
@@ -13425,7 +13752,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_refund> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_refund> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/refunds/${p["refund"]}`
     const headers = this._headers(
       {
@@ -13455,7 +13782,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_refund> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_refund> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/refunds/${p["refund"]}/cancel`
     const headers = this._headers(
       {
@@ -13504,7 +13831,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/reporting/report_runs`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -13537,7 +13864,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_reporting_report_run> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_reporting_report_run> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/reporting/report_runs`
     const headers = this._headers(
       {
@@ -13561,7 +13890,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_reporting_report_run> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_reporting_report_run> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/reporting/report_runs/${p["reportRun"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
     const query = this._query(
@@ -13593,7 +13924,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/reporting/report_types`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -13617,7 +13948,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_reporting_report_type> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_reporting_report_type> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/reporting/report_types/${p["reportType"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
     const query = this._query(
@@ -13660,7 +13993,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/reviews`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -13694,7 +14027,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_review> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_review> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/reviews/${p["review"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
     const query = this._query(
@@ -13717,7 +14050,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_review> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_review> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/reviews/${p["review"]}/approve`
     const headers = this._headers(
       {
@@ -13767,7 +14100,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/setup_attempts`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -13825,7 +14158,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/setup_intents`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -13861,7 +14194,9 @@ export class StripeApi extends AbstractFetchClient {
     } = {},
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_setup_intent> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_setup_intent> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/setup_intents`
     const headers = this._headers(
       {
@@ -13899,7 +14234,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_setup_intent> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_setup_intent> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/setup_intents/${p["intent"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
     const query = this._query(
@@ -13922,7 +14259,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_setup_intent> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_setup_intent> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/setup_intents/${p["intent"]}`
     const headers = this._headers(
       {
@@ -13956,7 +14295,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_setup_intent> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_setup_intent> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/setup_intents/${p["intent"]}/cancel`
     const headers = this._headers(
       {
@@ -13985,7 +14326,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_setup_intent> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_setup_intent> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/setup_intents/${p["intent"]}/confirm`
     const headers = this._headers(
       {
@@ -14017,7 +14360,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_setup_intent> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_setup_intent> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url =
       this.basePath + `/v1/setup_intents/${p["intent"]}/verify_microdeposits`
     const headers = this._headers(
@@ -14070,7 +14415,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/shipping_rates`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -14105,7 +14450,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_shipping_rate> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_shipping_rate> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/shipping_rates`
     const headers = this._headers(
       {
@@ -14131,7 +14478,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_shipping_rate> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_shipping_rate> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/shipping_rates/${p["shippingRateToken"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
     const query = this._query(
@@ -14154,7 +14503,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_shipping_rate> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_shipping_rate> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/shipping_rates/${p["shippingRateToken"]}`
     const headers = this._headers(
       {
@@ -14185,7 +14536,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_sigma_sigma_api_query> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_sigma_sigma_api_query> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/sigma/saved_queries/${p["id"]}`
     const headers = this._headers(
       {
@@ -14226,7 +14579,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/sigma/scheduled_query_runs`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -14255,7 +14608,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_scheduled_query_run> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_scheduled_query_run> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url =
       this.basePath + `/v1/sigma/scheduled_query_runs/${p["scheduledQueryRun"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -14278,7 +14633,7 @@ export class StripeApi extends AbstractFetchClient {
     } = {},
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_source> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_source> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/sources`
     const headers = this._headers(
       {
@@ -14314,7 +14669,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_source> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_source> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/sources/${p["source"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
     const query = this._query(
@@ -14337,7 +14692,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_source> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_source> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/sources/${p["source"]}`
     const headers = this._headers(
       {
@@ -14372,7 +14727,8 @@ export class StripeApi extends AbstractFetchClient {
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<
-    Res<200, t_source_mandate_notification> | Res<StatusCode, t_error>
+    | Res<200, t_source_mandate_notification>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url =
       this.basePath +
@@ -14411,7 +14767,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/sources/${p["source"]}/source_transactions`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -14441,7 +14797,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_source_transaction> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_source_transaction> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url =
       this.basePath +
       `/v1/sources/${p["source"]}/source_transactions/${p["sourceTransaction"]}`
@@ -14466,7 +14824,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_source> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_source> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/sources/${p["source"]}/verify`
     const headers = this._headers(
       {
@@ -14503,7 +14861,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/subscription_items`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -14532,7 +14890,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_subscription_item> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_subscription_item> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/subscription_items`
     const headers = this._headers(
       {
@@ -14560,7 +14920,10 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_deleted_subscription_item> | Res<StatusCode, t_error>> {
+  ): Promise<
+    | Res<200, t_deleted_subscription_item>
+    | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/subscription_items/${p["item"]}`
     const headers = this._headers(
       {
@@ -14587,7 +14950,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_subscription_item> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_subscription_item> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/subscription_items/${p["item"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
     const query = this._query(
@@ -14610,7 +14975,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_subscription_item> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_subscription_item> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/subscription_items/${p["item"]}`
     const headers = this._headers(
       {
@@ -14690,7 +15057,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/subscription_schedules`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -14740,7 +15107,9 @@ export class StripeApi extends AbstractFetchClient {
     } = {},
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_subscription_schedule> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_subscription_schedule> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/subscription_schedules`
     const headers = this._headers(
       {
@@ -14774,7 +15143,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_subscription_schedule> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_subscription_schedule> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/subscription_schedules/${p["schedule"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
     const query = this._query(
@@ -14797,7 +15168,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_subscription_schedule> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_subscription_schedule> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/subscription_schedules/${p["schedule"]}`
     const headers = this._headers(
       {
@@ -14829,7 +15202,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_subscription_schedule> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_subscription_schedule> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url =
       this.basePath + `/v1/subscription_schedules/${p["schedule"]}/cancel`
     const headers = this._headers(
@@ -14859,7 +15234,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_subscription_schedule> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_subscription_schedule> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url =
       this.basePath + `/v1/subscription_schedules/${p["schedule"]}/release`
     const headers = this._headers(
@@ -14947,7 +15324,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/subscriptions`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -15000,7 +15377,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_subscription> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_subscription> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/subscriptions`
     const headers = this._headers(
       {
@@ -15055,7 +15434,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/subscriptions/search`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -15084,7 +15463,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_subscription> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_subscription> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url =
       this.basePath + `/v1/subscriptions/${p["subscriptionExposedId"]}`
     const headers = this._headers(
@@ -15115,7 +15496,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_subscription> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_subscription> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url =
       this.basePath + `/v1/subscriptions/${p["subscriptionExposedId"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -15139,7 +15522,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_subscription> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_subscription> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url =
       this.basePath + `/v1/subscriptions/${p["subscriptionExposedId"]}`
     const headers = this._headers(
@@ -15188,7 +15573,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_deleted_discount> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_deleted_discount> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url =
       this.basePath + `/v1/subscriptions/${p["subscriptionExposedId"]}/discount`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -15203,7 +15590,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_subscription> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_subscription> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/subscriptions/${p["subscription"]}/migrate`
     const headers = this._headers(
       {
@@ -15227,7 +15616,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_subscription> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_subscription> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/subscriptions/${p["subscription"]}/resume`
     const headers = this._headers(
       {
@@ -15255,7 +15646,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_tax_calculation> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_tax_calculation> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/tax/calculations`
     const headers = this._headers(
       {
@@ -15282,7 +15675,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_tax_calculation> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_tax_calculation> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/tax/calculations/${p["calculation"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
     const query = this._query(
@@ -15318,7 +15713,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url =
       this.basePath + `/v1/tax/calculations/${p["calculation"]}/line_items`
@@ -15366,7 +15761,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/tax/registrations`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -15395,7 +15790,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_tax_registration> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_tax_registration> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/tax/registrations`
     const headers = this._headers(
       {
@@ -15420,7 +15817,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_tax_registration> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_tax_registration> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/tax/registrations/${p["id"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
     const query = this._query(
@@ -15443,7 +15842,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_tax_registration> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_tax_registration> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/tax/registrations/${p["id"]}`
     const headers = this._headers(
       {
@@ -15473,7 +15874,9 @@ export class StripeApi extends AbstractFetchClient {
     } = {},
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_tax_settings> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_tax_settings> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/tax/settings`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
     const query = this._query(
@@ -15495,7 +15898,9 @@ export class StripeApi extends AbstractFetchClient {
     } = {},
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_tax_settings> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_tax_settings> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/tax/settings`
     const headers = this._headers(
       {
@@ -15525,7 +15930,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_tax_transaction> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_tax_transaction> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/tax/transactions/create_from_calculation`
     const headers = this._headers(
       {
@@ -15548,7 +15955,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_tax_transaction> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_tax_transaction> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/tax/transactions/create_reversal`
     const headers = this._headers(
       {
@@ -15574,7 +15983,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_tax_transaction> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_tax_transaction> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/tax/transactions/${p["transaction"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
     const query = this._query(
@@ -15610,7 +16021,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url =
       this.basePath + `/v1/tax/transactions/${p["transaction"]}/line_items`
@@ -15652,7 +16063,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/tax_codes`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -15681,7 +16092,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_tax_code> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_tax_code> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/tax_codes/${p["id"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
     const query = this._query(
@@ -15726,7 +16137,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/tax_ids`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -15759,7 +16170,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_tax_id> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_tax_id> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/tax_ids`
     const headers = this._headers(
       {
@@ -15782,7 +16193,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_deleted_tax_id> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_deleted_tax_id> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/tax_ids/${p["id"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
 
@@ -15796,7 +16209,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_tax_id> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_tax_id> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/tax_ids/${p["id"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
     const query = this._query(
@@ -15841,7 +16254,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/tax_rates`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -15876,7 +16289,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_tax_rate> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_tax_rate> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/tax_rates`
     const headers = this._headers(
       {
@@ -15900,7 +16313,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_tax_rate> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_tax_rate> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/tax_rates/${p["taxRate"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
     const query = this._query(
@@ -15923,7 +16336,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_tax_rate> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_tax_rate> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/tax_rates/${p["taxRate"]}`
     const headers = this._headers(
       {
@@ -15966,7 +16379,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/terminal/configurations`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -15995,7 +16408,9 @@ export class StripeApi extends AbstractFetchClient {
     } = {},
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_terminal_configuration> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_terminal_configuration> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/terminal/configurations`
     const headers = this._headers(
       {
@@ -16031,7 +16446,8 @@ export class StripeApi extends AbstractFetchClient {
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<
-    Res<200, t_deleted_terminal_configuration> | Res<StatusCode, t_error>
+    | Res<200, t_deleted_terminal_configuration>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url =
       this.basePath + `/v1/terminal/configurations/${p["configuration"]}`
@@ -16049,7 +16465,7 @@ export class StripeApi extends AbstractFetchClient {
     opts: RequestInit = {},
   ): Promise<
     | Res<200, t_terminal_configuration | t_deleted_terminal_configuration>
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url =
       this.basePath + `/v1/terminal/configurations/${p["configuration"]}`
@@ -16076,7 +16492,7 @@ export class StripeApi extends AbstractFetchClient {
     opts: RequestInit = {},
   ): Promise<
     | Res<200, t_terminal_configuration | t_deleted_terminal_configuration>
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url =
       this.basePath + `/v1/terminal/configurations/${p["configuration"]}`
@@ -16113,7 +16529,10 @@ export class StripeApi extends AbstractFetchClient {
     } = {},
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_terminal_connection_token> | Res<StatusCode, t_error>> {
+  ): Promise<
+    | Res<200, t_terminal_connection_token>
+    | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/terminal/connection_tokens`
     const headers = this._headers(
       {
@@ -16154,7 +16573,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/terminal/locations`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -16182,7 +16601,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_terminal_location> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_terminal_location> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/terminal/locations`
     const headers = this._headers(
       {
@@ -16206,7 +16627,10 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_deleted_terminal_location> | Res<StatusCode, t_error>> {
+  ): Promise<
+    | Res<200, t_deleted_terminal_location>
+    | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/terminal/locations/${p["location"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
 
@@ -16222,7 +16646,7 @@ export class StripeApi extends AbstractFetchClient {
     opts: RequestInit = {},
   ): Promise<
     | Res<200, t_terminal_location | t_deleted_terminal_location>
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/terminal/locations/${p["location"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -16248,7 +16672,7 @@ export class StripeApi extends AbstractFetchClient {
     opts: RequestInit = {},
   ): Promise<
     | Res<200, t_terminal_location | t_deleted_terminal_location>
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/terminal/locations/${p["location"]}`
     const headers = this._headers(
@@ -16308,7 +16732,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/terminal/readers`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -16340,7 +16764,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_terminal_reader> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_terminal_reader> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/terminal/readers`
     const headers = this._headers(
       {
@@ -16363,7 +16789,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_deleted_terminal_reader> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_deleted_terminal_reader> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/terminal/readers/${p["reader"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
 
@@ -16379,7 +16807,7 @@ export class StripeApi extends AbstractFetchClient {
     opts: RequestInit = {},
   ): Promise<
     | Res<200, t_terminal_reader | t_deleted_terminal_reader>
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/terminal/readers/${p["reader"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -16405,7 +16833,7 @@ export class StripeApi extends AbstractFetchClient {
     opts: RequestInit = {},
   ): Promise<
     | Res<200, t_terminal_reader | t_deleted_terminal_reader>
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/terminal/readers/${p["reader"]}`
     const headers = this._headers(
@@ -16437,7 +16865,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_terminal_reader> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_terminal_reader> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url =
       this.basePath + `/v1/terminal/readers/${p["reader"]}/cancel_action`
     const headers = this._headers(
@@ -16467,7 +16897,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_terminal_reader> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_terminal_reader> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url =
       this.basePath + `/v1/terminal/readers/${p["reader"]}/collect_inputs`
     const headers = this._headers(
@@ -16493,7 +16925,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_terminal_reader> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_terminal_reader> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url =
       this.basePath +
       `/v1/terminal/readers/${p["reader"]}/collect_payment_method`
@@ -16519,7 +16953,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_terminal_reader> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_terminal_reader> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url =
       this.basePath +
       `/v1/terminal/readers/${p["reader"]}/confirm_payment_intent`
@@ -16545,7 +16981,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_terminal_reader> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_terminal_reader> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url =
       this.basePath +
       `/v1/terminal/readers/${p["reader"]}/process_payment_intent`
@@ -16571,7 +17009,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_terminal_reader> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_terminal_reader> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url =
       this.basePath + `/v1/terminal/readers/${p["reader"]}/process_setup_intent`
     const headers = this._headers(
@@ -16596,7 +17036,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_terminal_reader> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_terminal_reader> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url =
       this.basePath + `/v1/terminal/readers/${p["reader"]}/refund_payment`
     const headers = this._headers(
@@ -16628,7 +17070,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_terminal_reader> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_terminal_reader> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url =
       this.basePath + `/v1/terminal/readers/${p["reader"]}/set_reader_display`
     const headers = this._headers(
@@ -16652,7 +17096,9 @@ export class StripeApi extends AbstractFetchClient {
     } = {},
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_confirmation_token> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_confirmation_token> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/test_helpers/confirmation_tokens`
     const headers = this._headers(
       {
@@ -16685,7 +17131,8 @@ export class StripeApi extends AbstractFetchClient {
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<
-    Res<200, t_customer_cash_balance_transaction> | Res<StatusCode, t_error>
+    | Res<200, t_customer_cash_balance_transaction>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url =
       this.basePath +
@@ -16710,7 +17157,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_issuing_authorization> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_issuing_authorization> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/test_helpers/issuing/authorizations`
     const headers = this._headers(
       {
@@ -16739,7 +17188,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_issuing_authorization> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_issuing_authorization> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url =
       this.basePath +
       `/v1/test_helpers/issuing/authorizations/${p["authorization"]}/capture`
@@ -16771,7 +17222,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_issuing_authorization> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_issuing_authorization> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url =
       this.basePath +
       `/v1/test_helpers/issuing/authorizations/${p["authorization"]}/expire`
@@ -16802,7 +17255,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_issuing_authorization> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_issuing_authorization> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url =
       this.basePath +
       `/v1/test_helpers/issuing/authorizations/${p["authorization"]}/finalize_amount`
@@ -16829,7 +17284,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_issuing_authorization> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_issuing_authorization> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url =
       this.basePath +
       `/v1/test_helpers/issuing/authorizations/${p["authorization"]}/fraud_challenges/respond`
@@ -16854,7 +17311,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_issuing_authorization> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_issuing_authorization> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url =
       this.basePath +
       `/v1/test_helpers/issuing/authorizations/${p["authorization"]}/increment`
@@ -16879,7 +17338,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_issuing_authorization> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_issuing_authorization> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url =
       this.basePath +
       `/v1/test_helpers/issuing/authorizations/${p["authorization"]}/reverse`
@@ -16910,7 +17371,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_issuing_card> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_issuing_card> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url =
       this.basePath +
       `/v1/test_helpers/issuing/cards/${p["card"]}/shipping/deliver`
@@ -16941,7 +17404,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_issuing_card> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_issuing_card> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url =
       this.basePath +
       `/v1/test_helpers/issuing/cards/${p["card"]}/shipping/fail`
@@ -16972,7 +17437,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_issuing_card> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_issuing_card> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url =
       this.basePath +
       `/v1/test_helpers/issuing/cards/${p["card"]}/shipping/return`
@@ -17003,7 +17470,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_issuing_card> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_issuing_card> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url =
       this.basePath +
       `/v1/test_helpers/issuing/cards/${p["card"]}/shipping/ship`
@@ -17034,7 +17503,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_issuing_card> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_issuing_card> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url =
       this.basePath +
       `/v1/test_helpers/issuing/cards/${p["card"]}/shipping/submit`
@@ -17066,7 +17537,8 @@ export class StripeApi extends AbstractFetchClient {
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<
-    Res<200, t_issuing_personalization_design> | Res<StatusCode, t_error>
+    | Res<200, t_issuing_personalization_design>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url =
       this.basePath +
@@ -17099,7 +17571,8 @@ export class StripeApi extends AbstractFetchClient {
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<
-    Res<200, t_issuing_personalization_design> | Res<StatusCode, t_error>
+    | Res<200, t_issuing_personalization_design>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url =
       this.basePath +
@@ -17132,7 +17605,8 @@ export class StripeApi extends AbstractFetchClient {
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<
-    Res<200, t_issuing_personalization_design> | Res<StatusCode, t_error>
+    | Res<200, t_issuing_personalization_design>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url =
       this.basePath +
@@ -17158,7 +17632,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_issuing_settlement> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_issuing_settlement> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/test_helpers/issuing/settlements`
     const headers = this._headers(
       {
@@ -17181,7 +17657,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_issuing_settlement> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_issuing_settlement> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url =
       this.basePath +
       `/v1/test_helpers/issuing/settlements/${p["settlement"]}/complete`
@@ -17211,7 +17689,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_issuing_transaction> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_issuing_transaction> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url =
       this.basePath +
       `/v1/test_helpers/issuing/transactions/create_force_capture`
@@ -17237,7 +17717,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_issuing_transaction> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_issuing_transaction> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url =
       this.basePath +
       `/v1/test_helpers/issuing/transactions/create_unlinked_refund`
@@ -17264,7 +17746,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_issuing_transaction> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_issuing_transaction> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url =
       this.basePath +
       `/v1/test_helpers/issuing/transactions/${p["transaction"]}/refund`
@@ -17295,7 +17779,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_refund> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_refund> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/test_helpers/refunds/${p["refund"]}/expire`
     const headers = this._headers(
       {
@@ -17324,7 +17808,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_terminal_reader> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_terminal_reader> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url =
       this.basePath +
       `/v1/test_helpers/terminal/readers/${p["reader"]}/present_payment_method`
@@ -17357,7 +17843,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_terminal_reader> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_terminal_reader> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url =
       this.basePath +
       `/v1/test_helpers/terminal/readers/${p["reader"]}/succeed_input_collection`
@@ -17388,7 +17876,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_terminal_reader> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_terminal_reader> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url =
       this.basePath +
       `/v1/test_helpers/terminal/readers/${p["reader"]}/timeout_input_collection`
@@ -17431,7 +17921,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/test_helpers/test_clocks`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -17459,7 +17949,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_test_helpers_test_clock> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_test_helpers_test_clock> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/test_helpers/test_clocks`
     const headers = this._headers(
       {
@@ -17482,7 +17974,8 @@ export class StripeApi extends AbstractFetchClient {
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<
-    Res<200, t_deleted_test_helpers_test_clock> | Res<StatusCode, t_error>
+    | Res<200, t_deleted_test_helpers_test_clock>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/test_helpers/test_clocks/${p["testClock"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -17497,7 +17990,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_test_helpers_test_clock> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_test_helpers_test_clock> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/test_helpers/test_clocks/${p["testClock"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
     const query = this._query(
@@ -17520,7 +18015,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_test_helpers_test_clock> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_test_helpers_test_clock> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url =
       this.basePath + `/v1/test_helpers/test_clocks/${p["testClock"]}/advance`
     const headers = this._headers(
@@ -17544,7 +18041,10 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_treasury_inbound_transfer> | Res<StatusCode, t_error>> {
+  ): Promise<
+    | Res<200, t_treasury_inbound_transfer>
+    | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url =
       this.basePath +
       `/v1/test_helpers/treasury/inbound_transfers/${p["id"]}/fail`
@@ -17576,7 +18076,10 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_treasury_inbound_transfer> | Res<StatusCode, t_error>> {
+  ): Promise<
+    | Res<200, t_treasury_inbound_transfer>
+    | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url =
       this.basePath +
       `/v1/test_helpers/treasury/inbound_transfers/${p["id"]}/return`
@@ -17607,7 +18110,10 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_treasury_inbound_transfer> | Res<StatusCode, t_error>> {
+  ): Promise<
+    | Res<200, t_treasury_inbound_transfer>
+    | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url =
       this.basePath +
       `/v1/test_helpers/treasury/inbound_transfers/${p["id"]}/succeed`
@@ -17638,7 +18144,10 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_treasury_outbound_payment> | Res<StatusCode, t_error>> {
+  ): Promise<
+    | Res<200, t_treasury_outbound_payment>
+    | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url =
       this.basePath + `/v1/test_helpers/treasury/outbound_payments/${p["id"]}`
     const headers = this._headers(
@@ -17663,7 +18172,10 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_treasury_outbound_payment> | Res<StatusCode, t_error>> {
+  ): Promise<
+    | Res<200, t_treasury_outbound_payment>
+    | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url =
       this.basePath +
       `/v1/test_helpers/treasury/outbound_payments/${p["id"]}/fail`
@@ -17694,7 +18206,10 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_treasury_outbound_payment> | Res<StatusCode, t_error>> {
+  ): Promise<
+    | Res<200, t_treasury_outbound_payment>
+    | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url =
       this.basePath +
       `/v1/test_helpers/treasury/outbound_payments/${p["id"]}/post`
@@ -17725,7 +18240,10 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_treasury_outbound_payment> | Res<StatusCode, t_error>> {
+  ): Promise<
+    | Res<200, t_treasury_outbound_payment>
+    | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url =
       this.basePath +
       `/v1/test_helpers/treasury/outbound_payments/${p["id"]}/return`
@@ -17758,7 +18276,8 @@ export class StripeApi extends AbstractFetchClient {
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<
-    Res<200, t_treasury_outbound_transfer> | Res<StatusCode, t_error>
+    | Res<200, t_treasury_outbound_transfer>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url =
       this.basePath +
@@ -17786,7 +18305,8 @@ export class StripeApi extends AbstractFetchClient {
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<
-    Res<200, t_treasury_outbound_transfer> | Res<StatusCode, t_error>
+    | Res<200, t_treasury_outbound_transfer>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url =
       this.basePath +
@@ -17819,7 +18339,8 @@ export class StripeApi extends AbstractFetchClient {
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<
-    Res<200, t_treasury_outbound_transfer> | Res<StatusCode, t_error>
+    | Res<200, t_treasury_outbound_transfer>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url =
       this.basePath +
@@ -17852,7 +18373,8 @@ export class StripeApi extends AbstractFetchClient {
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<
-    Res<200, t_treasury_outbound_transfer> | Res<StatusCode, t_error>
+    | Res<200, t_treasury_outbound_transfer>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url =
       this.basePath +
@@ -17884,7 +18406,10 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_treasury_received_credit> | Res<StatusCode, t_error>> {
+  ): Promise<
+    | Res<200, t_treasury_received_credit>
+    | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/test_helpers/treasury/received_credits`
     const headers = this._headers(
       {
@@ -17907,7 +18432,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_treasury_received_debit> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_treasury_received_debit> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/test_helpers/treasury/received_debits`
     const headers = this._headers(
       {
@@ -17930,7 +18457,7 @@ export class StripeApi extends AbstractFetchClient {
     } = {},
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_token> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_token> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/tokens`
     const headers = this._headers(
       {
@@ -17965,7 +18492,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_token> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_token> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/tokens/${p["token"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
     const query = this._query(
@@ -18022,7 +18549,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/topups`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -18061,7 +18588,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_topup> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_topup> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/topups`
     const headers = this._headers(
       {
@@ -18085,7 +18612,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_topup> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_topup> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/topups/${p["topup"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
     const query = this._query(
@@ -18108,7 +18635,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_topup> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_topup> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/topups/${p["topup"]}`
     const headers = this._headers(
       {
@@ -18138,7 +18665,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_topup> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_topup> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/topups/${p["topup"]}/cancel`
     const headers = this._headers(
       {
@@ -18189,7 +18716,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/transfers`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -18224,7 +18751,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_transfer> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_transfer> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/transfers`
     const headers = this._headers(
       {
@@ -18261,7 +18788,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/transfers/${p["id"]}/reversals`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -18290,7 +18817,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_transfer_reversal> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_transfer_reversal> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/transfers/${p["id"]}/reversals`
     const headers = this._headers(
       {
@@ -18320,7 +18849,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_transfer> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_transfer> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/transfers/${p["transfer"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
     const query = this._query(
@@ -18343,7 +18872,7 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_transfer> | Res<StatusCode, t_error>> {
+  ): Promise<Res<200, t_transfer> | Res<Exclude<StatusCode, 200>, t_error>> {
     const url = this.basePath + `/v1/transfers/${p["transfer"]}`
     const headers = this._headers(
       {
@@ -18374,7 +18903,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_transfer_reversal> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_transfer_reversal> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url =
       this.basePath + `/v1/transfers/${p["transfer"]}/reversals/${p["id"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -18399,7 +18930,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_transfer_reversal> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_transfer_reversal> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url =
       this.basePath + `/v1/transfers/${p["transfer"]}/reversals/${p["id"]}`
     const headers = this._headers(
@@ -18445,7 +18978,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/treasury/credit_reversals`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -18476,7 +19009,10 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_treasury_credit_reversal> | Res<StatusCode, t_error>> {
+  ): Promise<
+    | Res<200, t_treasury_credit_reversal>
+    | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/treasury/credit_reversals`
     const headers = this._headers(
       {
@@ -18500,7 +19036,10 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_treasury_credit_reversal> | Res<StatusCode, t_error>> {
+  ): Promise<
+    | Res<200, t_treasury_credit_reversal>
+    | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url =
       this.basePath + `/v1/treasury/credit_reversals/${p["creditReversal"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -18540,7 +19079,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/treasury/debit_reversals`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -18572,7 +19111,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_treasury_debit_reversal> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_treasury_debit_reversal> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/treasury/debit_reversals`
     const headers = this._headers(
       {
@@ -18596,7 +19137,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_treasury_debit_reversal> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_treasury_debit_reversal> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url =
       this.basePath + `/v1/treasury/debit_reversals/${p["debitReversal"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -18641,7 +19184,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/treasury/financial_accounts`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -18676,7 +19219,8 @@ export class StripeApi extends AbstractFetchClient {
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<
-    Res<200, t_treasury_financial_account> | Res<StatusCode, t_error>
+    | Res<200, t_treasury_financial_account>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/treasury/financial_accounts`
     const headers = this._headers(
@@ -18706,7 +19250,8 @@ export class StripeApi extends AbstractFetchClient {
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<
-    Res<200, t_treasury_financial_account> | Res<StatusCode, t_error>
+    | Res<200, t_treasury_financial_account>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url =
       this.basePath + `/v1/treasury/financial_accounts/${p["financialAccount"]}`
@@ -18732,7 +19277,8 @@ export class StripeApi extends AbstractFetchClient {
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<
-    Res<200, t_treasury_financial_account> | Res<StatusCode, t_error>
+    | Res<200, t_treasury_financial_account>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url =
       this.basePath + `/v1/treasury/financial_accounts/${p["financialAccount"]}`
@@ -18769,7 +19315,8 @@ export class StripeApi extends AbstractFetchClient {
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<
-    Res<200, t_treasury_financial_account> | Res<StatusCode, t_error>
+    | Res<200, t_treasury_financial_account>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url =
       this.basePath +
@@ -18803,7 +19350,8 @@ export class StripeApi extends AbstractFetchClient {
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<
-    Res<200, t_treasury_financial_account_features> | Res<StatusCode, t_error>
+    | Res<200, t_treasury_financial_account_features>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url =
       this.basePath +
@@ -18830,7 +19378,8 @@ export class StripeApi extends AbstractFetchClient {
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<
-    Res<200, t_treasury_financial_account_features> | Res<StatusCode, t_error>
+    | Res<200, t_treasury_financial_account_features>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url =
       this.basePath +
@@ -18888,7 +19437,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/treasury/inbound_transfers`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -18918,7 +19467,10 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_treasury_inbound_transfer> | Res<StatusCode, t_error>> {
+  ): Promise<
+    | Res<200, t_treasury_inbound_transfer>
+    | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/treasury/inbound_transfers`
     const headers = this._headers(
       {
@@ -18942,7 +19494,10 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_treasury_inbound_transfer> | Res<StatusCode, t_error>> {
+  ): Promise<
+    | Res<200, t_treasury_inbound_transfer>
+    | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/treasury/inbound_transfers/${p["id"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
     const query = this._query(
@@ -18965,7 +19520,10 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_treasury_inbound_transfer> | Res<StatusCode, t_error>> {
+  ): Promise<
+    | Res<200, t_treasury_inbound_transfer>
+    | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url =
       this.basePath +
       `/v1/treasury/inbound_transfers/${p["inboundTransfer"]}/cancel`
@@ -19025,7 +19583,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/treasury/outbound_payments`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -19061,7 +19619,10 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_treasury_outbound_payment> | Res<StatusCode, t_error>> {
+  ): Promise<
+    | Res<200, t_treasury_outbound_payment>
+    | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/treasury/outbound_payments`
     const headers = this._headers(
       {
@@ -19088,7 +19649,10 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_treasury_outbound_payment> | Res<StatusCode, t_error>> {
+  ): Promise<
+    | Res<200, t_treasury_outbound_payment>
+    | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/treasury/outbound_payments/${p["id"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
     const query = this._query(
@@ -19111,7 +19675,10 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_treasury_outbound_payment> | Res<StatusCode, t_error>> {
+  ): Promise<
+    | Res<200, t_treasury_outbound_payment>
+    | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url =
       this.basePath + `/v1/treasury/outbound_payments/${p["id"]}/cancel`
     const headers = this._headers(
@@ -19161,7 +19728,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/treasury/outbound_transfers`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -19192,7 +19759,8 @@ export class StripeApi extends AbstractFetchClient {
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<
-    Res<200, t_treasury_outbound_transfer> | Res<StatusCode, t_error>
+    | Res<200, t_treasury_outbound_transfer>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/treasury/outbound_transfers`
     const headers = this._headers(
@@ -19220,7 +19788,8 @@ export class StripeApi extends AbstractFetchClient {
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<
-    Res<200, t_treasury_outbound_transfer> | Res<StatusCode, t_error>
+    | Res<200, t_treasury_outbound_transfer>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url =
       this.basePath + `/v1/treasury/outbound_transfers/${p["outboundTransfer"]}`
@@ -19246,7 +19815,8 @@ export class StripeApi extends AbstractFetchClient {
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<
-    Res<200, t_treasury_outbound_transfer> | Res<StatusCode, t_error>
+    | Res<200, t_treasury_outbound_transfer>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url =
       this.basePath +
@@ -19301,7 +19871,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/treasury/received_credits`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -19337,7 +19907,10 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_treasury_received_credit> | Res<StatusCode, t_error>> {
+  ): Promise<
+    | Res<200, t_treasury_received_credit>
+    | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/treasury/received_credits/${p["id"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
     const query = this._query(
@@ -19374,7 +19947,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/treasury/received_debits`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -19405,7 +19978,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_treasury_received_debit> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_treasury_received_debit> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/treasury/received_debits/${p["id"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
     const query = this._query(
@@ -19459,7 +20034,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/treasury/transaction_entries`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -19502,7 +20077,8 @@ export class StripeApi extends AbstractFetchClient {
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<
-    Res<200, t_treasury_transaction_entry> | Res<StatusCode, t_error>
+    | Res<200, t_treasury_transaction_entry>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/treasury/transaction_entries/${p["id"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -19559,7 +20135,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/treasury/transactions`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -19601,7 +20177,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_treasury_transaction> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_treasury_transaction> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/treasury/transactions/${p["id"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
     const query = this._query(
@@ -19636,7 +20214,7 @@ export class StripeApi extends AbstractFetchClient {
           url: string
         }
       >
-    | Res<StatusCode, t_error>
+    | Res<Exclude<StatusCode, 200>, t_error>
   > {
     const url = this.basePath + `/v1/webhook_endpoints`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -19664,7 +20242,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_webhook_endpoint> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_webhook_endpoint> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/webhook_endpoints`
     const headers = this._headers(
       {
@@ -19689,7 +20269,10 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_deleted_webhook_endpoint> | Res<StatusCode, t_error>> {
+  ): Promise<
+    | Res<200, t_deleted_webhook_endpoint>
+    | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/webhook_endpoints/${p["webhookEndpoint"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
 
@@ -19703,7 +20286,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_webhook_endpoint> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_webhook_endpoint> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/webhook_endpoints/${p["webhookEndpoint"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
     const query = this._query(
@@ -19726,7 +20311,9 @@ export class StripeApi extends AbstractFetchClient {
     },
     timeout?: number,
     opts: RequestInit = {},
-  ): Promise<Res<200, t_webhook_endpoint> | Res<StatusCode, t_error>> {
+  ): Promise<
+    Res<200, t_webhook_endpoint> | Res<Exclude<StatusCode, 200>, t_error>
+  > {
     const url = this.basePath + `/v1/webhook_endpoints/${p["webhookEndpoint"]}`
     const headers = this._headers(
       {

--- a/integration-tests/typescript-fetch/src/generated/todo-lists.yaml/client.ts
+++ b/integration-tests/typescript-fetch/src/generated/todo-lists.yaml/client.ts
@@ -193,7 +193,9 @@ export class TodoListsExampleApi extends AbstractFetchClient {
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<
-    Res<200, t_TodoList> | Res<StatusCode4xx, t_Error> | Res<StatusCode, void>
+    | Res<200, t_TodoList>
+    | Res<StatusCode4xx, t_Error>
+    | Res<Exclude<StatusCode, 200 | StatusCode4xx>, void>
   > {
     const url = this.basePath + `/list/${p["listId"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
@@ -209,7 +211,9 @@ export class TodoListsExampleApi extends AbstractFetchClient {
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<
-    Res<200, t_TodoList> | Res<StatusCode4xx, t_Error> | Res<StatusCode, void>
+    | Res<200, t_TodoList>
+    | Res<StatusCode4xx, t_Error>
+    | Res<Exclude<StatusCode, 200 | StatusCode4xx>, void>
   > {
     const url = this.basePath + `/list/${p["listId"]}`
     const headers = this._headers(
@@ -228,7 +232,9 @@ export class TodoListsExampleApi extends AbstractFetchClient {
     timeout?: number,
     opts: RequestInit = {},
   ): Promise<
-    Res<204, void> | Res<StatusCode4xx, t_Error> | Res<StatusCode, void>
+    | Res<204, void>
+    | Res<StatusCode4xx, t_Error>
+    | Res<Exclude<StatusCode, 204 | StatusCode4xx>, void>
   > {
     const url = this.basePath + `/list/${p["listId"]}`
     const headers = this._headers({Accept: "application/json"}, opts.headers)

--- a/packages/openapi-code-generator/src/typescript/client/typescript-fetch/typescript-fetch-client-builder.ts
+++ b/packages/openapi-code-generator/src/typescript/client/typescript-fetch/typescript-fetch-client-builder.ts
@@ -79,10 +79,15 @@ export class TypescriptFetchClientBuilder extends AbstractClientBuilder {
     const query = builder.query()
     const headers = builder.headers({nullContentTypeValue: "undefined"})
 
-    const returnType = builder
-      .returnType()
-      .map(({statusType, responseType}) => {
-        return `Res<${statusType},${responseType}>`
+    const builderReturnType = builder.returnType()
+    const nonDefaultStatusTypes = builderReturnType
+      .filter(({isDefault}) => !isDefault)
+      .map(({statusType}) => statusType)
+    const returnType = builderReturnType
+      .map(({statusType, responseType, isDefault}) => {
+        return isDefault
+          ? `Res<Exclude<StatusCode, ${nonDefaultStatusTypes.join(" | ")}>,${responseType}>`
+          : `Res<${statusType},${responseType}>`
       })
       .join(" | ")
 

--- a/packages/openapi-code-generator/src/typescript/client/typescript-fetch/typescript-fetch-client-builder.ts
+++ b/packages/openapi-code-generator/src/typescript/client/typescript-fetch/typescript-fetch-client-builder.ts
@@ -80,16 +80,18 @@ export class TypescriptFetchClientBuilder extends AbstractClientBuilder {
     const headers = builder.headers({nullContentTypeValue: "undefined"})
 
     const builderReturnType = builder.returnType()
+
     const nonDefaultStatusTypes = builderReturnType
       .filter(({isDefault}) => !isDefault)
       .map(({statusType}) => statusType)
-    const returnType = builderReturnType
-      .map(({statusType, responseType, isDefault}) => {
+
+    const returnType = union(
+      builderReturnType.map(({statusType, responseType, isDefault}) => {
         return isDefault
-          ? `Res<Exclude<StatusCode, ${nonDefaultStatusTypes.join(" | ")}>,${responseType}>`
+          ? `Res<Exclude<StatusCode, ${union(nonDefaultStatusTypes)}>,${responseType}>`
           : `Res<${statusType},${responseType}>`
-      })
-      .join(" | ")
+      }),
+    )
 
     const responseSchemas = this.config.enableRuntimeResponseValidation
       ? builder.responseSchemas()


### PR DESCRIPTION
relates #439, and includes changes from #444 as the actual fix

- adds failing test showing that type narrowing isn't working as expected for fetch clients when a default response is present
- adjusts the types to exclude specific status codes from the default response branch. The specification states that the default response is only to be used for responses not otherwise declared:
> The documentation of responses other than the ones declared for specific HTTP response codes. Use this field to cover undeclared responses.