### PR TITLE
chore: bump gh action deps, drop node v20 from ci

### DIFF
--- a/.github/actions/setup-node-pnpm/action.yml
+++ b/.github/actions/setup-node-pnpm/action.yml
@@ -11,7 +11,7 @@ runs:
   using: composite
   steps:
     - name: Install pnpm
-      uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6.0.0
+      uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6.0.3
 
     - name: Use Node.js ${{ inputs.node-version }}
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/actions/setup-node-pnpm/action.yml
+++ b/.github/actions/setup-node-pnpm/action.yml
@@ -4,26 +4,18 @@ description: Install pnpm and setup Node with pnpm cache
 
 inputs:
   node-version:
-    description: Node.js version to use (e.g., 20.x)
+    description: Node.js version to use (e.g., 24.x)
     required: true
-  registry-url:
-    description: NPM registry URL
-    required: false
-    default: https://registry.npmjs.org
-  cache:
-    description: Enable package manager cache
-    required: false
-    default: pnpm
 
 runs:
   using: composite
   steps:
     - name: Install pnpm
-      uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
+      uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6.0.0
 
     - name: Use Node.js ${{ inputs.node-version }}
-      uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
-        registry-url: ${{ inputs.registry-url }}
+        registry-url: https://registry.npmjs.org
         node-version: ${{ inputs.node-version }}
-        cache: ${{ inputs.cache }}
+        cache: pnpm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,6 @@ on:
   pull_request:
     branches: [main]
 
-
 permissions:
   contents: read
 
@@ -15,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: &node-versions [20.x, 22.x, 24.x]
+        node-version: &node-versions [22.x, 24.x]
 
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
       - name: setup
@@ -45,8 +44,9 @@ jobs:
               -cvf ${{ runner.temp }}/workspace.tar .
 
       - name: Upload workspace
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
+          # todo: use archive: false?
           name: workspace-${{ matrix.node-version }}
           path: ${{ runner.temp }}/workspace.tar
           retention-days: 7
@@ -58,7 +58,7 @@ jobs:
       matrix:
         node-version: [24.x]
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
       - name: setup
@@ -66,7 +66,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         id: nextjs-cache
         with:
           path: packages/documentation/.next/cache
@@ -75,7 +75,7 @@ jobs:
             ${{ runner.os }}-nextjs-${{ hashFiles('pnpm-lock.yaml') }}-
 
       - name: Download built workspace
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: workspace-${{ matrix.node-version }}
           path: ${{runner.temp}}
@@ -94,7 +94,7 @@ jobs:
       matrix:
         node-version: *node-versions
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
       - name: setup
@@ -102,7 +102,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - name: Download built workspace
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: workspace-${{ matrix.node-version }}
           path: ${{runner.temp}}
@@ -125,7 +125,7 @@ jobs:
         node-version: *node-versions
         schema-builder: [joi, zod-v3, zod-v4]
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
       - name: setup
@@ -134,7 +134,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: Download built workspace
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: workspace-${{ matrix.node-version }}
           path: ${{runner.temp}}
@@ -159,7 +159,7 @@ jobs:
       matrix:
         node-version: *node-versions
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
       - name: setup
@@ -168,7 +168,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: Download built workspace
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: workspace-${{ matrix.node-version }}
           path: ${{runner.temp}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,6 @@ jobs:
       - name: Upload workspace
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          # todo: use archive: false?
           name: workspace-${{ matrix.node-version }}
           path: ${{ runner.temp }}/workspace.tar
           retention-days: 7

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -11,19 +11,19 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Install pnpm
-        uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
+        uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6.0.0
 
       - name: Use Node.js
-        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: '.nvmrc'
 
-      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         id: nextjs-cache
         with:
           path: packages/documentation/.next/cache

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -16,7 +16,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install pnpm
-        uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6.0.0
+        uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6.0.3
 
       - name: Use Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -13,21 +13,21 @@ jobs:
     runs-on: ubuntu-latest
     environment: prod
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Install pnpm
-        uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
+        uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6.0.0
 
       - name: Use Node.js
-        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           registry-url: "https://registry.npmjs.org"
           node-version-file: '.nvmrc'
           cache: "pnpm"
 
-      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         id: nextjs-cache
         with:
           path: packages/documentation/.next/cache

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -18,7 +18,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install pnpm
-        uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6.0.0
+        uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6.0.3
 
       - name: Use Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/integration-tests/typescript-angular/package.json
+++ b/integration-tests/typescript-angular/package.json
@@ -23,6 +23,6 @@
     "@angular/build": "^21.2.8",
     "@angular/cli": "^21.2.8",
     "@angular/compiler-cli": "^21.2.10",
-    "typescript": "~6.0.3"
+    "typescript": "^6.0.3"
   }
 }

--- a/integration-tests/typescript-axios/package.json
+++ b/integration-tests/typescript-axios/package.json
@@ -16,7 +16,7 @@
     "tslib": "^2.8.1"
   },
   "devDependencies": {
-    "@types/node": "22.16.5",
+    "@types/node": "^22.19.17",
     "typescript": "^6.0.3"
   }
 }

--- a/integration-tests/typescript-fetch/package.json
+++ b/integration-tests/typescript-fetch/package.json
@@ -16,7 +16,7 @@
     "tslib": "^2.8.1"
   },
   "devDependencies": {
-    "@types/node": "22.16.5",
+    "@types/node": "^22.19.17",
     "typescript": "^6.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@swc/jest": "^0.2.39",
     "@tsconfig/node24": "^24.0.4",
     "@tsconfig/strictest": "^2.0.8",
-    "@types/node": "22.16.5",
+    "@types/node": "^22.19.17",
     "ajv": "^8.20.0",
     "ajv-draft-04": "^1.0.0",
     "ajv-formats": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     ]
   },
   "engines": {
-    "node": ">=20 <25"
+    "node": ">=22"
   },
   "packageManager": "pnpm@10.33.2+sha512.a90faf6feeab71ad6c6e57f94e0fe1a12f5dcc22cd754db40ae9593eb6a3e0b6b12e3540218bb37ae083404b1f2ce6db2a4121e979829b4aff94b99f49da1cf8"
 }

--- a/packages/documentation/package.json
+++ b/packages/documentation/package.json
@@ -48,5 +48,8 @@
     "gh-pages": "^6.3.0",
     "tsx": "^4.21.0",
     "typescript": "^6.0.3"
+  },
+  "engines": {
+    "node": ">=22"
   }
 }

--- a/packages/documentation/package.json
+++ b/packages/documentation/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@types/lodash": "^4.17.24",
-    "@types/node": "22.16.5",
+    "@types/node": "^22.19.17",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "gh-pages": "^6.3.0",

--- a/packages/openapi-code-generator/package.json
+++ b/packages/openapi-code-generator/package.json
@@ -146,6 +146,9 @@
     "axios",
     "angular"
   ],
+  "engines": {
+    "node": ">=22"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/typescript-axios-runtime/package.json
+++ b/packages/typescript-axios-runtime/package.json
@@ -55,6 +55,9 @@
     "typescript-axios",
     "axios"
   ],
+  "engines": {
+    "node": ">=22"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/typescript-common-runtime/package.json
+++ b/packages/typescript-common-runtime/package.json
@@ -84,6 +84,9 @@
     "runtime",
     "typescript"
   ],
+  "engines": {
+    "node": ">=22"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/typescript-express-runtime/package.json
+++ b/packages/typescript-express-runtime/package.json
@@ -97,6 +97,9 @@
     "express",
     "zod"
   ],
+  "engines": {
+    "node": ">=22"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/typescript-fetch-runtime/package.json
+++ b/packages/typescript-fetch-runtime/package.json
@@ -80,6 +80,9 @@
     "typescript-fetch",
     "fetch"
   ],
+  "engines": {
+    "node": ">=22"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/typescript-koa-runtime/package.json
+++ b/packages/typescript-koa-runtime/package.json
@@ -102,6 +102,9 @@
     "koa",
     "zod"
   ],
