### PR TITLE
feat: use tsgo for most integration test builds

### DIFF
--- a/integration-tests/typescript-axios/package.json
+++ b/integration-tests/typescript-axios/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "scripts": {
     "clean": "rm -rf ./dist && rm -rf ./src/generated",
-    "validate": "tsc -p ./tsconfig.json"
+    "validate": "tsgo -p ./tsconfig.json"
   },
   "dependencies": {
     "@nahkies/typescript-axios-runtime": "workspace:*",
@@ -17,6 +17,6 @@
   },
   "devDependencies": {
     "@types/node": "^22.19.17",
-    "typescript": "^6.0.3"
+    "@typescript/native-preview": "^7.0.0-dev.20260421.2"
   }
 }

--- a/integration-tests/typescript-express/package.json
+++ b/integration-tests/typescript-express/package.json
@@ -8,7 +8,7 @@
   "type": "module",
   "scripts": {
     "clean": "rm -rf ./dist && rm -rf ./src/generated",
-    "validate": "tsc -p ./tsconfig.json"
+    "validate": "tsgo -p ./tsconfig.json"
   },
   "dependencies": {
     "@nahkies/typescript-express-runtime": "workspace:*",
@@ -19,6 +19,6 @@
   },
   "devDependencies": {
     "@types/express": "^5.0.6",
-    "typescript": "^6.0.3"
+    "@typescript/native-preview": "^7.0.0-dev.20260421.2"
   }
 }

--- a/integration-tests/typescript-fetch/package.json
+++ b/integration-tests/typescript-fetch/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "scripts": {
     "clean": "rm -rf ./dist && rm -rf ./src/generated",
-    "validate": "tsc -p ./tsconfig.json"
+    "validate": "tsgo -p ./tsconfig.json"
   },
   "type": "module",
   "dependencies": {
@@ -17,6 +17,6 @@
   },
   "devDependencies": {
     "@types/node": "^22.19.17",
-    "typescript": "^6.0.3"
+    "@typescript/native-preview": "^7.0.0-dev.20260421.2"
   }
 }

