### PR TITLE
[typescript-fetch] Fix default response signature

### DIFF
--- a/packages/openapi-code-generator/src/typescript/client/typescript-fetch/typescript-fetch-client-builder.ts
+++ b/packages/openapi-code-generator/src/typescript/client/typescript-fetch/typescript-fetch-client-builder.ts
@@ -79,10 +79,15 @@ export class TypescriptFetchClientBuilder extends AbstractClientBuilder {
     const query = builder.query()
     const headers = builder.headers({nullContentTypeValue: "undefined"})
 
-    const returnType = builder
-      .returnType()
-      .map(({statusType, responseType}) => {
-        return `Res<${statusType},${responseType}>`
+    const builderReturnType = builder.returnType()
+    const nonDefaultStatusTypes = builderReturnType
+      .filter(({isDefault}) => !isDefault)
+      .map(({statusType}) => statusType)
+    const returnType = builderReturnType
+      .map(({statusType, responseType, isDefault}) => {
+        return isDefault
+          ? `Res<Exclude<StatusCode, ${nonDefaultStatusTypes.join(" | ")}>,${responseType}>`
+          : `Res<${statusType},${responseType}>`
       })
       .join(" | ")
 


### PR DESCRIPTION
Fix for https://github.com/mnahkies/openapi-code-generator/issues/439

Exclude already processed StatusCodes from default signature