+  "engines": {
+    "node": ">=22"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,13 +5,13 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  axios: ^1.15.2
   '@isaacs/brace-expansion': ^5.0.1
-  '@types/node': 22.16.5
-  tar: ^7.5.11
-  zod@4.1.11: 4.1.13
+  '@types/node': ^22.19.17
+  axios: ^1.15.2
   lodash-es@~4.17: ^4.18.0
   qs: ^6.14.2
+  tar: ^7.5.11
+  zod@4.1.11: 4.1.13
 
 patchedDependencies:
   axios:
@@ -50,8 +50,8 @@ importers:
         specifier: ^2.0.8
         version: 2.0.8
       '@types/node':
-        specifier: 22.16.5
-        version: 22.16.5
+        specifier: ^22.19.17
+        version: 22.19.17
       ajv:
         specifier: ^8.20.0
         version: 8.20.0
@@ -69,13 +69,13 @@ importers:
         version: 9.1.7
       jest:
         specifier: ^30.3.0
-        version: 30.3.0(@types/node@22.16.5)
+        version: 30.3.0(@types/node@22.19.17)
       json5:
         specifier: ^2.2.3
         version: 2.2.3
       lerna:
         specifier: ^9.0.7
-        version: 9.0.7(@swc/core@1.15.30(@swc/helpers@0.5.21))(@types/node@22.16.5)
+        version: 9.0.7(@swc/core@1.15.30(@swc/helpers@0.5.21))(@types/node@22.19.17)
       lint-staged:
         specifier: ^16.4.0
         version: 16.4.0
@@ -142,7 +142,7 @@ importers:
         version: 30.3.0
       jest:
         specifier: ^30.3.0
-        version: 30.3.0(@types/node@22.16.5)
+        version: 30.3.0(@types/node@22.19.17)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -176,15 +176,15 @@ importers:
     devDependencies:
       '@angular/build':
         specifier: ^21.2.8
-        version: 21.2.8(@angular/compiler-cli@21.2.10(@angular/compiler@21.2.10)(typescript@6.0.3))(@angular/compiler@21.2.10)(@angular/core@21.2.10(@angular/compiler@21.2.10)(rxjs@7.8.2))(@angular/platform-browser@21.2.10(@angular/common@21.2.10(@angular/core@21.2.10(@angular/compiler@21.2.10)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.10(@angular/compiler@21.2.10)(rxjs@7.8.2)))(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.16.5)(chokidar@5.0.0)(postcss@8.5.10)(tslib@2.8.1)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.8.3)
+        version: 21.2.8(@angular/compiler-cli@21.2.10(@angular/compiler@21.2.10)(typescript@6.0.3))(@angular/compiler@21.2.10)(@angular/core@21.2.10(@angular/compiler@21.2.10)(rxjs@7.8.2))(@angular/platform-browser@21.2.10(@angular/common@21.2.10(@angular/core@21.2.10(@angular/compiler@21.2.10)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.10(@angular/compiler@21.2.10)(rxjs@7.8.2)))(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.19.17)(chokidar@5.0.0)(postcss@8.5.10)(tslib@2.8.1)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.8.3)
       '@angular/cli':
         specifier: ^21.2.8
-        version: 21.2.8(@types/node@22.16.5)(chokidar@5.0.0)
+        version: 21.2.8(@types/node@22.19.17)(chokidar@5.0.0)
       '@angular/compiler-cli':
         specifier: ^21.2.10
         version: 21.2.10(@angular/compiler@21.2.10)(typescript@6.0.3)
       typescript:
-        specifier: ~6.0.3
+        specifier: ^6.0.3
         version: 6.0.3
 
   integration-tests/typescript-axios:
@@ -203,8 +203,8 @@ importers:
         version: 2.8.1
     devDependencies:
       '@types/node':
-        specifier: 22.16.5
-        version: 22.16.5
+        specifier: ^22.19.17
+        version: 22.19.17
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -247,8 +247,8 @@ importers:
         version: 2.8.1
     devDependencies:
       '@types/node':
-        specifier: 22.16.5
-        version: 22.16.5
+        specifier: ^22.19.17
+        version: 22.19.17
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -333,8 +333,8 @@ importers:
         specifier: ^4.17.24
         version: 4.17.24
       '@types/node':
-        specifier: 22.16.5
-        version: 22.16.5
+        specifier: ^22.19.17
+        version: 22.19.17
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.14
@@ -401,16 +401,16 @@ importers:
     devDependencies:
       '@azure-tools/typespec-autorest':
         specifier: 0.63.0
-        version: 0.63.0(2019f027f72c47ef2d289eb409624b4f)
+        version: 0.63.0(02c9c3c3817780bc83061a8046d79dfd)
       '@azure-tools/typespec-azure-core':
         specifier: 0.63.0
-        version: 0.63.0(@typespec/compiler@1.11.0(@types/node@22.16.5))(@typespec/http@1.11.0(@typespec/compiler@1.11.0(@types/node@22.16.5))(@typespec/streams@0.77.0(@typespec/compiler@1.11.0(@types/node@22.16.5))))(@typespec/rest@0.77.0(@typespec/compiler@1.11.0(@types/node@22.16.5))(@typespec/http@1.11.0(@typespec/compiler@1.11.0(@types/node@22.16.5))(@typespec/streams@0.77.0(@typespec/compiler@1.11.0(@types/node@22.16.5)))))
+        version: 0.63.0(@typespec/compiler@1.11.0(@types/node@22.19.17))(@typespec/http@1.11.0(@typespec/compiler@1.11.0(@types/node@22.19.17))(@typespec/streams@0.77.0(@typespec/compiler@1.11.0(@types/node@22.19.17))))(@typespec/rest@0.77.0(@typespec/compiler@1.11.0(@types/node@22.19.17))(@typespec/http@1.11.0(@typespec/compiler@1.11.0(@types/node@22.19.17))(@typespec/streams@0.77.0(@typespec/compiler@1.11.0(@types/node@22.19.17)))))
       '@azure-tools/typespec-azure-resource-manager':
         specifier: 0.63.0
-        version: 0.63.0(df6004f4eaed9e7113cd025c7a4acc18)
+        version: 0.63.0(9623cb64f653cfa782115b439f5ad24c)
       '@azure-tools/typespec-client-generator-core':
         specifier: 0.63.0
-        version: 0.63.0(f1ad636167586dc39f4c45ceec3352a1)
+        version: 0.63.0(0a3a00857c16e34a87e17adefb593b1f)
       '@jest/globals':
         specifier: ^30.3.0
         version: 30.3.0
@@ -422,34 +422,34 @@ importers:
         version: 4.17.24
       '@typespec/compiler':
         specifier: ^1.11.0
-        version: 1.11.0(@types/node@22.16.5)
+        version: 1.11.0(@types/node@22.19.17)
       '@typespec/events':
         specifier: 0.77.0
-        version: 0.77.0(@typespec/compiler@1.11.0(@types/node@22.16.5))
+        version: 0.77.0(@typespec/compiler@1.11.0(@types/node@22.19.17))
       '@typespec/http':
         specifier: ^1.11.0
-        version: 1.11.0(@typespec/compiler@1.11.0(@types/node@22.16.5))(@typespec/streams@0.77.0(@typespec/compiler@1.11.0(@types/node@22.16.5)))
+        version: 1.11.0(@typespec/compiler@1.11.0(@types/node@22.19.17))(@typespec/streams@0.77.0(@typespec/compiler@1.11.0(@types/node@22.19.17)))
       '@typespec/openapi':
         specifier: ^1.11.0
-        version: 1.11.0(@typespec/compiler@1.11.0(@types/node@22.16.5))(@typespec/http@1.11.0(@typespec/compiler@1.11.0(@types/node@22.16.5))(@typespec/streams@0.77.0(@typespec/compiler@1.11.0(@types/node@22.16.5))))
+        version: 1.11.0(@typespec/compiler@1.11.0(@types/node@22.19.17))(@typespec/http@1.11.0(@typespec/compiler@1.11.0(@types/node@22.19.17))(@typespec/streams@0.77.0(@typespec/compiler@1.11.0(@types/node@22.19.17))))
       '@typespec/openapi3':
         specifier: ^1.11.0
-        version: 1.11.0(4b3d5b490f6f4fbd5949b16cbbfe6df5)
+        version: 1.11.0(312cf85998a1f60704746b0f014fcd5d)
       '@typespec/rest':
         specifier: 0.77.0
-        version: 0.77.0(@typespec/compiler@1.11.0(@types/node@22.16.5))(@typespec/http@1.11.0(@typespec/compiler@1.11.0(@types/node@22.16.5))(@typespec/streams@0.77.0(@typespec/compiler@1.11.0(@types/node@22.16.5))))
+        version: 0.77.0(@typespec/compiler@1.11.0(@types/node@22.19.17))(@typespec/http@1.11.0(@typespec/compiler@1.11.0(@types/node@22.19.17))(@typespec/streams@0.77.0(@typespec/compiler@1.11.0(@types/node@22.19.17))))
       '@typespec/sse':
         specifier: 0.77.0
-        version: 0.77.0(@typespec/compiler@1.11.0(@types/node@22.16.5))(@typespec/events@0.77.0(@typespec/compiler@1.11.0(@types/node@22.16.5)))(@typespec/http@1.11.0(@typespec/compiler@1.11.0(@types/node@22.16.5))(@typespec/streams@0.77.0(@typespec/compiler@1.11.0(@types/node@22.16.5))))(@typespec/streams@0.77.0(@typespec/compiler@1.11.0(@types/node@22.16.5)))
+        version: 0.77.0(@typespec/compiler@1.11.0(@types/node@22.19.17))(@typespec/events@0.77.0(@typespec/compiler@1.11.0(@types/node@22.19.17)))(@typespec/http@1.11.0(@typespec/compiler@1.11.0(@types/node@22.19.17))(@typespec/streams@0.77.0(@typespec/compiler@1.11.0(@types/node@22.19.17))))(@typespec/streams@0.77.0(@typespec/compiler@1.11.0(@types/node@22.19.17)))
       '@typespec/streams':
         specifier: 0.77.0
-        version: 0.77.0(@typespec/compiler@1.11.0(@types/node@22.16.5))
+        version: 0.77.0(@typespec/compiler@1.11.0(@types/node@22.19.17))
       '@typespec/versioning':
         specifier: 0.77.0
-        version: 0.77.0(@typespec/compiler@1.11.0(@types/node@22.16.5))
+        version: 0.77.0(@typespec/compiler@1.11.0(@types/node@22.19.17))
       '@typespec/xml':
         specifier: 0.77.0
-        version: 0.77.0(@typespec/compiler@1.11.0(@types/node@22.16.5))
+        version: 0.77.0(@typespec/compiler@1.11.0(@types/node@22.19.17))
       joi:
         specifier: ^18.1.2
         version: 18.1.2
@@ -474,7 +474,7 @@ importers:
         version: 1.15.2(patch_hash=4bffed10bfd597c1fb8eeee6d8138fa747018b38673cc158906121f78d03e78e)
       jest:
         specifier: ^30.3.0
-        version: 30.3.0(@types/node@22.16.5)
+        version: 30.3.0(@types/node@22.19.17)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -493,7 +493,7 @@ importers:
         version: 30.3.0
       jest:
         specifier: ^30.3.0
-        version: 30.3.0(@types/node@22.16.5)
+        version: 30.3.0(@types/node@22.19.17)
       joi:
         specifier: ^18.1.2
         version: 18.1.2
@@ -533,7 +533,7 @@ importers:
         version: 2.2.2
       jest:
         specifier: ^30.3.0
-        version: 30.3.0(@types/node@22.16.5)
+        version: 30.3.0(@types/node@22.19.17)
       joi:
         specifier: ^18.1.2
         version: 18.1.2
@@ -558,7 +558,7 @@ importers:
         version: 30.3.0
       jest:
         specifier: ^30.3.0
-        version: 30.3.0(@types/node@22.16.5)
+        version: 30.3.0(@types/node@22.19.17)
       joi:
         specifier: ^18.1.2
         version: 18.1.2
@@ -598,7 +598,7 @@ importers:
         version: 12.0.5
       jest:
         specifier: ^30.3.0
-        version: 30.3.0(@types/node@22.16.5)
+        version: 30.3.0(@types/node@22.19.17)
       joi:
         specifier: ^18.1.2
         version: 18.1.2
@@ -1711,7 +1711,7 @@ packages:
     resolution: {integrity: sha512-VXukHf0RR1doGe6Sm4F0Em7SWYLTHSsbGfJdS9Ja2bX5/D5uwVOEjr07cncLROdBvmnvCATYEWlHqYmXv2IlQA==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@types/node': 22.16.5
+      '@types/node': ^22.19.17
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -1720,7 +1720,7 @@ packages:
     resolution: {integrity: sha512-w6KF8ZYRvqHhROkOTHXYC3qIV/KYEu5o12oLqQySvch61vrYtRxNSHTONSdJqWiFJPlCUQAHT5OgOIyuTr+MHQ==}
     engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
     peerDependencies:
-      '@types/node': 22.16.5
+      '@types/node': ^22.19.17
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -1729,7 +1729,7 @@ packages:
     resolution: {integrity: sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@types/node': 22.16.5
+      '@types/node': ^22.19.17
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -1738,7 +1738,7 @@ packages:
     resolution: {integrity: sha512-h9FgGun3QwVYNj5TWIZZ+slii73bMoBFjPfVIGtnFuL4t8gBiNDV9PcSfIzkuxvgquJKt9nr1QzszpBzTbH8Og==}
     engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
     peerDependencies:
-      '@types/node': 22.16.5
+      '@types/node': ^22.19.17
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -1747,7 +1747,7 @@ packages:
     resolution: {integrity: sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@types/node': 22.16.5
+      '@types/node': ^22.19.17
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -1756,7 +1756,7 @@ packages:
     resolution: {integrity: sha512-BDE4fG22uYh1bGSifcj7JSx119TVYNViMhMu85usp4Fswrzh6M0DV3yld64jA98uOAa2GSQ4Bg4bZRm2d2cwSg==}
     engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
     peerDependencies:
-      '@types/node': 22.16.5
+      '@types/node': ^22.19.17
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -1765,7 +1765,7 @@ packages:
     resolution: {integrity: sha512-aLSROkEwirotxZ1pBaP8tugXRFCxW94gwrQLxXfrZsKkfjOYC1aRvAZuhpJOb5cu4IBTJdsCigUlf2iCOu4ZDQ==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@types/node': 22.16.5
+      '@types/node': ^22.19.17
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -1774,7 +1774,7 @@ packages:
     resolution: {integrity: sha512-6y11LgmNpmn5D2aB5FgnCfBUBK8ZstwLCalyJmORcJZ/WrhOjm16mu6eSqIx8DnErxDqSLr+Jkp+GP8/Nwd5tA==}
     engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
     peerDependencies:
-      '@types/node': 22.16.5
+      '@types/node': ^22.19.17
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -1783,7 +1783,7 @@ packages:
     resolution: {integrity: sha512-nRzdOyFYnpeYTTR2qFwEVmIWypzdAx/sIkCMeTNTcflFOovfqUk+HcFhQQVBftAh9gmGrpFj6QcGEqrDMDOiew==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@types/node': 22.16.5
+      '@types/node': ^22.19.17
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -1792,7 +1792,7 @@ packages:
     resolution: {integrity: sha512-dF2zvrFo9LshkcB23/O1il13kBkBltWIXzut1evfbuBLXMiGIuC45c+ZQ0uukjCDsvI8OWqun4FRYMnzFCQa3g==}
     engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
     peerDependencies:
-      '@types/node': 22.16.5
+      '@types/node': ^22.19.17
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -1801,7 +1801,7 @@ packages:
     resolution: {integrity: sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@types/node': 22.16.5
+      '@types/node': ^22.19.17
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -1810,7 +1810,7 @@ packages:
     resolution: {integrity: sha512-lDSwMgg+M5rq6JKBYaJwSX6T9e/HK2qqZ1oxmOwn4AQoJE5D+7TumsxLGC02PWS//rkIVqbZv3XA3ejsc9FYvg==}
     engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
     peerDependencies:
-      '@types/node': 22.16.5
+      '@types/node': ^22.19.17
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -1827,7 +1827,7 @@ packages:
     resolution: {integrity: sha512-kN0pAM4yPrLjJ1XJBjDxyfDduXOuQHrBB8aLDMueuwUGn+vNpF7Gq7TvyVxx8u4SHlFFj4trmj+a2cbpG4Jn1g==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@types/node': 22.16.5
+      '@types/node': ^22.19.17
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -1836,7 +1836,7 @@ packages:
     resolution: {integrity: sha512-uiMFBl4LqFzJClh80Q3f9hbOFJ6kgkDWI4LjAeBuyO6EanVVMF69AgOvpi1qdqjDSjDN6578B6nky9ceEpI+1Q==}
     engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
     peerDependencies:
-      '@types/node': 22.16.5
+      '@types/node': ^22.19.17
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -1845,7 +1845,7 @@ packages:
     resolution: {integrity: sha512-5Smv0OK7K0KUzUfYUXDXQc9jrf8OHo4ktlEayFlelCjwMXz0299Y8OrI+lj7i4gCBY15UObk76q0QtxjzFcFcg==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@types/node': 22.16.5
+      '@types/node': ^22.19.17
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -1854,7 +1854,7 @@ packages:
     resolution: {integrity: sha512-/vrwhEf7Xsuh+YlHF4IjSy3g1cyrQuPaSiHIxCEbLu8qnfvrcvJyCkoktOOF+xV9gSb77/G0n3h04RbMDW2sIg==}
     engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
     peerDependencies:
-      '@types/node': 22.16.5
+      '@types/node': ^22.19.17
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -1863,7 +1863,7 @@ packages:
     resolution: {integrity: sha512-zREJHjhT5vJBMZX/IUbyI9zVtVfOLiTO66MrF/3GFZYZ7T4YILW5MSkEYHceSii/KtRk+4i3RE7E1CUXA2jHcA==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@types/node': 22.16.5
+      '@types/node': ^22.19.17
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -1872,7 +1872,7 @@ packages:
     resolution: {integrity: sha512-CBh7YHju623lxJRcAOo498ZUwIuMy63bqW/vVq0tQAZVv+lkWlHkP9ealYE1utWSisEShY5VMdzIXRmyEODzcQ==}
     engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
     peerDependencies:
-      '@types/node': 22.16.5
+      '@types/node': ^22.19.17
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -1881,7 +1881,7 @@ packages:
     resolution: {integrity: sha512-Dx/y9bCQcXLI5ooQ5KyvA4FTgeo2jYj/7plWfV5Ak5wDPKQZgudKez2ixyfz7tKXzcJciTxqLeK7R9HItwiByg==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@types/node': 22.16.5
+      '@types/node': ^22.19.17
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -1890,7 +1890,7 @@ packages:
     resolution: {integrity: sha512-XJmn/wY4AX56l1BRU+ZjDrFtg9+2uBEi4JvJQj82kwJDQKiPgSn4CEsbfGGygS4Gw6rkL4W18oATjfVfaqub2Q==}
     engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
     peerDependencies:
-      '@types/node': 22.16.5
+      '@types/node': ^22.19.17
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -1899,7 +1899,7 @@ packages:
     resolution: {integrity: sha512-+LLQB8XGr3I5LZN/GuAHo+GpDJegQwuPARLChlMICNdwW7OwV2izlCSCxN6cqpL0sMXmbKbFcItJgdQq5EBXTw==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@types/node': 22.16.5
+      '@types/node': ^22.19.17
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -1908,7 +1908,7 @@ packages:
     resolution: {integrity: sha512-Su7FQvp5buZmCymN3PPoYv31ZQQX4ve2j02k7piGgKAWgE+AQRB5YoYVveGXcl3TZ9ldgRMSxj56YfDFmmaqLg==}
     engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
     peerDependencies:
-      '@types/node': 22.16.5
+      '@types/node': ^22.19.17
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -1917,7 +1917,7 @@ packages:
     resolution: {integrity: sha512-p2bvRfENXCZdWF/U2BXvnSI9h+tuA8iNqtUKb9UWbmLYCRQxd8WkvwWvYn+3NgYaNwdUkHytJMGG4MMLucI1kA==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@types/node': 22.16.5
+      '@types/node': ^22.19.17
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -1926,7 +1926,7 @@ packages:
     resolution: {integrity: sha512-fGiHKGD6DyPIYUWxoXnQTeXeyYqSOUrasDMABBmMHUalH/LxkuzY0xVRtimXAt1sUeeyYkVuKQx1bebMuN11Kw==}
     engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
     peerDependencies:
-      '@types/node': 22.16.5
+      '@types/node': ^22.19.17
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -1935,7 +1935,7 @@ packages:
     resolution: {integrity: sha512-l4xMuJo55MAe+N7Qr4rX90vypFwCajSakx59qe/tMaC1aEHWLyw68wF4o0A4SLAY4E0nd+Vt+EyskeDIqu1M6w==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@types/node': 22.16.5
+      '@types/node': ^22.19.17
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -1944,7 +1944,7 @@ packages:
     resolution: {integrity: sha512-2kWcGKPMLAXAWRp1AH1SLsQmX+j0QjeljyXMUji9WMZC8nRDO0b7qquIGr6143E7KMLt3VAIGNXzwa/6PXQs4Q==}
     engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
     peerDependencies:
-      '@types/node': 22.16.5
+      '@types/node': ^22.19.17
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -1953,7 +1953,7 @@ packages:
     resolution: {integrity: sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@types/node': 22.16.5
+      '@types/node': ^22.19.17
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -1962,7 +1962,7 @@ packages:
     resolution: {integrity: sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q==}
     engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
     peerDependencies:
-      '@types/node': 22.16.5
+      '@types/node': ^22.19.17
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -3503,8 +3503,8 @@ packages:
   '@types/nlcst@2.0.3':
     resolution: {integrity: sha512-vSYNSDe6Ix3q+6Z7ri9lyWqgGhJTmzRjZRqyq15N0Z/1/UnVsno9G/N40NBijoYx2seFDIl0+B2mgAb9mezUCA==}
 
-  '@types/node@22.16.5':
-    resolution: {integrity: sha512-bJFoMATwIGaxxx8VJPeM8TonI8t579oRvgAuT8zFugJsJZgzqv0Fu8Mhp68iecjzG7cnN3mO2dJQ5uUM2EFrgQ==}
+  '@types/node@22.19.17':
+    resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
@@ -5407,7 +5407,7 @@ packages:
     resolution: {integrity: sha512-603xXOgyfxhuis4nfnWaZrMaotNT0Km9XwwBNWUKbIDqeCY89jGr2F9YPEMiNhU6XjIP4VoWISMBFfcc5NgrTw==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@types/node': 22.16.5
+      '@types/node': ^22.19.17
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -5618,7 +5618,7 @@ packages:
     resolution: {integrity: sha512-WPMAkMAtNDY9P/oKObtsRG/6KTrhtgPJoBTmk20uDn4Uy6/3EJnnaZJre/FMT1KVRx8cve1r7/FlMIOfRVWL4w==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
     peerDependencies:
-      '@types/node': 22.16.5
+      '@types/node': ^22.19.17
       esbuild-register: '>=3.4.0'
       ts-node: '>=9.0.0'
     peerDependenciesMeta:
@@ -7774,7 +7774,7 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
-      '@types/node': 22.16.5
+      '@types/node': ^22.19.17
       jiti: '>=1.21.0'
       less: ^4.0.0
       lightningcss: ^1.21.0
@@ -8115,7 +8115,7 @@ snapshots:
     transitivePeerDependencies:
       - chokidar
 
-  '@angular/build@21.2.8(@angular/compiler-cli@21.2.10(@angular/compiler@21.2.10)(typescript@6.0.3))(@angular/compiler@21.2.10)(@angular/core@21.2.10(@angular/compiler@21.2.10)(rxjs@7.8.2))(@angular/platform-browser@21.2.10(@angular/common@21.2.10(@angular/core@21.2.10(@angular/compiler@21.2.10)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.10(@angular/compiler@21.2.10)(rxjs@7.8.2)))(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.16.5)(chokidar@5.0.0)(postcss@8.5.10)(tslib@2.8.1)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.8.3)':
+  '@angular/build@21.2.8(@angular/compiler-cli@21.2.10(@angular/compiler@21.2.10)(typescript@6.0.3))(@angular/compiler@21.2.10)(@angular/core@21.2.10(@angular/compiler@21.2.10)(rxjs@7.8.2))(@angular/platform-browser@21.2.10(@angular/common@21.2.10(@angular/core@21.2.10(@angular/compiler@21.2.10)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.10(@angular/compiler@21.2.10)(rxjs@7.8.2)))(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.19.17)(chokidar@5.0.0)(postcss@8.5.10)(tslib@2.8.1)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.8.3)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2102.8(chokidar@5.0.0)
@@ -8124,8 +8124,8 @@ snapshots:
       '@babel/core': 7.29.0
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-split-export-declaration': 7.24.7
-      '@inquirer/confirm': 5.1.21(@types/node@22.16.5)
-      '@vitejs/plugin-basic-ssl': 2.1.4(vite@7.3.2(@types/node@22.16.5)(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.3))
+      '@inquirer/confirm': 5.1.21(@types/node@22.19.17)
+      '@vitejs/plugin-basic-ssl': 2.1.4(vite@7.3.2(@types/node@22.19.17)(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.3))
       beasties: 0.4.1
       browserslist: 4.28.2
       esbuild: 0.27.3
@@ -8146,7 +8146,7 @@ snapshots:
       tslib: 2.8.1
       typescript: 6.0.3
       undici: 7.24.4
-      vite: 7.3.2(@types/node@22.16.5)(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 7.3.2(@types/node@22.19.17)(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.3)
       watchpack: 2.5.1
     optionalDependencies:
       '@angular/core': 21.2.10(@angular/compiler@21.2.10)(rxjs@7.8.2)
@@ -8168,13 +8168,13 @@ snapshots:
       - tsx
       - yaml
 
-  '@angular/cli@21.2.8(@types/node@22.16.5)(chokidar@5.0.0)':
+  '@angular/cli@21.2.8(@types/node@22.19.17)(chokidar@5.0.0)':
     dependencies:
       '@angular-devkit/architect': 0.2102.8(chokidar@5.0.0)
       '@angular-devkit/core': 21.2.8(chokidar@5.0.0)
       '@angular-devkit/schematics': 21.2.8(chokidar@5.0.0)
-      '@inquirer/prompts': 7.10.1(@types/node@22.16.5)
-      '@listr2/prompt-adapter-inquirer': 3.0.5(@inquirer/prompts@7.10.1(@types/node@22.16.5))(@types/node@22.16.5)(listr2@9.0.5)
+      '@inquirer/prompts': 7.10.1(@types/node@22.19.17)
+      '@listr2/prompt-adapter-inquirer': 3.0.5(@inquirer/prompts@7.10.1(@types/node@22.19.17))(@types/node@22.19.17)(listr2@9.0.5)
       '@modelcontextprotocol/sdk': 1.26.0(zod@4.3.6)
       '@schematics/angular': 21.2.8(chokidar@5.0.0)
       '@yarnpkg/lockfile': 1.1.0
@@ -8255,48 +8255,48 @@ snapshots:
       package-manager-detector: 1.6.0
       tinyexec: 1.1.1
 
-  '@azure-tools/typespec-autorest@0.63.0(2019f027f72c47ef2d289eb409624b4f)':
+  '@azure-tools/typespec-autorest@0.63.0(02c9c3c3817780bc83061a8046d79dfd)':
     dependencies:
-      '@azure-tools/typespec-azure-core': 0.63.0(@typespec/compiler@1.11.0(@types/node@22.16.5))(@typespec/http@1.11.0(@typespec/compiler@1.11.0(@types/node@22.16.5))(@typespec/streams@0.77.0(@typespec/compiler@1.11.0(@types/node@22.16.5))))(@typespec/rest@0.77.0(@typespec/compiler@1.11.0(@types/node@22.16.5))(@typespec/http@1.11.0(@typespec/compiler@1.11.0(@types/node@22.16.5))(@typespec/streams@0.77.0(@typespec/compiler@1.11.0(@types/node@22.16.5)))))
-      '@azure-tools/typespec-azure-resource-manager': 0.63.0(df6004f4eaed9e7113cd025c7a4acc18)
-      '@azure-tools/typespec-client-generator-core': 0.63.0(f1ad636167586dc39f4c45ceec3352a1)
-      '@typespec/compiler': 1.11.0(@types/node@22.16.5)
-      '@typespec/http': 1.11.0(@typespec/compiler@1.11.0(@types/node@22.16.5))(@typespec/streams@0.77.0(@typespec/compiler@1.11.0(@types/node@22.16.5)))
-      '@typespec/openapi': 1.11.0(@typespec/compiler@1.11.0(@types/node@22.16.5))(@typespec/http@1.11.0(@typespec/compiler@1.11.0(@types/node@22.16.5))(@typespec/streams@0.77.0(@typespec/compiler@1.11.0(@types/node@22.16.5))))
-      '@typespec/rest': 0.77.0(@typespec/compiler@1.11.0(@types/node@22.16.5))(@typespec/http@1.11.0(@typespec/compiler@1.11.0(@types/node@22.16.5))(@typespec/streams@0.77.0(@typespec/compiler@1.11.0(@types/node@22.16.5))))
-      '@typespec/versioning': 0.77.0(@typespec/compiler@1.11.0(@types/node@22.16.5))
+      '@azure-tools/typespec-azure-core': 0.63.0(@typespec/compiler@1.11.0(@types/node@22.19.17))(@typespec/http@1.11.0(@typespec/compiler@1.11.0(@types/node@22.19.17))(@typespec/streams@0.77.0(@typespec/compiler@1.11.0(@types/node@22.19.17))))(@typespec/rest@0.77.0(@typespec/compiler@1.11.0(@types/node@22.19.17))(@typespec/http@1.11.0(@typespec/compiler@1.11.0(@types/node@22.19.17))(@typespec/streams@0.77.0(@typespec/compiler@1.11.0(@types/node@22.19.17)))))
+      '@azure-tools/typespec-azure-resource-manager': 0.63.0(9623cb64f653cfa782115b439f5ad24c)
+      '@azure-tools/typespec-client-generator-core': 0.63.0(0a3a00857c16e34a87e17adefb593b1f)
+      '@typespec/compiler': 1.11.0(@types/node@22.19.17)
+      '@typespec/http': 1.11.0(@typespec/compiler@1.11.0(@types/node@22.19.17))(@typespec/streams@0.77.0(@typespec/compiler@1.11.0(@types/node@22.19.17)))
+      '@typespec/openapi': 1.11.0(@typespec/compiler@1.11.0(@types/node@22.19.17))(@typespec/http@1.11.0(@typespec/compiler@1.11.0(@types/node@22.19.17))(@typespec/streams@0.77.0(@typespec/compiler@1.11.0(@types/node@22.19.17))))
+      '@typespec/rest': 0.77.0(@typespec/compiler@1.11.0(@types/node@22.19.17))(@typespec/http@1.11.0(@typespec/compiler@1.11.0(@types/node@22.19.17))(@typespec/streams@0.77.0(@typespec/compiler@1.11.0(@types/node@22.19.17))))
+      '@typespec/versioning': 0.77.0(@typespec/compiler@1.11.0(@types/node@22.19.17))
     optionalDependencies:
-      '@typespec/xml': 0.77.0(@typespec/compiler@1.11.0(@types/node@22.16.5))
+      '@typespec/xml': 0.77.0(@typespec/compiler@1.11.0(@types/node@22.19.17))
 
-  '@azure-tools/typespec-azure-core@0.63.0(@typespec/compiler@1.11.0(@types/node@22.16.5))(@typespec/http@1.11.0(@typespec/compiler@1.11.0(@types/node@22.16.5))(@typespec/streams@0.77.0(@typespec/compiler@1.11.0(@types/node@22.16.5))))(@typespec/rest@0.77.0(@typespec/compiler@1.11.0(@types/node@22.16.5))(@typespec/http@1.11.0(@typespec/compiler@1.11.0(@types/node@22.16.5))(@typespec/streams@0.77.0(@typespec/compiler@1.11.0(@types/node@22.16.5)))))':
+  '@azure-tools/typespec-azure-core@0.63.0(@typespec/compiler@1.11.0(@types/node@22.19.17))(@typespec/http@1.11.0(@typespec/compiler@1.11.0(@types/node@22.19.17))(@typespec/streams@0.77.0(@typespec/compiler@1.11.0(@types/node@22.19.17))))(@typespec/rest@0.77.0(@typespec/compiler@1.11.0(@types/node@22.19.17))(@typespec/http@1.11.0(@typespec/compiler@1.11.0(@types/node@22.19.17))(@typespec/streams@0.77.0(@typespec/compiler@1.11.0(@types/node@22.19.17)))))':
     dependencies:
-      '@typespec/compiler': 1.11.0(@types/node@22.16.5)
-      '@typespec/http': 1.11.0(@typespec/compiler@1.11.0(@types/node@22.16.5))(@typespec/streams@0.77.0(@typespec/compiler@1.11.0(@types/node@22.16.5)))
-      '@typespec/rest': 0.77.0(@typespec/compiler@1.11.0(@types/node@22.16.5))(@typespec/http@1.11.0(@typespec/compiler@1.11.0(@types/node@22.16.5))(@typespec/streams@0.77.0(@typespec/compiler@1.11.0(@types/node@22.16.5))))
+      '@typespec/compiler': 1.11.0(@types/node@22.19.17)
+      '@typespec/http': 1.11.0(@typespec/compiler@1.11.0(@types/node@22.19.17))(@typespec/streams@0.77.0(@typespec/compiler@1.11.0(@types/node@22.19.17)))
+      '@typespec/rest': 0.77.0(@typespec/compiler@1.11.0(@types/node@22.19.17))(@typespec/http@1.11.0(@typespec/compiler@1.11.0(@types/node@22.19.17))(@typespec/streams@0.77.0(@typespec/compiler@1.11.0(@types/node@22.19.17))))
 
-  '@azure-tools/typespec-azure-resource-manager@0.63.0(df6004f4eaed9e7113cd025c7a4acc18)':
+  '@azure-tools/typespec-azure-resource-manager@0.63.0(9623cb64f653cfa782115b439f5ad24c)':
     dependencies:
-      '@azure-tools/typespec-azure-core': 0.63.0(@typespec/compiler@1.11.0(@types/node@22.16.5))(@typespec/http@1.11.0(@typespec/compiler@1.11.0(@types/node@22.16.5))(@typespec/streams@0.77.0(@typespec/compiler@1.11.0(@types/node@22.16.5))))(@typespec/rest@0.77.0(@typespec/compiler@1.11.0(@types/node@22.16.5))(@typespec/http@1.11.0(@typespec/compiler@1.11.0(@types/node@22.16.5))(@typespec/streams@0.77.0(@typespec/compiler@1.11.0(@types/node@22.16.5)))))
-      '@typespec/compiler': 1.11.0(@types/node@22.16.5)
-      '@typespec/http': 1.11.0(@typespec/compiler@1.11.0(@types/node@22.16.5))(@typespec/streams@0.77.0(@typespec/compiler@1.11.0(@types/node@22.16.5)))
-      '@typespec/openapi': 1.11.0(@typespec/compiler@1.11.0(@types/node@22.16.5))(@typespec/http@1.11.0(@typespec/compiler@1.11.0(@types/node@22.16.5))(@typespec/streams@0.77.0(@typespec/compiler@1.11.0(@types/node@22.16.5))))
-      '@typespec/rest': 0.77.0(@typespec/compiler@1.11.0(@types/node@22.16.5))(@typespec/http@1.11.0(@typespec/compiler@1.11.0(@types/node@22.16.5))(@typespec/streams@0.77.0(@typespec/compiler@1.11.0(@types/node@22.16.5))))
-      '@typespec/versioning': 0.77.0(@typespec/compiler@1.11.0(@types/node@22.16.5))
+      '@azure-tools/typespec-azure-core': 0.63.0(@typespec/compiler@1.11.0(@types/node@22.19.17))(@typespec/http@1.11.0(@typespec/compiler@1.11.0(@types/node@22.19.17))(@typespec/streams@0.77.0(@typespec/compiler@1.11.0(@types/node@22.19.17))))(@typespec/rest@0.77.0(@typespec/compiler@1.11.0(@types/node@22.19.17))(@typespec/http@1.11.0(@typespec/compiler@1.11.0(@types/node@22.19.17))(@typespec/streams@0.77.0(@typespec/compiler@1.11.0(@types/node@22.19.17)))))
+      '@typespec/compiler': 1.11.0(@types/node@22.19.17)
+      '@typespec/http': 1.11.0(@typespec/compiler@1.11.0(@types/node@22.19.17))(@typespec/streams@0.77.0(@typespec/compiler@1.11.0(@types/node@22.19.17)))
+      '@typespec/openapi': 1.11.0(@typespec/compiler@1.11.0(@types/node@22.19.17))(@typespec/http@1.11.0(@typespec/compiler@1.11.0(@types/node@22.19.17))(@typespec/streams@0.77.0(@typespec/compiler@1.11.0(@types/node@22.19.17))))
+      '@typespec/rest': 0.77.0(@typespec/compiler@1.11.0(@types/node@22.19.17))(@typespec/http@1.11.0(@typespec/compiler@1.11.0(@types/node@22.19.17))(@typespec/streams@0.77.0(@typespec/compiler@1.11.0(@types/node@22.19.17))))
+      '@typespec/versioning': 0.77.0(@typespec/compiler@1.11.0(@types/node@22.19.17))
       change-case: 5.4.4
       pluralize: 8.0.0
 
-  '@azure-tools/typespec-client-generator-core@0.63.0(f1ad636167586dc39f4c45ceec3352a1)':
+  '@azure-tools/typespec-client-generator-core@0.63.0(0a3a00857c16e34a87e17adefb593b1f)':
     dependencies:
-      '@azure-tools/typespec-azure-core': 0.63.0(@typespec/compiler@1.11.0(@types/node@22.16.5))(@typespec/http@1.11.0(@typespec/compiler@1.11.0(@types/node@22.16.5))(@typespec/streams@0.77.0(@typespec/compiler@1.11.0(@types/node@22.16.5))))(@typespec/rest@0.77.0(@typespec/compiler@1.11.0(@types/node@22.16.5))(@typespec/http@1.11.0(@typespec/compiler@1.11.0(@types/node@22.16.5))(@typespec/streams@0.77.0(@typespec/compiler@1.11.0(@types/node@22.16.5)))))
-      '@typespec/compiler': 1.11.0(@types/node@22.16.5)
-      '@typespec/events': 0.77.0(@typespec/compiler@1.11.0(@types/node@22.16.5))
-      '@typespec/http': 1.11.0(@typespec/compiler@1.11.0(@types/node@22.16.5))(@typespec/streams@0.77.0(@typespec/compiler@1.11.0(@types/node@22.16.5)))
-      '@typespec/openapi': 1.11.0(@typespec/compiler@1.11.0(@types/node@22.16.5))(@typespec/http@1.11.0(@typespec/compiler@1.11.0(@types/node@22.16.5))(@typespec/streams@0.77.0(@typespec/compiler@1.11.0(@types/node@22.16.5))))
-      '@typespec/rest': 0.77.0(@typespec/compiler@1.11.0(@types/node@22.16.5))(@typespec/http@1.11.0(@typespec/compiler@1.11.0(@types/node@22.16.5))(@typespec/streams@0.77.0(@typespec/compiler@1.11.0(@types/node@22.16.5))))
-      '@typespec/sse': 0.77.0(@typespec/compiler@1.11.0(@types/node@22.16.5))(@typespec/events@0.77.0(@typespec/compiler@1.11.0(@types/node@22.16.5)))(@typespec/http@1.11.0(@typespec/compiler@1.11.0(@types/node@22.16.5))(@typespec/streams@0.77.0(@typespec/compiler@1.11.0(@types/node@22.16.5))))(@typespec/streams@0.77.0(@typespec/compiler@1.11.0(@types/node@22.16.5)))
-      '@typespec/streams': 0.77.0(@typespec/compiler@1.11.0(@types/node@22.16.5))
-      '@typespec/versioning': 0.77.0(@typespec/compiler@1.11.0(@types/node@22.16.5))
-      '@typespec/xml': 0.77.0(@typespec/compiler@1.11.0(@types/node@22.16.5))
+      '@azure-tools/typespec-azure-core': 0.63.0(@typespec/compiler@1.11.0(@types/node@22.19.17))(@typespec/http@1.11.0(@typespec/compiler@1.11.0(@types/node@22.19.17))(@typespec/streams@0.77.0(@typespec/compiler@1.11.0(@types/node@22.19.17))))(@typespec/rest@0.77.0(@typespec/compiler@1.11.0(@types/node@22.19.17))(@typespec/http@1.11.0(@typespec/compiler@1.11.0(@types/node@22.19.17))(@typespec/streams@0.77.0(@typespec/compiler@1.11.0(@types/node@22.19.17)))))
+      '@typespec/compiler': 1.11.0(@types/node@22.19.17)
+      '@typespec/events': 0.77.0(@typespec/compiler@1.11.0(@types/node@22.19.17))
+      '@typespec/http': 1.11.0(@typespec/compiler@1.11.0(@types/node@22.19.17))(@typespec/streams@0.77.0(@typespec/compiler@1.11.0(@types/node@22.19.17)))
+      '@typespec/openapi': 1.11.0(@typespec/compiler@1.11.0(@types/node@22.19.17))(@typespec/http@1.11.0(@typespec/compiler@1.11.0(@types/node@22.19.17))(@typespec/streams@0.77.0(@typespec/compiler@1.11.0(@types/node@22.19.17))))
+      '@typespec/rest': 0.77.0(@typespec/compiler@1.11.0(@types/node@22.19.17))(@typespec/http@1.11.0(@typespec/compiler@1.11.0(@types/node@22.19.17))(@typespec/streams@0.77.0(@typespec/compiler@1.11.0(@types/node@22.19.17))))
+      '@typespec/sse': 0.77.0(@typespec/compiler@1.11.0(@types/node@22.19.17))(@typespec/events@0.77.0(@typespec/compiler@1.11.0(@types/node@22.19.17)))(@typespec/http@1.11.0(@typespec/compiler@1.11.0(@types/node@22.19.17))(@typespec/streams@0.77.0(@typespec/compiler@1.11.0(@types/node@22.19.17))))(@typespec/streams@0.77.0(@typespec/compiler@1.11.0(@types/node@22.19.17)))
+      '@typespec/streams': 0.77.0(@typespec/compiler@1.11.0(@types/node@22.19.17))
+      '@typespec/versioning': 0.77.0(@typespec/compiler@1.11.0(@types/node@22.19.17))
+      '@typespec/xml': 0.77.0(@typespec/compiler@1.11.0(@types/node@22.19.17))
       change-case: 5.4.4
       pluralize: 8.0.0
       yaml: 2.8.3
@@ -8927,245 +8927,245 @@ snapshots:
 
   '@inquirer/ansi@2.0.5': {}
 
-  '@inquirer/checkbox@4.3.2(@types/node@22.16.5)':
+  '@inquirer/checkbox@4.3.2(@types/node@22.19.17)':
     dependencies:
       '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.2(@types/node@22.16.5)
+      '@inquirer/core': 10.3.2(@types/node@22.19.17)
       '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@22.16.5)
+      '@inquirer/type': 3.0.10(@types/node@22.19.17)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 22.16.5
+      '@types/node': 22.19.17
 
-  '@inquirer/checkbox@5.1.4(@types/node@22.16.5)':
+  '@inquirer/checkbox@5.1.4(@types/node@22.19.17)':
     dependencies:
       '@inquirer/ansi': 2.0.5
-      '@inquirer/core': 11.1.9(@types/node@22.16.5)
+      '@inquirer/core': 11.1.9(@types/node@22.19.17)
       '@inquirer/figures': 2.0.5
-      '@inquirer/type': 4.0.5(@types/node@22.16.5)
+      '@inquirer/type': 4.0.5(@types/node@22.19.17)
     optionalDependencies:
-      '@types/node': 22.16.5
+      '@types/node': 22.19.17
 
-  '@inquirer/confirm@5.1.21(@types/node@22.16.5)':
+  '@inquirer/confirm@5.1.21(@types/node@22.19.17)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@22.16.5)
-      '@inquirer/type': 3.0.10(@types/node@22.16.5)
+      '@inquirer/core': 10.3.2(@types/node@22.19.17)
+      '@inquirer/type': 3.0.10(@types/node@22.19.17)
     optionalDependencies:
-      '@types/node': 22.16.5
+      '@types/node': 22.19.17
 
-  '@inquirer/confirm@6.0.12(@types/node@22.16.5)':
+  '@inquirer/confirm@6.0.12(@types/node@22.19.17)':
     dependencies:
-      '@inquirer/core': 11.1.9(@types/node@22.16.5)
-      '@inquirer/type': 4.0.5(@types/node@22.16.5)
+      '@inquirer/core': 11.1.9(@types/node@22.19.17)
+      '@inquirer/type': 4.0.5(@types/node@22.19.17)
     optionalDependencies:
-      '@types/node': 22.16.5
+      '@types/node': 22.19.17
 
-  '@inquirer/core@10.3.2(@types/node@22.16.5)':
+  '@inquirer/core@10.3.2(@types/node@22.19.17)':
     dependencies:
       '@inquirer/ansi': 1.0.2
       '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@22.16.5)
+      '@inquirer/type': 3.0.10(@types/node@22.19.17)
       cli-width: 4.1.0
       mute-stream: 2.0.0
       signal-exit: 4.1.0
       wrap-ansi: 6.2.0
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 22.16.5
+      '@types/node': 22.19.17
 
-  '@inquirer/core@11.1.9(@types/node@22.16.5)':
+  '@inquirer/core@11.1.9(@types/node@22.19.17)':
     dependencies:
       '@inquirer/ansi': 2.0.5
       '@inquirer/figures': 2.0.5
-      '@inquirer/type': 4.0.5(@types/node@22.16.5)
+      '@inquirer/type': 4.0.5(@types/node@22.19.17)
       cli-width: 4.1.0
       fast-wrap-ansi: 0.2.0
       mute-stream: 3.0.0
       signal-exit: 4.1.0
     optionalDependencies:
-      '@types/node': 22.16.5
+      '@types/node': 22.19.17
 
-  '@inquirer/editor@4.2.23(@types/node@22.16.5)':
+  '@inquirer/editor@4.2.23(@types/node@22.19.17)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@22.16.5)
-      '@inquirer/external-editor': 1.0.3(@types/node@22.16.5)
-      '@inquirer/type': 3.0.10(@types/node@22.16.5)
+      '@inquirer/core': 10.3.2(@types/node@22.19.17)
+      '@inquirer/external-editor': 1.0.3(@types/node@22.19.17)
+      '@inquirer/type': 3.0.10(@types/node@22.19.17)
     optionalDependencies:
-      '@types/node': 22.16.5
+      '@types/node': 22.19.17
 
-  '@inquirer/editor@5.1.1(@types/node@22.16.5)':
+  '@inquirer/editor@5.1.1(@types/node@22.19.17)':
     dependencies:
-      '@inquirer/core': 11.1.9(@types/node@22.16.5)
-      '@inquirer/external-editor': 3.0.0(@types/node@22.16.5)
-      '@inquirer/type': 4.0.5(@types/node@22.16.5)
+      '@inquirer/core': 11.1.9(@types/node@22.19.17)
+      '@inquirer/external-editor': 3.0.0(@types/node@22.19.17)
+      '@inquirer/type': 4.0.5(@types/node@22.19.17)
     optionalDependencies:
-      '@types/node': 22.16.5
+      '@types/node': 22.19.17
 
-  '@inquirer/expand@4.0.23(@types/node@22.16.5)':
+  '@inquirer/expand@4.0.23(@types/node@22.19.17)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@22.16.5)
-      '@inquirer/type': 3.0.10(@types/node@22.16.5)
+      '@inquirer/core': 10.3.2(@types/node@22.19.17)
+      '@inquirer/type': 3.0.10(@types/node@22.19.17)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 22.16.5
+      '@types/node': 22.19.17
 
-  '@inquirer/expand@5.0.13(@types/node@22.16.5)':
+  '@inquirer/expand@5.0.13(@types/node@22.19.17)':
     dependencies:
-      '@inquirer/core': 11.1.9(@types/node@22.16.5)
-      '@inquirer/type': 4.0.5(@types/node@22.16.5)
+      '@inquirer/core': 11.1.9(@types/node@22.19.17)
+      '@inquirer/type': 4.0.5(@types/node@22.19.17)
     optionalDependencies:
-      '@types/node': 22.16.5
+      '@types/node': 22.19.17
 
-  '@inquirer/external-editor@1.0.3(@types/node@22.16.5)':
-    dependencies:
-      chardet: 2.1.1
-      iconv-lite: 0.7.2
-    optionalDependencies:
-      '@types/node': 22.16.5
-
-  '@inquirer/external-editor@3.0.0(@types/node@22.16.5)':
+  '@inquirer/external-editor@1.0.3(@types/node@22.19.17)':
     dependencies:
       chardet: 2.1.1
       iconv-lite: 0.7.2
     optionalDependencies:
-      '@types/node': 22.16.5
+      '@types/node': 22.19.17
+
+  '@inquirer/external-editor@3.0.0(@types/node@22.19.17)':
+    dependencies:
+      chardet: 2.1.1
+      iconv-lite: 0.7.2
+    optionalDependencies:
+      '@types/node': 22.19.17
 
   '@inquirer/figures@1.0.15': {}
 
   '@inquirer/figures@2.0.5': {}
 
-  '@inquirer/input@4.3.1(@types/node@22.16.5)':
+  '@inquirer/input@4.3.1(@types/node@22.19.17)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@22.16.5)
-      '@inquirer/type': 3.0.10(@types/node@22.16.5)
+      '@inquirer/core': 10.3.2(@types/node@22.19.17)
+      '@inquirer/type': 3.0.10(@types/node@22.19.17)
     optionalDependencies:
-      '@types/node': 22.16.5
+      '@types/node': 22.19.17
 
-  '@inquirer/input@5.0.12(@types/node@22.16.5)':
+  '@inquirer/input@5.0.12(@types/node@22.19.17)':
     dependencies:
-      '@inquirer/core': 11.1.9(@types/node@22.16.5)
-      '@inquirer/type': 4.0.5(@types/node@22.16.5)
+      '@inquirer/core': 11.1.9(@types/node@22.19.17)
+      '@inquirer/type': 4.0.5(@types/node@22.19.17)
     optionalDependencies:
-      '@types/node': 22.16.5
+      '@types/node': 22.19.17
 
-  '@inquirer/number@3.0.23(@types/node@22.16.5)':
+  '@inquirer/number@3.0.23(@types/node@22.19.17)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@22.16.5)
-      '@inquirer/type': 3.0.10(@types/node@22.16.5)
+      '@inquirer/core': 10.3.2(@types/node@22.19.17)
+      '@inquirer/type': 3.0.10(@types/node@22.19.17)
     optionalDependencies:
-      '@types/node': 22.16.5
+      '@types/node': 22.19.17
 
-  '@inquirer/number@4.0.12(@types/node@22.16.5)':
+  '@inquirer/number@4.0.12(@types/node@22.19.17)':
     dependencies:
-      '@inquirer/core': 11.1.9(@types/node@22.16.5)
-      '@inquirer/type': 4.0.5(@types/node@22.16.5)
+      '@inquirer/core': 11.1.9(@types/node@22.19.17)
+      '@inquirer/type': 4.0.5(@types/node@22.19.17)
     optionalDependencies:
-      '@types/node': 22.16.5
+      '@types/node': 22.19.17
 
-  '@inquirer/password@4.0.23(@types/node@22.16.5)':
-    dependencies:
-      '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.2(@types/node@22.16.5)
-      '@inquirer/type': 3.0.10(@types/node@22.16.5)
-    optionalDependencies:
-      '@types/node': 22.16.5
-
-  '@inquirer/password@5.0.12(@types/node@22.16.5)':
-    dependencies:
-      '@inquirer/ansi': 2.0.5
-      '@inquirer/core': 11.1.9(@types/node@22.16.5)
-      '@inquirer/type': 4.0.5(@types/node@22.16.5)
-    optionalDependencies:
-      '@types/node': 22.16.5
-
-  '@inquirer/prompts@7.10.1(@types/node@22.16.5)':
-    dependencies:
-      '@inquirer/checkbox': 4.3.2(@types/node@22.16.5)
-      '@inquirer/confirm': 5.1.21(@types/node@22.16.5)
-      '@inquirer/editor': 4.2.23(@types/node@22.16.5)
-      '@inquirer/expand': 4.0.23(@types/node@22.16.5)
-      '@inquirer/input': 4.3.1(@types/node@22.16.5)
-      '@inquirer/number': 3.0.23(@types/node@22.16.5)
-      '@inquirer/password': 4.0.23(@types/node@22.16.5)
-      '@inquirer/rawlist': 4.1.11(@types/node@22.16.5)
-      '@inquirer/search': 3.2.2(@types/node@22.16.5)
-      '@inquirer/select': 4.4.2(@types/node@22.16.5)
-    optionalDependencies:
-      '@types/node': 22.16.5
-
-  '@inquirer/prompts@8.4.2(@types/node@22.16.5)':
-    dependencies:
-      '@inquirer/checkbox': 5.1.4(@types/node@22.16.5)
-      '@inquirer/confirm': 6.0.12(@types/node@22.16.5)
-      '@inquirer/editor': 5.1.1(@types/node@22.16.5)
-      '@inquirer/expand': 5.0.13(@types/node@22.16.5)
-      '@inquirer/input': 5.0.12(@types/node@22.16.5)
-      '@inquirer/number': 4.0.12(@types/node@22.16.5)
-      '@inquirer/password': 5.0.12(@types/node@22.16.5)
-      '@inquirer/rawlist': 5.2.8(@types/node@22.16.5)
-      '@inquirer/search': 4.1.8(@types/node@22.16.5)
-      '@inquirer/select': 5.1.4(@types/node@22.16.5)
-    optionalDependencies:
-      '@types/node': 22.16.5
-
-  '@inquirer/rawlist@4.1.11(@types/node@22.16.5)':
-    dependencies:
-      '@inquirer/core': 10.3.2(@types/node@22.16.5)
-      '@inquirer/type': 3.0.10(@types/node@22.16.5)
-      yoctocolors-cjs: 2.1.3
-    optionalDependencies:
-      '@types/node': 22.16.5
-
-  '@inquirer/rawlist@5.2.8(@types/node@22.16.5)':
-    dependencies:
-      '@inquirer/core': 11.1.9(@types/node@22.16.5)
-      '@inquirer/type': 4.0.5(@types/node@22.16.5)
-    optionalDependencies:
-      '@types/node': 22.16.5
-
-  '@inquirer/search@3.2.2(@types/node@22.16.5)':
-    dependencies:
-      '@inquirer/core': 10.3.2(@types/node@22.16.5)
-      '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@22.16.5)
-      yoctocolors-cjs: 2.1.3
-    optionalDependencies:
-      '@types/node': 22.16.5
-
-  '@inquirer/search@4.1.8(@types/node@22.16.5)':
-    dependencies:
-      '@inquirer/core': 11.1.9(@types/node@22.16.5)
-      '@inquirer/figures': 2.0.5
-      '@inquirer/type': 4.0.5(@types/node@22.16.5)
-    optionalDependencies:
-      '@types/node': 22.16.5
-
-  '@inquirer/select@4.4.2(@types/node@22.16.5)':
+  '@inquirer/password@4.0.23(@types/node@22.19.17)':
     dependencies:
       '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.2(@types/node@22.16.5)
-      '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@22.16.5)
-      yoctocolors-cjs: 2.1.3
+      '@inquirer/core': 10.3.2(@types/node@22.19.17)
+      '@inquirer/type': 3.0.10(@types/node@22.19.17)
     optionalDependencies:
-      '@types/node': 22.16.5
+      '@types/node': 22.19.17
 
-  '@inquirer/select@5.1.4(@types/node@22.16.5)':
+  '@inquirer/password@5.0.12(@types/node@22.19.17)':
     dependencies:
       '@inquirer/ansi': 2.0.5
-      '@inquirer/core': 11.1.9(@types/node@22.16.5)
+      '@inquirer/core': 11.1.9(@types/node@22.19.17)
+      '@inquirer/type': 4.0.5(@types/node@22.19.17)
+    optionalDependencies:
+      '@types/node': 22.19.17
+
+  '@inquirer/prompts@7.10.1(@types/node@22.19.17)':
+    dependencies:
+      '@inquirer/checkbox': 4.3.2(@types/node@22.19.17)
+      '@inquirer/confirm': 5.1.21(@types/node@22.19.17)
+      '@inquirer/editor': 4.2.23(@types/node@22.19.17)
+      '@inquirer/expand': 4.0.23(@types/node@22.19.17)
+      '@inquirer/input': 4.3.1(@types/node@22.19.17)
+      '@inquirer/number': 3.0.23(@types/node@22.19.17)
+      '@inquirer/password': 4.0.23(@types/node@22.19.17)
+      '@inquirer/rawlist': 4.1.11(@types/node@22.19.17)
+      '@inquirer/search': 3.2.2(@types/node@22.19.17)
+      '@inquirer/select': 4.4.2(@types/node@22.19.17)
+    optionalDependencies:
+      '@types/node': 22.19.17
+
+  '@inquirer/prompts@8.4.2(@types/node@22.19.17)':
+    dependencies:
+      '@inquirer/checkbox': 5.1.4(@types/node@22.19.17)
+      '@inquirer/confirm': 6.0.12(@types/node@22.19.17)
+      '@inquirer/editor': 5.1.1(@types/node@22.19.17)
+      '@inquirer/expand': 5.0.13(@types/node@22.19.17)
+      '@inquirer/input': 5.0.12(@types/node@22.19.17)
+      '@inquirer/number': 4.0.12(@types/node@22.19.17)
+      '@inquirer/password': 5.0.12(@types/node@22.19.17)
+      '@inquirer/rawlist': 5.2.8(@types/node@22.19.17)
+      '@inquirer/search': 4.1.8(@types/node@22.19.17)
+      '@inquirer/select': 5.1.4(@types/node@22.19.17)
+    optionalDependencies:
+      '@types/node': 22.19.17
+
+  '@inquirer/rawlist@4.1.11(@types/node@22.19.17)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@22.19.17)
+      '@inquirer/type': 3.0.10(@types/node@22.19.17)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 22.19.17
+
+  '@inquirer/rawlist@5.2.8(@types/node@22.19.17)':
+    dependencies:
+      '@inquirer/core': 11.1.9(@types/node@22.19.17)
+      '@inquirer/type': 4.0.5(@types/node@22.19.17)
+    optionalDependencies:
+      '@types/node': 22.19.17
+
+  '@inquirer/search@3.2.2(@types/node@22.19.17)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@22.19.17)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@22.19.17)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 22.19.17
+
+  '@inquirer/search@4.1.8(@types/node@22.19.17)':
+    dependencies:
+      '@inquirer/core': 11.1.9(@types/node@22.19.17)
       '@inquirer/figures': 2.0.5
-      '@inquirer/type': 4.0.5(@types/node@22.16.5)
+      '@inquirer/type': 4.0.5(@types/node@22.19.17)
     optionalDependencies:
-      '@types/node': 22.16.5
+      '@types/node': 22.19.17
 
-  '@inquirer/type@3.0.10(@types/node@22.16.5)':
+  '@inquirer/select@4.4.2(@types/node@22.19.17)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/core': 10.3.2(@types/node@22.19.17)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@22.19.17)
+      yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 22.16.5
+      '@types/node': 22.19.17
 
-  '@inquirer/type@4.0.5(@types/node@22.16.5)':
+  '@inquirer/select@5.1.4(@types/node@22.19.17)':
+    dependencies:
+      '@inquirer/ansi': 2.0.5
+      '@inquirer/core': 11.1.9(@types/node@22.19.17)
+      '@inquirer/figures': 2.0.5
+      '@inquirer/type': 4.0.5(@types/node@22.19.17)
     optionalDependencies:
-      '@types/node': 22.16.5
+      '@types/node': 22.19.17
+
+  '@inquirer/type@3.0.10(@types/node@22.19.17)':
+    optionalDependencies:
+      '@types/node': 22.19.17
+
+  '@inquirer/type@4.0.5(@types/node@22.19.17)':
+    optionalDependencies:
+      '@types/node': 22.19.17
 
   '@internationalized/date@3.12.1':
     dependencies:
@@ -9209,7 +9209,7 @@ snapshots:
   '@jest/console@30.3.0':
     dependencies:
       '@jest/types': 30.3.0
-      '@types/node': 22.16.5
+      '@types/node': 22.19.17
       chalk: 4.1.2
       jest-message-util: 30.3.0
       jest-util: 30.3.0
@@ -9223,14 +9223,14 @@ snapshots:
       '@jest/test-result': 30.3.0
       '@jest/transform': 30.3.0
       '@jest/types': 30.3.0
-      '@types/node': 22.16.5
+      '@types/node': 22.19.17
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 4.4.0
       exit-x: 0.2.2
       graceful-fs: 4.2.11
       jest-changed-files: 30.3.0
-      jest-config: 30.3.0(@types/node@22.16.5)
+      jest-config: 30.3.0(@types/node@22.19.17)
       jest-haste-map: 30.3.0
       jest-message-util: 30.3.0
       jest-regex-util: 30.0.1
@@ -9262,7 +9262,7 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 30.3.0
       '@jest/types': 30.3.0
-      '@types/node': 22.16.5
+      '@types/node': 22.19.17
       jest-mock: 30.3.0
 
   '@jest/expect-utils@30.3.0':
@@ -9280,7 +9280,7 @@ snapshots:
     dependencies:
       '@jest/types': 30.3.0
       '@sinonjs/fake-timers': 15.3.2
-      '@types/node': 22.16.5
+      '@types/node': 22.19.17
       jest-message-util: 30.3.0
       jest-mock: 30.3.0
       jest-util: 30.3.0
@@ -9298,7 +9298,7 @@ snapshots:
 
   '@jest/pattern@30.0.1':
     dependencies:
-      '@types/node': 22.16.5
+      '@types/node': 22.19.17
       jest-regex-util: 30.0.1
 
   '@jest/reporters@30.3.0':
@@ -9309,7 +9309,7 @@ snapshots:
       '@jest/transform': 30.3.0
       '@jest/types': 30.3.0
       '@jridgewell/trace-mapping': 0.3.31
-      '@types/node': 22.16.5
+      '@types/node': 22.19.17
       chalk: 4.1.2
       collect-v8-coverage: 1.0.3
       exit-x: 0.2.2
@@ -9385,7 +9385,7 @@ snapshots:
       '@jest/schemas': 30.0.5
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 22.16.5
+      '@types/node': 22.19.17
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
@@ -9421,10 +9421,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@listr2/prompt-adapter-inquirer@3.0.5(@inquirer/prompts@7.10.1(@types/node@22.16.5))(@types/node@22.16.5)(listr2@9.0.5)':
+  '@listr2/prompt-adapter-inquirer@3.0.5(@inquirer/prompts@7.10.1(@types/node@22.19.17))(@types/node@22.19.17)(listr2@9.0.5)':
     dependencies:
-      '@inquirer/prompts': 7.10.1(@types/node@22.16.5)
-      '@inquirer/type': 3.0.10(@types/node@22.16.5)
+      '@inquirer/prompts': 7.10.1(@types/node@22.19.17)
+      '@inquirer/type': 3.0.10(@types/node@22.19.17)
       listr2: 9.0.5
     transitivePeerDependencies:
       - '@types/node'
@@ -10464,7 +10464,7 @@ snapshots:
 
   '@types/accepts@1.3.7':
     dependencies:
-      '@types/node': 22.16.5
+      '@types/node': 22.19.17
 
   '@types/babel__core@7.20.5':
     dependencies:
@@ -10490,16 +10490,16 @@ snapshots:
   '@types/body-parser@1.19.6':
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 22.16.5
+      '@types/node': 22.19.17
 
   '@types/co-body@6.1.3':
     dependencies:
-      '@types/node': 22.16.5
+      '@types/node': 22.19.17
       '@types/qs': 6.15.0
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 22.16.5
+      '@types/node': 22.19.17
 
   '@types/content-disposition@0.5.9': {}
 
@@ -10508,11 +10508,11 @@ snapshots:
       '@types/connect': 3.4.38
       '@types/express': 5.0.6
       '@types/keygrip': 1.0.6
-      '@types/node': 22.16.5
+      '@types/node': 22.19.17
 
   '@types/cors@2.8.19':
     dependencies:
-      '@types/node': 22.16.5
+      '@types/node': 22.19.17
 
   '@types/d3-array@3.2.2': {}
 
@@ -10643,7 +10643,7 @@ snapshots:
 
   '@types/express-serve-static-core@5.1.1':
     dependencies:
-      '@types/node': 22.16.5
+      '@types/node': 22.19.17
       '@types/qs': 6.15.0
       '@types/range-parser': 1.2.7
       '@types/send': 1.2.1
@@ -10656,7 +10656,7 @@ snapshots:
 
   '@types/formidable@2.0.6':
     dependencies:
-      '@types/node': 22.16.5
+      '@types/node': 22.19.17
 
   '@types/geojson@7946.0.16': {}
 
@@ -10697,7 +10697,7 @@ snapshots:
       '@types/http-errors': 2.0.5
       '@types/keygrip': 1.0.6
       '@types/koa-compose': 3.2.9
-      '@types/node': 22.16.5
+      '@types/node': 22.19.17
 
   '@types/koa@3.0.2':
     dependencies:
@@ -10708,7 +10708,7 @@ snapshots:
       '@types/http-errors': 2.0.5
       '@types/keygrip': 1.0.6
       '@types/koa-compose': 3.2.9
-      '@types/node': 22.16.5
+      '@types/node': 22.19.17
 
   '@types/koa__cors@5.0.1':
     dependencies:
@@ -10734,7 +10734,7 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
-  '@types/node@22.16.5':
+  '@types/node@22.19.17':
     dependencies:
       undici-types: 6.21.0
 
@@ -10754,12 +10754,12 @@ snapshots:
 
   '@types/send@1.2.1':
     dependencies:
-      '@types/node': 22.16.5
+      '@types/node': 22.19.17
 
   '@types/serve-static@2.2.0':
     dependencies:
       '@types/http-errors': 2.0.5
-      '@types/node': 22.16.5
+      '@types/node': 22.19.17
 
   '@types/stack-utils@2.0.3': {}
 
@@ -10785,14 +10785,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typespec/asset-emitter@0.79.1(@typespec/compiler@1.11.0(@types/node@22.16.5))':
+  '@typespec/asset-emitter@0.79.1(@typespec/compiler@1.11.0(@types/node@22.19.17))':
     dependencies:
-      '@typespec/compiler': 1.11.0(@types/node@22.16.5)
+      '@typespec/compiler': 1.11.0(@types/node@22.19.17)
 
-  '@typespec/compiler@1.11.0(@types/node@22.16.5)':
+  '@typespec/compiler@1.11.0(@types/node@22.19.17)':
     dependencies:
       '@babel/code-frame': 7.29.0
-      '@inquirer/prompts': 8.4.2(@types/node@22.16.5)
+      '@inquirer/prompts': 8.4.2(@types/node@22.19.17)
       ajv: 8.18.0
       change-case: 5.4.4
       env-paths: 4.0.0
@@ -10811,61 +10811,61 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  '@typespec/events@0.77.0(@typespec/compiler@1.11.0(@types/node@22.16.5))':
+  '@typespec/events@0.77.0(@typespec/compiler@1.11.0(@types/node@22.19.17))':
     dependencies:
-      '@typespec/compiler': 1.11.0(@types/node@22.16.5)
+      '@typespec/compiler': 1.11.0(@types/node@22.19.17)
 
-  '@typespec/http@1.11.0(@typespec/compiler@1.11.0(@types/node@22.16.5))(@typespec/streams@0.77.0(@typespec/compiler@1.11.0(@types/node@22.16.5)))':
+  '@typespec/http@1.11.0(@typespec/compiler@1.11.0(@types/node@22.19.17))(@typespec/streams@0.77.0(@typespec/compiler@1.11.0(@types/node@22.19.17)))':
     dependencies:
-      '@typespec/compiler': 1.11.0(@types/node@22.16.5)
+      '@typespec/compiler': 1.11.0(@types/node@22.19.17)
     optionalDependencies:
-      '@typespec/streams': 0.77.0(@typespec/compiler@1.11.0(@types/node@22.16.5))
+      '@typespec/streams': 0.77.0(@typespec/compiler@1.11.0(@types/node@22.19.17))
 
-  '@typespec/openapi3@1.11.0(4b3d5b490f6f4fbd5949b16cbbfe6df5)':
+  '@typespec/openapi3@1.11.0(312cf85998a1f60704746b0f014fcd5d)':
     dependencies:
       '@scalar/json-magic': 0.11.7
       '@scalar/openapi-parser': 0.24.17
       '@scalar/openapi-types': 0.5.4
-      '@typespec/asset-emitter': 0.79.1(@typespec/compiler@1.11.0(@types/node@22.16.5))
-      '@typespec/compiler': 1.11.0(@types/node@22.16.5)
-      '@typespec/http': 1.11.0(@typespec/compiler@1.11.0(@types/node@22.16.5))(@typespec/streams@0.77.0(@typespec/compiler@1.11.0(@types/node@22.16.5)))
-      '@typespec/openapi': 1.11.0(@typespec/compiler@1.11.0(@types/node@22.16.5))(@typespec/http@1.11.0(@typespec/compiler@1.11.0(@types/node@22.16.5))(@typespec/streams@0.77.0(@typespec/compiler@1.11.0(@types/node@22.16.5))))
+      '@typespec/asset-emitter': 0.79.1(@typespec/compiler@1.11.0(@types/node@22.19.17))
+      '@typespec/compiler': 1.11.0(@types/node@22.19.17)
+      '@typespec/http': 1.11.0(@typespec/compiler@1.11.0(@types/node@22.19.17))(@typespec/streams@0.77.0(@typespec/compiler@1.11.0(@types/node@22.19.17)))
+      '@typespec/openapi': 1.11.0(@typespec/compiler@1.11.0(@types/node@22.19.17))(@typespec/http@1.11.0(@typespec/compiler@1.11.0(@types/node@22.19.17))(@typespec/streams@0.77.0(@typespec/compiler@1.11.0(@types/node@22.19.17))))
       yaml: 2.8.3
     optionalDependencies:
-      '@typespec/events': 0.77.0(@typespec/compiler@1.11.0(@types/node@22.16.5))
-      '@typespec/sse': 0.77.0(@typespec/compiler@1.11.0(@types/node@22.16.5))(@typespec/events@0.77.0(@typespec/compiler@1.11.0(@types/node@22.16.5)))(@typespec/http@1.11.0(@typespec/compiler@1.11.0(@types/node@22.16.5))(@typespec/streams@0.77.0(@typespec/compiler@1.11.0(@types/node@22.16.5))))(@typespec/streams@0.77.0(@typespec/compiler@1.11.0(@types/node@22.16.5)))
-      '@typespec/streams': 0.77.0(@typespec/compiler@1.11.0(@types/node@22.16.5))
-      '@typespec/versioning': 0.77.0(@typespec/compiler@1.11.0(@types/node@22.16.5))
-      '@typespec/xml': 0.77.0(@typespec/compiler@1.11.0(@types/node@22.16.5))
+      '@typespec/events': 0.77.0(@typespec/compiler@1.11.0(@types/node@22.19.17))
+      '@typespec/sse': 0.77.0(@typespec/compiler@1.11.0(@types/node@22.19.17))(@typespec/events@0.77.0(@typespec/compiler@1.11.0(@types/node@22.19.17)))(@typespec/http@1.11.0(@typespec/compiler@1.11.0(@types/node@22.19.17))(@typespec/streams@0.77.0(@typespec/compiler@1.11.0(@types/node@22.19.17))))(@typespec/streams@0.77.0(@typespec/compiler@1.11.0(@types/node@22.19.17)))
+      '@typespec/streams': 0.77.0(@typespec/compiler@1.11.0(@types/node@22.19.17))
+      '@typespec/versioning': 0.77.0(@typespec/compiler@1.11.0(@types/node@22.19.17))
+      '@typespec/xml': 0.77.0(@typespec/compiler@1.11.0(@types/node@22.19.17))
 
-  '@typespec/openapi@1.11.0(@typespec/compiler@1.11.0(@types/node@22.16.5))(@typespec/http@1.11.0(@typespec/compiler@1.11.0(@types/node@22.16.5))(@typespec/streams@0.77.0(@typespec/compiler@1.11.0(@types/node@22.16.5))))':
+  '@typespec/openapi@1.11.0(@typespec/compiler@1.11.0(@types/node@22.19.17))(@typespec/http@1.11.0(@typespec/compiler@1.11.0(@types/node@22.19.17))(@typespec/streams@0.77.0(@typespec/compiler@1.11.0(@types/node@22.19.17))))':
     dependencies:
-      '@typespec/compiler': 1.11.0(@types/node@22.16.5)
-      '@typespec/http': 1.11.0(@typespec/compiler@1.11.0(@types/node@22.16.5))(@typespec/streams@0.77.0(@typespec/compiler@1.11.0(@types/node@22.16.5)))
+      '@typespec/compiler': 1.11.0(@types/node@22.19.17)
+      '@typespec/http': 1.11.0(@typespec/compiler@1.11.0(@types/node@22.19.17))(@typespec/streams@0.77.0(@typespec/compiler@1.11.0(@types/node@22.19.17)))
 
-  '@typespec/rest@0.77.0(@typespec/compiler@1.11.0(@types/node@22.16.5))(@typespec/http@1.11.0(@typespec/compiler@1.11.0(@types/node@22.16.5))(@typespec/streams@0.77.0(@typespec/compiler@1.11.0(@types/node@22.16.5))))':
+  '@typespec/rest@0.77.0(@typespec/compiler@1.11.0(@types/node@22.19.17))(@typespec/http@1.11.0(@typespec/compiler@1.11.0(@types/node@22.19.17))(@typespec/streams@0.77.0(@typespec/compiler@1.11.0(@types/node@22.19.17))))':
     dependencies:
-      '@typespec/compiler': 1.11.0(@types/node@22.16.5)
-      '@typespec/http': 1.11.0(@typespec/compiler@1.11.0(@types/node@22.16.5))(@typespec/streams@0.77.0(@typespec/compiler@1.11.0(@types/node@22.16.5)))
+      '@typespec/compiler': 1.11.0(@types/node@22.19.17)
+      '@typespec/http': 1.11.0(@typespec/compiler@1.11.0(@types/node@22.19.17))(@typespec/streams@0.77.0(@typespec/compiler@1.11.0(@types/node@22.19.17)))
 
-  '@typespec/sse@0.77.0(@typespec/compiler@1.11.0(@types/node@22.16.5))(@typespec/events@0.77.0(@typespec/compiler@1.11.0(@types/node@22.16.5)))(@typespec/http@1.11.0(@typespec/compiler@1.11.0(@types/node@22.16.5))(@typespec/streams@0.77.0(@typespec/compiler@1.11.0(@types/node@22.16.5))))(@typespec/streams@0.77.0(@typespec/compiler@1.11.0(@types/node@22.16.5)))':
+  '@typespec/sse@0.77.0(@typespec/compiler@1.11.0(@types/node@22.19.17))(@typespec/events@0.77.0(@typespec/compiler@1.11.0(@types/node@22.19.17)))(@typespec/http@1.11.0(@typespec/compiler@1.11.0(@types/node@22.19.17))(@typespec/streams@0.77.0(@typespec/compiler@1.11.0(@types/node@22.19.17))))(@typespec/streams@0.77.0(@typespec/compiler@1.11.0(@types/node@22.19.17)))':
     dependencies:
-      '@typespec/compiler': 1.11.0(@types/node@22.16.5)
-      '@typespec/events': 0.77.0(@typespec/compiler@1.11.0(@types/node@22.16.5))
-      '@typespec/http': 1.11.0(@typespec/compiler@1.11.0(@types/node@22.16.5))(@typespec/streams@0.77.0(@typespec/compiler@1.11.0(@types/node@22.16.5)))
-      '@typespec/streams': 0.77.0(@typespec/compiler@1.11.0(@types/node@22.16.5))
+      '@typespec/compiler': 1.11.0(@types/node@22.19.17)
+      '@typespec/events': 0.77.0(@typespec/compiler@1.11.0(@types/node@22.19.17))
+      '@typespec/http': 1.11.0(@typespec/compiler@1.11.0(@types/node@22.19.17))(@typespec/streams@0.77.0(@typespec/compiler@1.11.0(@types/node@22.19.17)))
+      '@typespec/streams': 0.77.0(@typespec/compiler@1.11.0(@types/node@22.19.17))
 
-  '@typespec/streams@0.77.0(@typespec/compiler@1.11.0(@types/node@22.16.5))':
+  '@typespec/streams@0.77.0(@typespec/compiler@1.11.0(@types/node@22.19.17))':
     dependencies:
-      '@typespec/compiler': 1.11.0(@types/node@22.16.5)
+      '@typespec/compiler': 1.11.0(@types/node@22.19.17)
 
-  '@typespec/versioning@0.77.0(@typespec/compiler@1.11.0(@types/node@22.16.5))':
+  '@typespec/versioning@0.77.0(@typespec/compiler@1.11.0(@types/node@22.19.17))':
     dependencies:
-      '@typespec/compiler': 1.11.0(@types/node@22.16.5)
+      '@typespec/compiler': 1.11.0(@types/node@22.19.17)
 
-  '@typespec/xml@0.77.0(@typespec/compiler@1.11.0(@types/node@22.16.5))':
+  '@typespec/xml@0.77.0(@typespec/compiler@1.11.0(@types/node@22.19.17))':
     dependencies:
-      '@typespec/compiler': 1.11.0(@types/node@22.16.5)
+      '@typespec/compiler': 1.11.0(@types/node@22.19.17)
 
   '@ungap/structured-clone@1.3.0': {}
 
@@ -10933,9 +10933,9 @@ snapshots:
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
 
-  '@vitejs/plugin-basic-ssl@2.1.4(vite@7.3.2(@types/node@22.16.5)(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.3))':
+  '@vitejs/plugin-basic-ssl@2.1.4(vite@7.3.2(@types/node@22.19.17)(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
-      vite: 7.3.2(@types/node@22.16.5)(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 7.3.2(@types/node@22.19.17)(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.3)
 
   '@xmldom/xmldom@0.9.10': {}
 
@@ -12774,17 +12774,17 @@ snapshots:
 
   inline-style-parser@0.2.7: {}
 
-  inquirer@12.9.6(@types/node@22.16.5):
+  inquirer@12.9.6(@types/node@22.19.17):
     dependencies:
       '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.2(@types/node@22.16.5)
-      '@inquirer/prompts': 7.10.1(@types/node@22.16.5)
-      '@inquirer/type': 3.0.10(@types/node@22.16.5)
+      '@inquirer/core': 10.3.2(@types/node@22.19.17)
+      '@inquirer/prompts': 7.10.1(@types/node@22.19.17)
+      '@inquirer/type': 3.0.10(@types/node@22.19.17)
       mute-stream: 2.0.0
       run-async: 4.0.6
       rxjs: 7.8.2
     optionalDependencies:
-      '@types/node': 22.16.5
+      '@types/node': 22.19.17
 
   internmap@1.0.1: {}
 
@@ -12944,7 +12944,7 @@ snapshots:
       '@jest/expect': 30.3.0
       '@jest/test-result': 30.3.0
       '@jest/types': 30.3.0
-      '@types/node': 22.16.5
+      '@types/node': 22.19.17
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.7.2
@@ -12964,7 +12964,7 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@30.3.0(@types/node@22.16.5):
+  jest-cli@30.3.0(@types/node@22.19.17):
     dependencies:
       '@jest/core': 30.3.0
       '@jest/test-result': 30.3.0
@@ -12972,7 +12972,7 @@ snapshots:
       chalk: 4.1.2
       exit-x: 0.2.2
       import-local: 3.2.0
-      jest-config: 30.3.0(@types/node@22.16.5)
+      jest-config: 30.3.0(@types/node@22.19.17)
       jest-util: 30.3.0
       jest-validate: 30.3.0
       yargs: 17.7.2
@@ -12983,7 +12983,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@30.3.0(@types/node@22.16.5):
+  jest-config@30.3.0(@types/node@22.19.17):
     dependencies:
       '@babel/core': 7.29.0
       '@jest/get-type': 30.1.0
@@ -13009,7 +13009,7 @@ snapshots:
       slash: 3.0.0
       strip-json-comments: 3.1.1
     optionalDependencies:
-      '@types/node': 22.16.5
+      '@types/node': 22.19.17
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -13038,7 +13038,7 @@ snapshots:
       '@jest/environment': 30.3.0
       '@jest/fake-timers': 30.3.0
       '@jest/types': 30.3.0
-      '@types/node': 22.16.5
+      '@types/node': 22.19.17
       jest-mock: 30.3.0
       jest-util: 30.3.0
       jest-validate: 30.3.0
@@ -13046,7 +13046,7 @@ snapshots:
   jest-haste-map@30.3.0:
     dependencies:
       '@jest/types': 30.3.0
-      '@types/node': 22.16.5
+      '@types/node': 22.19.17
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -13085,7 +13085,7 @@ snapshots:
   jest-mock@30.3.0:
     dependencies:
       '@jest/types': 30.3.0
-      '@types/node': 22.16.5
+      '@types/node': 22.19.17
       jest-util: 30.3.0
 
   jest-pnp-resolver@1.2.3(jest-resolve@30.3.0):
@@ -13119,7 +13119,7 @@ snapshots:
       '@jest/test-result': 30.3.0
       '@jest/transform': 30.3.0
       '@jest/types': 30.3.0
-      '@types/node': 22.16.5
+      '@types/node': 22.19.17
       chalk: 4.1.2
       emittery: 0.13.1
       exit-x: 0.2.2
@@ -13148,7 +13148,7 @@ snapshots:
       '@jest/test-result': 30.3.0
       '@jest/transform': 30.3.0
       '@jest/types': 30.3.0
-      '@types/node': 22.16.5
+      '@types/node': 22.19.17
       chalk: 4.1.2
       cjs-module-lexer: 2.2.0
       collect-v8-coverage: 1.0.3
@@ -13195,7 +13195,7 @@ snapshots:
   jest-util@30.3.0:
     dependencies:
       '@jest/types': 30.3.0
-      '@types/node': 22.16.5
+      '@types/node': 22.19.17
       chalk: 4.1.2
       ci-info: 4.4.0
       graceful-fs: 4.2.11
@@ -13214,7 +13214,7 @@ snapshots:
     dependencies:
       '@jest/test-result': 30.3.0
       '@jest/types': 30.3.0
-      '@types/node': 22.16.5
+      '@types/node': 22.19.17
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -13223,18 +13223,18 @@ snapshots:
 
   jest-worker@30.3.0:
     dependencies:
-      '@types/node': 22.16.5
+      '@types/node': 22.19.17
       '@ungap/structured-clone': 1.3.0
       jest-util: 30.3.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@30.3.0(@types/node@22.16.5):
+  jest@30.3.0(@types/node@22.19.17):
     dependencies:
       '@jest/core': 30.3.0
       '@jest/types': 30.3.0
       import-local: 3.2.0
-      jest-cli: 30.3.0(@types/node@22.16.5)
+      jest-cli: 30.3.0(@types/node@22.19.17)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -13360,7 +13360,7 @@ snapshots:
 
   layout-base@2.0.1: {}
 
-  lerna@9.0.7(@swc/core@1.15.30(@swc/helpers@0.5.21))(@types/node@22.16.5):
+  lerna@9.0.7(@swc/core@1.15.30(@swc/helpers@0.5.21))(@types/node@22.19.17):
     dependencies:
       '@npmcli/arborist': 9.1.6
       '@npmcli/package-json': 7.0.2
@@ -13391,7 +13391,7 @@ snapshots:
       import-local: 3.1.0
       ini: 1.3.8
       init-package-json: 8.2.2
-      inquirer: 12.9.6(@types/node@22.16.5)
+      inquirer: 12.9.6(@types/node@22.19.17)
       is-ci: 3.0.1
       jest-diff: 30.3.0
       js-yaml: 4.1.1
@@ -16201,7 +16201,7 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite@7.3.2(@types/node@22.16.5)(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.3):
+  vite@7.3.2(@types/node@22.19.17)(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       esbuild: 0.27.3
       fdir: 6.5.0(picomatch@4.0.4)
@@ -16210,7 +16210,7 @@ snapshots:
       rollup: 4.60.2
       tinyglobby: 0.2.15
     optionalDependencies:
-      '@types/node': 22.16.5
+      '@types/node': 22.19.17
       fsevents: 2.3.3
       sass: 1.97.3
       tsx: 4.21.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -288,7 +288,7 @@ importers:
     dependencies:
       '@hookform/resolvers':
         specifier: ^5.2.2
-        version: 5.2.2(react-hook-form@7.73.1(react@19.2.5))
+        version: 5.2.2(react-hook-form@7.74.0(react@19.2.5))
       '@monaco-editor/react':
         specifier: ^4.7.0
         version: 4.7.0(monaco-editor@0.55.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -321,7 +321,7 @@ importers:
         version: 19.2.5(react@19.2.5)
       react-hook-form:
         specifier: ^7.73.1
-        version: 7.73.1(react@19.2.5)
+        version: 7.74.0(react@19.2.5)
       tslib:
         specifier: ^2.8.1
         version: 2.8.1
@@ -1543,8 +1543,8 @@ packages:
   '@iconify/types@2.0.0':
     resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
 
-  '@iconify/utils@3.1.0':
-    resolution: {integrity: sha512-Zlzem1ZXhI1iHeeERabLNzBHdOa4VhQbqAcOQaMKuTuyZCpwKbC2R4Dd0Zo3g9EAc+Y4fiarO8HIHRAth7+skw==}
+  '@iconify/utils@3.1.1':
+    resolution: {integrity: sha512-MwzoDtw9rO1x+qfgLTV/IVXsHDBqeYZoMIQC8SfxfYSlaSUG+oWiAcoiB1yajAda6mqblm4/1/w2E8tRu7a7Tw==}
 
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
@@ -3968,8 +3968,8 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
-  baseline-browser-mapping@2.10.21:
-    resolution: {integrity: sha512-Q+rUQ7Uz8AHM7DEaNdwvfFCTq7a43lNTzuS94eiWqwyxfV/wJv+oUivef51T91mmRY4d4A1u9rcSvkeufCVXlA==}
+  baseline-browser-mapping@2.10.22:
+    resolution: {integrity: sha512-6qruVrb5rse6WylFkU0FhBKKGuecWseqdpQfhkawn6ztyk2QlfwSRjsDxMCLJrkfmfN21qvhl9ABgaMeRkuwww==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -4067,8 +4067,8 @@ packages:
     resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
     engines: {node: '>=10'}
 
-  caniuse-lite@1.0.30001790:
-    resolution: {integrity: sha512-bOoxfJPyYo+ds6W0YfptaCWbFnJYjh2Y1Eow5lRv+vI2u8ganPZqNm1JwNh0t2ELQCqIWg4B3dWEusgAmsoyOw==}
+  caniuse-lite@1.0.30001791:
+    resolution: {integrity: sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -6921,8 +6921,8 @@ packages:
     peerDependencies:
       react: ^19.2.5
 
-  react-hook-form@7.73.1:
-    resolution: {integrity: sha512-VAfVYOPcx3piiEVQy95vyFmBwbVUsP/AUIN+mpFG8h11yshDd444nn0VyfaGWSRnhOLVgiDu7HIuBtAIzxn9dA==}
+  react-hook-form@7.74.0:
+    resolution: {integrity: sha512-yR6wHr99p9wFv686jhRWVSFhUvDvNbdUf2dKlbno8/VKOCuoNobDGC6S+M2dua9A9Yo8vpcrp8assIYbsZCQ9g==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       react: ^16.8.0 || ^17 || ^18 || ^19
@@ -8811,16 +8811,16 @@ snapshots:
     dependencies:
       hono: 4.12.15
 
-  '@hookform/resolvers@5.2.2(react-hook-form@7.73.1(react@19.2.5))':
+  '@hookform/resolvers@5.2.2(react-hook-form@7.74.0(react@19.2.5))':
     dependencies:
       '@standard-schema/utils': 0.3.0
-      react-hook-form: 7.73.1(react@19.2.5)
+      react-hook-form: 7.74.0(react@19.2.5)
 
   '@hutson/parse-repository-url@3.0.2': {}
 
   '@iconify/types@2.0.0': {}
 
-  '@iconify/utils@3.1.0':
+  '@iconify/utils@3.1.1':
     dependencies:
       '@antfu/install-pkg': 1.1.0
       '@iconify/types': 2.0.0
@@ -11149,7 +11149,7 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  baseline-browser-mapping@2.10.21: {}
+  baseline-browser-mapping@2.10.22: {}
 
   beasties@0.4.1:
     dependencies:
@@ -11223,8 +11223,8 @@ snapshots:
 
   browserslist@4.28.2:
     dependencies:
-      baseline-browser-mapping: 2.10.21
-      caniuse-lite: 1.0.30001790
+      baseline-browser-mapping: 2.10.22
+      caniuse-lite: 1.0.30001791
       electron-to-chromium: 1.5.344
       node-releases: 2.0.38
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
@@ -11279,7 +11279,7 @@ snapshots:
 
   camelcase@6.3.0: {}
 
-  caniuse-lite@1.0.30001790: {}
+  caniuse-lite@1.0.30001791: {}
 
   ccount@2.0.1: {}
 
@@ -13854,7 +13854,7 @@ snapshots:
   mermaid@11.14.0:
     dependencies:
       '@braintree/sanitize-url': 7.1.2
-      '@iconify/utils': 3.1.0
+      '@iconify/utils': 3.1.1
       '@mermaid-js/parser': 1.1.0
       '@types/d3': 7.4.3
       '@upsetjs/venn.js': 2.0.0
@@ -14325,8 +14325,8 @@ snapshots:
     dependencies:
       '@next/env': 16.2.4
       '@swc/helpers': 0.5.15
-      baseline-browser-mapping: 2.10.21
-      caniuse-lite: 1.0.30001790
+      baseline-browser-mapping: 2.10.22
+      caniuse-lite: 1.0.30001791
       postcss: 8.4.31
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
@@ -15140,7 +15140,7 @@ snapshots:
       react: 19.2.5
       scheduler: 0.27.0
 
-  react-hook-form@7.73.1(react@19.2.5):
+  react-hook-form@7.74.0(react@19.2.5):
     dependencies:
       react: 19.2.5
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -19,8 +19,6 @@ ignoredBuiltDependencies:
 
 linkWorkspacePackages: deep
 
-managePackageManagerVersions: false
-
 minimumReleaseAge: 10080
 
 minimumReleaseAgeExclude: []

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -19,6 +19,8 @@ ignoredBuiltDependencies:
 
 linkWorkspacePackages: deep
 
+managePackageManagerVersions: false
+
 minimumReleaseAge: 10080
 
 minimumReleaseAgeExclude: []

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -27,7 +27,7 @@ nodeOptions: ${NODE_OPTIONS:- } --experimental-vm-modules
 
 overrides:
   '@isaacs/brace-expansion': ^5.0.1
-  '@types/node': 22.16.5
+  '@types/node': ^22.19.17
   axios: ^1.15.2
   'lodash-es@~4.17': ^4.18.0
   qs: ^6.14.2

--- a/scripts/assert-clean-working-directory.sh
+++ b/scripts/assert-clean-working-directory.sh
@@ -5,5 +5,8 @@ set -e
 if [ -n "$(git status --porcelain=v1)" ]; then
   echo "Uncommitted changes to repo found!"
   git status --porcelain=v1
+
+  git diff pnpm-lock.yaml
+
   exit 1
 fi

--- a/scripts/assert-clean-working-directory.sh
+++ b/scripts/assert-clean-working-directory.sh
@@ -5,8 +5,5 @@ set -e
 if [ -n "$(git status --porcelain=v1)" ]; then
   echo "Uncommitted changes to repo found!"
   git status --porcelain=v1
-
-  git diff pnpm-lock.yaml
-
   exit 1
 fi


### PR DESCRIPTION
- depedency updates are mainly switching to node v24 runtime
- node v20 is now EOL, so we can stop regression testing against it