--- a/integration-tests/typescript-koa/package.json
+++ b/integration-tests/typescript-koa/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "scripts": {
     "clean": "rm -rf ./dist && rm -rf ./src/generated",
-    "validate": "tsc -p ./tsconfig.json"
+    "validate": "tsgo -p ./tsconfig.json"
   },
   "dependencies": {
     "@koa/router": "^14.0.0",
@@ -20,6 +20,6 @@
   "devDependencies": {
     "@types/koa": "^3.0.2",
     "@types/koa__router": "^12.0.5",
-    "typescript": "^6.0.3"
+    "@typescript/native-preview": "^7.0.0-dev.20260421.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -205,9 +205,9 @@ importers:
       '@types/node':
         specifier: ^22.19.17
         version: 22.19.17
-      typescript:
-        specifier: ^6.0.3
-        version: 6.0.3
+      '@typescript/native-preview':
+        specifier: ^7.0.0-dev.20260421.2
+        version: 7.0.0-dev.20260426.1
 
   integration-tests/typescript-express:
     dependencies:
@@ -230,9 +230,9 @@ importers:
       '@types/express':
         specifier: ^5.0.6
         version: 5.0.6
-      typescript:
-        specifier: ^6.0.3
-        version: 6.0.3
+      '@typescript/native-preview':
+        specifier: ^7.0.0-dev.20260421.2
+        version: 7.0.0-dev.20260426.1
 
   integration-tests/typescript-fetch:
     dependencies:
@@ -249,9 +249,9 @@ importers:
       '@types/node':
         specifier: ^22.19.17
         version: 22.19.17
-      typescript:
-        specifier: ^6.0.3
-        version: 6.0.3
+      '@typescript/native-preview':
+        specifier: ^7.0.0-dev.20260421.2
+        version: 7.0.0-dev.20260426.1
 
   integration-tests/typescript-koa:
     dependencies:
@@ -280,9 +280,9 @@ importers:
       '@types/koa__router':
         specifier: ^12.0.5
         version: 12.0.5
-      typescript:
-        specifier: ^6.0.3
-        version: 6.0.3
+      '@typescript/native-preview':
+        specifier: ^7.0.0-dev.20260421.2
+        version: 7.0.0-dev.20260426.1
 
   packages/documentation:
     dependencies:
@@ -3549,6 +3549,53 @@ packages:
 
   '@types/yargs@17.0.35':
     resolution: {integrity: sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==}
+
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260426.1':
+    resolution: {integrity: sha512-HzGvERpIFO7p6pMljPN1fIOHqAv2oMeVIqYLSt27TKILkTRpe7fANW3R2OAM+/A+pLtYNNXGDbKl/wR+DHz9KA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260426.1':
+    resolution: {integrity: sha512-aE17wCPNQ09K4jV7TQYYRYF/Q/6nFS9jLpbyTYHtS+i+0yV1Rrs4VsqboisS1R/iSWsq3m1Yhh3uS4x3/9KUkg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260426.1':
+    resolution: {integrity: sha512-6OfhODChD1N6FX+ITzA1lny3WX6uew/Nw9kN7uWhymXlM3/vE0qtaAfsMpgdHdCbTPgcdpGaNFhbcMieju9Vdg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260426.1':
+    resolution: {integrity: sha512-/XJRC8B6JeOOb2/iek/BrzW4r5Nut+fkucG7ntEOQn63IRTsfP+AfJdJodG1VIwXOleNlFgG4RtYTUsvcbDJhg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260426.1':
+    resolution: {integrity: sha512-KPDpjmLo/4xY8ugfMGFm7Ona/1igPzZveLt/C0rb6/jNPYuShumRfKYnItGDRXBlmecJY/04lrqkWqQjhtSSPg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260426.1':
+    resolution: {integrity: sha512-I7ThiopxuNKX/iAcwgMwsm6L32GOwmwLOyPwQmXjh5c3VD2acq3FYyZRDJVk0aUUy1w6bTbODlo5ZHoPnlZtvw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260426.1':
+    resolution: {integrity: sha512-4624MJq72vN4H1msiWVBqAIyerJRi5Ni/U6eeE1A1Opqg4c4QoalYQQ+5h5RIuaZ6rY+9kvUn+SjsvbZwyLbjQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [win32]
+
+  '@typescript/native-preview@7.0.0-dev.20260426.1':
+    resolution: {integrity: sha512-zE7B6TIG4XDYr4Your5E2Bxm1vD2YiPyD8OFG4nD5Odt/uN6gO0Y+T4TIbtGUBmOftMRqEV2Jw1ZC4ka0my1yw==}
+    engines: {node: '>=16.20.0'}
+    hasBin: true
 
   '@typescript/vfs@1.6.4':
     resolution: {integrity: sha512-PJFXFS4ZJKiJ9Qiuix6Dz/OwEIqHD7Dme1UwZhTK11vR+5dqW2ACbdndWQexBzCx+CPuMe5WBYQWCsFyGlQLlQ==}
@@ -10777,6 +10824,37 @@ snapshots:
   '@types/yargs@17.0.35':
     dependencies:
       '@types/yargs-parser': 21.0.3
+
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260426.1':
+    optional: true
+
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260426.1':
+    optional: true
+
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260426.1':
+    optional: true
+
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260426.1':
+    optional: true
+
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260426.1':
+    optional: true
+
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260426.1':
+    optional: true
+
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260426.1':
+    optional: true
+
+  '@typescript/native-preview@7.0.0-dev.20260426.1':
+    optionalDependencies:
+      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260426.1
+      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260426.1
+      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260426.1
+      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260426.1
+      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260426.1
+      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260426.1
+      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260426.1
 
   '@typescript/vfs@1.6.4(typescript@6.0.3)':
     dependencies:


### PR DESCRIPTION
swaps to using `tsgo` beta for most of the integration test builds. locally I observe ~3x speed up

ref: https://devblogs.microsoft.com/typescript/announcing-typescript-7-0-beta/