### PR TITLE
feat!: enum of 1 is a literal

### DIFF
--- a/integration-tests/typescript-angular/src/generated/api.github.com.yaml/client.service.ts
+++ b/integration-tests/typescript-angular/src/generated/api.github.com.yaml/client.service.ts
@@ -1767,7 +1767,7 @@ export class GitHubV3RestApiService {
     ecosystem?: string
     package?: string
     epssPercentage?: string
-    has?: string | ("patch" | UnknownEnumStringValue)[]
+    has?: string | "patch"[]
     scope?: "development" | "runtime" | UnknownEnumStringValue
     sort?: "created" | "updated" | "epss_percentage" | UnknownEnumStringValue
     direction?: "asc" | "desc" | UnknownEnumStringValue
@@ -6176,7 +6176,7 @@ export class GitHubV3RestApiService {
     ecosystem?: string
     package?: string
     epssPercentage?: string
-    has?: string | ("patch" | UnknownEnumStringValue)[]
+    has?: string | "patch"[]
     scope?: "development" | "runtime" | UnknownEnumStringValue
     sort?: "created" | "updated" | "epss_percentage" | UnknownEnumStringValue
     direction?: "asc" | "desc" | UnknownEnumStringValue
@@ -7753,7 +7753,7 @@ export class GitHubV3RestApiService {
     org: string
     perPage?: number
     page?: number
-    exclude?: ("repositories" | UnknownEnumStringValue)[]
+    exclude?: "repositories"[]
   }): Observable<
     (HttpResponse<t_migration[]> & {status: 200}) | HttpResponse<unknown>
   > {
@@ -7810,7 +7810,7 @@ export class GitHubV3RestApiService {
   migrationsGetStatusForOrg(p: {
     org: string
     migrationId: number
-    exclude?: ("repositories" | UnknownEnumStringValue)[]
+    exclude?: "repositories"[]
   }): Observable<
     | (HttpResponse<t_migration> & {status: 200})
     | (HttpResponse<t_basic_error> & {status: 404})
@@ -8509,7 +8509,7 @@ export class GitHubV3RestApiService {
     org: string
     perPage?: number
     page?: number
-    sort?: "created_at" | UnknownEnumStringValue
+    sort?: "created_at"
     direction?: "asc" | "desc" | UnknownEnumStringValue
     owner?: string[]
     repository?: string
@@ -8657,7 +8657,7 @@ export class GitHubV3RestApiService {
     org: string
     perPage?: number
     page?: number
-    sort?: "created_at" | UnknownEnumStringValue
+    sort?: "created_at"
     direction?: "asc" | "desc" | UnknownEnumStringValue
     owner?: string[]
     repository?: string
@@ -15210,7 +15210,7 @@ export class GitHubV3RestApiService {
     ref?: t_code_scanning_ref
     sarifId?: t_code_scanning_analysis_sarif_id
     direction?: "asc" | "desc" | UnknownEnumStringValue
-    sort?: "created" | UnknownEnumStringValue
+    sort?: "created"
   }): Observable<
     | (HttpResponse<t_code_scanning_analysis[]> & {status: 200})
     | (HttpResponse<t_basic_error> & {status: 403})
@@ -16842,7 +16842,7 @@ export class GitHubV3RestApiService {
     package?: string
     manifest?: string
     epssPercentage?: string
-    has?: string | ("patch" | UnknownEnumStringValue)[]
+    has?: string | "patch"[]
     scope?: "development" | "runtime" | UnknownEnumStringValue
     sort?: "created" | "updated" | "epss_percentage" | UnknownEnumStringValue
     direction?: "asc" | "desc" | UnknownEnumStringValue
@@ -23934,7 +23934,7 @@ export class GitHubV3RestApiService {
 
   searchCode(p: {
     q: string
-    sort?: "indexed" | UnknownEnumStringValue
+    sort?: "indexed"
     order?: "desc" | "asc" | UnknownEnumStringValue
     perPage?: number
     page?: number

--- a/integration-tests/typescript-angular/src/generated/api.github.com.yaml/models.ts
+++ b/integration-tests/typescript-angular/src/generated/api.github.com.yaml/models.ts
@@ -324,7 +324,7 @@ export type t_app_permissions = {
   metadata?: "read" | "write" | UnknownEnumStringValue
   organization_administration?: "read" | "write" | UnknownEnumStringValue
   organization_announcement_banners?: "read" | "write" | UnknownEnumStringValue
-  organization_copilot_seat_management?: "write" | UnknownEnumStringValue
+  organization_copilot_seat_management?: "write"
   organization_custom_org_roles?: "read" | "write" | UnknownEnumStringValue
   organization_custom_properties?:
     | "read"
@@ -332,7 +332,7 @@ export type t_app_permissions = {
     | "admin"
     | UnknownEnumStringValue
   organization_custom_roles?: "read" | "write" | UnknownEnumStringValue
-  organization_events?: "read" | UnknownEnumStringValue
+  organization_events?: "read"
   organization_hooks?: "read" | "write" | UnknownEnumStringValue
   organization_packages?: "read" | "write" | UnknownEnumStringValue
   organization_personal_access_token_requests?:
@@ -343,14 +343,14 @@ export type t_app_permissions = {
     | "read"
     | "write"
     | UnknownEnumStringValue
-  organization_plan?: "read" | UnknownEnumStringValue
+  organization_plan?: "read"
   organization_projects?: "read" | "write" | "admin" | UnknownEnumStringValue
   organization_secrets?: "read" | "write" | UnknownEnumStringValue
   organization_self_hosted_runners?: "read" | "write" | UnknownEnumStringValue
   organization_user_blocking?: "read" | "write" | UnknownEnumStringValue
   packages?: "read" | "write" | UnknownEnumStringValue
   pages?: "read" | "write" | UnknownEnumStringValue
-  profile?: "write" | UnknownEnumStringValue
+  profile?: "write"
   pull_requests?: "read" | "write" | UnknownEnumStringValue
   repository_custom_properties?: "read" | "write" | UnknownEnumStringValue
   repository_hooks?: "read" | "write" | UnknownEnumStringValue
@@ -363,7 +363,7 @@ export type t_app_permissions = {
   statuses?: "read" | "write" | UnknownEnumStringValue
   team_discussions?: "read" | "write" | UnknownEnumStringValue
   vulnerability_alerts?: "read" | "write" | UnknownEnumStringValue
-  workflows?: "write" | UnknownEnumStringValue
+  workflows?: "write"
 }
 
 export type t_artifact = {
@@ -1167,7 +1167,7 @@ export type t_code_scanning_default_setup = {
   query_suite?: "default" | "extended" | UnknownEnumStringValue
   runner_label?: string | null
   runner_type?: "standard" | "labeled" | UnknownEnumStringValue | null
-  schedule?: "weekly" | UnknownEnumStringValue | null
+  schedule?: "weekly" | null
   state?: "configured" | "not-configured" | UnknownEnumStringValue
   threat_model?: "remote" | "remote_and_local" | UnknownEnumStringValue
   updated_at?: string | null
@@ -1893,7 +1893,7 @@ export type t_content_file = {
   size: number
   submodule_git_url?: string
   target?: string
-  type: "file" | UnknownEnumStringValue
+  type: "file"
   url: string
 }
 
@@ -1911,7 +1911,7 @@ export type t_content_submodule = {
   sha: string
   size: number
   submodule_git_url: string
-  type: "submodule" | UnknownEnumStringValue
+  type: "submodule"
   url: string
 }
 
@@ -1929,7 +1929,7 @@ export type t_content_symlink = {
   sha: string
   size: number
   target: string
-  type: "symlink" | UnknownEnumStringValue
+  type: "symlink"
   url: string
 }
 
@@ -6301,14 +6301,14 @@ export type t_repository_rule_branch_name_pattern = {
       | UnknownEnumStringValue
     pattern: string
   }
-  type: "branch_name_pattern" | UnknownEnumStringValue
+  type: "branch_name_pattern"
 }
 
 export type t_repository_rule_code_scanning = {
   parameters?: {
     code_scanning_tools: t_repository_rule_params_code_scanning_tool[]
   }
-  type: "code_scanning" | UnknownEnumStringValue
+  type: "code_scanning"
 }
 
 export type t_repository_rule_commit_author_email_pattern = {
@@ -6323,7 +6323,7 @@ export type t_repository_rule_commit_author_email_pattern = {
       | UnknownEnumStringValue
     pattern: string
   }
-  type: "commit_author_email_pattern" | UnknownEnumStringValue
+  type: "commit_author_email_pattern"
 }
 
 export type t_repository_rule_commit_message_pattern = {
@@ -6338,7 +6338,7 @@ export type t_repository_rule_commit_message_pattern = {
       | UnknownEnumStringValue
     pattern: string
   }
-  type: "commit_message_pattern" | UnknownEnumStringValue
+  type: "commit_message_pattern"
 }
 
 export type t_repository_rule_committer_email_pattern = {
@@ -6353,15 +6353,15 @@ export type t_repository_rule_committer_email_pattern = {
       | UnknownEnumStringValue
     pattern: string
   }
-  type: "committer_email_pattern" | UnknownEnumStringValue
+  type: "committer_email_pattern"
 }
 
 export type t_repository_rule_creation = {
-  type: "creation" | UnknownEnumStringValue
+  type: "creation"
 }
 
 export type t_repository_rule_deletion = {
-  type: "deletion" | UnknownEnumStringValue
+  type: "deletion"
 }
 
 export type t_repository_rule_detailed =
@@ -6399,28 +6399,28 @@ export type t_repository_rule_file_extension_restriction = {
   parameters?: {
     restricted_file_extensions: string[]
   }
-  type: "file_extension_restriction" | UnknownEnumStringValue
+  type: "file_extension_restriction"
 }
 
 export type t_repository_rule_file_path_restriction = {
   parameters?: {
     restricted_file_paths: string[]
   }
-  type: "file_path_restriction" | UnknownEnumStringValue
+  type: "file_path_restriction"
 }
 
 export type t_repository_rule_max_file_path_length = {
   parameters?: {
     max_file_path_length: number
   }
-  type: "max_file_path_length" | UnknownEnumStringValue
+  type: "max_file_path_length"
 }
 
 export type t_repository_rule_max_file_size = {
   parameters?: {
     max_file_size: number
   }
-  type: "max_file_size" | UnknownEnumStringValue
+  type: "max_file_size"
 }
 
 export type t_repository_rule_merge_queue = {
@@ -6433,11 +6433,11 @@ export type t_repository_rule_merge_queue = {
     min_entries_to_merge: number
     min_entries_to_merge_wait_minutes: number
   }
-  type: "merge_queue" | UnknownEnumStringValue
+  type: "merge_queue"
 }
 
 export type t_repository_rule_non_fast_forward = {
-  type: "non_fast_forward" | UnknownEnumStringValue
+  type: "non_fast_forward"
 }
 
 export type t_repository_rule_params_code_scanning_tool = {
@@ -6484,22 +6484,22 @@ export type t_repository_rule_pull_request = {
     required_approving_review_count: number
     required_review_thread_resolution: boolean
   }
-  type: "pull_request" | UnknownEnumStringValue
+  type: "pull_request"
 }
 
 export type t_repository_rule_required_deployments = {
   parameters?: {
     required_deployment_environments: string[]
   }
-  type: "required_deployments" | UnknownEnumStringValue
+  type: "required_deployments"
 }
 
 export type t_repository_rule_required_linear_history = {
-  type: "required_linear_history" | UnknownEnumStringValue
+  type: "required_linear_history"
 }
 
 export type t_repository_rule_required_signatures = {
-  type: "required_signatures" | UnknownEnumStringValue
+  type: "required_signatures"
 }
 
 export type t_repository_rule_required_status_checks = {
@@ -6508,7 +6508,7 @@ export type t_repository_rule_required_status_checks = {
     required_status_checks: t_repository_rule_params_status_check_configuration[]
     strict_required_status_checks_policy: boolean
   }
-  type: "required_status_checks" | UnknownEnumStringValue
+  type: "required_status_checks"
 }
 
 export type t_repository_rule_ruleset_info = {
@@ -6529,14 +6529,14 @@ export type t_repository_rule_tag_name_pattern = {
       | UnknownEnumStringValue
     pattern: string
   }
-  type: "tag_name_pattern" | UnknownEnumStringValue
+  type: "tag_name_pattern"
 }
 
 export type t_repository_rule_update = {
   parameters?: {
     update_allows_fetch_and_merge: boolean
   }
-  type: "update" | UnknownEnumStringValue
+  type: "update"
 }
 
 export type t_repository_rule_violation_error = {
@@ -6558,7 +6558,7 @@ export type t_repository_rule_workflows = {
     do_not_enforce_on_create?: boolean
     workflows: t_repository_rule_params_workflow_file_reference[]
   }
-  type: "workflows" | UnknownEnumStringValue
+  type: "workflows"
 }
 
 export type t_repository_ruleset = {
@@ -8547,7 +8547,7 @@ export type t_ChecksCreateRequestBody = {
         | "stale"
         | "timed_out"
         | UnknownEnumStringValue
-      status: "completed" | UnknownEnumStringValue
+      status: "completed"
       [key: string]: unknown | undefined
     }
   | {
@@ -8633,7 +8633,7 @@ export type t_ChecksUpdateRequestBody = {
         | "stale"
         | "timed_out"
         | UnknownEnumStringValue
-      status?: "completed" | UnknownEnumStringValue
+      status?: "completed"
       [key: string]: unknown | undefined
     }
   | {
@@ -9501,7 +9501,7 @@ export type t_MigrationsSetLfsPreferenceRequestBody = {
 }
 
 export type t_MigrationsStartForAuthenticatedUserRequestBody = {
-  exclude?: ("repositories" | UnknownEnumStringValue)[]
+  exclude?: "repositories"[]
   exclude_attachments?: boolean
   exclude_git_data?: boolean
   exclude_metadata?: boolean
@@ -9513,7 +9513,7 @@ export type t_MigrationsStartForAuthenticatedUserRequestBody = {
 }
 
 export type t_MigrationsStartForOrgRequestBody = {
-  exclude?: ("repositories" | UnknownEnumStringValue)[]
+  exclude?: "repositories"[]
   exclude_attachments?: boolean
   exclude_git_data?: boolean
   exclude_metadata?: boolean
@@ -9653,15 +9653,15 @@ export type t_OrgsUpdateRequestBody = {
 }
 
 export type t_OrgsUpdateMembershipForAuthenticatedUserRequestBody = {
-  state: "active" | UnknownEnumStringValue
+  state: "active"
 }
 
 export type t_OrgsUpdatePatAccessRequestBody = {
-  action: "revoke" | UnknownEnumStringValue
+  action: "revoke"
 }
 
 export type t_OrgsUpdatePatAccessesRequestBody = {
-  action: "revoke" | UnknownEnumStringValue
+  action: "revoke"
   pat_ids: number[]
 }
 
@@ -9843,7 +9843,7 @@ export type t_PullsCreateReviewCommentRequestBody = {
 }
 
 export type t_PullsDismissReviewRequestBody = {
-  event?: "DISMISS" | UnknownEnumStringValue
+  event?: "DISMISS"
   message: string
 }
 

--- a/integration-tests/typescript-angular/src/generated/azure-core-data-plane-service.tsp/models.ts
+++ b/integration-tests/typescript-angular/src/generated/azure-core-data-plane-service.tsp/models.ts
@@ -66,7 +66,7 @@ export type t_Widget = {
 }
 
 export type t_WidgetAnalytics = {
-  id: "current" | UnknownEnumStringValue
+  id: "current"
   repairCount: number
   useCount: number
 }

--- a/integration-tests/typescript-angular/src/generated/azure-resource-manager.tsp/models.ts
+++ b/integration-tests/typescript-angular/src/generated/azure-resource-manager.tsp/models.ts
@@ -12,10 +12,7 @@ export type t_Azure_Core_azureLocation = string
 
 export type t_Azure_Core_uuid = string
 
-export type t_Azure_ResourceManager_CommonTypes_ActionType =
-  | "Internal"
-  | UnknownEnumStringValue
-  | string
+export type t_Azure_ResourceManager_CommonTypes_ActionType = "Internal" | string
 
 export type t_Azure_ResourceManager_CommonTypes_ErrorAdditionalInfo = {
   info?: unknown

--- a/integration-tests/typescript-angular/src/generated/okta.idp.yaml/client.service.ts
+++ b/integration-tests/typescript-angular/src/generated/okta.idp.yaml/client.service.ts
@@ -507,13 +507,13 @@ export class MyAccountManagementService {
         _links: {
           poll: {
             hints: {
-              allow: ("GET" | UnknownEnumStringValue)[]
+              allow: "GET"[]
             }
             href: string
           }
           verify: {
             hints: {
-              allow: ("POST" | UnknownEnumStringValue)[]
+              allow: "POST"[]
             }
             href: string
           }
@@ -859,7 +859,7 @@ export class MyAccountManagementService {
         _links?: {
           verify?: {
             hints: {
-              allow: ("GET" | UnknownEnumStringValue)[]
+              allow: "GET"[]
             }
             href: string
           }

--- a/integration-tests/typescript-angular/src/generated/okta.idp.yaml/models.ts
+++ b/integration-tests/typescript-angular/src/generated/okta.idp.yaml/models.ts
@@ -14,7 +14,7 @@ export type t_AppAuthenticatorEnrollment = {
     createdDate?: string
     id?: string
     lastUpdated?: string
-    status?: "ACTIVE" | UnknownEnumStringValue
+    status?: "ACTIVE"
   }
   id?: string
   lastUpdated?: string
@@ -34,7 +34,7 @@ export type t_AppAuthenticatorEnrollment = {
       links?: {
         pending?: {
           hints?: {
-            allow?: ("GET" | UnknownEnumStringValue)[]
+            allow?: "GET"[]
           }
           href?: string
         }
@@ -192,9 +192,9 @@ export type t_HttpMethod =
   | UnknownEnumStringValue
 
 export type t_KeyEC = {
-  crv: "P-256" | UnknownEnumStringValue
+  crv: "P-256"
   kid: string
-  kty: "EC" | UnknownEnumStringValue
+  kty: "EC"
   "okta:kpr": "HARDWARE" | "SOFTWARE" | UnknownEnumStringValue
   x: string
   y: string
@@ -205,7 +205,7 @@ export type t_KeyObject = t_KeyEC | t_KeyRSA
 export type t_KeyRSA = {
   e: string
   kid: string
-  kty: "RSA" | UnknownEnumStringValue
+  kty: "RSA"
   n: string
   "okta:kpr": "HARDWARE" | "SOFTWARE" | UnknownEnumStringValue
 }
@@ -220,7 +220,7 @@ export type t_Organization = {
   _links?: {
     self?: {
       hints?: {
-        allow?: ("GET" | UnknownEnumStringValue)[]
+        allow?: "GET"[]
       }
       href?: string
     }
@@ -290,12 +290,12 @@ export type t_Profile = {
 
 export type t_PushNotificationChallenge = {
   challenge?: string
-  payloadVersion?: "IDXv1" | UnknownEnumStringValue
+  payloadVersion?: "IDXv1"
 }
 
 export type t_PushNotificationVerification = {
   challengeResponse?: string
-  method?: "push" | UnknownEnumStringValue
+  method?: "push"
 }
 
 export type t_Schema = {

--- a/integration-tests/typescript-angular/src/generated/okta.oauth.yaml/models.ts
+++ b/integration-tests/typescript-angular/src/generated/okta.oauth.yaml/models.ts
@@ -91,7 +91,7 @@ export type t_Client = {
   tos_uri?: string | null
 }
 
-export type t_CodeChallengeMethod = "S256" | UnknownEnumStringValue
+export type t_CodeChallengeMethod = "S256"
 
 export type t_DeviceAuthorizeResponse = {
   device_code?: string
@@ -311,7 +311,7 @@ export type t_SigningAlgorithm =
 
 export type t_SubjectType = "pairwise" | "public" | UnknownEnumStringValue
 
-export type t_TokenDeliveryMode = "poll" | UnknownEnumStringValue
+export type t_TokenDeliveryMode = "poll"
 
 export type t_TokenResponse = {
   access_token?: string
@@ -349,6 +349,6 @@ export type t_UserInfo = {
 }
 
 export type t_sub_id = {
-  format?: "opaque" | UnknownEnumStringValue
+  format?: "opaque"
   id?: string
 }

--- a/integration-tests/typescript-angular/src/generated/stripe.yaml/client.service.ts
+++ b/integration-tests/typescript-angular/src/generated/stripe.yaml/client.service.ts
@@ -412,7 +412,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_account[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -663,7 +663,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_capability[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -764,7 +764,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: (t_bank_account | t_card)[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -946,7 +946,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_person[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -1110,7 +1110,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_person[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -1290,7 +1290,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_apple_pay_domain[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -1423,7 +1423,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_application_fee[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -1589,7 +1589,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_fee_refund[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -1660,7 +1660,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_apps_secret[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -1838,7 +1838,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_balance_transaction[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -1939,7 +1939,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_balance_transaction[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -2018,7 +2018,7 @@ export class StripeApiService {
 
   getBillingAlerts(
     p: {
-      alertType?: "usage_threshold" | UnknownEnumStringValue
+      alertType?: "usage_threshold"
       endingBefore?: string
       expand?: string[]
       limit?: number
@@ -2030,7 +2030,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_billing_alert[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -2192,7 +2192,7 @@ export class StripeApiService {
     expand?: string[]
     filter: {
       applicability_scope?: {
-        price_type?: "metered" | UnknownEnumStringValue
+        price_type?: "metered"
         prices?: {
           id: string
         }[]
@@ -2246,7 +2246,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_billing_credit_balance_transaction[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -2330,7 +2330,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_billing_credit_grant[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -2541,7 +2541,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_billing_meter[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -2690,7 +2690,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_billing_meter_event_summary[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -2765,7 +2765,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_billing_portal_configuration[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -2924,7 +2924,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_charge[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -2999,7 +2999,7 @@ export class StripeApiService {
         data: t_charge[]
         has_more: boolean
         next_page?: string | null
-        object: "search_result" | UnknownEnumStringValue
+        object: "search_result"
         total_count?: number
         url: string
       }> & {status: 200})
@@ -3222,7 +3222,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_refund[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -3366,7 +3366,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_checkout_session[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -3525,7 +3525,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_item[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -3572,7 +3572,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_climate_order[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -3717,7 +3717,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_climate_product[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -3797,7 +3797,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_climate_supplier[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -3911,7 +3911,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_country_spec[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -3999,7 +3999,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_coupon[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -4159,7 +4159,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_credit_note[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -4241,8 +4241,7 @@ export class StripeApiService {
             taxable_amount: number
           }[]
         | ""
-        | UnknownEnumStringValue
-      tax_rates?: string[] | "" | UnknownEnumStringValue
+      tax_rates?: string[] | ""
       type: "custom_line_item" | "invoice_line_item" | UnknownEnumStringValue
       unit_amount?: number
       unit_amount_decimal?: string
@@ -4346,8 +4345,7 @@ export class StripeApiService {
             taxable_amount: number
           }[]
         | ""
-        | UnknownEnumStringValue
-      tax_rates?: string[] | "" | UnknownEnumStringValue
+      tax_rates?: string[] | ""
       type: "custom_line_item" | "invoice_line_item" | UnknownEnumStringValue
       unit_amount?: number
       unit_amount_decimal?: string
@@ -4375,7 +4373,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_credit_note_line_item[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -4450,7 +4448,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_credit_note_line_item[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -4605,7 +4603,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_customer[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -4679,7 +4677,7 @@ export class StripeApiService {
         data: t_customer[]
         has_more: boolean
         next_page?: string | null
-        object: "search_result" | UnknownEnumStringValue
+        object: "search_result"
         total_count?: number
         url: string
       }> & {status: 200})
@@ -4803,7 +4801,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_customer_balance_transaction[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -4932,7 +4930,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_bank_account[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -5109,7 +5107,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_card[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -5314,7 +5312,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_customer_cash_balance_transaction[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -5529,7 +5527,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_payment_method[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -5613,7 +5611,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: (t_bank_account | t_card | t_source)[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -5791,7 +5789,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_subscription[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -6001,7 +5999,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_tax_id[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -6139,7 +6137,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_dispute[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -6269,7 +6267,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_entitlements_active_entitlement[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -6352,7 +6350,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_entitlements_feature[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -6531,7 +6529,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_event[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -6623,7 +6621,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_exchange_rate[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -6735,7 +6733,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_file_link[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -6892,7 +6890,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_file[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -7005,7 +7003,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_financial_connections_account[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -7115,7 +7113,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_financial_connections_account_owner[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -7298,7 +7296,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_financial_connections_transaction[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -7396,7 +7394,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_forwarding_request[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -7513,7 +7511,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_identity_verification_report[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -7617,7 +7615,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_identity_verification_session[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -7792,7 +7790,7 @@ export class StripeApiService {
       limit?: number
       payment?: {
         payment_intent?: string
-        type: "payment_intent" | UnknownEnumStringValue
+        type: "payment_intent"
       }
       startingAfter?: string
       status?: "canceled" | "open" | "paid" | UnknownEnumStringValue
@@ -7802,7 +7800,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_invoice_payment[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -7890,7 +7888,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_invoice_rendering_template[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -8029,7 +8027,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_invoiceitem[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -8211,7 +8209,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_invoice[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -8313,7 +8311,7 @@ export class StripeApiService {
         data: t_invoice[]
         has_more: boolean
         next_page?: string | null
-        object: "search_result" | UnknownEnumStringValue
+        object: "search_result"
         total_count?: number
         url: string
       }> & {status: 200})
@@ -8503,7 +8501,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_line_item[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -8722,7 +8720,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_issuing_authorization[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -8890,7 +8888,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_issuing_cardholder[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -9037,7 +9035,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_issuing_card[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -9188,7 +9186,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_issuing_dispute[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -9351,7 +9349,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_issuing_personalization_design[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -9489,7 +9487,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_issuing_physical_bundle[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -9640,7 +9638,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_issuing_token[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -9760,7 +9758,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_issuing_transaction[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -9929,7 +9927,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_financial_connections_account[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -10037,7 +10035,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_financial_connections_account_owner[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -10149,7 +10147,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_payment_intent[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -10222,7 +10220,7 @@ export class StripeApiService {
         data: t_payment_intent[]
         has_more: boolean
         next_page?: string | null
-        object: "search_result" | UnknownEnumStringValue
+        object: "search_result"
         total_count?: number
         url: string
       }> & {status: 200})
@@ -10462,7 +10460,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_payment_link[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -10585,7 +10583,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_item[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -10622,7 +10620,7 @@ export class StripeApiService {
 
   getPaymentMethodConfigurations(
     p: {
-      application?: string | "" | UnknownEnumStringValue
+      application?: string | ""
       endingBefore?: string
       expand?: string[]
       limit?: number
@@ -10633,7 +10631,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_payment_method_configuration[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -10765,7 +10763,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_payment_method_domain[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -10966,7 +10964,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_payment_method[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -11153,7 +11151,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_payout[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -11342,7 +11340,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_plan[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -11512,7 +11510,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_price[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -11598,7 +11596,7 @@ export class StripeApiService {
         data: t_price[]
         has_more: boolean
         next_page?: string | null
-        object: "search_result" | UnknownEnumStringValue
+        object: "search_result"
         total_count?: number
         url: string
       }> & {status: 200})
@@ -11713,7 +11711,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_product[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -11793,7 +11791,7 @@ export class StripeApiService {
         data: t_product[]
         has_more: boolean
         next_page?: string | null
-        object: "search_result" | UnknownEnumStringValue
+        object: "search_result"
         total_count?: number
         url: string
       }> & {status: 200})
@@ -11917,7 +11915,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_product_feature[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -12055,7 +12053,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_promotion_code[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -12195,7 +12193,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_quote[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -12364,7 +12362,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_item[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -12433,7 +12431,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_item[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -12529,7 +12527,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_radar_early_fraud_warning[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -12625,7 +12623,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_radar_value_list_item[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -12765,7 +12763,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_radar_value_list[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -12927,7 +12925,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_refund[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -13087,7 +13085,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_reporting_report_run[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -13187,7 +13185,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_reporting_report_type[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -13270,7 +13268,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_review[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -13384,7 +13382,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_setup_attempt[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -13448,7 +13446,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_setup_intent[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -13657,7 +13655,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_shipping_rate[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -13809,7 +13807,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_scheduled_query_run[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -14001,7 +13999,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_source_transaction[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -14104,7 +14102,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_subscription_item[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -14284,7 +14282,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_subscription_schedule[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -14521,7 +14519,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_subscription[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -14613,7 +14611,7 @@ export class StripeApiService {
         data: t_subscription[]
         has_more: boolean
         next_page?: string | null
-        object: "search_result" | UnknownEnumStringValue
+        object: "search_result"
         total_count?: number
         url: string
       }> & {status: 200})
@@ -14858,7 +14856,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_tax_calculation_line_item[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -14912,7 +14910,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_tax_registration[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -15162,7 +15160,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_tax_transaction_line_item[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -15210,7 +15208,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_tax_code[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -15300,7 +15298,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_tax_id[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -15438,7 +15436,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_tax_rate[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -15569,7 +15567,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_terminal_configuration[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -15743,7 +15741,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_terminal_location[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -15906,7 +15904,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_terminal_reader[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -16832,7 +16830,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_test_helpers_test_clock[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -17349,7 +17347,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_topup[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -17515,7 +17513,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_transfer[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -17589,7 +17587,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_transfer_reversal[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -17773,7 +17771,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_treasury_credit_reversal[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -17880,7 +17878,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_treasury_debit_reversal[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -17995,7 +17993,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_treasury_financial_account[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -18211,7 +18209,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_treasury_inbound_transfer[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -18352,7 +18350,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_treasury_outbound_payment[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -18489,7 +18487,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_treasury_outbound_transfer[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -18625,7 +18623,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_treasury_received_credit[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -18712,7 +18710,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_treasury_received_debit[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -18811,7 +18809,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_treasury_transaction_entry[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -18923,7 +18921,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_treasury_transaction[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})
@@ -19016,7 +19014,7 @@ export class StripeApiService {
     | (HttpResponse<{
         data: t_webhook_endpoint[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }> & {status: 200})
     | (HttpResponse<t_error> & {status: StatusCode})

--- a/integration-tests/typescript-angular/src/generated/stripe.yaml/models.ts
+++ b/integration-tests/typescript-angular/src/generated/stripe.yaml/models.ts
@@ -27,7 +27,7 @@ export type t_account = {
   external_accounts?: {
     data: (t_bank_account | t_card)[]
     has_more: boolean
-    object: "list" | UnknownEnumStringValue
+    object: "list"
     url: string
   }
   future_requirements?: t_account_future_requirements
@@ -35,7 +35,7 @@ export type t_account = {
   id: string
   individual?: t_person
   metadata?: Record<string, string>
-  object: "account" | UnknownEnumStringValue
+  object: "account"
   payouts_enabled?: boolean
   requirements?: t_account_requirements
   settings?: t_account_settings | null
@@ -367,7 +367,7 @@ export type t_account_invoices_settings = {
 export type t_account_link = {
   created: number
   expires_at: number
-  object: "account_link" | UnknownEnumStringValue
+  object: "account_link"
   url: string
 }
 
@@ -532,7 +532,7 @@ export type t_account_session = {
   components: t_connect_embedded_account_session_create_components
   expires_at: number
   livemode: boolean
-  object: "account_session" | UnknownEnumStringValue
+  object: "account_session"
 }
 
 export type t_account_settings = {
@@ -602,7 +602,7 @@ export type t_address = {
 
 export type t_amazon_pay_underlying_payment_method_funding_details = {
   card?: t_payment_method_details_passthrough_card
-  type?: "card" | UnknownEnumStringValue | null
+  type?: "card" | null
 }
 
 export type t_api_errors = {
@@ -634,13 +634,13 @@ export type t_apple_pay_domain = {
   domain_name: string
   id: string
   livemode: boolean
-  object: "apple_pay_domain" | UnknownEnumStringValue
+  object: "apple_pay_domain"
 }
 
 export type t_application = {
   id: string
   name?: string | null
-  object: "application" | UnknownEnumStringValue
+  object: "application"
 }
 
 export type t_application_fee = {
@@ -655,13 +655,13 @@ export type t_application_fee = {
   fee_source?: t_platform_earning_fee_source | null
   id: string
   livemode: boolean
-  object: "application_fee" | UnknownEnumStringValue
+  object: "application_fee"
   originating_transaction?: string | t_charge | null
   refunded: boolean
   refunds: {
     data: t_fee_refund[]
     has_more: boolean
-    object: "list" | UnknownEnumStringValue
+    object: "list"
     url: string
   }
 }
@@ -673,7 +673,7 @@ export type t_apps_secret = {
   id: string
   livemode: boolean
   name: string
-  object: "apps.secret" | UnknownEnumStringValue
+  object: "apps.secret"
   payload?: string | null
   scope: t_secret_service_resource_scope
 }
@@ -701,7 +701,7 @@ export type t_balance = {
   instant_available?: t_balance_amount_net[]
   issuing?: t_balance_detail
   livemode: boolean
-  object: "balance" | UnknownEnumStringValue
+  object: "balance"
   pending: t_balance_amount[]
   refund_and_dispute_prefunding?: t_balance_detail_ungated
 }
@@ -756,7 +756,7 @@ export type t_balance_transaction = {
   fee_details: t_fee[]
   id: string
   net: number
-  object: "balance_transaction" | UnknownEnumStringValue
+  object: "balance_transaction"
   reporting_category: string
   source?:
     | string
@@ -844,7 +844,7 @@ export type t_bank_account = {
   id: string
   last4: string
   metadata?: Record<string, string> | null
-  object: "bank_account" | UnknownEnumStringValue
+  object: "bank_account"
   requirements?: t_external_account_requirements | null
   routing_number?: string | null
   status: string
@@ -912,10 +912,10 @@ export type t_bank_connections_resource_transaction_resource_status_transitions 
   }
 
 export type t_billing_alert = {
-  alert_type: "usage_threshold" | UnknownEnumStringValue
+  alert_type: "usage_threshold"
   id: string
   livemode: boolean
-  object: "billing.alert" | UnknownEnumStringValue
+  object: "billing.alert"
   status?: "active" | "archived" | "inactive" | UnknownEnumStringValue | null
   title: string
   usage_threshold?: t_thresholds_resource_usage_threshold_config | null
@@ -925,7 +925,7 @@ export type t_billing_credit_balance_summary = {
   balances: t_credit_balance[]
   customer: string | t_customer | t_deleted_customer
   livemode: boolean
-  object: "billing.credit_balance_summary" | UnknownEnumStringValue
+  object: "billing.credit_balance_summary"
 }
 
 export type t_billing_credit_balance_transaction = {
@@ -936,7 +936,7 @@ export type t_billing_credit_balance_transaction = {
   effective_at: number
   id: string
   livemode: boolean
-  object: "billing.credit_balance_transaction" | UnknownEnumStringValue
+  object: "billing.credit_balance_transaction"
   test_clock?: string | t_test_helpers_test_clock | null
   type?: "credit" | "debit" | UnknownEnumStringValue | null
 }
@@ -953,7 +953,7 @@ export type t_billing_credit_grant = {
   livemode: boolean
   metadata: Record<string, string>
   name?: string | null
-  object: "billing.credit_grant" | UnknownEnumStringValue
+  object: "billing.credit_grant"
   priority?: number | null
   test_clock?: string | t_test_helpers_test_clock | null
   updated: number
@@ -969,7 +969,7 @@ export type t_billing_meter = {
   event_time_window?: "day" | "hour" | UnknownEnumStringValue | null
   id: string
   livemode: boolean
-  object: "billing.meter" | UnknownEnumStringValue
+  object: "billing.meter"
   status: "active" | "inactive" | UnknownEnumStringValue
   status_transitions: t_billing_meter_resource_billing_meter_status_transitions
   updated: number
@@ -981,7 +981,7 @@ export type t_billing_meter_event = {
   event_name: string
   identifier: string
   livemode: boolean
-  object: "billing.meter_event" | UnknownEnumStringValue
+  object: "billing.meter_event"
   payload: Record<string, string>
   timestamp: number
 }
@@ -990,9 +990,9 @@ export type t_billing_meter_event_adjustment = {
   cancel?: t_billing_meter_resource_billing_meter_event_adjustment_cancel | null
   event_name: string
   livemode: boolean
-  object: "billing.meter_event_adjustment" | UnknownEnumStringValue
+  object: "billing.meter_event_adjustment"
   status: "complete" | "pending" | UnknownEnumStringValue
-  type: "cancel" | UnknownEnumStringValue
+  type: "cancel"
 }
 
 export type t_billing_meter_event_summary = {
@@ -1001,13 +1001,13 @@ export type t_billing_meter_event_summary = {
   id: string
   livemode: boolean
   meter: string
-  object: "billing.meter_event_summary" | UnknownEnumStringValue
+  object: "billing.meter_event_summary"
   start_time: number
 }
 
 export type t_billing_bill_resource_invoice_item_parents_invoice_item_parent = {
   subscription_details?: t_billing_bill_resource_invoice_item_parents_invoice_item_subscription_parent | null
-  type: "subscription_details" | UnknownEnumStringValue
+  type: "subscription_details"
 }
 
 export type t_billing_bill_resource_invoice_item_parents_invoice_item_subscription_parent =
@@ -1071,7 +1071,7 @@ export type t_billing_bill_resource_invoicing_parents_invoice_subscription_paren
 
 export type t_billing_bill_resource_invoicing_pricing_pricing = {
   price_details?: t_billing_bill_resource_invoicing_pricing_pricing_price_details
-  type: "price_details" | UnknownEnumStringValue
+  type: "price_details"
   unit_amount_decimal?: string | null
 }
 
@@ -1103,7 +1103,7 @@ export type t_billing_bill_resource_invoicing_taxes_tax = {
     | "zero_rated"
     | UnknownEnumStringValue
   taxable_amount?: number | null
-  type: "tax_rate_details" | UnknownEnumStringValue
+  type: "tax_rate_details"
 }
 
 export type t_billing_bill_resource_invoicing_taxes_tax_rate_details = {
@@ -1121,7 +1121,7 @@ export type t_billing_clocks_resource_status_details_status_details = {
 
 export type t_billing_credit_grants_resource_amount = {
   monetary?: t_billing_credit_grants_resource_monetary_amount | null
-  type: "monetary" | UnknownEnumStringValue
+  type: "monetary"
 }
 
 export type t_billing_credit_grants_resource_applicability_config = {
@@ -1168,7 +1168,7 @@ export type t_billing_credit_grants_resource_monetary_amount = {
 }
 
 export type t_billing_credit_grants_resource_scope = {
-  price_type?: "metered" | UnknownEnumStringValue
+  price_type?: "metered"
   prices?: t_billing_credit_grants_resource_applicable_price[]
 }
 
@@ -1198,7 +1198,7 @@ export type t_billing_meter_resource_billing_meter_value = {
 
 export type t_billing_meter_resource_customer_mapping_settings = {
   event_payload_key: string
-  type: "by_id" | UnknownEnumStringValue
+  type: "by_id"
 }
 
 export type t_billing_portal_configuration = {
@@ -1213,7 +1213,7 @@ export type t_billing_portal_configuration = {
   livemode: boolean
   login_page: t_portal_login_page
   metadata?: Record<string, string> | null
-  object: "billing_portal.configuration" | UnknownEnumStringValue
+  object: "billing_portal.configuration"
   updated: number
 }
 
@@ -1274,7 +1274,7 @@ export type t_billing_portal_session = {
     | "zh-TW"
     | UnknownEnumStringValue
     | null
-  object: "billing_portal.session" | UnknownEnumStringValue
+  object: "billing_portal.session"
   on_behalf_of?: string | null
   return_url?: string | null
   url: string
@@ -1305,7 +1305,7 @@ export type t_capability = {
   account: string | t_account
   future_requirements?: t_account_capability_future_requirements
   id: string
-  object: "capability" | UnknownEnumStringValue
+  object: "capability"
   requested: boolean
   requested_at?: number | null
   requirements?: t_account_capability_requirements
@@ -1353,7 +1353,7 @@ export type t_card = {
   metadata?: Record<string, string> | null
   name?: string | null
   networks?: t_token_card_networks
-  object: "card" | UnknownEnumStringValue
+  object: "card"
   regulated_status?: "regulated" | "unregulated" | UnknownEnumStringValue | null
   status?: string | null
   tokenization_method?: string | null
@@ -1376,7 +1376,7 @@ export type t_cash_balance = {
   available?: Record<string, number> | null
   customer: string
   livemode: boolean
-  object: "cash_balance" | UnknownEnumStringValue
+  object: "cash_balance"
   settings: t_customer_balance_customer_balance_settings
 }
 
@@ -1403,7 +1403,7 @@ export type t_charge = {
   id: string
   livemode: boolean
   metadata: Record<string, string>
-  object: "charge" | UnknownEnumStringValue
+  object: "charge"
   on_behalf_of?: string | t_account | null
   outcome?: t_charge_outcome | null
   paid: boolean
@@ -1419,7 +1419,7 @@ export type t_charge = {
   refunds?: {
     data: t_refund[]
     has_more: boolean
-    object: "list" | UnknownEnumStringValue
+    object: "list"
     url: string
   } | null
   review?: string | t_review | null
@@ -1496,7 +1496,7 @@ export type t_checkout_session = {
   line_items?: {
     data: t_item[]
     has_more: boolean
-    object: "list" | UnknownEnumStringValue
+    object: "list"
     url: string
   }
   livemode: boolean
@@ -1546,7 +1546,7 @@ export type t_checkout_session = {
     | null
   metadata?: Record<string, string> | null
   mode: "payment" | "setup" | "subscription" | UnknownEnumStringValue
-  object: "checkout.session" | UnknownEnumStringValue
+  object: "checkout.session"
   optional_items?: t_payment_pages_checkout_session_optional_item[] | null
   origin_context?: "mobile_app" | "web" | UnknownEnumStringValue | null
   payment_intent?: string | t_payment_intent | null
@@ -1627,15 +1627,15 @@ export type t_checkout_acss_debit_payment_method_options = {
 }
 
 export type t_checkout_affirm_payment_method_options = {
-  setup_future_usage?: "none" | UnknownEnumStringValue
+  setup_future_usage?: "none"
 }
 
 export type t_checkout_afterpay_clearpay_payment_method_options = {
-  setup_future_usage?: "none" | UnknownEnumStringValue
+  setup_future_usage?: "none"
 }
 
 export type t_checkout_alipay_payment_method_options = {
-  setup_future_usage?: "none" | UnknownEnumStringValue
+  setup_future_usage?: "none"
 }
 
 export type t_checkout_amazon_pay_payment_method_options = {
@@ -1643,7 +1643,7 @@ export type t_checkout_amazon_pay_payment_method_options = {
 }
 
 export type t_checkout_au_becs_debit_payment_method_options = {
-  setup_future_usage?: "none" | UnknownEnumStringValue
+  setup_future_usage?: "none"
   target_date?: string
 }
 
@@ -1658,7 +1658,7 @@ export type t_checkout_bacs_debit_payment_method_options = {
 }
 
 export type t_checkout_bancontact_payment_method_options = {
-  setup_future_usage?: "none" | UnknownEnumStringValue
+  setup_future_usage?: "none"
 }
 
 export type t_checkout_boleto_payment_method_options = {
@@ -1702,7 +1702,7 @@ export type t_checkout_card_payment_method_options = {
 }
 
 export type t_checkout_cashapp_payment_method_options = {
-  setup_future_usage?: "none" | UnknownEnumStringValue
+  setup_future_usage?: "none"
 }
 
 export type t_checkout_customer_balance_bank_transfer_payment_method_options = {
@@ -1729,32 +1729,32 @@ export type t_checkout_customer_balance_bank_transfer_payment_method_options = {
 
 export type t_checkout_customer_balance_payment_method_options = {
   bank_transfer?: t_checkout_customer_balance_bank_transfer_payment_method_options
-  funding_type?: "bank_transfer" | UnknownEnumStringValue | null
-  setup_future_usage?: "none" | UnknownEnumStringValue
+  funding_type?: "bank_transfer" | null
+  setup_future_usage?: "none"
 }
 
 export type t_checkout_eps_payment_method_options = {
-  setup_future_usage?: "none" | UnknownEnumStringValue
+  setup_future_usage?: "none"
 }
 
 export type t_checkout_fpx_payment_method_options = {
-  setup_future_usage?: "none" | UnknownEnumStringValue
+  setup_future_usage?: "none"
 }
 
 export type t_checkout_giropay_payment_method_options = {
-  setup_future_usage?: "none" | UnknownEnumStringValue
+  setup_future_usage?: "none"
 }
 
 export type t_checkout_grab_pay_payment_method_options = {
-  setup_future_usage?: "none" | UnknownEnumStringValue
+  setup_future_usage?: "none"
 }
 
 export type t_checkout_ideal_payment_method_options = {
-  setup_future_usage?: "none" | UnknownEnumStringValue
+  setup_future_usage?: "none"
 }
 
 export type t_checkout_kakao_pay_payment_method_options = {
-  capture_method?: "manual" | UnknownEnumStringValue
+  capture_method?: "manual"
   setup_future_usage?: "none" | "off_session" | UnknownEnumStringValue
 }
 
@@ -1768,11 +1768,11 @@ export type t_checkout_klarna_payment_method_options = {
 
 export type t_checkout_konbini_payment_method_options = {
   expires_after_days?: number | null
-  setup_future_usage?: "none" | UnknownEnumStringValue
+  setup_future_usage?: "none"
 }
 
 export type t_checkout_kr_card_payment_method_options = {
-  capture_method?: "manual" | UnknownEnumStringValue
+  capture_method?: "manual"
   setup_future_usage?: "none" | "off_session" | UnknownEnumStringValue
 }
 
@@ -1785,29 +1785,29 @@ export type t_checkout_link_wallet_options = {
 }
 
 export type t_checkout_mobilepay_payment_method_options = {
-  setup_future_usage?: "none" | UnknownEnumStringValue
+  setup_future_usage?: "none"
 }
 
 export type t_checkout_multibanco_payment_method_options = {
-  setup_future_usage?: "none" | UnknownEnumStringValue
+  setup_future_usage?: "none"
 }
 
 export type t_checkout_naver_pay_payment_method_options = {
-  capture_method?: "manual" | UnknownEnumStringValue
+  capture_method?: "manual"
   setup_future_usage?: "none" | "off_session" | UnknownEnumStringValue
 }
 
 export type t_checkout_oxxo_payment_method_options = {
   expires_after_days: number
-  setup_future_usage?: "none" | UnknownEnumStringValue
+  setup_future_usage?: "none"
 }
 
 export type t_checkout_p24_payment_method_options = {
-  setup_future_usage?: "none" | UnknownEnumStringValue
+  setup_future_usage?: "none"
 }
 
 export type t_checkout_payco_payment_method_options = {
-  capture_method?: "manual" | UnknownEnumStringValue
+  capture_method?: "manual"
 }
 
 export type t_checkout_payment_method_options_mandate_options_bacs_debit = {
@@ -1819,11 +1819,11 @@ export type t_checkout_payment_method_options_mandate_options_sepa_debit = {
 }
 
 export type t_checkout_paynow_payment_method_options = {
-  setup_future_usage?: "none" | UnknownEnumStringValue
+  setup_future_usage?: "none"
 }
 
 export type t_checkout_paypal_payment_method_options = {
-  capture_method?: "manual" | UnknownEnumStringValue
+  capture_method?: "manual"
   preferred_locale?: string | null
   reference?: string | null
   setup_future_usage?: "none" | "off_session" | UnknownEnumStringValue
@@ -1831,7 +1831,7 @@ export type t_checkout_paypal_payment_method_options = {
 
 export type t_checkout_pix_payment_method_options = {
   expires_after_seconds?: number | null
-  setup_future_usage?: "none" | UnknownEnumStringValue
+  setup_future_usage?: "none"
 }
 
 export type t_checkout_revolut_pay_payment_method_options = {
@@ -1839,7 +1839,7 @@ export type t_checkout_revolut_pay_payment_method_options = {
 }
 
 export type t_checkout_samsung_pay_payment_method_options = {
-  capture_method?: "manual" | UnknownEnumStringValue
+  capture_method?: "manual"
 }
 
 export type t_checkout_sepa_debit_payment_method_options = {
@@ -1897,7 +1897,7 @@ export type t_checkout_session_wallet_options = {
 }
 
 export type t_checkout_sofort_payment_method_options = {
-  setup_future_usage?: "none" | UnknownEnumStringValue
+  setup_future_usage?: "none"
 }
 
 export type t_checkout_swish_payment_method_options = {
@@ -1939,7 +1939,7 @@ export type t_climate_order = {
   livemode: boolean
   metadata: Record<string, string>
   metric_tons: string
-  object: "climate.order" | UnknownEnumStringValue
+  object: "climate.order"
   product: string | t_climate_product
   product_substituted_at?: number | null
   status:
@@ -1962,7 +1962,7 @@ export type t_climate_product = {
   livemode: boolean
   metric_tons_available: string
   name: string
-  object: "climate.product" | UnknownEnumStringValue
+  object: "climate.product"
   suppliers: t_climate_supplier[]
 }
 
@@ -1972,7 +1972,7 @@ export type t_climate_supplier = {
   livemode: boolean
   locations: t_climate_removals_location[]
   name: string
-  object: "climate.supplier" | UnknownEnumStringValue
+  object: "climate.supplier"
   removal_pathway:
     | "biomass_carbon_removal_and_storage"
     | "direct_air_capture"
@@ -2012,7 +2012,7 @@ export type t_confirmation_token = {
   id: string
   livemode: boolean
   mandate_data?: t_confirmation_tokens_resource_mandate_data | null
-  object: "confirmation_token" | UnknownEnumStringValue
+  object: "confirmation_token"
   payment_intent?: string | null
   payment_method_options?: t_confirmation_tokens_resource_payment_method_options | null
   payment_method_preview?: t_confirmation_tokens_resource_payment_method_preview | null
@@ -2187,7 +2187,7 @@ export type t_connect_collection_transfer = {
   destination: string | t_account
   id: string
   livemode: boolean
-  object: "connect_collection_transfer" | UnknownEnumStringValue
+  object: "connect_collection_transfer"
 }
 
 export type t_connect_embedded_account_config_claim = {
@@ -2336,7 +2336,7 @@ export type t_connect_embedded_payouts_features = {
 export type t_country_spec = {
   default_currency: string
   id: string
-  object: "country_spec" | UnknownEnumStringValue
+  object: "country_spec"
   supported_bank_account_currencies: Record<string, string[]>
   supported_payment_currencies: string[]
   supported_payment_methods: string[]
@@ -2367,7 +2367,7 @@ export type t_coupon = {
   max_redemptions?: number | null
   metadata?: Record<string, string> | null
   name?: string | null
-  object: "coupon" | UnknownEnumStringValue
+  object: "coupon"
   percent_off?: number | null
   redeem_by?: number | null
   times_redeemed: number
@@ -2402,14 +2402,14 @@ export type t_credit_note = {
   lines: {
     data: t_credit_note_line_item[]
     has_more: boolean
-    object: "list" | UnknownEnumStringValue
+    object: "list"
     url: string
   }
   livemode: boolean
   memo?: string | null
   metadata?: Record<string, string> | null
   number: string
-  object: "credit_note" | UnknownEnumStringValue
+  object: "credit_note"
   out_of_band_amount?: number | null
   pdf: string
   post_payment_amount: number
@@ -2442,7 +2442,7 @@ export type t_credit_note_line_item = {
   id: string
   invoice_line_item?: string
   livemode: boolean
-  object: "credit_note_line_item" | UnknownEnumStringValue
+  object: "credit_note_line_item"
   pretax_credit_amounts: t_credit_notes_pretax_credit_amount[]
   quantity?: number | null
   tax_rates: t_tax_rate[]
@@ -2502,20 +2502,20 @@ export type t_customer = {
   metadata?: Record<string, string>
   name?: string | null
   next_invoice_sequence?: number
-  object: "customer" | UnknownEnumStringValue
+  object: "customer"
   phone?: string | null
   preferred_locales?: string[] | null
   shipping?: t_shipping | null
   sources?: {
     data: (t_bank_account | t_card | t_source)[]
     has_more: boolean
-    object: "list" | UnknownEnumStringValue
+    object: "list"
     url: string
   }
   subscriptions?: {
     data: t_subscription[]
     has_more: boolean
-    object: "list" | UnknownEnumStringValue
+    object: "list"
     url: string
   }
   tax?: t_customer_tax
@@ -2523,7 +2523,7 @@ export type t_customer = {
   tax_ids?: {
     data: t_tax_id[]
     has_more: boolean
-    object: "list" | UnknownEnumStringValue
+    object: "list"
     url: string
   }
   test_clock?: string | t_test_helpers_test_clock | null
@@ -2628,7 +2628,7 @@ export type t_customer_balance_transaction = {
   invoice?: string | t_invoice | null
   livemode: boolean
   metadata?: Record<string, string> | null
-  object: "customer_balance_transaction" | UnknownEnumStringValue
+  object: "customer_balance_transaction"
   type:
     | "adjustment"
     | "applied_to_invoice"
@@ -2656,7 +2656,7 @@ export type t_customer_cash_balance_transaction = {
   id: string
   livemode: boolean
   net_amount: number
-  object: "customer_cash_balance_transaction" | UnknownEnumStringValue
+  object: "customer_cash_balance_transaction"
   refunded_from_payment?: t_customer_balance_resource_cash_balance_transaction_resource_refunded_from_payment_transaction
   transferred_to_balance?: t_customer_balance_resource_cash_balance_transaction_resource_transferred_to_balance
   type:
@@ -2680,7 +2680,7 @@ export type t_customer_session = {
   customer: string | t_customer
   expires_at: number
   livemode: boolean
-  object: "customer_session" | UnknownEnumStringValue
+  object: "customer_session"
 }
 
 export type t_customer_session_resource_components = {
@@ -2746,46 +2746,46 @@ export type t_customer_tax_location = {
 export type t_deleted_account = {
   deleted: true
   id: string
-  object: "account" | UnknownEnumStringValue
+  object: "account"
 }
 
 export type t_deleted_apple_pay_domain = {
   deleted: true
   id: string
-  object: "apple_pay_domain" | UnknownEnumStringValue
+  object: "apple_pay_domain"
 }
 
 export type t_deleted_application = {
   deleted: true
   id: string
   name?: string | null
-  object: "application" | UnknownEnumStringValue
+  object: "application"
 }
 
 export type t_deleted_bank_account = {
   currency?: string | null
   deleted: true
   id: string
-  object: "bank_account" | UnknownEnumStringValue
+  object: "bank_account"
 }
 
 export type t_deleted_card = {
   currency?: string | null
   deleted: true
   id: string
-  object: "card" | UnknownEnumStringValue
+  object: "card"
 }
 
 export type t_deleted_coupon = {
   deleted: true
   id: string
-  object: "coupon" | UnknownEnumStringValue
+  object: "coupon"
 }
 
 export type t_deleted_customer = {
   deleted: true
   id: string
-  object: "customer" | UnknownEnumStringValue
+  object: "customer"
 }
 
 export type t_deleted_discount = {
@@ -2796,7 +2796,7 @@ export type t_deleted_discount = {
   id: string
   invoice?: string | null
   invoice_item?: string | null
-  object: "discount" | UnknownEnumStringValue
+  object: "discount"
   promotion_code?: string | t_promotion_code | null
   start: number
   subscription?: string | null
@@ -2808,13 +2808,13 @@ export type t_deleted_external_account = t_deleted_bank_account | t_deleted_card
 export type t_deleted_invoice = {
   deleted: true
   id: string
-  object: "invoice" | UnknownEnumStringValue
+  object: "invoice"
 }
 
 export type t_deleted_invoiceitem = {
   deleted: true
   id: string
-  object: "invoiceitem" | UnknownEnumStringValue
+  object: "invoiceitem"
 }
 
 export type t_deleted_payment_source = t_deleted_bank_account | t_deleted_card
@@ -2822,85 +2822,85 @@ export type t_deleted_payment_source = t_deleted_bank_account | t_deleted_card
 export type t_deleted_person = {
   deleted: true
   id: string
-  object: "person" | UnknownEnumStringValue
+  object: "person"
 }
 
 export type t_deleted_plan = {
   deleted: true
   id: string
-  object: "plan" | UnknownEnumStringValue
+  object: "plan"
 }
 
 export type t_deleted_price = {
   deleted: true
   id: string
-  object: "price" | UnknownEnumStringValue
+  object: "price"
 }
 
 export type t_deleted_product = {
   deleted: true
   id: string
-  object: "product" | UnknownEnumStringValue
+  object: "product"
 }
 
 export type t_deleted_product_feature = {
   deleted: true
   id: string
-  object: "product_feature" | UnknownEnumStringValue
+  object: "product_feature"
 }
 
 export type t_deleted_radar_value_list = {
   deleted: true
   id: string
-  object: "radar.value_list" | UnknownEnumStringValue
+  object: "radar.value_list"
 }
 
 export type t_deleted_radar_value_list_item = {
   deleted: true
   id: string
-  object: "radar.value_list_item" | UnknownEnumStringValue
+  object: "radar.value_list_item"
 }
 
 export type t_deleted_subscription_item = {
   deleted: true
   id: string
-  object: "subscription_item" | UnknownEnumStringValue
+  object: "subscription_item"
 }
 
 export type t_deleted_tax_id = {
   deleted: true
   id: string
-  object: "tax_id" | UnknownEnumStringValue
+  object: "tax_id"
 }
 
 export type t_deleted_terminal_configuration = {
   deleted: true
   id: string
-  object: "terminal.configuration" | UnknownEnumStringValue
+  object: "terminal.configuration"
 }
 
 export type t_deleted_terminal_location = {
   deleted: true
   id: string
-  object: "terminal.location" | UnknownEnumStringValue
+  object: "terminal.location"
 }
 
 export type t_deleted_terminal_reader = {
   deleted: true
   id: string
-  object: "terminal.reader" | UnknownEnumStringValue
+  object: "terminal.reader"
 }
 
 export type t_deleted_test_helpers_test_clock = {
   deleted: true
   id: string
-  object: "test_helpers.test_clock" | UnknownEnumStringValue
+  object: "test_helpers.test_clock"
 }
 
 export type t_deleted_webhook_endpoint = {
   deleted: true
   id: string
-  object: "webhook_endpoint" | UnknownEnumStringValue
+  object: "webhook_endpoint"
 }
 
 export type t_destination_details_unimplemented = Record<string, unknown>
@@ -2913,7 +2913,7 @@ export type t_discount = {
   id: string
   invoice?: string | null
   invoice_item?: string | null
-  object: "discount" | UnknownEnumStringValue
+  object: "discount"
   promotion_code?: string | t_promotion_code | null
   start: number
   subscription?: string | null
@@ -2948,7 +2948,7 @@ export type t_dispute = {
   is_charge_refundable: boolean
   livemode: boolean
   metadata: Record<string, string>
-  object: "dispute" | UnknownEnumStringValue
+  object: "dispute"
   payment_intent?: string | t_payment_intent | null
   payment_method_details?: t_dispute_payment_method_details
   reason: string
@@ -3116,7 +3116,7 @@ export type t_entitlements_active_entitlement = {
   id: string
   livemode: boolean
   lookup_key: string
-  object: "entitlements.active_entitlement" | UnknownEnumStringValue
+  object: "entitlements.active_entitlement"
 }
 
 export type t_entitlements_feature = {
@@ -3126,7 +3126,7 @@ export type t_entitlements_feature = {
   lookup_key: string
   metadata: Record<string, string>
   name: string
-  object: "entitlements.feature" | UnknownEnumStringValue
+  object: "entitlements.feature"
 }
 
 export type t_ephemeral_key = {
@@ -3134,7 +3134,7 @@ export type t_ephemeral_key = {
   expires: number
   id: string
   livemode: boolean
-  object: "ephemeral_key" | UnknownEnumStringValue
+  object: "ephemeral_key"
   secret?: string
 }
 
@@ -3150,7 +3150,7 @@ export type t_event = {
   data: t_notification_event_data
   id: string
   livemode: boolean
-  object: "event" | UnknownEnumStringValue
+  object: "event"
   pending_webhooks: number
   request?: t_notification_event_request | null
   type: string
@@ -3158,7 +3158,7 @@ export type t_event = {
 
 export type t_exchange_rate = {
   id: string
-  object: "exchange_rate" | UnknownEnumStringValue
+  object: "exchange_rate"
   rates: Record<string, number>
 }
 
@@ -3187,7 +3187,7 @@ export type t_fee_refund = {
   fee: string | t_application_fee
   id: string
   metadata?: Record<string, string> | null
-  object: "fee_refund" | UnknownEnumStringValue
+  object: "fee_refund"
 }
 
 export type t_file = {
@@ -3198,10 +3198,10 @@ export type t_file = {
   links?: {
     data: t_file_link[]
     has_more: boolean
-    object: "list" | UnknownEnumStringValue
+    object: "list"
     url: string
   } | null
-  object: "file" | UnknownEnumStringValue
+  object: "file"
   purpose:
     | "account_requirement"
     | "additional_verification"
@@ -3235,7 +3235,7 @@ export type t_file_link = {
   id: string
   livemode: boolean
   metadata: Record<string, string>
-  object: "file_link" | UnknownEnumStringValue
+  object: "file_link"
   url?: string | null
 }
 
@@ -3250,7 +3250,7 @@ export type t_financial_connections_account = {
   institution_name: string
   last4?: string | null
   livemode: boolean
-  object: "financial_connections.account" | UnknownEnumStringValue
+  object: "financial_connections.account"
   ownership?: string | t_financial_connections_account_ownership | null
   ownership_refresh?: t_bank_connections_resource_ownership_refresh | null
   permissions?:
@@ -3271,7 +3271,7 @@ export type t_financial_connections_account = {
     | "other"
     | "savings"
     | UnknownEnumStringValue
-  subscriptions?: ("transactions" | UnknownEnumStringValue)[] | null
+  subscriptions?: "transactions"[] | null
   supported_payment_method_types: (
     | "link"
     | "us_bank_account"
@@ -3284,7 +3284,7 @@ export type t_financial_connections_account_owner = {
   email?: string | null
   id: string
   name: string
-  object: "financial_connections.account_owner" | UnknownEnumStringValue
+  object: "financial_connections.account_owner"
   ownership: string
   phone?: string | null
   raw_address?: string | null
@@ -3294,11 +3294,11 @@ export type t_financial_connections_account_owner = {
 export type t_financial_connections_account_ownership = {
   created: number
   id: string
-  object: "financial_connections.account_ownership" | UnknownEnumStringValue
+  object: "financial_connections.account_ownership"
   owners: {
     data: t_financial_connections_account_owner[]
     has_more: boolean
-    object: "list" | UnknownEnumStringValue
+    object: "list"
     url: string
   }
 }
@@ -3308,14 +3308,14 @@ export type t_financial_connections_session = {
   accounts: {
     data: t_financial_connections_account[]
     has_more: boolean
-    object: "list" | UnknownEnumStringValue
+    object: "list"
     url: string
   }
   client_secret: string
   filters?: t_bank_connections_resource_link_account_session_filters
   id: string
   livemode: boolean
-  object: "financial_connections.session" | UnknownEnumStringValue
+  object: "financial_connections.session"
   permissions: (
     | "balances"
     | "ownership"
@@ -3336,7 +3336,7 @@ export type t_financial_connections_transaction = {
   description: string
   id: string
   livemode: boolean
-  object: "financial_connections.transaction" | UnknownEnumStringValue
+  object: "financial_connections.transaction"
   status: "pending" | "posted" | "void" | UnknownEnumStringValue
   status_transitions: t_bank_connections_resource_transaction_resource_status_transitions
   transacted_at: number
@@ -3363,7 +3363,7 @@ export type t_forwarded_request_context = {
 export type t_forwarded_request_details = {
   body: string
   headers: t_forwarded_request_header[]
-  http_method: "POST" | UnknownEnumStringValue
+  http_method: "POST"
 }
 
 export type t_forwarded_request_header = {
@@ -3382,7 +3382,7 @@ export type t_forwarding_request = {
   id: string
   livemode: boolean
   metadata?: Record<string, string> | null
-  object: "forwarding.request" | UnknownEnumStringValue
+  object: "forwarding.request"
   payment_method: string
   replacements: (
     | "card_cvc"
@@ -3401,9 +3401,9 @@ export type t_forwarding_request = {
 export type t_funding_instructions = {
   bank_transfer: t_funding_instructions_bank_transfer
   currency: string
-  funding_type: "bank_transfer" | UnknownEnumStringValue
+  funding_type: "bank_transfer"
   livemode: boolean
-  object: "funding_instructions" | UnknownEnumStringValue
+  object: "funding_instructions"
 }
 
 export type t_funding_instructions_bank_transfer = {
@@ -3763,7 +3763,7 @@ export type t_identity_verification_report = {
   id: string
   id_number?: t_gelato_id_number_report
   livemode: boolean
-  object: "identity.verification_report" | UnknownEnumStringValue
+  object: "identity.verification_report"
   options?: t_gelato_verification_report_options
   phone?: t_gelato_phone_report
   selfie?: t_gelato_selfie_report
@@ -3781,7 +3781,7 @@ export type t_identity_verification_session = {
   last_verification_report?: string | t_identity_verification_report | null
   livemode: boolean
   metadata: Record<string, string>
-  object: "identity.verification_session" | UnknownEnumStringValue
+  object: "identity.verification_session"
   options?: t_gelato_verification_session_options | null
   provided_details?: t_gelato_provided_details | null
   redaction?: t_verification_session_redaction | null
@@ -3801,7 +3801,7 @@ export type t_identity_verification_session = {
 
 export type t_inbound_transfers = {
   billing_details: t_treasury_shared_resource_billing_details
-  type: "us_bank_account" | UnknownEnumStringValue
+  type: "us_bank_account"
   us_bank_account?: t_inbound_transfers_payment_method_details_us_bank_account
 }
 
@@ -3812,7 +3812,7 @@ export type t_inbound_transfers_payment_method_details_us_bank_account = {
   fingerprint?: string | null
   last4?: string | null
   mandate?: string | t_mandate
-  network: "ach" | UnknownEnumStringValue
+  network: "ach"
   routing_number?: string | null
 }
 
@@ -3891,21 +3891,21 @@ export type t_invoice = {
   lines: {
     data: t_line_item[]
     has_more: boolean
-    object: "list" | UnknownEnumStringValue
+    object: "list"
     url: string
   }
   livemode: boolean
   metadata?: Record<string, string> | null
   next_payment_attempt?: number | null
   number?: string | null
-  object: "invoice" | UnknownEnumStringValue
+  object: "invoice"
   on_behalf_of?: string | t_account | null
   parent?: t_billing_bill_resource_invoicing_parents_invoice_parent | null
   payment_settings: t_invoices_payment_settings
   payments?: {
     data: t_invoice_payment[]
     has_more: boolean
-    object: "list" | UnknownEnumStringValue
+    object: "list"
     url: string
   }
   period_end: number
@@ -3970,7 +3970,7 @@ export type t_invoice_payment = {
   invoice: string | t_invoice | t_deleted_invoice
   is_default: boolean
   livemode: boolean
-  object: "invoice_payment" | UnknownEnumStringValue
+  object: "invoice_payment"
   payment: t_invoices_payments_invoice_payment_associated_payment
   status: string
   status_transitions: t_invoices_payments_invoice_payment_status_transitions
@@ -4005,7 +4005,7 @@ export type t_invoice_payment_method_options_card = {
 
 export type t_invoice_payment_method_options_customer_balance = {
   bank_transfer?: t_invoice_payment_method_options_customer_balance_bank_transfer
-  funding_type?: "bank_transfer" | UnknownEnumStringValue | null
+  funding_type?: "bank_transfer" | null
 }
 
 export type t_invoice_payment_method_options_customer_balance_bank_transfer = {
@@ -4064,7 +4064,7 @@ export type t_invoice_rendering_template = {
   livemode: boolean
   metadata?: Record<string, string> | null
   nickname?: string | null
-  object: "invoice_rendering_template" | UnknownEnumStringValue
+  object: "invoice_rendering_template"
   status: "active" | "archived" | UnknownEnumStringValue
   version: number
 }
@@ -4125,7 +4125,7 @@ export type t_invoiceitem = {
   invoice?: string | t_invoice | null
   livemode: boolean
   metadata?: Record<string, string> | null
-  object: "invoiceitem" | UnknownEnumStringValue
+  object: "invoiceitem"
   parent?: t_billing_bill_resource_invoice_item_parents_invoice_item_parent | null
   period: t_invoice_line_item_period
   pricing?: t_billing_bill_resource_invoicing_pricing_pricing | null
@@ -4390,7 +4390,7 @@ export type t_issuing_authorization = {
   merchant_data: t_issuing_authorization_merchant_data
   metadata: Record<string, string>
   network_data?: t_issuing_authorization_network_data | null
-  object: "issuing.authorization" | UnknownEnumStringValue
+  object: "issuing.authorization"
   pending_request?: t_issuing_authorization_pending_request | null
   request_history: t_issuing_authorization_request[]
   status: "closed" | "expired" | "pending" | "reversed" | UnknownEnumStringValue
@@ -4422,7 +4422,7 @@ export type t_issuing_card = {
   livemode: boolean
   metadata: Record<string, string>
   number?: string
-  object: "issuing.card" | UnknownEnumStringValue
+  object: "issuing.card"
   personalization_design?: string | t_issuing_personalization_design | null
   replaced_by?: string | t_issuing_card | null
   replacement_for?: string | t_issuing_card | null
@@ -4450,7 +4450,7 @@ export type t_issuing_cardholder = {
   livemode: boolean
   metadata: Record<string, string>
   name: string
-  object: "issuing.cardholder" | UnknownEnumStringValue
+  object: "issuing.cardholder"
   phone_number?: string | null
   preferred_locales?:
     | ("de" | "en" | "es" | "fr" | "it" | UnknownEnumStringValue)[]
@@ -4492,7 +4492,7 @@ export type t_issuing_dispute = {
     | "transaction_unattended"
     | UnknownEnumStringValue
   metadata: Record<string, string>
-  object: "issuing.dispute" | UnknownEnumStringValue
+  object: "issuing.dispute"
   status:
     | "expired"
     | "lost"
@@ -4513,7 +4513,7 @@ export type t_issuing_personalization_design = {
   lookup_key?: string | null
   metadata: Record<string, string>
   name?: string | null
-  object: "issuing.personalization_design" | UnknownEnumStringValue
+  object: "issuing.personalization_design"
   physical_bundle: string | t_issuing_physical_bundle
   preferences: t_issuing_personalization_design_preferences
   rejection_reasons: t_issuing_personalization_design_rejection_reasons
@@ -4525,7 +4525,7 @@ export type t_issuing_physical_bundle = {
   id: string
   livemode: boolean
   name: string
-  object: "issuing.physical_bundle" | UnknownEnumStringValue
+  object: "issuing.physical_bundle"
   status: "active" | "inactive" | "review" | UnknownEnumStringValue
   type: "custom" | "standard" | UnknownEnumStringValue
 }
@@ -4543,7 +4543,7 @@ export type t_issuing_settlement = {
   network: "maestro" | "visa" | UnknownEnumStringValue
   network_fees_amount: number
   network_settlement_identifier: string
-  object: "issuing.settlement" | UnknownEnumStringValue
+  object: "issuing.settlement"
   settlement_service: string
   status: "complete" | "pending" | UnknownEnumStringValue
   transaction_amount: number
@@ -4560,7 +4560,7 @@ export type t_issuing_token = {
   network: "mastercard" | "visa" | UnknownEnumStringValue
   network_data?: t_issuing_network_token_network_data
   network_updated_at: number
-  object: "issuing.token" | UnknownEnumStringValue
+  object: "issuing.token"
   status:
     | "active"
     | "deleted"
@@ -4591,7 +4591,7 @@ export type t_issuing_transaction = {
   merchant_data: t_issuing_authorization_merchant_data
   metadata: Record<string, string>
   network_data?: t_issuing_transaction_network_data | null
-  object: "issuing.transaction" | UnknownEnumStringValue
+  object: "issuing.transaction"
   purchase_details?: t_issuing_transaction_purchase_details | null
   token?: string | t_issuing_token | null
   treasury?: t_issuing_transaction_treasury | null
@@ -4664,7 +4664,7 @@ export type t_issuing_authorization_fleet_tax_data = {
 }
 
 export type t_issuing_authorization_fraud_challenge = {
-  channel: "sms" | UnknownEnumStringValue
+  channel: "sms"
   status:
     | "expired"
     | "pending"
@@ -7119,7 +7119,7 @@ export type t_item = {
   description?: string | null
   discounts?: t_line_items_discount_amount[]
   id: string
-  object: "item" | UnknownEnumStringValue
+  object: "item"
   price?: t_price | null
   quantity?: number | null
   taxes?: t_line_items_tax_amount[]
@@ -7255,7 +7255,7 @@ export type t_line_item = {
   invoice?: string | null
   livemode: boolean
   metadata: Record<string, string>
-  object: "line_item" | UnknownEnumStringValue
+  object: "line_item"
   parent?: t_billing_bill_resource_invoicing_lines_parents_invoice_line_item_parent | null
   period: t_invoice_line_item_period
   pretax_credit_amounts?: t_invoices_resource_pretax_credit_amount[] | null
@@ -7311,7 +7311,7 @@ export type t_linked_account_options_common = {
 
 export type t_login_link = {
   created: number
-  object: "login_link" | UnknownEnumStringValue
+  object: "login_link"
   url: string
 }
 
@@ -7320,7 +7320,7 @@ export type t_mandate = {
   id: string
   livemode: boolean
   multi_use?: t_mandate_multi_use
-  object: "mandate" | UnknownEnumStringValue
+  object: "mandate"
   on_behalf_of?: string
   payment_method: string | t_payment_method
   payment_method_details: t_mandate_payment_method_details
@@ -7419,7 +7419,7 @@ export type t_mandate_single_use = {
 }
 
 export type t_mandate_us_bank_account = {
-  collection_method?: "paper" | UnknownEnumStringValue
+  collection_method?: "paper"
 }
 
 export type t_networks = {
@@ -7453,7 +7453,7 @@ export type t_outbound_payments_payment_method_details = {
 
 export type t_outbound_payments_payment_method_details_financial_account = {
   id: string
-  network: "stripe" | UnknownEnumStringValue
+  network: "stripe"
 }
 
 export type t_outbound_payments_payment_method_details_us_bank_account = {
@@ -7476,7 +7476,7 @@ export type t_outbound_transfers_payment_method_details = {
 
 export type t_outbound_transfers_payment_method_details_financial_account = {
   id: string
-  network: "stripe" | UnknownEnumStringValue
+  network: "stripe"
 }
 
 export type t_outbound_transfers_payment_method_details_us_bank_account = {
@@ -7578,7 +7578,7 @@ export type t_payment_flows_private_payment_methods_financial_connections_common
 
 export type t_payment_flows_private_payment_methods_kakao_pay_payment_method_options =
   {
-    capture_method?: "manual" | UnknownEnumStringValue
+    capture_method?: "manual"
     setup_future_usage?: "none" | "off_session" | UnknownEnumStringValue
   }
 
@@ -7590,18 +7590,18 @@ export type t_payment_flows_private_payment_methods_klarna_dob = {
 
 export type t_payment_flows_private_payment_methods_naver_pay_payment_method_options =
   {
-    capture_method?: "manual" | UnknownEnumStringValue
+    capture_method?: "manual"
     setup_future_usage?: "none" | "off_session" | UnknownEnumStringValue
   }
 
 export type t_payment_flows_private_payment_methods_payco_payment_method_options =
   {
-    capture_method?: "manual" | UnknownEnumStringValue
+    capture_method?: "manual"
   }
 
 export type t_payment_flows_private_payment_methods_samsung_pay_payment_method_options =
   {
-    capture_method?: "manual" | UnknownEnumStringValue
+    capture_method?: "manual"
   }
 
 export type t_payment_intent = {
@@ -7643,7 +7643,7 @@ export type t_payment_intent = {
   livemode: boolean
   metadata?: Record<string, string>
   next_action?: t_payment_intent_next_action | null
-  object: "payment_intent" | UnknownEnumStringValue
+  object: "payment_intent"
   on_behalf_of?: string | t_account | null
   payment_method?: string | t_payment_method | null
   payment_method_configuration_details?: t_payment_method_config_biz_payment_method_configuration_details | null
@@ -8052,11 +8052,11 @@ export type t_payment_intent_payment_method_options_bacs_debit = {
 }
 
 export type t_payment_intent_payment_method_options_blik = {
-  setup_future_usage?: "none" | UnknownEnumStringValue
+  setup_future_usage?: "none"
 }
 
 export type t_payment_intent_payment_method_options_card = {
-  capture_method?: "manual" | UnknownEnumStringValue
+  capture_method?: "manual"
   installments?: t_payment_method_options_card_installments | null
   mandate_options?: t_payment_method_options_card_mandate_options | null
   network?:
@@ -8102,11 +8102,11 @@ export type t_payment_intent_payment_method_options_card = {
 }
 
 export type t_payment_intent_payment_method_options_eps = {
-  setup_future_usage?: "none" | UnknownEnumStringValue
+  setup_future_usage?: "none"
 }
 
 export type t_payment_intent_payment_method_options_link = {
-  capture_method?: "manual" | UnknownEnumStringValue
+  capture_method?: "manual"
   setup_future_usage?: "none" | "off_session" | UnknownEnumStringValue
 }
 
@@ -8134,8 +8134,8 @@ export type t_payment_intent_payment_method_options_mandate_options_sepa_debit =
   }
 
 export type t_payment_intent_payment_method_options_mobilepay = {
-  capture_method?: "manual" | UnknownEnumStringValue
-  setup_future_usage?: "none" | UnknownEnumStringValue
+  capture_method?: "manual"
+  setup_future_usage?: "none"
 }
 
 export type t_payment_intent_payment_method_options_nz_bank_account = {
@@ -8159,7 +8159,7 @@ export type t_payment_intent_payment_method_options_sepa_debit = {
 
 export type t_payment_intent_payment_method_options_swish = {
   reference?: string | null
-  setup_future_usage?: "none" | UnknownEnumStringValue
+  setup_future_usage?: "none"
 }
 
 export type t_payment_intent_payment_method_options_us_bank_account = {
@@ -8181,7 +8181,7 @@ export type t_payment_intent_payment_method_options_us_bank_account = {
 
 export type t_payment_intent_processing = {
   card?: t_payment_intent_card_processing
-  type: "card" | UnknownEnumStringValue
+  type: "card"
 }
 
 export type t_payment_intent_processing_customer_notification = {
@@ -8227,12 +8227,12 @@ export type t_payment_link = {
   line_items?: {
     data: t_item[]
     has_more: boolean
-    object: "list" | UnknownEnumStringValue
+    object: "list"
     url: string
   }
   livemode: boolean
   metadata: Record<string, string>
-  object: "payment_link" | UnknownEnumStringValue
+  object: "payment_link"
   on_behalf_of?: string | t_account | null
   optional_items?: t_payment_links_resource_optional_item[] | null
   payment_intent_data?: t_payment_links_resource_payment_intent_data | null
@@ -8348,7 +8348,7 @@ export type t_payment_links_resource_custom_fields_dropdown_option = {
 
 export type t_payment_links_resource_custom_fields_label = {
   custom?: string | null
-  type: "custom" | UnknownEnumStringValue
+  type: "custom"
 }
 
 export type t_payment_links_resource_custom_fields_numeric = {
@@ -8747,7 +8747,7 @@ export type t_payment_method = {
   multibanco?: t_payment_method_multibanco
   naver_pay?: t_payment_method_naver_pay
   nz_bank_account?: t_payment_method_nz_bank_account
-  object: "payment_method" | UnknownEnumStringValue
+  object: "payment_method"
   oxxo?: t_payment_method_oxxo
   p24?: t_payment_method_p24
   pay_by_bank?: t_payment_method_pay_by_bank
@@ -9027,7 +9027,7 @@ export type t_payment_method_configuration = {
   name: string
   naver_pay?: t_payment_method_config_resource_payment_method_properties
   nz_bank_account?: t_payment_method_config_resource_payment_method_properties
-  object: "payment_method_configuration" | UnknownEnumStringValue
+  object: "payment_method_configuration"
   oxxo?: t_payment_method_config_resource_payment_method_properties
   p24?: t_payment_method_config_resource_payment_method_properties
   parent?: string | null
@@ -9226,7 +9226,7 @@ export type t_payment_method_details_card_installments = {
 
 export type t_payment_method_details_card_installments_plan = {
   count?: number | null
-  interval?: "month" | UnknownEnumStringValue | null
+  interval?: "month" | null
   type: "bonus" | "fixed_count" | "revolving" | UnknownEnumStringValue
 }
 
@@ -9270,7 +9270,7 @@ export type t_payment_method_details_card_present = {
 
 export type t_payment_method_details_card_present_offline = {
   stored_at?: number | null
-  type?: "deferred" | UnknownEnumStringValue | null
+  type?: "deferred" | null
 }
 
 export type t_payment_method_details_card_present_receipt = {
@@ -9759,7 +9759,7 @@ export type t_payment_method_domain = {
   klarna: t_payment_method_domain_resource_payment_method_status
   link: t_payment_method_domain_resource_payment_method_status
   livemode: boolean
-  object: "payment_method_domain" | UnknownEnumStringValue
+  object: "payment_method_domain"
   paypal: t_payment_method_domain_resource_payment_method_status
 }
 
@@ -9964,15 +9964,15 @@ export type t_payment_method_nz_bank_account = {
 }
 
 export type t_payment_method_options_affirm = {
-  capture_method?: "manual" | UnknownEnumStringValue
+  capture_method?: "manual"
   preferred_locale?: string
-  setup_future_usage?: "none" | UnknownEnumStringValue
+  setup_future_usage?: "none"
 }
 
 export type t_payment_method_options_afterpay_clearpay = {
-  capture_method?: "manual" | UnknownEnumStringValue
+  capture_method?: "manual"
   reference?: string | null
-  setup_future_usage?: "none" | UnknownEnumStringValue
+  setup_future_usage?: "none"
 }
 
 export type t_payment_method_options_alipay = {
@@ -9980,11 +9980,11 @@ export type t_payment_method_options_alipay = {
 }
 
 export type t_payment_method_options_alma = {
-  capture_method?: "manual" | UnknownEnumStringValue
+  capture_method?: "manual"
 }
 
 export type t_payment_method_options_amazon_pay = {
-  capture_method?: "manual" | UnknownEnumStringValue
+  capture_method?: "manual"
   setup_future_usage?: "none" | "off_session" | UnknownEnumStringValue
 }
 
@@ -9994,7 +9994,7 @@ export type t_payment_method_options_bancontact = {
 }
 
 export type t_payment_method_options_billie = {
-  capture_method?: "manual" | UnknownEnumStringValue
+  capture_method?: "manual"
 }
 
 export type t_payment_method_options_boleto = {
@@ -10027,7 +10027,7 @@ export type t_payment_method_options_card_mandate_options = {
   interval_count?: number | null
   reference: string
   start_date: number
-  supported_types?: ("india" | UnknownEnumStringValue)[] | null
+  supported_types?: "india"[] | null
 }
 
 export type t_payment_method_options_card_present = {
@@ -10045,7 +10045,7 @@ export type t_payment_method_options_card_present_routing = {
 }
 
 export type t_payment_method_options_cashapp = {
-  capture_method?: "manual" | UnknownEnumStringValue
+  capture_method?: "manual"
   setup_future_usage?:
     | "none"
     | "off_session"
@@ -10054,13 +10054,13 @@ export type t_payment_method_options_cashapp = {
 }
 
 export type t_payment_method_options_crypto = {
-  setup_future_usage?: "none" | UnknownEnumStringValue
+  setup_future_usage?: "none"
 }
 
 export type t_payment_method_options_customer_balance = {
   bank_transfer?: t_payment_method_options_customer_balance_bank_transfer
-  funding_type?: "bank_transfer" | UnknownEnumStringValue | null
-  setup_future_usage?: "none" | UnknownEnumStringValue
+  funding_type?: "bank_transfer" | null
+  setup_future_usage?: "none"
 }
 
 export type t_payment_method_options_customer_balance_bank_transfer = {
@@ -10090,15 +10090,15 @@ export type t_payment_method_options_customer_balance_eu_bank_account = {
 }
 
 export type t_payment_method_options_fpx = {
-  setup_future_usage?: "none" | UnknownEnumStringValue
+  setup_future_usage?: "none"
 }
 
 export type t_payment_method_options_giropay = {
-  setup_future_usage?: "none" | UnknownEnumStringValue
+  setup_future_usage?: "none"
 }
 
 export type t_payment_method_options_grabpay = {
-  setup_future_usage?: "none" | UnknownEnumStringValue
+  setup_future_usage?: "none"
 }
 
 export type t_payment_method_options_ideal = {
@@ -10108,7 +10108,7 @@ export type t_payment_method_options_ideal = {
 export type t_payment_method_options_interac_present = Record<string, unknown>
 
 export type t_payment_method_options_klarna = {
-  capture_method?: "manual" | UnknownEnumStringValue
+  capture_method?: "manual"
   preferred_locale?: string | null
   setup_future_usage?:
     | "none"
@@ -10122,35 +10122,35 @@ export type t_payment_method_options_konbini = {
   expires_after_days?: number | null
   expires_at?: number | null
   product_description?: string | null
-  setup_future_usage?: "none" | UnknownEnumStringValue
+  setup_future_usage?: "none"
 }
 
 export type t_payment_method_options_kr_card = {
-  capture_method?: "manual" | UnknownEnumStringValue
+  capture_method?: "manual"
   setup_future_usage?: "none" | "off_session" | UnknownEnumStringValue
 }
 
 export type t_payment_method_options_multibanco = {
-  setup_future_usage?: "none" | UnknownEnumStringValue
+  setup_future_usage?: "none"
 }
 
 export type t_payment_method_options_oxxo = {
   expires_after_days: number
-  setup_future_usage?: "none" | UnknownEnumStringValue
+  setup_future_usage?: "none"
 }
 
 export type t_payment_method_options_p24 = {
-  setup_future_usage?: "none" | UnknownEnumStringValue
+  setup_future_usage?: "none"
 }
 
 export type t_payment_method_options_pay_by_bank = Record<string, unknown>
 
 export type t_payment_method_options_paynow = {
-  setup_future_usage?: "none" | UnknownEnumStringValue
+  setup_future_usage?: "none"
 }
 
 export type t_payment_method_options_paypal = {
-  capture_method?: "manual" | UnknownEnumStringValue
+  capture_method?: "manual"
   preferred_locale?: string | null
   reference?: string | null
   setup_future_usage?: "none" | "off_session" | UnknownEnumStringValue
@@ -10159,20 +10159,20 @@ export type t_payment_method_options_paypal = {
 export type t_payment_method_options_pix = {
   expires_after_seconds?: number | null
   expires_at?: number | null
-  setup_future_usage?: "none" | UnknownEnumStringValue
+  setup_future_usage?: "none"
 }
 
 export type t_payment_method_options_promptpay = {
-  setup_future_usage?: "none" | UnknownEnumStringValue
+  setup_future_usage?: "none"
 }
 
 export type t_payment_method_options_revolut_pay = {
-  capture_method?: "manual" | UnknownEnumStringValue
+  capture_method?: "manual"
   setup_future_usage?: "none" | "off_session" | UnknownEnumStringValue
 }
 
 export type t_payment_method_options_satispay = {
-  capture_method?: "manual" | UnknownEnumStringValue
+  capture_method?: "manual"
 }
 
 export type t_payment_method_options_sofort = {
@@ -10190,21 +10190,21 @@ export type t_payment_method_options_sofort = {
 }
 
 export type t_payment_method_options_twint = {
-  setup_future_usage?: "none" | UnknownEnumStringValue
+  setup_future_usage?: "none"
 }
 
 export type t_payment_method_options_us_bank_account_mandate_options = {
-  collection_method?: "paper" | UnknownEnumStringValue
+  collection_method?: "paper"
 }
 
 export type t_payment_method_options_wechat_pay = {
   app_id?: string | null
   client?: "android" | "ios" | "web" | UnknownEnumStringValue | null
-  setup_future_usage?: "none" | UnknownEnumStringValue
+  setup_future_usage?: "none"
 }
 
 export type t_payment_method_options_zip = {
-  setup_future_usage?: "none" | UnknownEnumStringValue
+  setup_future_usage?: "none"
 }
 
 export type t_payment_method_oxxo = Record<string, unknown>
@@ -10365,7 +10365,7 @@ export type t_payment_pages_checkout_session_collected_information = {
 
 export type t_payment_pages_checkout_session_consent = {
   promotions?: "opt_in" | "opt_out" | UnknownEnumStringValue | null
-  terms_of_service?: "accepted" | UnknownEnumStringValue | null
+  terms_of_service?: "accepted" | null
 }
 
 export type t_payment_pages_checkout_session_consent_collection = {
@@ -10399,7 +10399,7 @@ export type t_payment_pages_checkout_session_custom_fields_dropdown = {
 
 export type t_payment_pages_checkout_session_custom_fields_label = {
   custom?: string | null
-  type: "custom" | UnknownEnumStringValue
+  type: "custom"
 }
 
 export type t_payment_pages_checkout_session_custom_fields_numeric = {
@@ -10927,7 +10927,7 @@ export type t_payout = {
   livemode: boolean
   metadata?: Record<string, string> | null
   method: string
-  object: "payout" | UnknownEnumStringValue
+  object: "payout"
   original_payout?: string | t_payout | null
   reconciliation_status:
     | "completed"
@@ -10982,7 +10982,7 @@ export type t_person = {
   maiden_name?: string | null
   metadata?: Record<string, string>
   nationality?: string | null
-  object: "person" | UnknownEnumStringValue
+  object: "person"
   phone?: string | null
   political_exposure?: "existing" | "none" | UnknownEnumStringValue
   registered_address?: t_address
@@ -11101,7 +11101,7 @@ export type t_plan = {
   metadata?: Record<string, string> | null
   meter?: string | null
   nickname?: string | null
-  object: "plan" | UnknownEnumStringValue
+  object: "plan"
   product?: string | t_product | t_deleted_product | null
   tiers?: t_plan_tier[]
   tiers_mode?: "graduated" | "volume" | UnknownEnumStringValue | null
@@ -11203,7 +11203,7 @@ export type t_portal_flows_flow_subscription_update_confirm = {
 
 export type t_portal_flows_retention = {
   coupon_offer?: t_portal_flows_coupon_offer | null
-  type: "coupon_offer" | UnknownEnumStringValue
+  type: "coupon_offer"
 }
 
 export type t_portal_flows_subscription_update_confirm_discount = {
@@ -11308,7 +11308,7 @@ export type t_price = {
   lookup_key?: string | null
   metadata: Record<string, string>
   nickname?: string | null
-  object: "price" | UnknownEnumStringValue
+  object: "price"
   product: string | t_product | t_deleted_product
   recurring?: t_recurring | null
   tax_behavior?:
@@ -11344,7 +11344,7 @@ export type t_product = {
   marketing_features: t_product_marketing_feature[]
   metadata: Record<string, string>
   name: string
-  object: "product" | UnknownEnumStringValue
+  object: "product"
   package_dimensions?: t_package_dimensions | null
   shippable?: boolean | null
   statement_descriptor?: string | null
@@ -11358,7 +11358,7 @@ export type t_product_feature = {
   entitlement_feature: t_entitlements_feature
   id: string
   livemode: boolean
-  object: "product_feature" | UnknownEnumStringValue
+  object: "product_feature"
 }
 
 export type t_product_marketing_feature = {
@@ -11376,7 +11376,7 @@ export type t_promotion_code = {
   livemode: boolean
   max_redemptions?: number | null
   metadata?: Record<string, string> | null
-  object: "promotion_code" | UnknownEnumStringValue
+  object: "promotion_code"
   restrictions: t_promotion_codes_resource_restrictions
   times_redeemed: number
 }
@@ -11420,13 +11420,13 @@ export type t_quote = {
   line_items?: {
     data: t_item[]
     has_more: boolean
-    object: "list" | UnknownEnumStringValue
+    object: "list"
     url: string
   }
   livemode: boolean
   metadata: Record<string, string>
   number?: string | null
-  object: "quote" | UnknownEnumStringValue
+  object: "quote"
   on_behalf_of?: string | t_account | null
   status: "accepted" | "canceled" | "draft" | "open" | UnknownEnumStringValue
   status_transitions: t_quotes_resource_status_transitions
@@ -11510,7 +11510,7 @@ export type t_quotes_resource_upfront = {
   line_items?: {
     data: t_item[]
     has_more: boolean
-    object: "list" | UnknownEnumStringValue
+    object: "list"
     url: string
   }
   total_details: t_quotes_resource_total_details
@@ -11523,7 +11523,7 @@ export type t_radar_early_fraud_warning = {
   fraud_type: string
   id: string
   livemode: boolean
-  object: "radar.early_fraud_warning" | UnknownEnumStringValue
+  object: "radar.early_fraud_warning"
   payment_intent?: string | t_payment_intent
 }
 
@@ -11547,13 +11547,13 @@ export type t_radar_value_list = {
   list_items: {
     data: t_radar_value_list_item[]
     has_more: boolean
-    object: "list" | UnknownEnumStringValue
+    object: "list"
     url: string
   }
   livemode: boolean
   metadata: Record<string, string>
   name: string
-  object: "radar.value_list" | UnknownEnumStringValue
+  object: "radar.value_list"
 }
 
 export type t_radar_value_list_item = {
@@ -11561,7 +11561,7 @@ export type t_radar_value_list_item = {
   created_by: string
   id: string
   livemode: boolean
-  object: "radar.value_list_item" | UnknownEnumStringValue
+  object: "radar.value_list_item"
   value: string
   value_list: string
 }
@@ -11587,7 +11587,7 @@ export type t_radar_review_resource_session = {
 
 export type t_received_payment_method_details_financial_account = {
   id: string
-  network: "stripe" | UnknownEnumStringValue
+  network: "stripe"
 }
 
 export type t_recurring = {
@@ -11611,7 +11611,7 @@ export type t_refund = {
   instructions_email?: string
   metadata?: Record<string, string> | null
   next_action?: t_refund_next_action
-  object: "refund" | UnknownEnumStringValue
+  object: "refund"
   payment_intent?: string | t_payment_intent | null
   pending_reason?:
     | "charge_pending"
@@ -11751,7 +11751,7 @@ export type t_reporting_report_run = {
   error?: string | null
   id: string
   livemode: boolean
-  object: "reporting.report_run" | UnknownEnumStringValue
+  object: "reporting.report_run"
   parameters: t_financial_reporting_finance_report_run_run_parameters
   report_type: string
   result?: t_file | null
@@ -11766,7 +11766,7 @@ export type t_reporting_report_type = {
   id: string
   livemode: boolean
   name: string
-  object: "reporting.report_type" | UnknownEnumStringValue
+  object: "reporting.report_type"
   updated: number
   version: number
 }
@@ -11776,7 +11776,7 @@ export type t_reserve_transaction = {
   currency: string
   description?: string | null
   id: string
-  object: "reserve_transaction" | UnknownEnumStringValue
+  object: "reserve_transaction"
 }
 
 export type t_review = {
@@ -11796,7 +11796,7 @@ export type t_review = {
   ip_address?: string | null
   ip_address_location?: t_radar_review_resource_location | null
   livemode: boolean
-  object: "review" | UnknownEnumStringValue
+  object: "review"
   open: boolean
   opened_reason: "manual" | "rule" | UnknownEnumStringValue
   payment_intent?: string | t_payment_intent
@@ -11806,7 +11806,7 @@ export type t_review = {
 
 export type t_revolut_pay_underlying_payment_method_funding_details = {
   card?: t_payment_method_details_passthrough_card
-  type?: "card" | UnknownEnumStringValue | null
+  type?: "card" | null
 }
 
 export type t_rule = {
@@ -11822,7 +11822,7 @@ export type t_scheduled_query_run = {
   file?: t_file | null
   id: string
   livemode: boolean
-  object: "scheduled_query_run" | UnknownEnumStringValue
+  object: "scheduled_query_run"
   result_available_until: number
   sql: string
   status: string
@@ -11830,7 +11830,7 @@ export type t_scheduled_query_run = {
 }
 
 export type t_schedules_phase_automatic_tax = {
-  disabled_reason?: "requires_location_inputs" | UnknownEnumStringValue | null
+  disabled_reason?: "requires_location_inputs" | null
   enabled: boolean
   liability?: t_connect_account_reference | null
 }
@@ -11853,7 +11853,7 @@ export type t_setup_attempt = {
   flow_directions?: ("inbound" | "outbound" | UnknownEnumStringValue)[] | null
   id: string
   livemode: boolean
-  object: "setup_attempt" | UnknownEnumStringValue
+  object: "setup_attempt"
   on_behalf_of?: string | t_account | null
   payment_method: string | t_payment_method
   payment_method_details: t_setup_attempt_payment_method_details
@@ -12090,7 +12090,7 @@ export type t_setup_intent = {
   mandate?: string | t_mandate | null
   metadata?: Record<string, string> | null
   next_action?: t_setup_intent_next_action | null
-  object: "setup_intent" | UnknownEnumStringValue
+  object: "setup_intent"
   on_behalf_of?: string | t_account | null
   payment_method?: string | t_payment_method | null
   payment_method_configuration_details?: t_payment_method_config_biz_payment_method_configuration_details | null
@@ -12225,7 +12225,7 @@ export type t_setup_intent_payment_method_options_card_mandate_options = {
   interval_count?: number | null
   reference: string
   start_date: number
-  supported_types?: ("india" | UnknownEnumStringValue)[] | null
+  supported_types?: "india"[] | null
 }
 
 export type t_setup_intent_payment_method_options_card_present = Record<
@@ -12304,7 +12304,7 @@ export type t_shipping_rate = {
   id: string
   livemode: boolean
   metadata: Record<string, string>
-  object: "shipping_rate" | UnknownEnumStringValue
+  object: "shipping_rate"
   tax_behavior?:
     | "exclusive"
     | "inclusive"
@@ -12312,7 +12312,7 @@ export type t_shipping_rate = {
     | UnknownEnumStringValue
     | null
   tax_code?: string | t_tax_code | null
-  type: "fixed_amount" | UnknownEnumStringValue
+  type: "fixed_amount"
 }
 
 export type t_shipping_rate_currency_option = {
@@ -12351,7 +12351,7 @@ export type t_sigma_sigma_api_query = {
   id: string
   livemode: boolean
   name: string
-  object: "sigma.sigma_api_query" | UnknownEnumStringValue
+  object: "sigma.sigma_api_query"
   sql: string
 }
 
@@ -12389,7 +12389,7 @@ export type t_source = {
   livemode: boolean
   metadata?: Record<string, string> | null
   multibanco?: t_source_type_multibanco
-  object: "source" | UnknownEnumStringValue
+  object: "source"
   owner?: t_source_owner | null
   p24?: t_source_type_p24
   receiver?: t_source_receiver_flow
@@ -12436,7 +12436,7 @@ export type t_source_mandate_notification = {
   created: number
   id: string
   livemode: boolean
-  object: "source_mandate_notification" | UnknownEnumStringValue
+  object: "source_mandate_notification"
   reason: string
   sepa_debit?: t_source_mandate_notification_sepa_debit_data
   source: t_source
@@ -12511,7 +12511,7 @@ export type t_source_transaction = {
   gbp_credit_transfer?: t_source_transaction_gbp_credit_transfer_data
   id: string
   livemode: boolean
-  object: "source_transaction" | UnknownEnumStringValue
+  object: "source_transaction"
   paper_check?: t_source_transaction_paper_check_data
   sepa_credit_transfer?: t_source_transaction_sepa_credit_transfer_data
   source: string
@@ -12811,14 +12811,14 @@ export type t_subscription = {
   items: {
     data: t_subscription_item[]
     has_more: boolean
-    object: "list" | UnknownEnumStringValue
+    object: "list"
     url: string
   }
   latest_invoice?: string | t_invoice | null
   livemode: boolean
   metadata: Record<string, string>
   next_pending_invoice_item_invoice?: number | null
-  object: "subscription" | UnknownEnumStringValue
+  object: "subscription"
   on_behalf_of?: string | t_account | null
   pause_collection?: t_subscriptions_resource_pause_collection | null
   payment_settings?: t_subscriptions_resource_payment_settings | null
@@ -12845,7 +12845,7 @@ export type t_subscription = {
 }
 
 export type t_subscription_automatic_tax = {
-  disabled_reason?: "requires_location_inputs" | UnknownEnumStringValue | null
+  disabled_reason?: "requires_location_inputs" | null
   enabled: boolean
   liability?: t_connect_account_reference | null
 }
@@ -12863,7 +12863,7 @@ export type t_subscription_item = {
   discounts: (string | t_discount)[]
   id: string
   metadata: Record<string, string>
-  object: "subscription_item" | UnknownEnumStringValue
+  object: "subscription_item"
   price: t_price
   quantity?: number
   subscription: string
@@ -12918,7 +12918,7 @@ export type t_subscription_schedule = {
   id: string
   livemode: boolean
   metadata?: Record<string, string> | null
-  object: "subscription_schedule" | UnknownEnumStringValue
+  object: "subscription_schedule"
   phases: t_subscription_schedule_phase_configuration[]
   released_at?: number | null
   released_subscription?: string | null
@@ -13007,7 +13007,7 @@ export type t_subscription_schedules_resource_default_settings = {
 }
 
 export type t_subscription_schedules_resource_default_settings_automatic_tax = {
-  disabled_reason?: "requires_location_inputs" | UnknownEnumStringValue | null
+  disabled_reason?: "requires_location_inputs" | null
   enabled: boolean
   liability?: t_connect_account_reference | null
 }
@@ -13137,11 +13137,11 @@ export type t_tax_calculation = {
   line_items?: {
     data: t_tax_calculation_line_item[]
     has_more: boolean
-    object: "list" | UnknownEnumStringValue
+    object: "list"
     url: string
   } | null
   livemode: boolean
-  object: "tax.calculation" | UnknownEnumStringValue
+  object: "tax.calculation"
   ship_from_details?: t_tax_product_resource_ship_from_details | null
   shipping_cost?: t_tax_product_resource_tax_calculation_shipping_cost | null
   tax_amount_exclusive: number
@@ -13156,7 +13156,7 @@ export type t_tax_calculation_line_item = {
   id: string
   livemode: boolean
   metadata?: Record<string, string> | null
-  object: "tax.calculation_line_item" | UnknownEnumStringValue
+  object: "tax.calculation_line_item"
   product?: string | null
   quantity: number
   reference: string
@@ -13173,7 +13173,7 @@ export type t_tax_registration = {
   expires_at?: number | null
   id: string
   livemode: boolean
-  object: "tax.registration" | UnknownEnumStringValue
+  object: "tax.registration"
   status: "active" | "expired" | "scheduled" | UnknownEnumStringValue
 }
 
@@ -13181,7 +13181,7 @@ export type t_tax_settings = {
   defaults: t_tax_product_resource_tax_settings_defaults
   head_office?: t_tax_product_resource_tax_settings_head_office | null
   livemode: boolean
-  object: "tax.settings" | UnknownEnumStringValue
+  object: "tax.settings"
   status: "active" | "pending" | UnknownEnumStringValue
   status_details: t_tax_product_resource_tax_settings_status_details
 }
@@ -13195,12 +13195,12 @@ export type t_tax_transaction = {
   line_items?: {
     data: t_tax_transaction_line_item[]
     has_more: boolean
-    object: "list" | UnknownEnumStringValue
+    object: "list"
     url: string
   } | null
   livemode: boolean
   metadata?: Record<string, string> | null
-  object: "tax.transaction" | UnknownEnumStringValue
+  object: "tax.transaction"
   posted_at: number
   reference: string
   reversal?: t_tax_product_resource_tax_transaction_resource_reversal | null
@@ -13216,7 +13216,7 @@ export type t_tax_transaction_line_item = {
   id: string
   livemode: boolean
   metadata?: Record<string, string> | null
-  object: "tax.transaction_line_item" | UnknownEnumStringValue
+  object: "tax.transaction_line_item"
   product?: string | null
   quantity: number
   reference: string
@@ -13230,12 +13230,12 @@ export type t_tax_code = {
   description: string
   id: string
   name: string
-  object: "tax_code" | UnknownEnumStringValue
+  object: "tax_code"
 }
 
 export type t_tax_deducted_at_source = {
   id: string
-  object: "tax_deducted_at_source" | UnknownEnumStringValue
+  object: "tax_deducted_at_source"
   period_end: number
   period_start: number
   tax_deduction_account_number: string
@@ -13254,7 +13254,7 @@ export type t_tax_id = {
   customer?: string | t_customer | null
   id: string
   livemode: boolean
-  object: "tax_id" | UnknownEnumStringValue
+  object: "tax_id"
   owner?: t_tax_i_ds_owner | null
   type:
     | "ad_nrt"
@@ -13497,13 +13497,13 @@ export type t_tax_product_registrations_resource_country_options_canada = {
 }
 
 export type t_tax_product_registrations_resource_country_options_default = {
-  type: "standard" | UnknownEnumStringValue
+  type: "standard"
 }
 
 export type t_tax_product_registrations_resource_country_options_default_inbound_goods =
   {
     standard?: t_tax_product_registrations_resource_country_options_default_standard
-    type: "standard" | UnknownEnumStringValue
+    type: "standard"
   }
 
 export type t_tax_product_registrations_resource_country_options_default_standard =
@@ -13533,7 +13533,7 @@ export type t_tax_product_registrations_resource_country_options_europe = {
 }
 
 export type t_tax_product_registrations_resource_country_options_simplified = {
-  type: "simplified" | UnknownEnumStringValue
+  type: "simplified"
 }
 
 export type t_tax_product_registrations_resource_country_options_united_states =
@@ -13901,7 +13901,7 @@ export type t_tax_rate = {
     | null
   livemode: boolean
   metadata?: Record<string, string> | null
-  object: "tax_rate" | UnknownEnumStringValue
+  object: "tax_rate"
   percentage: number
   rate_type?: "flat_amount" | "percentage" | UnknownEnumStringValue | null
   state?: string | null
@@ -13935,7 +13935,7 @@ export type t_terminal_configuration = {
   is_account_default?: boolean | null
   livemode: boolean
   name?: string | null
-  object: "terminal.configuration" | UnknownEnumStringValue
+  object: "terminal.configuration"
   offline?: t_terminal_configuration_configuration_resource_offline_config
   reboot_window?: t_terminal_configuration_configuration_resource_reboot_window
   stripe_s700?: t_terminal_configuration_configuration_resource_device_type_specific_config
@@ -13946,7 +13946,7 @@ export type t_terminal_configuration = {
 
 export type t_terminal_connection_token = {
   location?: string
-  object: "terminal.connection_token" | UnknownEnumStringValue
+  object: "terminal.connection_token"
   secret: string
 }
 
@@ -13957,7 +13957,7 @@ export type t_terminal_location = {
   id: string
   livemode: boolean
   metadata: Record<string, string>
-  object: "terminal.location" | UnknownEnumStringValue
+  object: "terminal.location"
 }
 
 export type t_terminal_reader = {
@@ -13980,7 +13980,7 @@ export type t_terminal_reader = {
   livemode: boolean
   location?: string | t_terminal_location | null
   metadata: Record<string, string>
-  object: "terminal.reader" | UnknownEnumStringValue
+  object: "terminal.reader"
   serial_number: string
   status?: "offline" | "online" | UnknownEnumStringValue | null
 }
@@ -14220,7 +14220,7 @@ export type t_terminal_reader_reader_resource_selection = {
 
 export type t_terminal_reader_reader_resource_set_reader_display_action = {
   cart?: t_terminal_reader_reader_resource_cart | null
-  type: "cart" | UnknownEnumStringValue
+  type: "cart"
 }
 
 export type t_terminal_reader_reader_resource_signature = {
@@ -14249,7 +14249,7 @@ export type t_test_helpers_test_clock = {
   id: string
   livemode: boolean
   name?: string | null
-  object: "test_helpers.test_clock" | UnknownEnumStringValue
+  object: "test_helpers.test_clock"
   status: "advancing" | "internal_failure" | "ready" | UnknownEnumStringValue
   status_details: t_billing_clocks_resource_status_details_status_details
 }
@@ -14336,14 +14336,14 @@ export type t_three_d_secure_usage = {
 
 export type t_thresholds_resource_usage_alert_filter = {
   customer?: string | t_customer | null
-  type: "customer" | UnknownEnumStringValue
+  type: "customer"
 }
 
 export type t_thresholds_resource_usage_threshold_config = {
   filters?: t_thresholds_resource_usage_alert_filter[] | null
   gte: number
   meter: string | t_billing_meter
-  recurrence: "one_time" | UnknownEnumStringValue
+  recurrence: "one_time"
 }
 
 export type t_token = {
@@ -14353,7 +14353,7 @@ export type t_token = {
   created: number
   id: string
   livemode: boolean
-  object: "token" | UnknownEnumStringValue
+  object: "token"
   type: string
   used: boolean
 }
@@ -14374,7 +14374,7 @@ export type t_topup = {
   id: string
   livemode: boolean
   metadata: Record<string, string>
-  object: "topup" | UnknownEnumStringValue
+  object: "topup"
   source?: t_source | null
   statement_descriptor?: string | null
   status:
@@ -14399,11 +14399,11 @@ export type t_transfer = {
   id: string
   livemode: boolean
   metadata: Record<string, string>
-  object: "transfer" | UnknownEnumStringValue
+  object: "transfer"
   reversals: {
     data: t_transfer_reversal[]
     has_more: boolean
-    object: "list" | UnknownEnumStringValue
+    object: "list"
     url: string
   }
   reversed: boolean
@@ -14425,7 +14425,7 @@ export type t_transfer_reversal = {
   destination_payment_refund?: string | t_refund | null
   id: string
   metadata?: Record<string, string> | null
-  object: "transfer_reversal" | UnknownEnumStringValue
+  object: "transfer_reversal"
   source_refund?: string | t_refund | null
   transfer: string | t_transfer
 }
@@ -14468,7 +14468,7 @@ export type t_treasury_credit_reversal = {
   livemode: boolean
   metadata: Record<string, string>
   network: "ach" | "stripe" | UnknownEnumStringValue
-  object: "treasury.credit_reversal" | UnknownEnumStringValue
+  object: "treasury.credit_reversal"
   received_credit: string
   status: "canceled" | "posted" | "processing" | UnknownEnumStringValue
   status_transitions: t_treasury_received_credits_resource_status_transitions
@@ -14486,7 +14486,7 @@ export type t_treasury_debit_reversal = {
   livemode: boolean
   metadata: Record<string, string>
   network: "ach" | "card" | UnknownEnumStringValue
-  object: "treasury.debit_reversal" | UnknownEnumStringValue
+  object: "treasury.debit_reversal"
   received_debit: string
   status: "failed" | "processing" | "succeeded" | UnknownEnumStringValue
   status_transitions: t_treasury_received_debits_resource_status_transitions
@@ -14518,7 +14518,7 @@ export type t_treasury_financial_account = {
   livemode: boolean
   metadata?: Record<string, string> | null
   nickname?: string | null
-  object: "treasury.financial_account" | UnknownEnumStringValue
+  object: "treasury.financial_account"
   pending_features?: (
     | "card_issuing"
     | "deposit_insurance"
@@ -14559,7 +14559,7 @@ export type t_treasury_financial_account_features = {
   financial_addresses?: t_treasury_financial_accounts_resource_financial_addresses_features
   inbound_transfers?: t_treasury_financial_accounts_resource_inbound_transfers
   intra_stripe_flows?: t_treasury_financial_accounts_resource_toggle_settings
-  object: "treasury.financial_account_features" | UnknownEnumStringValue
+  object: "treasury.financial_account_features"
   outbound_payments?: t_treasury_financial_accounts_resource_outbound_payments
   outbound_transfers?: t_treasury_financial_accounts_resource_outbound_transfers
 }
@@ -14577,7 +14577,7 @@ export type t_treasury_inbound_transfer = {
   linked_flows: t_treasury_inbound_transfers_resource_inbound_transfer_resource_linked_flows
   livemode: boolean
   metadata: Record<string, string>
-  object: "treasury.inbound_transfer" | UnknownEnumStringValue
+  object: "treasury.inbound_transfer"
   origin_payment_method?: string | null
   origin_payment_method_details?: t_inbound_transfers | null
   returned?: boolean | null
@@ -14608,7 +14608,7 @@ export type t_treasury_outbound_payment = {
   id: string
   livemode: boolean
   metadata: Record<string, string>
-  object: "treasury.outbound_payment" | UnknownEnumStringValue
+  object: "treasury.outbound_payment"
   returned_details?: t_treasury_outbound_payments_resource_returned_status | null
   statement_descriptor: string
   status:
@@ -14637,7 +14637,7 @@ export type t_treasury_outbound_transfer = {
   id: string
   livemode: boolean
   metadata: Record<string, string>
-  object: "treasury.outbound_transfer" | UnknownEnumStringValue
+  object: "treasury.outbound_transfer"
   returned_details?: t_treasury_outbound_transfers_resource_returned_details | null
   statement_descriptor: string
   status:
@@ -14676,7 +14676,7 @@ export type t_treasury_received_credit = {
     | "stripe"
     | "us_domestic_wire"
     | UnknownEnumStringValue
-  object: "treasury.received_credit" | UnknownEnumStringValue
+  object: "treasury.received_credit"
   reversal_details?: t_treasury_received_credits_resource_reversal_details | null
   status: "failed" | "succeeded" | UnknownEnumStringValue
   transaction?: string | t_treasury_transaction | null
@@ -14702,7 +14702,7 @@ export type t_treasury_received_debit = {
   linked_flows: t_treasury_received_debits_resource_linked_flows
   livemode: boolean
   network: "ach" | "card" | "stripe" | UnknownEnumStringValue
-  object: "treasury.received_debit" | UnknownEnumStringValue
+  object: "treasury.received_debit"
   reversal_details?: t_treasury_received_debits_resource_reversal_details | null
   status: "failed" | "succeeded" | UnknownEnumStringValue
   transaction?: string | t_treasury_transaction | null
@@ -14717,7 +14717,7 @@ export type t_treasury_transaction = {
   entries?: {
     data: t_treasury_transaction_entry[]
     has_more: boolean
-    object: "list" | UnknownEnumStringValue
+    object: "list"
     url: string
   } | null
   financial_account: string
@@ -14736,7 +14736,7 @@ export type t_treasury_transaction = {
     | UnknownEnumStringValue
   id: string
   livemode: boolean
-  object: "treasury.transaction" | UnknownEnumStringValue
+  object: "treasury.transaction"
   status: "open" | "posted" | "void" | UnknownEnumStringValue
   status_transitions: t_treasury_transactions_resource_abstract_transaction_resource_status_transitions
 }
@@ -14762,7 +14762,7 @@ export type t_treasury_transaction_entry = {
     | UnknownEnumStringValue
   id: string
   livemode: boolean
-  object: "treasury.transaction_entry" | UnknownEnumStringValue
+  object: "treasury.transaction_entry"
   transaction: string | t_treasury_transaction
   type:
     | "credit_reversal"
@@ -14820,7 +14820,7 @@ export type t_treasury_financial_accounts_resource_closed_status_details = {
 export type t_treasury_financial_accounts_resource_financial_address = {
   aba?: t_treasury_financial_accounts_resource_aba_record
   supported_networks?: ("ach" | "us_domestic_wire" | UnknownEnumStringValue)[]
-  type: "aba" | UnknownEnumStringValue
+  type: "aba"
 }
 
 export type t_treasury_financial_accounts_resource_financial_addresses_features =
@@ -15087,7 +15087,7 @@ export type t_treasury_shared_resource_billing_details = {
 
 export type t_treasury_shared_resource_initiating_payment_method_details_initiating_payment_method_details =
   {
-    balance?: "payments" | UnknownEnumStringValue
+    balance?: "payments"
     billing_details: t_treasury_shared_resource_billing_details
     financial_account?: t_received_payment_method_details_financial_account
     issuing_card?: string
@@ -15160,7 +15160,7 @@ export type t_webhook_endpoint = {
   id: string
   livemode: boolean
   metadata: Record<string, string>
-  object: "webhook_endpoint" | UnknownEnumStringValue
+  object: "webhook_endpoint"
   secret?: string
   status: string
   url: string

--- a/integration-tests/typescript-axios/src/generated/api.github.com.yaml/client.ts
+++ b/integration-tests/typescript-axios/src/generated/api.github.com.yaml/client.ts
@@ -1613,7 +1613,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       ecosystem?: string
       package?: string
       epssPercentage?: string
-      has?: string | ("patch" | UnknownEnumStringValue)[]
+      has?: string | "patch"[]
       scope?: "development" | "runtime" | UnknownEnumStringValue
       sort?: "created" | "updated" | "epss_percentage" | UnknownEnumStringValue
       direction?: "asc" | "desc" | UnknownEnumStringValue
@@ -5776,7 +5776,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       ecosystem?: string
       package?: string
       epssPercentage?: string
-      has?: string | ("patch" | UnknownEnumStringValue)[]
+      has?: string | "patch"[]
       scope?: "development" | "runtime" | UnknownEnumStringValue
       sort?: "created" | "updated" | "epss_percentage" | UnknownEnumStringValue
       direction?: "asc" | "desc" | UnknownEnumStringValue
@@ -7274,7 +7274,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       org: string
       perPage?: number
       page?: number
-      exclude?: ("repositories" | UnknownEnumStringValue)[]
+      exclude?: "repositories"[]
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -7329,7 +7329,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     p: {
       org: string
       migrationId: number
-      exclude?: ("repositories" | UnknownEnumStringValue)[]
+      exclude?: "repositories"[]
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -7981,7 +7981,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       org: string
       perPage?: number
       page?: number
-      sort?: "created_at" | UnknownEnumStringValue
+      sort?: "created_at"
       direction?: "asc" | "desc" | UnknownEnumStringValue
       owner?: string[]
       repository?: string
@@ -8110,7 +8110,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       org: string
       perPage?: number
       page?: number
-      sort?: "created_at" | UnknownEnumStringValue
+      sort?: "created_at"
       direction?: "asc" | "desc" | UnknownEnumStringValue
       owner?: string[]
       repository?: string
@@ -14335,7 +14335,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       ref?: t_code_scanning_ref
       sarifId?: t_code_scanning_analysis_sarif_id
       direction?: "asc" | "desc" | UnknownEnumStringValue
-      sort?: "created" | UnknownEnumStringValue
+      sort?: "created"
     },
     timeout?: number,
     opts: AxiosRequestConfig = {},
@@ -15733,7 +15733,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       package?: string
       manifest?: string
       epssPercentage?: string
-      has?: string | ("patch" | UnknownEnumStringValue)[]
+      has?: string | "patch"[]
       scope?: "development" | "runtime" | UnknownEnumStringValue
       sort?: "created" | "updated" | "epss_percentage" | UnknownEnumStringValue
       direction?: "asc" | "desc" | UnknownEnumStringValue
@@ -22363,7 +22363,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   async searchCode(
     p: {
       q: string
-      sort?: "indexed" | UnknownEnumStringValue
+      sort?: "indexed"
       order?: "desc" | "asc" | UnknownEnumStringValue
       perPage?: number
       page?: number

--- a/integration-tests/typescript-axios/src/generated/api.github.com.yaml/models.ts
+++ b/integration-tests/typescript-axios/src/generated/api.github.com.yaml/models.ts
@@ -342,9 +342,7 @@ export type t_app_permissions = {
   organization_announcement_banners?:
     | ("read" | "write" | UnknownEnumStringValue)
     | undefined
-  organization_copilot_seat_management?:
-    | ("write" | UnknownEnumStringValue)
-    | undefined
+  organization_copilot_seat_management?: "write" | undefined
   organization_custom_org_roles?:
     | ("read" | "write" | UnknownEnumStringValue)
     | undefined
@@ -354,7 +352,7 @@ export type t_app_permissions = {
   organization_custom_roles?:
     | ("read" | "write" | UnknownEnumStringValue)
     | undefined
-  organization_events?: ("read" | UnknownEnumStringValue) | undefined
+  organization_events?: "read" | undefined
   organization_hooks?: ("read" | "write" | UnknownEnumStringValue) | undefined
   organization_packages?:
     | ("read" | "write" | UnknownEnumStringValue)
@@ -365,7 +363,7 @@ export type t_app_permissions = {
   organization_personal_access_tokens?:
     | ("read" | "write" | UnknownEnumStringValue)
     | undefined
-  organization_plan?: ("read" | UnknownEnumStringValue) | undefined
+  organization_plan?: "read" | undefined
   organization_projects?:
     | ("read" | "write" | "admin" | UnknownEnumStringValue)
     | undefined
@@ -378,7 +376,7 @@ export type t_app_permissions = {
     | undefined
   packages?: ("read" | "write" | UnknownEnumStringValue) | undefined
   pages?: ("read" | "write" | UnknownEnumStringValue) | undefined
-  profile?: ("write" | UnknownEnumStringValue) | undefined
+  profile?: "write" | undefined
   pull_requests?: ("read" | "write" | UnknownEnumStringValue) | undefined
   repository_custom_properties?:
     | ("read" | "write" | UnknownEnumStringValue)
@@ -397,7 +395,7 @@ export type t_app_permissions = {
   statuses?: ("read" | "write" | UnknownEnumStringValue) | undefined
   team_discussions?: ("read" | "write" | UnknownEnumStringValue) | undefined
   vulnerability_alerts?: ("read" | "write" | UnknownEnumStringValue) | undefined
-  workflows?: ("write" | UnknownEnumStringValue) | undefined
+  workflows?: "write" | undefined
 }
 
 export type t_artifact = {
@@ -1225,7 +1223,7 @@ export type t_code_scanning_default_setup = {
   runner_type?:
     | ("standard" | "labeled" | UnknownEnumStringValue | null)
     | undefined
-  schedule?: ("weekly" | UnknownEnumStringValue | null) | undefined
+  schedule?: ("weekly" | null) | undefined
   state?: ("configured" | "not-configured" | UnknownEnumStringValue) | undefined
   threat_model?:
     | ("remote" | "remote_and_local" | UnknownEnumStringValue)
@@ -1968,7 +1966,7 @@ export type t_content_file = {
   size: number
   submodule_git_url?: string | undefined
   target?: string | undefined
-  type: "file" | UnknownEnumStringValue
+  type: "file"
   url: string
 }
 
@@ -1986,7 +1984,7 @@ export type t_content_submodule = {
   sha: string
   size: number
   submodule_git_url: string
-  type: "submodule" | UnknownEnumStringValue
+  type: "submodule"
   url: string
 }
 
@@ -2004,7 +2002,7 @@ export type t_content_symlink = {
   sha: string
   size: number
   target: string
-  type: "symlink" | UnknownEnumStringValue
+  type: "symlink"
   url: string
 }
 
@@ -6547,7 +6545,7 @@ export type t_repository_rule_branch_name_pattern = {
         pattern: string
       }
     | undefined
-  type: "branch_name_pattern" | UnknownEnumStringValue
+  type: "branch_name_pattern"
 }
 
 export type t_repository_rule_code_scanning = {
@@ -6556,7 +6554,7 @@ export type t_repository_rule_code_scanning = {
         code_scanning_tools: t_repository_rule_params_code_scanning_tool[]
       }
     | undefined
-  type: "code_scanning" | UnknownEnumStringValue
+  type: "code_scanning"
 }
 
 export type t_repository_rule_commit_author_email_pattern = {
@@ -6573,7 +6571,7 @@ export type t_repository_rule_commit_author_email_pattern = {
         pattern: string
       }
     | undefined
-  type: "commit_author_email_pattern" | UnknownEnumStringValue
+  type: "commit_author_email_pattern"
 }
 
 export type t_repository_rule_commit_message_pattern = {
@@ -6590,7 +6588,7 @@ export type t_repository_rule_commit_message_pattern = {
         pattern: string
       }
     | undefined
-  type: "commit_message_pattern" | UnknownEnumStringValue
+  type: "commit_message_pattern"
 }
 
 export type t_repository_rule_committer_email_pattern = {
@@ -6607,15 +6605,15 @@ export type t_repository_rule_committer_email_pattern = {
         pattern: string
       }
     | undefined
-  type: "committer_email_pattern" | UnknownEnumStringValue
+  type: "committer_email_pattern"
 }
 
 export type t_repository_rule_creation = {
-  type: "creation" | UnknownEnumStringValue
+  type: "creation"
 }
 
 export type t_repository_rule_deletion = {
-  type: "deletion" | UnknownEnumStringValue
+  type: "deletion"
 }
 
 export type t_repository_rule_detailed =
@@ -6655,7 +6653,7 @@ export type t_repository_rule_file_extension_restriction = {
         restricted_file_extensions: string[]
       }
     | undefined
-  type: "file_extension_restriction" | UnknownEnumStringValue
+  type: "file_extension_restriction"
 }
 
 export type t_repository_rule_file_path_restriction = {
@@ -6664,7 +6662,7 @@ export type t_repository_rule_file_path_restriction = {
         restricted_file_paths: string[]
       }
     | undefined
-  type: "file_path_restriction" | UnknownEnumStringValue
+  type: "file_path_restriction"
 }
 
 export type t_repository_rule_max_file_path_length = {
@@ -6673,7 +6671,7 @@ export type t_repository_rule_max_file_path_length = {
         max_file_path_length: number
       }
     | undefined
-  type: "max_file_path_length" | UnknownEnumStringValue
+  type: "max_file_path_length"
 }
 
 export type t_repository_rule_max_file_size = {
@@ -6682,7 +6680,7 @@ export type t_repository_rule_max_file_size = {
         max_file_size: number
       }
     | undefined
-  type: "max_file_size" | UnknownEnumStringValue
+  type: "max_file_size"
 }
 
 export type t_repository_rule_merge_queue = {
@@ -6697,11 +6695,11 @@ export type t_repository_rule_merge_queue = {
         min_entries_to_merge_wait_minutes: number
       }
     | undefined
-  type: "merge_queue" | UnknownEnumStringValue
+  type: "merge_queue"
 }
 
 export type t_repository_rule_non_fast_forward = {
-  type: "non_fast_forward" | UnknownEnumStringValue
+  type: "non_fast_forward"
 }
 
 export type t_repository_rule_params_code_scanning_tool = {
@@ -6747,7 +6745,7 @@ export type t_repository_rule_pull_request = {
         required_review_thread_resolution: boolean
       }
     | undefined
-  type: "pull_request" | UnknownEnumStringValue
+  type: "pull_request"
 }
 
 export type t_repository_rule_required_deployments = {
@@ -6756,15 +6754,15 @@ export type t_repository_rule_required_deployments = {
         required_deployment_environments: string[]
       }
     | undefined
-  type: "required_deployments" | UnknownEnumStringValue
+  type: "required_deployments"
 }
 
 export type t_repository_rule_required_linear_history = {
-  type: "required_linear_history" | UnknownEnumStringValue
+  type: "required_linear_history"
 }
 
 export type t_repository_rule_required_signatures = {
-  type: "required_signatures" | UnknownEnumStringValue
+  type: "required_signatures"
 }
 
 export type t_repository_rule_required_status_checks = {
@@ -6775,7 +6773,7 @@ export type t_repository_rule_required_status_checks = {
         strict_required_status_checks_policy: boolean
       }
     | undefined
-  type: "required_status_checks" | UnknownEnumStringValue
+  type: "required_status_checks"
 }
 
 export type t_repository_rule_ruleset_info = {
@@ -6800,7 +6798,7 @@ export type t_repository_rule_tag_name_pattern = {
         pattern: string
       }
     | undefined
-  type: "tag_name_pattern" | UnknownEnumStringValue
+  type: "tag_name_pattern"
 }
 
 export type t_repository_rule_update = {
@@ -6809,7 +6807,7 @@ export type t_repository_rule_update = {
         update_allows_fetch_and_merge: boolean
       }
     | undefined
-  type: "update" | UnknownEnumStringValue
+  type: "update"
 }
 
 export type t_repository_rule_violation_error = {
@@ -6841,7 +6839,7 @@ export type t_repository_rule_workflows = {
         workflows: t_repository_rule_params_workflow_file_reference[]
       }
     | undefined
-  type: "workflows" | UnknownEnumStringValue
+  type: "workflows"
 }
 
 export type t_repository_ruleset = {
@@ -8943,7 +8941,7 @@ export type t_ChecksCreateRequestBody = {
         | "stale"
         | "timed_out"
         | UnknownEnumStringValue
-      status: "completed" | UnknownEnumStringValue
+      status: "completed"
       [key: string]: unknown | undefined
     }
   | {
@@ -9045,7 +9043,7 @@ export type t_ChecksUpdateRequestBody = {
         | "stale"
         | "timed_out"
         | UnknownEnumStringValue
-      status?: ("completed" | UnknownEnumStringValue) | undefined
+      status?: "completed" | undefined
       [key: string]: unknown | undefined
     }
   | {
@@ -9919,7 +9917,7 @@ export type t_MigrationsSetLfsPreferenceRequestBody = {
 }
 
 export type t_MigrationsStartForAuthenticatedUserRequestBody = {
-  exclude?: ("repositories" | UnknownEnumStringValue)[] | undefined
+  exclude?: "repositories"[] | undefined
   exclude_attachments?: boolean | undefined
   exclude_git_data?: boolean | undefined
   exclude_metadata?: boolean | undefined
@@ -9931,7 +9929,7 @@ export type t_MigrationsStartForAuthenticatedUserRequestBody = {
 }
 
 export type t_MigrationsStartForOrgRequestBody = {
-  exclude?: ("repositories" | UnknownEnumStringValue)[] | undefined
+  exclude?: "repositories"[] | undefined
   exclude_attachments?: boolean | undefined
   exclude_git_data?: boolean | undefined
   exclude_metadata?: boolean | undefined
@@ -10075,15 +10073,15 @@ export type t_OrgsUpdateRequestBody = {
 }
 
 export type t_OrgsUpdateMembershipForAuthenticatedUserRequestBody = {
-  state: "active" | UnknownEnumStringValue
+  state: "active"
 }
 
 export type t_OrgsUpdatePatAccessRequestBody = {
-  action: "revoke" | UnknownEnumStringValue
+  action: "revoke"
 }
 
 export type t_OrgsUpdatePatAccessesRequestBody = {
-  action: "revoke" | UnknownEnumStringValue
+  action: "revoke"
   pat_ids: number[]
 }
 
@@ -10273,7 +10271,7 @@ export type t_PullsCreateReviewCommentRequestBody = {
 }
 
 export type t_PullsDismissReviewRequestBody = {
-  event?: ("DISMISS" | UnknownEnumStringValue) | undefined
+  event?: "DISMISS" | undefined
   message: string
 }
 

--- a/integration-tests/typescript-axios/src/generated/azure-core-data-plane-service.tsp/models.ts
+++ b/integration-tests/typescript-axios/src/generated/azure-core-data-plane-service.tsp/models.ts
@@ -66,7 +66,7 @@ export type t_Widget = {
 }
 
 export type t_WidgetAnalytics = {
-  id: "current" | UnknownEnumStringValue
+  id: "current"
   repairCount: number
   useCount: number
 }

--- a/integration-tests/typescript-axios/src/generated/azure-resource-manager.tsp/models.ts
+++ b/integration-tests/typescript-axios/src/generated/azure-resource-manager.tsp/models.ts
@@ -12,10 +12,7 @@ export type t_Azure_Core_azureLocation = string
 
 export type t_Azure_Core_uuid = string
 
-export type t_Azure_ResourceManager_CommonTypes_ActionType =
-  | "Internal"
-  | UnknownEnumStringValue
-  | string
+export type t_Azure_ResourceManager_CommonTypes_ActionType = "Internal" | string
 
 export type t_Azure_ResourceManager_CommonTypes_ErrorAdditionalInfo = {
   info?: unknown | undefined

--- a/integration-tests/typescript-axios/src/generated/okta.idp.yaml/client.ts
+++ b/integration-tests/typescript-axios/src/generated/okta.idp.yaml/client.ts
@@ -392,13 +392,13 @@ export class MyAccountManagement extends AbstractAxiosClient {
       _links: {
         poll: {
           hints: {
-            allow: ("GET" | UnknownEnumStringValue)[]
+            allow: "GET"[]
           }
           href: string
         }
         verify: {
           hints: {
-            allow: ("POST" | UnknownEnumStringValue)[]
+            allow: "POST"[]
           }
           href: string
         }
@@ -713,7 +713,7 @@ export class MyAccountManagement extends AbstractAxiosClient {
             verify?:
               | {
                   hints: {
-                    allow: ("GET" | UnknownEnumStringValue)[]
+                    allow: "GET"[]
                   }
                   href: string
                 }

--- a/integration-tests/typescript-axios/src/generated/okta.idp.yaml/models.ts
+++ b/integration-tests/typescript-axios/src/generated/okta.idp.yaml/models.ts
@@ -15,7 +15,7 @@ export type t_AppAuthenticatorEnrollment = {
         createdDate?: string | undefined
         id?: string | undefined
         lastUpdated?: string | undefined
-        status?: ("ACTIVE" | UnknownEnumStringValue) | undefined
+        status?: "ACTIVE" | undefined
       }
     | undefined
   id?: string | undefined
@@ -49,9 +49,7 @@ export type t_AppAuthenticatorEnrollment = {
                       | {
                           hints?:
                             | {
-                                allow?:
-                                  | ("GET" | UnknownEnumStringValue)[]
-                                  | undefined
+                                allow?: "GET"[] | undefined
                               }
                             | undefined
                           href?: string | undefined
@@ -272,9 +270,9 @@ export type t_HttpMethod =
   | UnknownEnumStringValue
 
 export type t_KeyEC = {
-  crv: "P-256" | UnknownEnumStringValue
+  crv: "P-256"
   kid: string
-  kty: "EC" | UnknownEnumStringValue
+  kty: "EC"
   "okta:kpr": "HARDWARE" | "SOFTWARE" | UnknownEnumStringValue
   x: string
   y: string
@@ -285,7 +283,7 @@ export type t_KeyObject = t_KeyEC | t_KeyRSA
 export type t_KeyRSA = {
   e: string
   kid: string
-  kty: "RSA" | UnknownEnumStringValue
+  kty: "RSA"
   n: string
   "okta:kpr": "HARDWARE" | "SOFTWARE" | UnknownEnumStringValue
 }
@@ -303,7 +301,7 @@ export type t_Organization = {
           | {
               hints?:
                 | {
-                    allow?: ("GET" | UnknownEnumStringValue)[] | undefined
+                    allow?: "GET"[] | undefined
                   }
                 | undefined
               href?: string | undefined
@@ -422,12 +420,12 @@ export type t_Profile = {
 
 export type t_PushNotificationChallenge = {
   challenge?: string | undefined
-  payloadVersion?: ("IDXv1" | UnknownEnumStringValue) | undefined
+  payloadVersion?: "IDXv1" | undefined
 }
 
 export type t_PushNotificationVerification = {
   challengeResponse?: string | undefined
-  method?: ("push" | UnknownEnumStringValue) | undefined
+  method?: "push" | undefined
 }
 
 export type t_Schema = {

--- a/integration-tests/typescript-axios/src/generated/okta.oauth.yaml/models.ts
+++ b/integration-tests/typescript-axios/src/generated/okta.oauth.yaml/models.ts
@@ -137,7 +137,7 @@ export type t_Client = {
   tos_uri?: (string | null) | undefined
 }
 
-export type t_CodeChallengeMethod = "S256" | UnknownEnumStringValue
+export type t_CodeChallengeMethod = "S256"
 
 export type t_DeviceAuthorizeRequest = {
   client_id?: string | undefined
@@ -388,7 +388,7 @@ export type t_SigningAlgorithm =
 
 export type t_SubjectType = "pairwise" | "public" | UnknownEnumStringValue
 
-export type t_TokenDeliveryMode = "poll" | UnknownEnumStringValue
+export type t_TokenDeliveryMode = "poll"
 
 export type t_TokenRequest = {
   grant_type?: t_GrantType | undefined
@@ -437,6 +437,6 @@ export type t_UserInfo = {
 }
 
 export type t_sub_id = {
-  format?: ("opaque" | UnknownEnumStringValue) | undefined
+  format?: "opaque" | undefined
   id?: string | undefined
 }

--- a/integration-tests/typescript-axios/src/generated/stripe.yaml/client.ts
+++ b/integration-tests/typescript-axios/src/generated/stripe.yaml/client.ts
@@ -632,7 +632,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_account[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -944,7 +944,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_capability[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -1051,7 +1051,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: (t_bank_account | t_card)[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -1267,7 +1267,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_person[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -1471,7 +1471,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_person[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -1697,7 +1697,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_apple_pay_domain[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -1827,7 +1827,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_application_fee[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -2010,7 +2010,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_fee_refund[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -2094,7 +2094,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_apps_secret[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -2279,7 +2279,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_balance_transaction[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -2372,7 +2372,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_balance_transaction[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -2442,7 +2442,7 @@ export class StripeApi extends AbstractAxiosClient {
 
   async getBillingAlerts(
     p: {
-      alertType?: "usage_threshold" | UnknownEnumStringValue
+      alertType?: "usage_threshold"
       endingBefore?: string
       expand?: string[]
       limit?: number
@@ -2455,7 +2455,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_billing_alert[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -2661,7 +2661,7 @@ export class StripeApi extends AbstractAxiosClient {
       filter: {
         applicability_scope?:
           | {
-              price_type?: ("metered" | UnknownEnumStringValue) | undefined
+              price_type?: "metered" | undefined
               prices?:
                 | {
                     id: string
@@ -2716,7 +2716,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_billing_credit_balance_transaction[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -2791,7 +2791,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_billing_credit_grant[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -3067,7 +3067,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_billing_meter[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -3249,7 +3249,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_billing_meter_event_summary[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -3334,7 +3334,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_billing_portal_configuration[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -3524,7 +3524,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_charge[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -3617,7 +3617,7 @@ export class StripeApi extends AbstractAxiosClient {
       data: t_charge[]
       has_more: boolean
       next_page?: (string | null) | undefined
-      object: "search_result" | UnknownEnumStringValue
+      object: "search_result"
       total_count?: number | undefined
       url: string
     }>
@@ -3907,7 +3907,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_refund[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -4071,7 +4071,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_checkout_session[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -4294,7 +4294,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_item[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -4337,7 +4337,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_climate_order[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -4514,7 +4514,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_climate_product[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -4586,7 +4586,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_climate_supplier[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -4687,7 +4687,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_country_spec[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -4767,7 +4767,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_coupon[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -4949,7 +4949,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_credit_note[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -5040,10 +5040,9 @@ export class StripeApi extends AbstractAxiosClient {
                   taxable_amount: number
                 }[]
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
-        tax_rates?: (string[] | "" | UnknownEnumStringValue) | undefined
+        tax_rates?: (string[] | "") | undefined
         type: "custom_line_item" | "invoice_line_item" | UnknownEnumStringValue
         unit_amount?: number | undefined
         unit_amount_decimal?: string | undefined
@@ -5144,10 +5143,9 @@ export class StripeApi extends AbstractAxiosClient {
                   taxable_amount: number
                 }[]
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
-        tax_rates?: (string[] | "" | UnknownEnumStringValue) | undefined
+        tax_rates?: (string[] | "") | undefined
         type: "custom_line_item" | "invoice_line_item" | UnknownEnumStringValue
         unit_amount?: number | undefined
         unit_amount_decimal?: string | undefined
@@ -5177,7 +5175,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_credit_note_line_item[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -5250,7 +5248,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_credit_note_line_item[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -5435,7 +5433,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_customer[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -5529,7 +5527,7 @@ export class StripeApi extends AbstractAxiosClient {
       data: t_customer[]
       has_more: boolean
       next_page?: (string | null) | undefined
-      object: "search_result" | UnknownEnumStringValue
+      object: "search_result"
       total_count?: number | undefined
       url: string
     }>
@@ -5667,7 +5665,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_customer_balance_transaction[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -5810,7 +5808,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_bank_account[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -6037,7 +6035,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_card[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -6292,7 +6290,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_customer_cash_balance_transaction[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -6500,7 +6498,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_payment_method[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -6577,7 +6575,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: (t_bank_account | t_card | t_source)[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -6805,7 +6803,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_subscription[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -7072,7 +7070,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_tax_id[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -7205,7 +7203,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_dispute[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -7359,7 +7357,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_entitlements_active_entitlement[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -7434,7 +7432,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_entitlements_feature[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -7657,7 +7655,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_event[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -7741,7 +7739,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_exchange_rate[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -7861,7 +7859,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_file_link[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -8035,7 +8033,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_file[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -8142,7 +8140,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_financial_connections_account[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -8258,7 +8256,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_financial_connections_account_owner[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -8469,7 +8467,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_financial_connections_transaction[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -8558,7 +8556,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_forwarding_request[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -8678,7 +8676,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_identity_verification_report[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -8774,7 +8772,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_identity_verification_session[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -8999,7 +8997,7 @@ export class StripeApi extends AbstractAxiosClient {
       limit?: number
       payment?: {
         payment_intent?: string | undefined
-        type: "payment_intent" | UnknownEnumStringValue
+        type: "payment_intent"
       }
       startingAfter?: string
       status?: "canceled" | "open" | "paid" | UnknownEnumStringValue
@@ -9010,7 +9008,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_invoice_payment[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -9090,7 +9088,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_invoice_rendering_template[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -9247,7 +9245,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_invoiceitem[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -9454,7 +9452,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_invoice[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -9603,7 +9601,7 @@ export class StripeApi extends AbstractAxiosClient {
       data: t_invoice[]
       has_more: boolean
       next_page?: (string | null) | undefined
-      object: "search_result" | UnknownEnumStringValue
+      object: "search_result"
       total_count?: number | undefined
       url: string
     }>
@@ -9852,7 +9850,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_line_item[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -10164,7 +10162,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_issuing_authorization[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -10367,7 +10365,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_issuing_cardholder[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -10540,7 +10538,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_issuing_card[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -10714,7 +10712,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_issuing_dispute[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -10917,7 +10915,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_issuing_personalization_design[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -11076,7 +11074,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_issuing_physical_bundle[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -11231,7 +11229,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_issuing_token[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -11351,7 +11349,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_issuing_transaction[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -11535,7 +11533,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_financial_connections_account[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -11651,7 +11649,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_financial_connections_account_owner[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -11764,7 +11762,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_payment_intent[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -11853,7 +11851,7 @@ export class StripeApi extends AbstractAxiosClient {
       data: t_payment_intent[]
       has_more: boolean
       next_page?: (string | null) | undefined
-      object: "search_result" | UnknownEnumStringValue
+      object: "search_result"
       total_count?: number | undefined
       url: string
     }>
@@ -12195,7 +12193,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_payment_link[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -12367,7 +12365,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_item[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -12399,7 +12397,7 @@ export class StripeApi extends AbstractAxiosClient {
 
   async getPaymentMethodConfigurations(
     p: {
-      application?: string | "" | UnknownEnumStringValue
+      application?: string | ""
       endingBefore?: string
       expand?: string[]
       limit?: number
@@ -12411,7 +12409,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_payment_method_configuration[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -12665,7 +12663,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_payment_method_domain[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -12891,7 +12889,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_payment_method[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -13178,7 +13176,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_payout[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -13412,7 +13410,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_plan[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -13602,7 +13600,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_price[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -13701,7 +13699,7 @@ export class StripeApi extends AbstractAxiosClient {
       data: t_price[]
       has_more: boolean
       next_page?: (string | null) | undefined
-      object: "search_result" | UnknownEnumStringValue
+      object: "search_result"
       total_count?: number | undefined
       url: string
     }>
@@ -13824,7 +13822,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_product[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -13915,7 +13913,7 @@ export class StripeApi extends AbstractAxiosClient {
       data: t_product[]
       has_more: boolean
       next_page?: (string | null) | undefined
-      object: "search_result" | UnknownEnumStringValue
+      object: "search_result"
       total_count?: number | undefined
       url: string
     }>
@@ -14052,7 +14050,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_product_feature[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -14187,7 +14185,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_promotion_code[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -14345,7 +14343,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_quote[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -14593,7 +14591,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_item[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -14673,7 +14671,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_item[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -14759,7 +14757,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_radar_early_fraud_warning[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -14848,7 +14846,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_radar_value_list_item[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -14985,7 +14983,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_radar_value_list[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -15160,7 +15158,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_refund[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -15356,7 +15354,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_reporting_report_run[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -15460,7 +15458,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_reporting_report_type[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -15535,7 +15533,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_review[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -15657,7 +15655,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_setup_attempt[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -15717,7 +15715,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_setup_intent[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -16004,7 +16002,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_shipping_rate[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -16189,7 +16187,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_scheduled_query_run[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -16403,7 +16401,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_source_transaction[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -16508,7 +16506,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_subscription_item[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -16724,7 +16722,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_subscription_schedule[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -17015,7 +17013,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_subscription[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -17131,7 +17129,7 @@ export class StripeApi extends AbstractAxiosClient {
       data: t_subscription[]
       has_more: boolean
       next_page?: (string | null) | undefined
-      object: "search_result" | UnknownEnumStringValue
+      object: "search_result"
       total_count?: number | undefined
       url: string
     }>
@@ -17446,7 +17444,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_tax_calculation_line_item[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -17495,7 +17493,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_tax_registration[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -17794,7 +17792,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_tax_transaction_line_item[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -17837,7 +17835,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_tax_code[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -17919,7 +17917,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_tax_id[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -18055,7 +18053,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_tax_rate[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -18202,7 +18200,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_terminal_configuration[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -18418,7 +18416,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_terminal_location[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -18594,7 +18592,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_terminal_reader[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -19914,7 +19912,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_test_helpers_test_clock[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -20605,7 +20603,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_topup[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -20801,7 +20799,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_transfer[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -20882,7 +20880,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_transfer_reversal[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -21099,7 +21097,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_treasury_credit_reversal[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -21208,7 +21206,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_treasury_debit_reversal[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -21323,7 +21321,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_treasury_financial_account[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -21592,7 +21590,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_treasury_inbound_transfer[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -21749,7 +21747,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_treasury_outbound_payment[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -21906,7 +21904,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_treasury_outbound_transfer[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -22059,7 +22057,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_treasury_received_credit[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -22140,7 +22138,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_treasury_received_debit[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -22233,7 +22231,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_treasury_transaction_entry[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -22342,7 +22340,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_treasury_transaction[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {
@@ -22427,7 +22425,7 @@ export class StripeApi extends AbstractAxiosClient {
     AxiosResponse<{
       data: t_webhook_endpoint[]
       has_more: boolean
-      object: "list" | UnknownEnumStringValue
+      object: "list"
       url: string
     }>
   > {

--- a/integration-tests/typescript-axios/src/generated/stripe.yaml/models.ts
+++ b/integration-tests/typescript-axios/src/generated/stripe.yaml/models.ts
@@ -31,7 +31,7 @@ export type t_account = {
     | {
         data: (t_bank_account | t_card)[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }
     | undefined
@@ -40,7 +40,7 @@ export type t_account = {
   id: string
   individual?: t_person | undefined
   metadata?: Record<string, string> | undefined
-  object: "account" | UnknownEnumStringValue
+  object: "account"
   payouts_enabled?: boolean | undefined
   requirements?: t_account_requirements | undefined
   settings?: (t_account_settings | null) | undefined
@@ -393,7 +393,7 @@ export type t_account_invoices_settings = {
 export type t_account_link = {
   created: number
   expires_at: number
-  object: "account_link" | UnknownEnumStringValue
+  object: "account_link"
   url: string
 }
 
@@ -561,7 +561,7 @@ export type t_account_session = {
   components: t_connect_embedded_account_session_create_components
   expires_at: number
   livemode: boolean
-  object: "account_session" | UnknownEnumStringValue
+  object: "account_session"
 }
 
 export type t_account_settings = {
@@ -635,7 +635,7 @@ export type t_address = {
 
 export type t_amazon_pay_underlying_payment_method_funding_details = {
   card?: t_payment_method_details_passthrough_card | undefined
-  type?: ("card" | UnknownEnumStringValue | null) | undefined
+  type?: ("card" | null) | undefined
 }
 
 export type t_api_errors = {
@@ -667,13 +667,13 @@ export type t_apple_pay_domain = {
   domain_name: string
   id: string
   livemode: boolean
-  object: "apple_pay_domain" | UnknownEnumStringValue
+  object: "apple_pay_domain"
 }
 
 export type t_application = {
   id: string
   name?: (string | null) | undefined
-  object: "application" | UnknownEnumStringValue
+  object: "application"
 }
 
 export type t_application_fee = {
@@ -688,13 +688,13 @@ export type t_application_fee = {
   fee_source?: (t_platform_earning_fee_source | null) | undefined
   id: string
   livemode: boolean
-  object: "application_fee" | UnknownEnumStringValue
+  object: "application_fee"
   originating_transaction?: (string | t_charge | null) | undefined
   refunded: boolean
   refunds: {
     data: t_fee_refund[]
     has_more: boolean
-    object: "list" | UnknownEnumStringValue
+    object: "list"
     url: string
   }
 }
@@ -706,7 +706,7 @@ export type t_apps_secret = {
   id: string
   livemode: boolean
   name: string
-  object: "apps.secret" | UnknownEnumStringValue
+  object: "apps.secret"
   payload?: (string | null) | undefined
   scope: t_secret_service_resource_scope
 }
@@ -740,7 +740,7 @@ export type t_balance = {
   instant_available?: t_balance_amount_net[] | undefined
   issuing?: t_balance_detail | undefined
   livemode: boolean
-  object: "balance" | UnknownEnumStringValue
+  object: "balance"
   pending: t_balance_amount[]
   refund_and_dispute_prefunding?: t_balance_detail_ungated | undefined
 }
@@ -798,7 +798,7 @@ export type t_balance_transaction = {
   fee_details: t_fee[]
   id: string
   net: number
-  object: "balance_transaction" | UnknownEnumStringValue
+  object: "balance_transaction"
   reporting_category: string
   source?:
     | (
@@ -889,7 +889,7 @@ export type t_bank_account = {
   id: string
   last4: string
   metadata?: (Record<string, string> | null) | undefined
-  object: "bank_account" | UnknownEnumStringValue
+  object: "bank_account"
   requirements?: (t_external_account_requirements | null) | undefined
   routing_number?: (string | null) | undefined
   status: string
@@ -964,10 +964,10 @@ export type t_bank_connections_resource_transaction_resource_status_transitions 
   }
 
 export type t_billing_alert = {
-  alert_type: "usage_threshold" | UnknownEnumStringValue
+  alert_type: "usage_threshold"
   id: string
   livemode: boolean
-  object: "billing.alert" | UnknownEnumStringValue
+  object: "billing.alert"
   status?:
     | ("active" | "archived" | "inactive" | UnknownEnumStringValue | null)
     | undefined
@@ -981,7 +981,7 @@ export type t_billing_credit_balance_summary = {
   balances: t_credit_balance[]
   customer: string | t_customer | t_deleted_customer
   livemode: boolean
-  object: "billing.credit_balance_summary" | UnknownEnumStringValue
+  object: "billing.credit_balance_summary"
 }
 
 export type t_billing_credit_balance_transaction = {
@@ -992,7 +992,7 @@ export type t_billing_credit_balance_transaction = {
   effective_at: number
   id: string
   livemode: boolean
-  object: "billing.credit_balance_transaction" | UnknownEnumStringValue
+  object: "billing.credit_balance_transaction"
   test_clock?: (string | t_test_helpers_test_clock | null) | undefined
   type?: ("credit" | "debit" | UnknownEnumStringValue | null) | undefined
 }
@@ -1009,7 +1009,7 @@ export type t_billing_credit_grant = {
   livemode: boolean
   metadata: Record<string, string>
   name?: (string | null) | undefined
-  object: "billing.credit_grant" | UnknownEnumStringValue
+  object: "billing.credit_grant"
   priority?: (number | null) | undefined
   test_clock?: (string | t_test_helpers_test_clock | null) | undefined
   updated: number
@@ -1027,7 +1027,7 @@ export type t_billing_meter = {
     | undefined
   id: string
   livemode: boolean
-  object: "billing.meter" | UnknownEnumStringValue
+  object: "billing.meter"
   status: "active" | "inactive" | UnknownEnumStringValue
   status_transitions: t_billing_meter_resource_billing_meter_status_transitions
   updated: number
@@ -1039,7 +1039,7 @@ export type t_billing_meter_event = {
   event_name: string
   identifier: string
   livemode: boolean
-  object: "billing.meter_event" | UnknownEnumStringValue
+  object: "billing.meter_event"
   payload: Record<string, string>
   timestamp: number
 }
@@ -1050,9 +1050,9 @@ export type t_billing_meter_event_adjustment = {
     | undefined
   event_name: string
   livemode: boolean
-  object: "billing.meter_event_adjustment" | UnknownEnumStringValue
+  object: "billing.meter_event_adjustment"
   status: "complete" | "pending" | UnknownEnumStringValue
-  type: "cancel" | UnknownEnumStringValue
+  type: "cancel"
 }
 
 export type t_billing_meter_event_summary = {
@@ -1061,7 +1061,7 @@ export type t_billing_meter_event_summary = {
   id: string
   livemode: boolean
   meter: string
-  object: "billing.meter_event_summary" | UnknownEnumStringValue
+  object: "billing.meter_event_summary"
   start_time: number
 }
 
@@ -1069,7 +1069,7 @@ export type t_billing_bill_resource_invoice_item_parents_invoice_item_parent = {
   subscription_details?:
     | (t_billing_bill_resource_invoice_item_parents_invoice_item_subscription_parent | null)
     | undefined
-  type: "subscription_details" | UnknownEnumStringValue
+  type: "subscription_details"
 }
 
 export type t_billing_bill_resource_invoice_item_parents_invoice_item_subscription_parent =
@@ -1149,7 +1149,7 @@ export type t_billing_bill_resource_invoicing_pricing_pricing = {
   price_details?:
     | t_billing_bill_resource_invoicing_pricing_pricing_price_details
     | undefined
-  type: "price_details" | UnknownEnumStringValue
+  type: "price_details"
   unit_amount_decimal?: (string | null) | undefined
 }
 
@@ -1183,7 +1183,7 @@ export type t_billing_bill_resource_invoicing_taxes_tax = {
     | "zero_rated"
     | UnknownEnumStringValue
   taxable_amount?: (number | null) | undefined
-  type: "tax_rate_details" | UnknownEnumStringValue
+  type: "tax_rate_details"
 }
 
 export type t_billing_bill_resource_invoicing_taxes_tax_rate_details = {
@@ -1205,7 +1205,7 @@ export type t_billing_credit_grants_resource_amount = {
   monetary?:
     | (t_billing_credit_grants_resource_monetary_amount | null)
     | undefined
-  type: "monetary" | UnknownEnumStringValue
+  type: "monetary"
 }
 
 export type t_billing_credit_grants_resource_applicability_config = {
@@ -1256,7 +1256,7 @@ export type t_billing_credit_grants_resource_monetary_amount = {
 }
 
 export type t_billing_credit_grants_resource_scope = {
-  price_type?: ("metered" | UnknownEnumStringValue) | undefined
+  price_type?: "metered" | undefined
   prices?: t_billing_credit_grants_resource_applicable_price[] | undefined
 }
 
@@ -1286,7 +1286,7 @@ export type t_billing_meter_resource_billing_meter_value = {
 
 export type t_billing_meter_resource_customer_mapping_settings = {
   event_payload_key: string
-  type: "by_id" | UnknownEnumStringValue
+  type: "by_id"
 }
 
 export type t_billing_portal_configuration = {
@@ -1303,7 +1303,7 @@ export type t_billing_portal_configuration = {
   livemode: boolean
   login_page: t_portal_login_page
   metadata?: (Record<string, string> | null) | undefined
-  object: "billing_portal.configuration" | UnknownEnumStringValue
+  object: "billing_portal.configuration"
   updated: number
 }
 
@@ -1367,7 +1367,7 @@ export type t_billing_portal_session = {
         | null
       )
     | undefined
-  object: "billing_portal.session" | UnknownEnumStringValue
+  object: "billing_portal.session"
   on_behalf_of?: (string | null) | undefined
   return_url?: (string | null) | undefined
   url: string
@@ -1404,7 +1404,7 @@ export type t_capability = {
   account: string | t_account
   future_requirements?: t_account_capability_future_requirements | undefined
   id: string
-  object: "capability" | UnknownEnumStringValue
+  object: "capability"
   requested: boolean
   requested_at?: (number | null) | undefined
   requirements?: t_account_capability_requirements | undefined
@@ -1449,7 +1449,7 @@ export type t_card = {
   metadata?: (Record<string, string> | null) | undefined
   name?: (string | null) | undefined
   networks?: t_token_card_networks | undefined
-  object: "card" | UnknownEnumStringValue
+  object: "card"
   regulated_status?:
     | ("regulated" | "unregulated" | UnknownEnumStringValue | null)
     | undefined
@@ -1474,7 +1474,7 @@ export type t_cash_balance = {
   available?: (Record<string, number> | null) | undefined
   customer: string
   livemode: boolean
-  object: "cash_balance" | UnknownEnumStringValue
+  object: "cash_balance"
   settings: t_customer_balance_customer_balance_settings
 }
 
@@ -1503,7 +1503,7 @@ export type t_charge = {
   id: string
   livemode: boolean
   metadata: Record<string, string>
-  object: "charge" | UnknownEnumStringValue
+  object: "charge"
   on_behalf_of?: (string | t_account | null) | undefined
   outcome?: (t_charge_outcome | null) | undefined
   paid: boolean
@@ -1522,7 +1522,7 @@ export type t_charge = {
     | ({
         data: t_refund[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       } | null)
     | undefined
@@ -1618,7 +1618,7 @@ export type t_checkout_session = {
     | {
         data: t_item[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }
     | undefined
@@ -1672,7 +1672,7 @@ export type t_checkout_session = {
     | undefined
   metadata?: (Record<string, string> | null) | undefined
   mode: "payment" | "setup" | "subscription" | UnknownEnumStringValue
-  object: "checkout.session" | UnknownEnumStringValue
+  object: "checkout.session"
   optional_items?:
     | (t_payment_pages_checkout_session_optional_item[] | null)
     | undefined
@@ -1777,15 +1777,15 @@ export type t_checkout_acss_debit_payment_method_options = {
 }
 
 export type t_checkout_affirm_payment_method_options = {
-  setup_future_usage?: ("none" | UnknownEnumStringValue) | undefined
+  setup_future_usage?: "none" | undefined
 }
 
 export type t_checkout_afterpay_clearpay_payment_method_options = {
-  setup_future_usage?: ("none" | UnknownEnumStringValue) | undefined
+  setup_future_usage?: "none" | undefined
 }
 
 export type t_checkout_alipay_payment_method_options = {
-  setup_future_usage?: ("none" | UnknownEnumStringValue) | undefined
+  setup_future_usage?: "none" | undefined
 }
 
 export type t_checkout_amazon_pay_payment_method_options = {
@@ -1795,7 +1795,7 @@ export type t_checkout_amazon_pay_payment_method_options = {
 }
 
 export type t_checkout_au_becs_debit_payment_method_options = {
-  setup_future_usage?: ("none" | UnknownEnumStringValue) | undefined
+  setup_future_usage?: "none" | undefined
   target_date?: string | undefined
 }
 
@@ -1810,7 +1810,7 @@ export type t_checkout_bacs_debit_payment_method_options = {
 }
 
 export type t_checkout_bancontact_payment_method_options = {
-  setup_future_usage?: ("none" | UnknownEnumStringValue) | undefined
+  setup_future_usage?: "none" | undefined
 }
 
 export type t_checkout_boleto_payment_method_options = {
@@ -1854,7 +1854,7 @@ export type t_checkout_card_payment_method_options = {
 }
 
 export type t_checkout_cashapp_payment_method_options = {
-  setup_future_usage?: ("none" | UnknownEnumStringValue) | undefined
+  setup_future_usage?: "none" | undefined
 }
 
 export type t_checkout_customer_balance_bank_transfer_payment_method_options = {
@@ -1890,32 +1890,32 @@ export type t_checkout_customer_balance_payment_method_options = {
   bank_transfer?:
     | t_checkout_customer_balance_bank_transfer_payment_method_options
     | undefined
-  funding_type?: ("bank_transfer" | UnknownEnumStringValue | null) | undefined
-  setup_future_usage?: ("none" | UnknownEnumStringValue) | undefined
+  funding_type?: ("bank_transfer" | null) | undefined
+  setup_future_usage?: "none" | undefined
 }
 
 export type t_checkout_eps_payment_method_options = {
-  setup_future_usage?: ("none" | UnknownEnumStringValue) | undefined
+  setup_future_usage?: "none" | undefined
 }
 
 export type t_checkout_fpx_payment_method_options = {
-  setup_future_usage?: ("none" | UnknownEnumStringValue) | undefined
+  setup_future_usage?: "none" | undefined
 }
 
 export type t_checkout_giropay_payment_method_options = {
-  setup_future_usage?: ("none" | UnknownEnumStringValue) | undefined
+  setup_future_usage?: "none" | undefined
 }
 
 export type t_checkout_grab_pay_payment_method_options = {
-  setup_future_usage?: ("none" | UnknownEnumStringValue) | undefined
+  setup_future_usage?: "none" | undefined
 }
 
 export type t_checkout_ideal_payment_method_options = {
-  setup_future_usage?: ("none" | UnknownEnumStringValue) | undefined
+  setup_future_usage?: "none" | undefined
 }
 
 export type t_checkout_kakao_pay_payment_method_options = {
-  capture_method?: ("manual" | UnknownEnumStringValue) | undefined
+  capture_method?: "manual" | undefined
   setup_future_usage?:
     | ("none" | "off_session" | UnknownEnumStringValue)
     | undefined
@@ -1929,11 +1929,11 @@ export type t_checkout_klarna_payment_method_options = {
 
 export type t_checkout_konbini_payment_method_options = {
   expires_after_days?: (number | null) | undefined
-  setup_future_usage?: ("none" | UnknownEnumStringValue) | undefined
+  setup_future_usage?: "none" | undefined
 }
 
 export type t_checkout_kr_card_payment_method_options = {
-  capture_method?: ("manual" | UnknownEnumStringValue) | undefined
+  capture_method?: "manual" | undefined
   setup_future_usage?:
     | ("none" | "off_session" | UnknownEnumStringValue)
     | undefined
@@ -1950,15 +1950,15 @@ export type t_checkout_link_wallet_options = {
 }
 
 export type t_checkout_mobilepay_payment_method_options = {
-  setup_future_usage?: ("none" | UnknownEnumStringValue) | undefined
+  setup_future_usage?: "none" | undefined
 }
 
 export type t_checkout_multibanco_payment_method_options = {
-  setup_future_usage?: ("none" | UnknownEnumStringValue) | undefined
+  setup_future_usage?: "none" | undefined
 }
 
 export type t_checkout_naver_pay_payment_method_options = {
-  capture_method?: ("manual" | UnknownEnumStringValue) | undefined
+  capture_method?: "manual" | undefined
   setup_future_usage?:
     | ("none" | "off_session" | UnknownEnumStringValue)
     | undefined
@@ -1966,15 +1966,15 @@ export type t_checkout_naver_pay_payment_method_options = {
 
 export type t_checkout_oxxo_payment_method_options = {
   expires_after_days: number
-  setup_future_usage?: ("none" | UnknownEnumStringValue) | undefined
+  setup_future_usage?: "none" | undefined
 }
 
 export type t_checkout_p24_payment_method_options = {
-  setup_future_usage?: ("none" | UnknownEnumStringValue) | undefined
+  setup_future_usage?: "none" | undefined
 }
 
 export type t_checkout_payco_payment_method_options = {
-  capture_method?: ("manual" | UnknownEnumStringValue) | undefined
+  capture_method?: "manual" | undefined
 }
 
 export type t_checkout_payment_method_options_mandate_options_bacs_debit = {
@@ -1986,11 +1986,11 @@ export type t_checkout_payment_method_options_mandate_options_sepa_debit = {
 }
 
 export type t_checkout_paynow_payment_method_options = {
-  setup_future_usage?: ("none" | UnknownEnumStringValue) | undefined
+  setup_future_usage?: "none" | undefined
 }
 
 export type t_checkout_paypal_payment_method_options = {
-  capture_method?: ("manual" | UnknownEnumStringValue) | undefined
+  capture_method?: "manual" | undefined
   preferred_locale?: (string | null) | undefined
   reference?: (string | null) | undefined
   setup_future_usage?:
@@ -2000,7 +2000,7 @@ export type t_checkout_paypal_payment_method_options = {
 
 export type t_checkout_pix_payment_method_options = {
   expires_after_seconds?: (number | null) | undefined
-  setup_future_usage?: ("none" | UnknownEnumStringValue) | undefined
+  setup_future_usage?: "none" | undefined
 }
 
 export type t_checkout_revolut_pay_payment_method_options = {
@@ -2010,7 +2010,7 @@ export type t_checkout_revolut_pay_payment_method_options = {
 }
 
 export type t_checkout_samsung_pay_payment_method_options = {
-  capture_method?: ("manual" | UnknownEnumStringValue) | undefined
+  capture_method?: "manual" | undefined
 }
 
 export type t_checkout_sepa_debit_payment_method_options = {
@@ -2074,7 +2074,7 @@ export type t_checkout_session_wallet_options = {
 }
 
 export type t_checkout_sofort_payment_method_options = {
-  setup_future_usage?: ("none" | UnknownEnumStringValue) | undefined
+  setup_future_usage?: "none" | undefined
 }
 
 export type t_checkout_swish_payment_method_options = {
@@ -2119,7 +2119,7 @@ export type t_climate_order = {
   livemode: boolean
   metadata: Record<string, string>
   metric_tons: string
-  object: "climate.order" | UnknownEnumStringValue
+  object: "climate.order"
   product: string | t_climate_product
   product_substituted_at?: (number | null) | undefined
   status:
@@ -2142,7 +2142,7 @@ export type t_climate_product = {
   livemode: boolean
   metric_tons_available: string
   name: string
-  object: "climate.product" | UnknownEnumStringValue
+  object: "climate.product"
   suppliers: t_climate_supplier[]
 }
 
@@ -2152,7 +2152,7 @@ export type t_climate_supplier = {
   livemode: boolean
   locations: t_climate_removals_location[]
   name: string
-  object: "climate.supplier" | UnknownEnumStringValue
+  object: "climate.supplier"
   removal_pathway:
     | "biomass_carbon_removal_and_storage"
     | "direct_air_capture"
@@ -2194,7 +2194,7 @@ export type t_confirmation_token = {
   mandate_data?:
     | (t_confirmation_tokens_resource_mandate_data | null)
     | undefined
-  object: "confirmation_token" | UnknownEnumStringValue
+  object: "confirmation_token"
   payment_intent?: (string | null) | undefined
   payment_method_options?:
     | (t_confirmation_tokens_resource_payment_method_options | null)
@@ -2375,7 +2375,7 @@ export type t_connect_collection_transfer = {
   destination: string | t_account
   id: string
   livemode: boolean
-  object: "connect_collection_transfer" | UnknownEnumStringValue
+  object: "connect_collection_transfer"
 }
 
 export type t_connect_embedded_account_config_claim = {
@@ -2524,7 +2524,7 @@ export type t_connect_embedded_payouts_features = {
 export type t_country_spec = {
   default_currency: string
   id: string
-  object: "country_spec" | UnknownEnumStringValue
+  object: "country_spec"
   supported_bank_account_currencies: Record<string, string[]>
   supported_payment_currencies: string[]
   supported_payment_methods: string[]
@@ -2555,7 +2555,7 @@ export type t_coupon = {
   max_redemptions?: (number | null) | undefined
   metadata?: (Record<string, string> | null) | undefined
   name?: (string | null) | undefined
-  object: "coupon" | UnknownEnumStringValue
+  object: "coupon"
   percent_off?: (number | null) | undefined
   redeem_by?: (number | null) | undefined
   times_redeemed: number
@@ -2592,14 +2592,14 @@ export type t_credit_note = {
   lines: {
     data: t_credit_note_line_item[]
     has_more: boolean
-    object: "list" | UnknownEnumStringValue
+    object: "list"
     url: string
   }
   livemode: boolean
   memo?: (string | null) | undefined
   metadata?: (Record<string, string> | null) | undefined
   number: string
-  object: "credit_note" | UnknownEnumStringValue
+  object: "credit_note"
   out_of_band_amount?: (number | null) | undefined
   pdf: string
   post_payment_amount: number
@@ -2637,7 +2637,7 @@ export type t_credit_note_line_item = {
   id: string
   invoice_line_item?: string | undefined
   livemode: boolean
-  object: "credit_note_line_item" | UnknownEnumStringValue
+  object: "credit_note_line_item"
   pretax_credit_amounts: t_credit_notes_pretax_credit_amount[]
   quantity?: (number | null) | undefined
   tax_rates: t_tax_rate[]
@@ -2704,7 +2704,7 @@ export type t_customer = {
   metadata?: Record<string, string> | undefined
   name?: (string | null) | undefined
   next_invoice_sequence?: number | undefined
-  object: "customer" | UnknownEnumStringValue
+  object: "customer"
   phone?: (string | null) | undefined
   preferred_locales?: (string[] | null) | undefined
   shipping?: (t_shipping | null) | undefined
@@ -2712,7 +2712,7 @@ export type t_customer = {
     | {
         data: (t_bank_account | t_card | t_source)[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }
     | undefined
@@ -2720,7 +2720,7 @@ export type t_customer = {
     | {
         data: t_subscription[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }
     | undefined
@@ -2732,7 +2732,7 @@ export type t_customer = {
     | {
         data: t_tax_id[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }
     | undefined
@@ -2848,7 +2848,7 @@ export type t_customer_balance_transaction = {
   invoice?: (string | t_invoice | null) | undefined
   livemode: boolean
   metadata?: (Record<string, string> | null) | undefined
-  object: "customer_balance_transaction" | UnknownEnumStringValue
+  object: "customer_balance_transaction"
   type:
     | "adjustment"
     | "applied_to_invoice"
@@ -2882,7 +2882,7 @@ export type t_customer_cash_balance_transaction = {
   id: string
   livemode: boolean
   net_amount: number
-  object: "customer_cash_balance_transaction" | UnknownEnumStringValue
+  object: "customer_cash_balance_transaction"
   refunded_from_payment?:
     | t_customer_balance_resource_cash_balance_transaction_resource_refunded_from_payment_transaction
     | undefined
@@ -2912,7 +2912,7 @@ export type t_customer_session = {
   customer: string | t_customer
   expires_at: number
   livemode: boolean
-  object: "customer_session" | UnknownEnumStringValue
+  object: "customer_session"
 }
 
 export type t_customer_session_resource_components = {
@@ -2978,46 +2978,46 @@ export type t_customer_tax_location = {
 export type t_deleted_account = {
   deleted: true
   id: string
-  object: "account" | UnknownEnumStringValue
+  object: "account"
 }
 
 export type t_deleted_apple_pay_domain = {
   deleted: true
   id: string
-  object: "apple_pay_domain" | UnknownEnumStringValue
+  object: "apple_pay_domain"
 }
 
 export type t_deleted_application = {
   deleted: true
   id: string
   name?: (string | null) | undefined
-  object: "application" | UnknownEnumStringValue
+  object: "application"
 }
 
 export type t_deleted_bank_account = {
   currency?: (string | null) | undefined
   deleted: true
   id: string
-  object: "bank_account" | UnknownEnumStringValue
+  object: "bank_account"
 }
 
 export type t_deleted_card = {
   currency?: (string | null) | undefined
   deleted: true
   id: string
-  object: "card" | UnknownEnumStringValue
+  object: "card"
 }
 
 export type t_deleted_coupon = {
   deleted: true
   id: string
-  object: "coupon" | UnknownEnumStringValue
+  object: "coupon"
 }
 
 export type t_deleted_customer = {
   deleted: true
   id: string
-  object: "customer" | UnknownEnumStringValue
+  object: "customer"
 }
 
 export type t_deleted_discount = {
@@ -3028,7 +3028,7 @@ export type t_deleted_discount = {
   id: string
   invoice?: (string | null) | undefined
   invoice_item?: (string | null) | undefined
-  object: "discount" | UnknownEnumStringValue
+  object: "discount"
   promotion_code?: (string | t_promotion_code | null) | undefined
   start: number
   subscription?: (string | null) | undefined
@@ -3040,13 +3040,13 @@ export type t_deleted_external_account = t_deleted_bank_account | t_deleted_card
 export type t_deleted_invoice = {
   deleted: true
   id: string
-  object: "invoice" | UnknownEnumStringValue
+  object: "invoice"
 }
 
 export type t_deleted_invoiceitem = {
   deleted: true
   id: string
-  object: "invoiceitem" | UnknownEnumStringValue
+  object: "invoiceitem"
 }
 
 export type t_deleted_payment_source = t_deleted_bank_account | t_deleted_card
@@ -3054,85 +3054,85 @@ export type t_deleted_payment_source = t_deleted_bank_account | t_deleted_card
 export type t_deleted_person = {
   deleted: true
   id: string
-  object: "person" | UnknownEnumStringValue
+  object: "person"
 }
 
 export type t_deleted_plan = {
   deleted: true
   id: string
-  object: "plan" | UnknownEnumStringValue
+  object: "plan"
 }
 
 export type t_deleted_price = {
   deleted: true
   id: string
-  object: "price" | UnknownEnumStringValue
+  object: "price"
 }
 
 export type t_deleted_product = {
   deleted: true
   id: string
-  object: "product" | UnknownEnumStringValue
+  object: "product"
 }
 
 export type t_deleted_product_feature = {
   deleted: true
   id: string
-  object: "product_feature" | UnknownEnumStringValue
+  object: "product_feature"
 }
 
 export type t_deleted_radar_value_list = {
   deleted: true
   id: string
-  object: "radar.value_list" | UnknownEnumStringValue
+  object: "radar.value_list"
 }
 
 export type t_deleted_radar_value_list_item = {
   deleted: true
   id: string
-  object: "radar.value_list_item" | UnknownEnumStringValue
+  object: "radar.value_list_item"
 }
 
 export type t_deleted_subscription_item = {
   deleted: true
   id: string
-  object: "subscription_item" | UnknownEnumStringValue
+  object: "subscription_item"
 }
 
 export type t_deleted_tax_id = {
   deleted: true
   id: string
-  object: "tax_id" | UnknownEnumStringValue
+  object: "tax_id"
 }
 
 export type t_deleted_terminal_configuration = {
   deleted: true
   id: string
-  object: "terminal.configuration" | UnknownEnumStringValue
+  object: "terminal.configuration"
 }
 
 export type t_deleted_terminal_location = {
   deleted: true
   id: string
-  object: "terminal.location" | UnknownEnumStringValue
+  object: "terminal.location"
 }
 
 export type t_deleted_terminal_reader = {
   deleted: true
   id: string
-  object: "terminal.reader" | UnknownEnumStringValue
+  object: "terminal.reader"
 }
 
 export type t_deleted_test_helpers_test_clock = {
   deleted: true
   id: string
-  object: "test_helpers.test_clock" | UnknownEnumStringValue
+  object: "test_helpers.test_clock"
 }
 
 export type t_deleted_webhook_endpoint = {
   deleted: true
   id: string
-  object: "webhook_endpoint" | UnknownEnumStringValue
+  object: "webhook_endpoint"
 }
 
 export type t_destination_details_unimplemented = Record<string, unknown>
@@ -3145,7 +3145,7 @@ export type t_discount = {
   id: string
   invoice?: (string | null) | undefined
   invoice_item?: (string | null) | undefined
-  object: "discount" | UnknownEnumStringValue
+  object: "discount"
   promotion_code?: (string | t_promotion_code | null) | undefined
   start: number
   subscription?: (string | null) | undefined
@@ -3180,7 +3180,7 @@ export type t_dispute = {
   is_charge_refundable: boolean
   livemode: boolean
   metadata: Record<string, string>
-  object: "dispute" | UnknownEnumStringValue
+  object: "dispute"
   payment_intent?: (string | t_payment_intent | null) | undefined
   payment_method_details?: t_dispute_payment_method_details | undefined
   reason: string
@@ -3354,7 +3354,7 @@ export type t_entitlements_active_entitlement = {
   id: string
   livemode: boolean
   lookup_key: string
-  object: "entitlements.active_entitlement" | UnknownEnumStringValue
+  object: "entitlements.active_entitlement"
 }
 
 export type t_entitlements_feature = {
@@ -3364,7 +3364,7 @@ export type t_entitlements_feature = {
   lookup_key: string
   metadata: Record<string, string>
   name: string
-  object: "entitlements.feature" | UnknownEnumStringValue
+  object: "entitlements.feature"
 }
 
 export type t_ephemeral_key = {
@@ -3372,7 +3372,7 @@ export type t_ephemeral_key = {
   expires: number
   id: string
   livemode: boolean
-  object: "ephemeral_key" | UnknownEnumStringValue
+  object: "ephemeral_key"
   secret?: string | undefined
 }
 
@@ -3388,7 +3388,7 @@ export type t_event = {
   data: t_notification_event_data
   id: string
   livemode: boolean
-  object: "event" | UnknownEnumStringValue
+  object: "event"
   pending_webhooks: number
   request?: (t_notification_event_request | null) | undefined
   type: string
@@ -3396,7 +3396,7 @@ export type t_event = {
 
 export type t_exchange_rate = {
   id: string
-  object: "exchange_rate" | UnknownEnumStringValue
+  object: "exchange_rate"
   rates: Record<string, number>
 }
 
@@ -3425,7 +3425,7 @@ export type t_fee_refund = {
   fee: string | t_application_fee
   id: string
   metadata?: (Record<string, string> | null) | undefined
-  object: "fee_refund" | UnknownEnumStringValue
+  object: "fee_refund"
 }
 
 export type t_file = {
@@ -3437,11 +3437,11 @@ export type t_file = {
     | ({
         data: t_file_link[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       } | null)
     | undefined
-  object: "file" | UnknownEnumStringValue
+  object: "file"
   purpose:
     | "account_requirement"
     | "additional_verification"
@@ -3475,7 +3475,7 @@ export type t_file_link = {
   id: string
   livemode: boolean
   metadata: Record<string, string>
-  object: "file_link" | UnknownEnumStringValue
+  object: "file_link"
   url?: (string | null) | undefined
 }
 
@@ -3494,7 +3494,7 @@ export type t_financial_connections_account = {
   institution_name: string
   last4?: (string | null) | undefined
   livemode: boolean
-  object: "financial_connections.account" | UnknownEnumStringValue
+  object: "financial_connections.account"
   ownership?:
     | (string | t_financial_connections_account_ownership | null)
     | undefined
@@ -3522,9 +3522,7 @@ export type t_financial_connections_account = {
     | "other"
     | "savings"
     | UnknownEnumStringValue
-  subscriptions?:
-    | (("transactions" | UnknownEnumStringValue)[] | null)
-    | undefined
+  subscriptions?: ("transactions"[] | null) | undefined
   supported_payment_method_types: (
     | "link"
     | "us_bank_account"
@@ -3539,7 +3537,7 @@ export type t_financial_connections_account_owner = {
   email?: (string | null) | undefined
   id: string
   name: string
-  object: "financial_connections.account_owner" | UnknownEnumStringValue
+  object: "financial_connections.account_owner"
   ownership: string
   phone?: (string | null) | undefined
   raw_address?: (string | null) | undefined
@@ -3549,11 +3547,11 @@ export type t_financial_connections_account_owner = {
 export type t_financial_connections_account_ownership = {
   created: number
   id: string
-  object: "financial_connections.account_ownership" | UnknownEnumStringValue
+  object: "financial_connections.account_ownership"
   owners: {
     data: t_financial_connections_account_owner[]
     has_more: boolean
-    object: "list" | UnknownEnumStringValue
+    object: "list"
     url: string
   }
 }
@@ -3565,14 +3563,14 @@ export type t_financial_connections_session = {
   accounts: {
     data: t_financial_connections_account[]
     has_more: boolean
-    object: "list" | UnknownEnumStringValue
+    object: "list"
     url: string
   }
   client_secret: string
   filters?: t_bank_connections_resource_link_account_session_filters | undefined
   id: string
   livemode: boolean
-  object: "financial_connections.session" | UnknownEnumStringValue
+  object: "financial_connections.session"
   permissions: (
     | "balances"
     | "ownership"
@@ -3596,7 +3594,7 @@ export type t_financial_connections_transaction = {
   description: string
   id: string
   livemode: boolean
-  object: "financial_connections.transaction" | UnknownEnumStringValue
+  object: "financial_connections.transaction"
   status: "pending" | "posted" | "void" | UnknownEnumStringValue
   status_transitions: t_bank_connections_resource_transaction_resource_status_transitions
   transacted_at: number
@@ -3623,7 +3621,7 @@ export type t_forwarded_request_context = {
 export type t_forwarded_request_details = {
   body: string
   headers: t_forwarded_request_header[]
-  http_method: "POST" | UnknownEnumStringValue
+  http_method: "POST"
 }
 
 export type t_forwarded_request_header = {
@@ -3642,7 +3640,7 @@ export type t_forwarding_request = {
   id: string
   livemode: boolean
   metadata?: (Record<string, string> | null) | undefined
-  object: "forwarding.request" | UnknownEnumStringValue
+  object: "forwarding.request"
   payment_method: string
   replacements: (
     | "card_cvc"
@@ -3661,9 +3659,9 @@ export type t_forwarding_request = {
 export type t_funding_instructions = {
   bank_transfer: t_funding_instructions_bank_transfer
   currency: string
-  funding_type: "bank_transfer" | UnknownEnumStringValue
+  funding_type: "bank_transfer"
   livemode: boolean
-  object: "funding_instructions" | UnknownEnumStringValue
+  object: "funding_instructions"
 }
 
 export type t_funding_instructions_bank_transfer = {
@@ -4042,7 +4040,7 @@ export type t_identity_verification_report = {
   id: string
   id_number?: t_gelato_id_number_report | undefined
   livemode: boolean
-  object: "identity.verification_report" | UnknownEnumStringValue
+  object: "identity.verification_report"
   options?: t_gelato_verification_report_options | undefined
   phone?: t_gelato_phone_report | undefined
   selfie?: t_gelato_selfie_report | undefined
@@ -4062,7 +4060,7 @@ export type t_identity_verification_session = {
     | undefined
   livemode: boolean
   metadata: Record<string, string>
-  object: "identity.verification_session" | UnknownEnumStringValue
+  object: "identity.verification_session"
   options?: (t_gelato_verification_session_options | null) | undefined
   provided_details?: (t_gelato_provided_details | null) | undefined
   redaction?: (t_verification_session_redaction | null) | undefined
@@ -4082,7 +4080,7 @@ export type t_identity_verification_session = {
 
 export type t_inbound_transfers = {
   billing_details: t_treasury_shared_resource_billing_details
-  type: "us_bank_account" | UnknownEnumStringValue
+  type: "us_bank_account"
   us_bank_account?:
     | t_inbound_transfers_payment_method_details_us_bank_account
     | undefined
@@ -4099,7 +4097,7 @@ export type t_inbound_transfers_payment_method_details_us_bank_account = {
   fingerprint?: (string | null) | undefined
   last4?: (string | null) | undefined
   mandate?: (string | t_mandate) | undefined
-  network: "ach" | UnknownEnumStringValue
+  network: "ach"
   routing_number?: (string | null) | undefined
 }
 
@@ -4186,14 +4184,14 @@ export type t_invoice = {
   lines: {
     data: t_line_item[]
     has_more: boolean
-    object: "list" | UnknownEnumStringValue
+    object: "list"
     url: string
   }
   livemode: boolean
   metadata?: (Record<string, string> | null) | undefined
   next_payment_attempt?: (number | null) | undefined
   number?: (string | null) | undefined
-  object: "invoice" | UnknownEnumStringValue
+  object: "invoice"
   on_behalf_of?: (string | t_account | null) | undefined
   parent?:
     | (t_billing_bill_resource_invoicing_parents_invoice_parent | null)
@@ -4203,7 +4201,7 @@ export type t_invoice = {
     | {
         data: t_invoice_payment[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }
     | undefined
@@ -4278,7 +4276,7 @@ export type t_invoice_payment = {
   invoice: string | t_invoice | t_deleted_invoice
   is_default: boolean
   livemode: boolean
-  object: "invoice_payment" | UnknownEnumStringValue
+  object: "invoice_payment"
   payment: t_invoices_payments_invoice_payment_associated_payment
   status: string
   status_transitions: t_invoices_payments_invoice_payment_status_transitions
@@ -4314,7 +4312,7 @@ export type t_invoice_payment_method_options_customer_balance = {
   bank_transfer?:
     | t_invoice_payment_method_options_customer_balance_bank_transfer
     | undefined
-  funding_type?: ("bank_transfer" | UnknownEnumStringValue | null) | undefined
+  funding_type?: ("bank_transfer" | null) | undefined
 }
 
 export type t_invoice_payment_method_options_customer_balance_bank_transfer = {
@@ -4391,7 +4389,7 @@ export type t_invoice_rendering_template = {
   livemode: boolean
   metadata?: (Record<string, string> | null) | undefined
   nickname?: (string | null) | undefined
-  object: "invoice_rendering_template" | UnknownEnumStringValue
+  object: "invoice_rendering_template"
   status: "active" | "archived" | UnknownEnumStringValue
   version: number
 }
@@ -4458,7 +4456,7 @@ export type t_invoiceitem = {
   invoice?: (string | t_invoice | null) | undefined
   livemode: boolean
   metadata?: (Record<string, string> | null) | undefined
-  object: "invoiceitem" | UnknownEnumStringValue
+  object: "invoiceitem"
   parent?:
     | (t_billing_bill_resource_invoice_item_parents_invoice_item_parent | null)
     | undefined
@@ -4737,7 +4735,7 @@ export type t_issuing_authorization = {
   merchant_data: t_issuing_authorization_merchant_data
   metadata: Record<string, string>
   network_data?: (t_issuing_authorization_network_data | null) | undefined
-  object: "issuing.authorization" | UnknownEnumStringValue
+  object: "issuing.authorization"
   pending_request?: (t_issuing_authorization_pending_request | null) | undefined
   request_history: t_issuing_authorization_request[]
   status: "closed" | "expired" | "pending" | "reversed" | UnknownEnumStringValue
@@ -4766,7 +4764,7 @@ export type t_issuing_card = {
   livemode: boolean
   metadata: Record<string, string>
   number?: string | undefined
-  object: "issuing.card" | UnknownEnumStringValue
+  object: "issuing.card"
   personalization_design?:
     | (string | t_issuing_personalization_design | null)
     | undefined
@@ -4799,7 +4797,7 @@ export type t_issuing_cardholder = {
   livemode: boolean
   metadata: Record<string, string>
   name: string
-  object: "issuing.cardholder" | UnknownEnumStringValue
+  object: "issuing.cardholder"
   phone_number?: (string | null) | undefined
   preferred_locales?:
     | (("de" | "en" | "es" | "fr" | "it" | UnknownEnumStringValue)[] | null)
@@ -4846,7 +4844,7 @@ export type t_issuing_dispute = {
       )
     | undefined
   metadata: Record<string, string>
-  object: "issuing.dispute" | UnknownEnumStringValue
+  object: "issuing.dispute"
   status:
     | "expired"
     | "lost"
@@ -4869,7 +4867,7 @@ export type t_issuing_personalization_design = {
   lookup_key?: (string | null) | undefined
   metadata: Record<string, string>
   name?: (string | null) | undefined
-  object: "issuing.personalization_design" | UnknownEnumStringValue
+  object: "issuing.personalization_design"
   physical_bundle: string | t_issuing_physical_bundle
   preferences: t_issuing_personalization_design_preferences
   rejection_reasons: t_issuing_personalization_design_rejection_reasons
@@ -4881,7 +4879,7 @@ export type t_issuing_physical_bundle = {
   id: string
   livemode: boolean
   name: string
-  object: "issuing.physical_bundle" | UnknownEnumStringValue
+  object: "issuing.physical_bundle"
   status: "active" | "inactive" | "review" | UnknownEnumStringValue
   type: "custom" | "standard" | UnknownEnumStringValue
 }
@@ -4899,7 +4897,7 @@ export type t_issuing_settlement = {
   network: "maestro" | "visa" | UnknownEnumStringValue
   network_fees_amount: number
   network_settlement_identifier: string
-  object: "issuing.settlement" | UnknownEnumStringValue
+  object: "issuing.settlement"
   settlement_service: string
   status: "complete" | "pending" | UnknownEnumStringValue
   transaction_amount: number
@@ -4916,7 +4914,7 @@ export type t_issuing_token = {
   network: "mastercard" | "visa" | UnknownEnumStringValue
   network_data?: t_issuing_network_token_network_data | undefined
   network_updated_at: number
-  object: "issuing.token" | UnknownEnumStringValue
+  object: "issuing.token"
   status:
     | "active"
     | "deleted"
@@ -4945,7 +4943,7 @@ export type t_issuing_transaction = {
   merchant_data: t_issuing_authorization_merchant_data
   metadata: Record<string, string>
   network_data?: (t_issuing_transaction_network_data | null) | undefined
-  object: "issuing.transaction" | UnknownEnumStringValue
+  object: "issuing.transaction"
   purchase_details?: (t_issuing_transaction_purchase_details | null) | undefined
   token?: (string | t_issuing_token | null) | undefined
   treasury?: (t_issuing_transaction_treasury | null) | undefined
@@ -5033,7 +5031,7 @@ export type t_issuing_authorization_fleet_tax_data = {
 }
 
 export type t_issuing_authorization_fraud_challenge = {
-  channel: "sms" | UnknownEnumStringValue
+  channel: "sms"
   status:
     | "expired"
     | "pending"
@@ -7552,7 +7550,7 @@ export type t_item = {
   description?: (string | null) | undefined
   discounts?: t_line_items_discount_amount[] | undefined
   id: string
-  object: "item" | UnknownEnumStringValue
+  object: "item"
   price?: (t_price | null) | undefined
   quantity?: (number | null) | undefined
   taxes?: t_line_items_tax_amount[] | undefined
@@ -7698,7 +7696,7 @@ export type t_line_item = {
   invoice?: (string | null) | undefined
   livemode: boolean
   metadata: Record<string, string>
-  object: "line_item" | UnknownEnumStringValue
+  object: "line_item"
   parent?:
     | (t_billing_bill_resource_invoicing_lines_parents_invoice_line_item_parent | null)
     | undefined
@@ -7770,7 +7768,7 @@ export type t_linked_account_options_common = {
 
 export type t_login_link = {
   created: number
-  object: "login_link" | UnknownEnumStringValue
+  object: "login_link"
   url: string
 }
 
@@ -7779,7 +7777,7 @@ export type t_mandate = {
   id: string
   livemode: boolean
   multi_use?: t_mandate_multi_use | undefined
-  object: "mandate" | UnknownEnumStringValue
+  object: "mandate"
   on_behalf_of?: string | undefined
   payment_method: string | t_payment_method
   payment_method_details: t_mandate_payment_method_details
@@ -7883,7 +7881,7 @@ export type t_mandate_single_use = {
 }
 
 export type t_mandate_us_bank_account = {
-  collection_method?: ("paper" | UnknownEnumStringValue) | undefined
+  collection_method?: "paper" | undefined
 }
 
 export type t_networks = {
@@ -7921,7 +7919,7 @@ export type t_outbound_payments_payment_method_details = {
 
 export type t_outbound_payments_payment_method_details_financial_account = {
   id: string
-  network: "stripe" | UnknownEnumStringValue
+  network: "stripe"
 }
 
 export type t_outbound_payments_payment_method_details_us_bank_account = {
@@ -7952,7 +7950,7 @@ export type t_outbound_transfers_payment_method_details = {
 
 export type t_outbound_transfers_payment_method_details_financial_account = {
   id: string
-  network: "stripe" | UnknownEnumStringValue
+  network: "stripe"
 }
 
 export type t_outbound_transfers_payment_method_details_us_bank_account = {
@@ -8060,7 +8058,7 @@ export type t_payment_flows_private_payment_methods_financial_connections_common
 
 export type t_payment_flows_private_payment_methods_kakao_pay_payment_method_options =
   {
-    capture_method?: ("manual" | UnknownEnumStringValue) | undefined
+    capture_method?: "manual" | undefined
     setup_future_usage?:
       | ("none" | "off_session" | UnknownEnumStringValue)
       | undefined
@@ -8074,7 +8072,7 @@ export type t_payment_flows_private_payment_methods_klarna_dob = {
 
 export type t_payment_flows_private_payment_methods_naver_pay_payment_method_options =
   {
-    capture_method?: ("manual" | UnknownEnumStringValue) | undefined
+    capture_method?: "manual" | undefined
     setup_future_usage?:
       | ("none" | "off_session" | UnknownEnumStringValue)
       | undefined
@@ -8082,12 +8080,12 @@ export type t_payment_flows_private_payment_methods_naver_pay_payment_method_opt
 
 export type t_payment_flows_private_payment_methods_payco_payment_method_options =
   {
-    capture_method?: ("manual" | UnknownEnumStringValue) | undefined
+    capture_method?: "manual" | undefined
   }
 
 export type t_payment_flows_private_payment_methods_samsung_pay_payment_method_options =
   {
-    capture_method?: ("manual" | UnknownEnumStringValue) | undefined
+    capture_method?: "manual" | undefined
   }
 
 export type t_payment_intent = {
@@ -8134,7 +8132,7 @@ export type t_payment_intent = {
   livemode: boolean
   metadata?: Record<string, string> | undefined
   next_action?: (t_payment_intent_next_action | null) | undefined
-  object: "payment_intent" | UnknownEnumStringValue
+  object: "payment_intent"
   on_behalf_of?: (string | t_account | null) | undefined
   payment_method?: (string | t_payment_method | null) | undefined
   payment_method_configuration_details?:
@@ -8727,11 +8725,11 @@ export type t_payment_intent_payment_method_options_bacs_debit = {
 }
 
 export type t_payment_intent_payment_method_options_blik = {
-  setup_future_usage?: ("none" | UnknownEnumStringValue) | undefined
+  setup_future_usage?: "none" | undefined
 }
 
 export type t_payment_intent_payment_method_options_card = {
-  capture_method?: ("manual" | UnknownEnumStringValue) | undefined
+  capture_method?: "manual" | undefined
   installments?: (t_payment_method_options_card_installments | null) | undefined
   mandate_options?:
     | (t_payment_method_options_card_mandate_options | null)
@@ -8779,11 +8777,11 @@ export type t_payment_intent_payment_method_options_card = {
 }
 
 export type t_payment_intent_payment_method_options_eps = {
-  setup_future_usage?: ("none" | UnknownEnumStringValue) | undefined
+  setup_future_usage?: "none" | undefined
 }
 
 export type t_payment_intent_payment_method_options_link = {
-  capture_method?: ("manual" | UnknownEnumStringValue) | undefined
+  capture_method?: "manual" | undefined
   setup_future_usage?:
     | ("none" | "off_session" | UnknownEnumStringValue)
     | undefined
@@ -8812,8 +8810,8 @@ export type t_payment_intent_payment_method_options_mandate_options_sepa_debit =
   }
 
 export type t_payment_intent_payment_method_options_mobilepay = {
-  capture_method?: ("manual" | UnknownEnumStringValue) | undefined
-  setup_future_usage?: ("none" | UnknownEnumStringValue) | undefined
+  capture_method?: "manual" | undefined
+  setup_future_usage?: "none" | undefined
 }
 
 export type t_payment_intent_payment_method_options_nz_bank_account = {
@@ -8835,7 +8833,7 @@ export type t_payment_intent_payment_method_options_sepa_debit = {
 
 export type t_payment_intent_payment_method_options_swish = {
   reference?: (string | null) | undefined
-  setup_future_usage?: ("none" | UnknownEnumStringValue) | undefined
+  setup_future_usage?: "none" | undefined
 }
 
 export type t_payment_intent_payment_method_options_us_bank_account = {
@@ -8857,7 +8855,7 @@ export type t_payment_intent_payment_method_options_us_bank_account = {
 
 export type t_payment_intent_processing = {
   card?: t_payment_intent_card_processing | undefined
-  type: "card" | UnknownEnumStringValue
+  type: "card"
 }
 
 export type t_payment_intent_processing_customer_notification = {
@@ -8908,13 +8906,13 @@ export type t_payment_link = {
     | {
         data: t_item[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }
     | undefined
   livemode: boolean
   metadata: Record<string, string>
-  object: "payment_link" | UnknownEnumStringValue
+  object: "payment_link"
   on_behalf_of?: (string | t_account | null) | undefined
   optional_items?: (t_payment_links_resource_optional_item[] | null) | undefined
   payment_intent_data?:
@@ -9045,7 +9043,7 @@ export type t_payment_links_resource_custom_fields_dropdown_option = {
 
 export type t_payment_links_resource_custom_fields_label = {
   custom?: (string | null) | undefined
-  type: "custom" | UnknownEnumStringValue
+  type: "custom"
 }
 
 export type t_payment_links_resource_custom_fields_numeric = {
@@ -9457,7 +9455,7 @@ export type t_payment_method = {
   multibanco?: t_payment_method_multibanco | undefined
   naver_pay?: t_payment_method_naver_pay | undefined
   nz_bank_account?: t_payment_method_nz_bank_account | undefined
-  object: "payment_method" | UnknownEnumStringValue
+  object: "payment_method"
   oxxo?: t_payment_method_oxxo | undefined
   p24?: t_payment_method_p24 | undefined
   pay_by_bank?: t_payment_method_pay_by_bank | undefined
@@ -9798,7 +9796,7 @@ export type t_payment_method_configuration = {
   nz_bank_account?:
     | t_payment_method_config_resource_payment_method_properties
     | undefined
-  object: "payment_method_configuration" | UnknownEnumStringValue
+  object: "payment_method_configuration"
   oxxo?: t_payment_method_config_resource_payment_method_properties | undefined
   p24?: t_payment_method_config_resource_payment_method_properties | undefined
   parent?: (string | null) | undefined
@@ -10035,7 +10033,7 @@ export type t_payment_method_details_card_installments = {
 
 export type t_payment_method_details_card_installments_plan = {
   count?: (number | null) | undefined
-  interval?: ("month" | UnknownEnumStringValue | null) | undefined
+  interval?: ("month" | null) | undefined
   type: "bonus" | "fixed_count" | "revolving" | UnknownEnumStringValue
 }
 
@@ -10084,7 +10082,7 @@ export type t_payment_method_details_card_present = {
 
 export type t_payment_method_details_card_present_offline = {
   stored_at?: (number | null) | undefined
-  type?: ("deferred" | UnknownEnumStringValue | null) | undefined
+  type?: ("deferred" | null) | undefined
 }
 
 export type t_payment_method_details_card_present_receipt = {
@@ -10608,7 +10606,7 @@ export type t_payment_method_domain = {
   klarna: t_payment_method_domain_resource_payment_method_status
   link: t_payment_method_domain_resource_payment_method_status
   livemode: boolean
-  object: "payment_method_domain" | UnknownEnumStringValue
+  object: "payment_method_domain"
   paypal: t_payment_method_domain_resource_payment_method_status
 }
 
@@ -10830,15 +10828,15 @@ export type t_payment_method_nz_bank_account = {
 }
 
 export type t_payment_method_options_affirm = {
-  capture_method?: ("manual" | UnknownEnumStringValue) | undefined
+  capture_method?: "manual" | undefined
   preferred_locale?: string | undefined
-  setup_future_usage?: ("none" | UnknownEnumStringValue) | undefined
+  setup_future_usage?: "none" | undefined
 }
 
 export type t_payment_method_options_afterpay_clearpay = {
-  capture_method?: ("manual" | UnknownEnumStringValue) | undefined
+  capture_method?: "manual" | undefined
   reference?: (string | null) | undefined
-  setup_future_usage?: ("none" | UnknownEnumStringValue) | undefined
+  setup_future_usage?: "none" | undefined
 }
 
 export type t_payment_method_options_alipay = {
@@ -10848,11 +10846,11 @@ export type t_payment_method_options_alipay = {
 }
 
 export type t_payment_method_options_alma = {
-  capture_method?: ("manual" | UnknownEnumStringValue) | undefined
+  capture_method?: "manual" | undefined
 }
 
 export type t_payment_method_options_amazon_pay = {
-  capture_method?: ("manual" | UnknownEnumStringValue) | undefined
+  capture_method?: "manual" | undefined
   setup_future_usage?:
     | ("none" | "off_session" | UnknownEnumStringValue)
     | undefined
@@ -10866,7 +10864,7 @@ export type t_payment_method_options_bancontact = {
 }
 
 export type t_payment_method_options_billie = {
-  capture_method?: ("manual" | UnknownEnumStringValue) | undefined
+  capture_method?: "manual" | undefined
 }
 
 export type t_payment_method_options_boleto = {
@@ -10899,7 +10897,7 @@ export type t_payment_method_options_card_mandate_options = {
   interval_count?: (number | null) | undefined
   reference: string
   start_date: number
-  supported_types?: (("india" | UnknownEnumStringValue)[] | null) | undefined
+  supported_types?: ("india"[] | null) | undefined
 }
 
 export type t_payment_method_options_card_present = {
@@ -10915,22 +10913,22 @@ export type t_payment_method_options_card_present_routing = {
 }
 
 export type t_payment_method_options_cashapp = {
-  capture_method?: ("manual" | UnknownEnumStringValue) | undefined
+  capture_method?: "manual" | undefined
   setup_future_usage?:
     | ("none" | "off_session" | "on_session" | UnknownEnumStringValue)
     | undefined
 }
 
 export type t_payment_method_options_crypto = {
-  setup_future_usage?: ("none" | UnknownEnumStringValue) | undefined
+  setup_future_usage?: "none" | undefined
 }
 
 export type t_payment_method_options_customer_balance = {
   bank_transfer?:
     | t_payment_method_options_customer_balance_bank_transfer
     | undefined
-  funding_type?: ("bank_transfer" | UnknownEnumStringValue | null) | undefined
-  setup_future_usage?: ("none" | UnknownEnumStringValue) | undefined
+  funding_type?: ("bank_transfer" | null) | undefined
+  setup_future_usage?: "none" | undefined
 }
 
 export type t_payment_method_options_customer_balance_bank_transfer = {
@@ -10967,15 +10965,15 @@ export type t_payment_method_options_customer_balance_eu_bank_account = {
 }
 
 export type t_payment_method_options_fpx = {
-  setup_future_usage?: ("none" | UnknownEnumStringValue) | undefined
+  setup_future_usage?: "none" | undefined
 }
 
 export type t_payment_method_options_giropay = {
-  setup_future_usage?: ("none" | UnknownEnumStringValue) | undefined
+  setup_future_usage?: "none" | undefined
 }
 
 export type t_payment_method_options_grabpay = {
-  setup_future_usage?: ("none" | UnknownEnumStringValue) | undefined
+  setup_future_usage?: "none" | undefined
 }
 
 export type t_payment_method_options_ideal = {
@@ -10987,7 +10985,7 @@ export type t_payment_method_options_ideal = {
 export type t_payment_method_options_interac_present = Record<string, unknown>
 
 export type t_payment_method_options_klarna = {
-  capture_method?: ("manual" | UnknownEnumStringValue) | undefined
+  capture_method?: "manual" | undefined
   preferred_locale?: (string | null) | undefined
   setup_future_usage?:
     | ("none" | "off_session" | "on_session" | UnknownEnumStringValue)
@@ -10999,37 +10997,37 @@ export type t_payment_method_options_konbini = {
   expires_after_days?: (number | null) | undefined
   expires_at?: (number | null) | undefined
   product_description?: (string | null) | undefined
-  setup_future_usage?: ("none" | UnknownEnumStringValue) | undefined
+  setup_future_usage?: "none" | undefined
 }
 
 export type t_payment_method_options_kr_card = {
-  capture_method?: ("manual" | UnknownEnumStringValue) | undefined
+  capture_method?: "manual" | undefined
   setup_future_usage?:
     | ("none" | "off_session" | UnknownEnumStringValue)
     | undefined
 }
 
 export type t_payment_method_options_multibanco = {
-  setup_future_usage?: ("none" | UnknownEnumStringValue) | undefined
+  setup_future_usage?: "none" | undefined
 }
 
 export type t_payment_method_options_oxxo = {
   expires_after_days: number
-  setup_future_usage?: ("none" | UnknownEnumStringValue) | undefined
+  setup_future_usage?: "none" | undefined
 }
 
 export type t_payment_method_options_p24 = {
-  setup_future_usage?: ("none" | UnknownEnumStringValue) | undefined
+  setup_future_usage?: "none" | undefined
 }
 
 export type t_payment_method_options_pay_by_bank = Record<string, unknown>
 
 export type t_payment_method_options_paynow = {
-  setup_future_usage?: ("none" | UnknownEnumStringValue) | undefined
+  setup_future_usage?: "none" | undefined
 }
 
 export type t_payment_method_options_paypal = {
-  capture_method?: ("manual" | UnknownEnumStringValue) | undefined
+  capture_method?: "manual" | undefined
   preferred_locale?: (string | null) | undefined
   reference?: (string | null) | undefined
   setup_future_usage?:
@@ -11040,22 +11038,22 @@ export type t_payment_method_options_paypal = {
 export type t_payment_method_options_pix = {
   expires_after_seconds?: (number | null) | undefined
   expires_at?: (number | null) | undefined
-  setup_future_usage?: ("none" | UnknownEnumStringValue) | undefined
+  setup_future_usage?: "none" | undefined
 }
 
 export type t_payment_method_options_promptpay = {
-  setup_future_usage?: ("none" | UnknownEnumStringValue) | undefined
+  setup_future_usage?: "none" | undefined
 }
 
 export type t_payment_method_options_revolut_pay = {
-  capture_method?: ("manual" | UnknownEnumStringValue) | undefined
+  capture_method?: "manual" | undefined
   setup_future_usage?:
     | ("none" | "off_session" | UnknownEnumStringValue)
     | undefined
 }
 
 export type t_payment_method_options_satispay = {
-  capture_method?: ("manual" | UnknownEnumStringValue) | undefined
+  capture_method?: "manual" | undefined
 }
 
 export type t_payment_method_options_sofort = {
@@ -11078,11 +11076,11 @@ export type t_payment_method_options_sofort = {
 }
 
 export type t_payment_method_options_twint = {
-  setup_future_usage?: ("none" | UnknownEnumStringValue) | undefined
+  setup_future_usage?: "none" | undefined
 }
 
 export type t_payment_method_options_us_bank_account_mandate_options = {
-  collection_method?: ("paper" | UnknownEnumStringValue) | undefined
+  collection_method?: "paper" | undefined
 }
 
 export type t_payment_method_options_wechat_pay = {
@@ -11090,11 +11088,11 @@ export type t_payment_method_options_wechat_pay = {
   client?:
     | ("android" | "ios" | "web" | UnknownEnumStringValue | null)
     | undefined
-  setup_future_usage?: ("none" | UnknownEnumStringValue) | undefined
+  setup_future_usage?: "none" | undefined
 }
 
 export type t_payment_method_options_zip = {
-  setup_future_usage?: ("none" | UnknownEnumStringValue) | undefined
+  setup_future_usage?: "none" | undefined
 }
 
 export type t_payment_method_oxxo = Record<string, unknown>
@@ -11279,7 +11277,7 @@ export type t_payment_pages_checkout_session_consent = {
   promotions?:
     | ("opt_in" | "opt_out" | UnknownEnumStringValue | null)
     | undefined
-  terms_of_service?: ("accepted" | UnknownEnumStringValue | null) | undefined
+  terms_of_service?: ("accepted" | null) | undefined
 }
 
 export type t_payment_pages_checkout_session_consent_collection = {
@@ -11317,7 +11315,7 @@ export type t_payment_pages_checkout_session_custom_fields_dropdown = {
 
 export type t_payment_pages_checkout_session_custom_fields_label = {
   custom?: (string | null) | undefined
-  type: "custom" | UnknownEnumStringValue
+  type: "custom"
 }
 
 export type t_payment_pages_checkout_session_custom_fields_numeric = {
@@ -11872,7 +11870,7 @@ export type t_payout = {
   livemode: boolean
   metadata?: (Record<string, string> | null) | undefined
   method: string
-  object: "payout" | UnknownEnumStringValue
+  object: "payout"
   original_payout?: (string | t_payout | null) | undefined
   reconciliation_status:
     | "completed"
@@ -11930,7 +11928,7 @@ export type t_person = {
   maiden_name?: (string | null) | undefined
   metadata?: Record<string, string> | undefined
   nationality?: (string | null) | undefined
-  object: "person" | UnknownEnumStringValue
+  object: "person"
   phone?: (string | null) | undefined
   political_exposure?:
     | ("existing" | "none" | UnknownEnumStringValue)
@@ -12057,7 +12055,7 @@ export type t_plan = {
   metadata?: (Record<string, string> | null) | undefined
   meter?: (string | null) | undefined
   nickname?: (string | null) | undefined
-  object: "plan" | UnknownEnumStringValue
+  object: "plan"
   product?: (string | t_product | t_deleted_product | null) | undefined
   tiers?: t_plan_tier[] | undefined
   tiers_mode?:
@@ -12171,7 +12169,7 @@ export type t_portal_flows_flow_subscription_update_confirm = {
 
 export type t_portal_flows_retention = {
   coupon_offer?: (t_portal_flows_coupon_offer | null) | undefined
-  type: "coupon_offer" | UnknownEnumStringValue
+  type: "coupon_offer"
 }
 
 export type t_portal_flows_subscription_update_confirm_discount = {
@@ -12276,7 +12274,7 @@ export type t_price = {
   lookup_key?: (string | null) | undefined
   metadata: Record<string, string>
   nickname?: (string | null) | undefined
-  object: "price" | UnknownEnumStringValue
+  object: "price"
   product: string | t_product | t_deleted_product
   recurring?: (t_recurring | null) | undefined
   tax_behavior?:
@@ -12317,7 +12315,7 @@ export type t_product = {
   marketing_features: t_product_marketing_feature[]
   metadata: Record<string, string>
   name: string
-  object: "product" | UnknownEnumStringValue
+  object: "product"
   package_dimensions?: (t_package_dimensions | null) | undefined
   shippable?: (boolean | null) | undefined
   statement_descriptor?: (string | null) | undefined
@@ -12331,7 +12329,7 @@ export type t_product_feature = {
   entitlement_feature: t_entitlements_feature
   id: string
   livemode: boolean
-  object: "product_feature" | UnknownEnumStringValue
+  object: "product_feature"
 }
 
 export type t_product_marketing_feature = {
@@ -12349,7 +12347,7 @@ export type t_promotion_code = {
   livemode: boolean
   max_redemptions?: (number | null) | undefined
   metadata?: (Record<string, string> | null) | undefined
-  object: "promotion_code" | UnknownEnumStringValue
+  object: "promotion_code"
   restrictions: t_promotion_codes_resource_restrictions
   times_redeemed: number
 }
@@ -12398,14 +12396,14 @@ export type t_quote = {
     | {
         data: t_item[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }
     | undefined
   livemode: boolean
   metadata: Record<string, string>
   number?: (string | null) | undefined
-  object: "quote" | UnknownEnumStringValue
+  object: "quote"
   on_behalf_of?: (string | t_account | null) | undefined
   status: "accepted" | "canceled" | "draft" | "open" | UnknownEnumStringValue
   status_transitions: t_quotes_resource_status_transitions
@@ -12493,7 +12491,7 @@ export type t_quotes_resource_upfront = {
     | {
         data: t_item[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       }
     | undefined
@@ -12507,7 +12505,7 @@ export type t_radar_early_fraud_warning = {
   fraud_type: string
   id: string
   livemode: boolean
-  object: "radar.early_fraud_warning" | UnknownEnumStringValue
+  object: "radar.early_fraud_warning"
   payment_intent?: (string | t_payment_intent) | undefined
 }
 
@@ -12531,13 +12529,13 @@ export type t_radar_value_list = {
   list_items: {
     data: t_radar_value_list_item[]
     has_more: boolean
-    object: "list" | UnknownEnumStringValue
+    object: "list"
     url: string
   }
   livemode: boolean
   metadata: Record<string, string>
   name: string
-  object: "radar.value_list" | UnknownEnumStringValue
+  object: "radar.value_list"
 }
 
 export type t_radar_value_list_item = {
@@ -12545,7 +12543,7 @@ export type t_radar_value_list_item = {
   created_by: string
   id: string
   livemode: boolean
-  object: "radar.value_list_item" | UnknownEnumStringValue
+  object: "radar.value_list_item"
   value: string
   value_list: string
 }
@@ -12571,7 +12569,7 @@ export type t_radar_review_resource_session = {
 
 export type t_received_payment_method_details_financial_account = {
   id: string
-  network: "stripe" | UnknownEnumStringValue
+  network: "stripe"
 }
 
 export type t_recurring = {
@@ -12595,7 +12593,7 @@ export type t_refund = {
   instructions_email?: string | undefined
   metadata?: (Record<string, string> | null) | undefined
   next_action?: t_refund_next_action | undefined
-  object: "refund" | UnknownEnumStringValue
+  object: "refund"
   payment_intent?: (string | t_payment_intent | null) | undefined
   pending_reason?:
     | (
@@ -12743,7 +12741,7 @@ export type t_reporting_report_run = {
   error?: (string | null) | undefined
   id: string
   livemode: boolean
-  object: "reporting.report_run" | UnknownEnumStringValue
+  object: "reporting.report_run"
   parameters: t_financial_reporting_finance_report_run_run_parameters
   report_type: string
   result?: (t_file | null) | undefined
@@ -12758,7 +12756,7 @@ export type t_reporting_report_type = {
   id: string
   livemode: boolean
   name: string
-  object: "reporting.report_type" | UnknownEnumStringValue
+  object: "reporting.report_type"
   updated: number
   version: number
 }
@@ -12768,7 +12766,7 @@ export type t_reserve_transaction = {
   currency: string
   description?: (string | null) | undefined
   id: string
-  object: "reserve_transaction" | UnknownEnumStringValue
+  object: "reserve_transaction"
 }
 
 export type t_review = {
@@ -12791,7 +12789,7 @@ export type t_review = {
   ip_address?: (string | null) | undefined
   ip_address_location?: (t_radar_review_resource_location | null) | undefined
   livemode: boolean
-  object: "review" | UnknownEnumStringValue
+  object: "review"
   open: boolean
   opened_reason: "manual" | "rule" | UnknownEnumStringValue
   payment_intent?: (string | t_payment_intent) | undefined
@@ -12801,7 +12799,7 @@ export type t_review = {
 
 export type t_revolut_pay_underlying_payment_method_funding_details = {
   card?: t_payment_method_details_passthrough_card | undefined
-  type?: ("card" | UnknownEnumStringValue | null) | undefined
+  type?: ("card" | null) | undefined
 }
 
 export type t_rule = {
@@ -12817,7 +12815,7 @@ export type t_scheduled_query_run = {
   file?: (t_file | null) | undefined
   id: string
   livemode: boolean
-  object: "scheduled_query_run" | UnknownEnumStringValue
+  object: "scheduled_query_run"
   result_available_until: number
   sql: string
   status: string
@@ -12825,9 +12823,7 @@ export type t_scheduled_query_run = {
 }
 
 export type t_schedules_phase_automatic_tax = {
-  disabled_reason?:
-    | ("requires_location_inputs" | UnknownEnumStringValue | null)
-    | undefined
+  disabled_reason?: ("requires_location_inputs" | null) | undefined
   enabled: boolean
   liability?: (t_connect_account_reference | null) | undefined
 }
@@ -12852,7 +12848,7 @@ export type t_setup_attempt = {
     | undefined
   id: string
   livemode: boolean
-  object: "setup_attempt" | UnknownEnumStringValue
+  object: "setup_attempt"
   on_behalf_of?: (string | t_account | null) | undefined
   payment_method: string | t_payment_method
   payment_method_details: t_setup_attempt_payment_method_details
@@ -13116,7 +13112,7 @@ export type t_setup_intent = {
   mandate?: (string | t_mandate | null) | undefined
   metadata?: (Record<string, string> | null) | undefined
   next_action?: (t_setup_intent_next_action | null) | undefined
-  object: "setup_intent" | UnknownEnumStringValue
+  object: "setup_intent"
   on_behalf_of?: (string | t_account | null) | undefined
   payment_method?: (string | t_payment_method | null) | undefined
   payment_method_configuration_details?:
@@ -13291,7 +13287,7 @@ export type t_setup_intent_payment_method_options_card_mandate_options = {
   interval_count?: (number | null) | undefined
   reference: string
   start_date: number
-  supported_types?: (("india" | UnknownEnumStringValue)[] | null) | undefined
+  supported_types?: ("india"[] | null) | undefined
 }
 
 export type t_setup_intent_payment_method_options_card_present = Record<
@@ -13371,7 +13367,7 @@ export type t_shipping_rate = {
   id: string
   livemode: boolean
   metadata: Record<string, string>
-  object: "shipping_rate" | UnknownEnumStringValue
+  object: "shipping_rate"
   tax_behavior?:
     | (
         | "exclusive"
@@ -13382,7 +13378,7 @@ export type t_shipping_rate = {
       )
     | undefined
   tax_code?: (string | t_tax_code | null) | undefined
-  type: "fixed_amount" | UnknownEnumStringValue
+  type: "fixed_amount"
 }
 
 export type t_shipping_rate_currency_option = {
@@ -13421,7 +13417,7 @@ export type t_sigma_sigma_api_query = {
   id: string
   livemode: boolean
   name: string
-  object: "sigma.sigma_api_query" | UnknownEnumStringValue
+  object: "sigma.sigma_api_query"
   sql: string
 }
 
@@ -13456,7 +13452,7 @@ export type t_source = {
   livemode: boolean
   metadata?: (Record<string, string> | null) | undefined
   multibanco?: t_source_type_multibanco | undefined
-  object: "source" | UnknownEnumStringValue
+  object: "source"
   owner?: (t_source_owner | null) | undefined
   p24?: t_source_type_p24 | undefined
   receiver?: t_source_receiver_flow | undefined
@@ -13503,7 +13499,7 @@ export type t_source_mandate_notification = {
   created: number
   id: string
   livemode: boolean
-  object: "source_mandate_notification" | UnknownEnumStringValue
+  object: "source_mandate_notification"
   reason: string
   sepa_debit?: t_source_mandate_notification_sepa_debit_data | undefined
   source: t_source
@@ -13584,7 +13580,7 @@ export type t_source_transaction = {
     | undefined
   id: string
   livemode: boolean
-  object: "source_transaction" | UnknownEnumStringValue
+  object: "source_transaction"
   paper_check?: t_source_transaction_paper_check_data | undefined
   sepa_credit_transfer?:
     | t_source_transaction_sepa_credit_transfer_data
@@ -13892,14 +13888,14 @@ export type t_subscription = {
   items: {
     data: t_subscription_item[]
     has_more: boolean
-    object: "list" | UnknownEnumStringValue
+    object: "list"
     url: string
   }
   latest_invoice?: (string | t_invoice | null) | undefined
   livemode: boolean
   metadata: Record<string, string>
   next_pending_invoice_item_invoice?: (number | null) | undefined
-  object: "subscription" | UnknownEnumStringValue
+  object: "subscription"
   on_behalf_of?: (string | t_account | null) | undefined
   pause_collection?:
     | (t_subscriptions_resource_pause_collection | null)
@@ -13934,9 +13930,7 @@ export type t_subscription = {
 }
 
 export type t_subscription_automatic_tax = {
-  disabled_reason?:
-    | ("requires_location_inputs" | UnknownEnumStringValue | null)
-    | undefined
+  disabled_reason?: ("requires_location_inputs" | null) | undefined
   enabled: boolean
   liability?: (t_connect_account_reference | null) | undefined
 }
@@ -13956,7 +13950,7 @@ export type t_subscription_item = {
   discounts: (string | t_discount)[]
   id: string
   metadata: Record<string, string>
-  object: "subscription_item" | UnknownEnumStringValue
+  object: "subscription_item"
   price: t_price
   quantity?: number | undefined
   subscription: string
@@ -14013,7 +14007,7 @@ export type t_subscription_schedule = {
   id: string
   livemode: boolean
   metadata?: (Record<string, string> | null) | undefined
-  object: "subscription_schedule" | UnknownEnumStringValue
+  object: "subscription_schedule"
   phases: t_subscription_schedule_phase_configuration[]
   released_at?: (number | null) | undefined
   released_subscription?: (string | null) | undefined
@@ -14102,9 +14096,7 @@ export type t_subscription_schedules_resource_default_settings = {
 }
 
 export type t_subscription_schedules_resource_default_settings_automatic_tax = {
-  disabled_reason?:
-    | ("requires_location_inputs" | UnknownEnumStringValue | null)
-    | undefined
+  disabled_reason?: ("requires_location_inputs" | null) | undefined
   enabled: boolean
   liability?: (t_connect_account_reference | null) | undefined
 }
@@ -14244,12 +14236,12 @@ export type t_tax_calculation = {
     | ({
         data: t_tax_calculation_line_item[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       } | null)
     | undefined
   livemode: boolean
-  object: "tax.calculation" | UnknownEnumStringValue
+  object: "tax.calculation"
   ship_from_details?:
     | (t_tax_product_resource_ship_from_details | null)
     | undefined
@@ -14268,7 +14260,7 @@ export type t_tax_calculation_line_item = {
   id: string
   livemode: boolean
   metadata?: (Record<string, string> | null) | undefined
-  object: "tax.calculation_line_item" | UnknownEnumStringValue
+  object: "tax.calculation_line_item"
   product?: (string | null) | undefined
   quantity: number
   reference: string
@@ -14287,7 +14279,7 @@ export type t_tax_registration = {
   expires_at?: (number | null) | undefined
   id: string
   livemode: boolean
-  object: "tax.registration" | UnknownEnumStringValue
+  object: "tax.registration"
   status: "active" | "expired" | "scheduled" | UnknownEnumStringValue
 }
 
@@ -14297,7 +14289,7 @@ export type t_tax_settings = {
     | (t_tax_product_resource_tax_settings_head_office | null)
     | undefined
   livemode: boolean
-  object: "tax.settings" | UnknownEnumStringValue
+  object: "tax.settings"
   status: "active" | "pending" | UnknownEnumStringValue
   status_details: t_tax_product_resource_tax_settings_status_details
 }
@@ -14312,13 +14304,13 @@ export type t_tax_transaction = {
     | ({
         data: t_tax_transaction_line_item[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       } | null)
     | undefined
   livemode: boolean
   metadata?: (Record<string, string> | null) | undefined
-  object: "tax.transaction" | UnknownEnumStringValue
+  object: "tax.transaction"
   posted_at: number
   reference: string
   reversal?:
@@ -14340,7 +14332,7 @@ export type t_tax_transaction_line_item = {
   id: string
   livemode: boolean
   metadata?: (Record<string, string> | null) | undefined
-  object: "tax.transaction_line_item" | UnknownEnumStringValue
+  object: "tax.transaction_line_item"
   product?: (string | null) | undefined
   quantity: number
   reference: string
@@ -14356,12 +14348,12 @@ export type t_tax_code = {
   description: string
   id: string
   name: string
-  object: "tax_code" | UnknownEnumStringValue
+  object: "tax_code"
 }
 
 export type t_tax_deducted_at_source = {
   id: string
-  object: "tax_deducted_at_source" | UnknownEnumStringValue
+  object: "tax_deducted_at_source"
   period_end: number
   period_start: number
   tax_deduction_account_number: string
@@ -14380,7 +14372,7 @@ export type t_tax_id = {
   customer?: (string | t_customer | null) | undefined
   id: string
   livemode: boolean
-  object: "tax_id" | UnknownEnumStringValue
+  object: "tax_id"
   owner?: (t_tax_i_ds_owner | null) | undefined
   type:
     | "ad_nrt"
@@ -14723,7 +14715,7 @@ export type t_tax_product_registrations_resource_country_options_canada = {
 }
 
 export type t_tax_product_registrations_resource_country_options_default = {
-  type: "standard" | UnknownEnumStringValue
+  type: "standard"
 }
 
 export type t_tax_product_registrations_resource_country_options_default_inbound_goods =
@@ -14731,7 +14723,7 @@ export type t_tax_product_registrations_resource_country_options_default_inbound
     standard?:
       | t_tax_product_registrations_resource_country_options_default_standard
       | undefined
-    type: "standard" | UnknownEnumStringValue
+    type: "standard"
   }
 
 export type t_tax_product_registrations_resource_country_options_default_standard =
@@ -14763,7 +14755,7 @@ export type t_tax_product_registrations_resource_country_options_europe = {
 }
 
 export type t_tax_product_registrations_resource_country_options_simplified = {
-  type: "simplified" | UnknownEnumStringValue
+  type: "simplified"
 }
 
 export type t_tax_product_registrations_resource_country_options_united_states =
@@ -15158,7 +15150,7 @@ export type t_tax_rate = {
     | undefined
   livemode: boolean
   metadata?: (Record<string, string> | null) | undefined
-  object: "tax_rate" | UnknownEnumStringValue
+  object: "tax_rate"
   percentage: number
   rate_type?:
     | ("flat_amount" | "percentage" | UnknownEnumStringValue | null)
@@ -15199,7 +15191,7 @@ export type t_terminal_configuration = {
   is_account_default?: (boolean | null) | undefined
   livemode: boolean
   name?: (string | null) | undefined
-  object: "terminal.configuration" | UnknownEnumStringValue
+  object: "terminal.configuration"
   offline?:
     | t_terminal_configuration_configuration_resource_offline_config
     | undefined
@@ -15218,7 +15210,7 @@ export type t_terminal_configuration = {
 
 export type t_terminal_connection_token = {
   location?: string | undefined
-  object: "terminal.connection_token" | UnknownEnumStringValue
+  object: "terminal.connection_token"
   secret: string
 }
 
@@ -15229,7 +15221,7 @@ export type t_terminal_location = {
   id: string
   livemode: boolean
   metadata: Record<string, string>
-  object: "terminal.location" | UnknownEnumStringValue
+  object: "terminal.location"
 }
 
 export type t_terminal_reader = {
@@ -15252,7 +15244,7 @@ export type t_terminal_reader = {
   livemode: boolean
   location?: (string | t_terminal_location | null) | undefined
   metadata: Record<string, string>
-  object: "terminal.reader" | UnknownEnumStringValue
+  object: "terminal.reader"
   serial_number: string
   status?: ("offline" | "online" | UnknownEnumStringValue | null) | undefined
 }
@@ -15561,7 +15553,7 @@ export type t_terminal_reader_reader_resource_selection = {
 
 export type t_terminal_reader_reader_resource_set_reader_display_action = {
   cart?: (t_terminal_reader_reader_resource_cart | null) | undefined
-  type: "cart" | UnknownEnumStringValue
+  type: "cart"
 }
 
 export type t_terminal_reader_reader_resource_signature = {
@@ -15592,7 +15584,7 @@ export type t_test_helpers_test_clock = {
   id: string
   livemode: boolean
   name?: (string | null) | undefined
-  object: "test_helpers.test_clock" | UnknownEnumStringValue
+  object: "test_helpers.test_clock"
   status: "advancing" | "internal_failure" | "ready" | UnknownEnumStringValue
   status_details: t_billing_clocks_resource_status_details_status_details
 }
@@ -15683,14 +15675,14 @@ export type t_three_d_secure_usage = {
 
 export type t_thresholds_resource_usage_alert_filter = {
   customer?: (string | t_customer | null) | undefined
-  type: "customer" | UnknownEnumStringValue
+  type: "customer"
 }
 
 export type t_thresholds_resource_usage_threshold_config = {
   filters?: (t_thresholds_resource_usage_alert_filter[] | null) | undefined
   gte: number
   meter: string | t_billing_meter
-  recurrence: "one_time" | UnknownEnumStringValue
+  recurrence: "one_time"
 }
 
 export type t_token = {
@@ -15700,7 +15692,7 @@ export type t_token = {
   created: number
   id: string
   livemode: boolean
-  object: "token" | UnknownEnumStringValue
+  object: "token"
   type: string
   used: boolean
 }
@@ -15721,7 +15713,7 @@ export type t_topup = {
   id: string
   livemode: boolean
   metadata: Record<string, string>
-  object: "topup" | UnknownEnumStringValue
+  object: "topup"
   source?: (t_source | null) | undefined
   statement_descriptor?: (string | null) | undefined
   status:
@@ -15746,11 +15738,11 @@ export type t_transfer = {
   id: string
   livemode: boolean
   metadata: Record<string, string>
-  object: "transfer" | UnknownEnumStringValue
+  object: "transfer"
   reversals: {
     data: t_transfer_reversal[]
     has_more: boolean
-    object: "list" | UnknownEnumStringValue
+    object: "list"
     url: string
   }
   reversed: boolean
@@ -15772,7 +15764,7 @@ export type t_transfer_reversal = {
   destination_payment_refund?: (string | t_refund | null) | undefined
   id: string
   metadata?: (Record<string, string> | null) | undefined
-  object: "transfer_reversal" | UnknownEnumStringValue
+  object: "transfer_reversal"
   source_refund?: (string | t_refund | null) | undefined
   transfer: string | t_transfer
 }
@@ -15817,7 +15809,7 @@ export type t_treasury_credit_reversal = {
   livemode: boolean
   metadata: Record<string, string>
   network: "ach" | "stripe" | UnknownEnumStringValue
-  object: "treasury.credit_reversal" | UnknownEnumStringValue
+  object: "treasury.credit_reversal"
   received_credit: string
   status: "canceled" | "posted" | "processing" | UnknownEnumStringValue
   status_transitions: t_treasury_received_credits_resource_status_transitions
@@ -15837,7 +15829,7 @@ export type t_treasury_debit_reversal = {
   livemode: boolean
   metadata: Record<string, string>
   network: "ach" | "card" | UnknownEnumStringValue
-  object: "treasury.debit_reversal" | UnknownEnumStringValue
+  object: "treasury.debit_reversal"
   received_debit: string
   status: "failed" | "processing" | "succeeded" | UnknownEnumStringValue
   status_transitions: t_treasury_received_debits_resource_status_transitions
@@ -15871,7 +15863,7 @@ export type t_treasury_financial_account = {
   livemode: boolean
   metadata?: (Record<string, string> | null) | undefined
   nickname?: (string | null) | undefined
-  object: "treasury.financial_account" | UnknownEnumStringValue
+  object: "treasury.financial_account"
   pending_features?:
     | (
         | "card_issuing"
@@ -15928,7 +15920,7 @@ export type t_treasury_financial_account_features = {
   intra_stripe_flows?:
     | t_treasury_financial_accounts_resource_toggle_settings
     | undefined
-  object: "treasury.financial_account_features" | UnknownEnumStringValue
+  object: "treasury.financial_account_features"
   outbound_payments?:
     | t_treasury_financial_accounts_resource_outbound_payments
     | undefined
@@ -15952,7 +15944,7 @@ export type t_treasury_inbound_transfer = {
   linked_flows: t_treasury_inbound_transfers_resource_inbound_transfer_resource_linked_flows
   livemode: boolean
   metadata: Record<string, string>
-  object: "treasury.inbound_transfer" | UnknownEnumStringValue
+  object: "treasury.inbound_transfer"
   origin_payment_method?: (string | null) | undefined
   origin_payment_method_details?: (t_inbound_transfers | null) | undefined
   returned?: (boolean | null) | undefined
@@ -15987,7 +15979,7 @@ export type t_treasury_outbound_payment = {
   id: string
   livemode: boolean
   metadata: Record<string, string>
-  object: "treasury.outbound_payment" | UnknownEnumStringValue
+  object: "treasury.outbound_payment"
   returned_details?:
     | (t_treasury_outbound_payments_resource_returned_status | null)
     | undefined
@@ -16020,7 +16012,7 @@ export type t_treasury_outbound_transfer = {
   id: string
   livemode: boolean
   metadata: Record<string, string>
-  object: "treasury.outbound_transfer" | UnknownEnumStringValue
+  object: "treasury.outbound_transfer"
   returned_details?:
     | (t_treasury_outbound_transfers_resource_returned_details | null)
     | undefined
@@ -16066,7 +16058,7 @@ export type t_treasury_received_credit = {
     | "stripe"
     | "us_domestic_wire"
     | UnknownEnumStringValue
-  object: "treasury.received_credit" | UnknownEnumStringValue
+  object: "treasury.received_credit"
   reversal_details?:
     | (t_treasury_received_credits_resource_reversal_details | null)
     | undefined
@@ -16099,7 +16091,7 @@ export type t_treasury_received_debit = {
   linked_flows: t_treasury_received_debits_resource_linked_flows
   livemode: boolean
   network: "ach" | "card" | "stripe" | UnknownEnumStringValue
-  object: "treasury.received_debit" | UnknownEnumStringValue
+  object: "treasury.received_debit"
   reversal_details?:
     | (t_treasury_received_debits_resource_reversal_details | null)
     | undefined
@@ -16117,7 +16109,7 @@ export type t_treasury_transaction = {
     | ({
         data: t_treasury_transaction_entry[]
         has_more: boolean
-        object: "list" | UnknownEnumStringValue
+        object: "list"
         url: string
       } | null)
     | undefined
@@ -16139,7 +16131,7 @@ export type t_treasury_transaction = {
     | UnknownEnumStringValue
   id: string
   livemode: boolean
-  object: "treasury.transaction" | UnknownEnumStringValue
+  object: "treasury.transaction"
   status: "open" | "posted" | "void" | UnknownEnumStringValue
   status_transitions: t_treasury_transactions_resource_abstract_transaction_resource_status_transitions
 }
@@ -16167,7 +16159,7 @@ export type t_treasury_transaction_entry = {
     | UnknownEnumStringValue
   id: string
   livemode: boolean
-  object: "treasury.transaction_entry" | UnknownEnumStringValue
+  object: "treasury.transaction_entry"
   transaction: string | t_treasury_transaction
   type:
     | "credit_reversal"
@@ -16227,7 +16219,7 @@ export type t_treasury_financial_accounts_resource_financial_address = {
   supported_networks?:
     | ("ach" | "us_domestic_wire" | UnknownEnumStringValue)[]
     | undefined
-  type: "aba" | UnknownEnumStringValue
+  type: "aba"
 }
 
 export type t_treasury_financial_accounts_resource_financial_addresses_features =
@@ -16529,7 +16521,7 @@ export type t_treasury_shared_resource_billing_details = {
 
 export type t_treasury_shared_resource_initiating_payment_method_details_initiating_payment_method_details =
   {
-    balance?: ("payments" | UnknownEnumStringValue) | undefined
+    balance?: "payments" | undefined
     billing_details: t_treasury_shared_resource_billing_details
     financial_account?:
       | t_received_payment_method_details_financial_account
@@ -16606,7 +16598,7 @@ export type t_webhook_endpoint = {
   id: string
   livemode: boolean
   metadata: Record<string, string>
-  object: "webhook_endpoint" | UnknownEnumStringValue
+  object: "webhook_endpoint"
   secret?: string | undefined
   status: string
   url: string
@@ -16646,7 +16638,7 @@ export type t_DeleteSubscriptionItemsItemRequestBody = {
 export type t_DeleteSubscriptionsSubscriptionExposedIdRequestBody = {
   cancellation_details?:
     | {
-        comment?: (string | "" | UnknownEnumStringValue) | undefined
+        comment?: (string | "") | undefined
         feedback?:
           | (
               | ""
@@ -16924,7 +16916,7 @@ export type t_PostAccountsRequestBody = {
                     | undefined
                 }
               | undefined
-            object?: ("bank_account" | UnknownEnumStringValue) | undefined
+            object?: "bank_account" | undefined
             routing_number?: string | undefined
           }
         | string
@@ -16971,7 +16963,7 @@ export type t_PostAccountsRequestBody = {
           | undefined
         support_email?: string | undefined
         support_phone?: string | undefined
-        support_url?: (string | "" | UnknownEnumStringValue) | undefined
+        support_url?: (string | "") | undefined
         url?: string | undefined
       }
     | undefined
@@ -17356,7 +17348,6 @@ export type t_PostAccountsRequestBody = {
                   year: number
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         registration_number?: string | undefined
@@ -17488,7 +17479,7 @@ export type t_PostAccountsRequestBody = {
   external_account?: string | undefined
   groups?:
     | {
-        payments_pricing?: (string | "" | UnknownEnumStringValue) | undefined
+        payments_pricing?: (string | "") | undefined
       }
     | undefined
   individual?:
@@ -17533,14 +17524,13 @@ export type t_PostAccountsRequestBody = {
                   year: number
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         email?: string | undefined
         first_name?: string | undefined
         first_name_kana?: string | undefined
         first_name_kanji?: string | undefined
-        full_name_aliases?: (string[] | "" | UnknownEnumStringValue) | undefined
+        full_name_aliases?: (string[] | "") | undefined
         gender?: string | undefined
         id_number?: string | undefined
         id_number_secondary?: string | undefined
@@ -17548,9 +17538,7 @@ export type t_PostAccountsRequestBody = {
         last_name_kana?: string | undefined
         last_name_kanji?: string | undefined
         maiden_name?: string | undefined
-        metadata?:
-          | (Record<string, string> | "" | UnknownEnumStringValue)
-          | undefined
+        metadata?: (Record<string, string> | "") | undefined
         phone?: string | undefined
         political_exposure?:
           | ("existing" | "none" | UnknownEnumStringValue)
@@ -17570,9 +17558,7 @@ export type t_PostAccountsRequestBody = {
               director?: boolean | undefined
               executive?: boolean | undefined
               owner?: boolean | undefined
-              percent_ownership?:
-                | (number | "" | UnknownEnumStringValue)
-                | undefined
+              percent_ownership?: (number | "") | undefined
               title?: string | undefined
             }
           | undefined
@@ -17595,7 +17581,7 @@ export type t_PostAccountsRequestBody = {
           | undefined
       }
     | undefined
-  metadata?: (Record<string, string> | "" | UnknownEnumStringValue) | undefined
+  metadata?: (Record<string, string> | "") | undefined
   settings?:
     | {
         bacs_debit_payments?:
@@ -17617,9 +17603,7 @@ export type t_PostAccountsRequestBody = {
                 | {
                     date?: number | undefined
                     ip?: string | undefined
-                    user_agent?:
-                      | (string | "" | UnknownEnumStringValue)
-                      | undefined
+                    user_agent?: (string | "") | undefined
                   }
                 | undefined
             }
@@ -17633,12 +17617,8 @@ export type t_PostAccountsRequestBody = {
                   }
                 | undefined
               statement_descriptor_prefix?: string | undefined
-              statement_descriptor_prefix_kana?:
-                | (string | "" | UnknownEnumStringValue)
-                | undefined
-              statement_descriptor_prefix_kanji?:
-                | (string | "" | UnknownEnumStringValue)
-                | undefined
+              statement_descriptor_prefix_kana?: (string | "") | undefined
+              statement_descriptor_prefix_kanji?: (string | "") | undefined
             }
           | undefined
         invoices?:
@@ -17660,9 +17640,7 @@ export type t_PostAccountsRequestBody = {
               debit_negative_balances?: boolean | undefined
               schedule?:
                 | {
-                    delay_days?:
-                      | ("minimum" | UnknownEnumStringValue | number)
-                      | undefined
+                    delay_days?: ("minimum" | number) | undefined
                     interval?:
                       | (
                           | "daily"
@@ -17709,9 +17687,7 @@ export type t_PostAccountsRequestBody = {
                 | {
                     date?: number | undefined
                     ip?: string | undefined
-                    user_agent?:
-                      | (string | "" | UnknownEnumStringValue)
-                      | undefined
+                    user_agent?: (string | "") | undefined
                   }
                 | undefined
             }
@@ -17774,7 +17750,7 @@ export type t_PostAccountsAccountRequestBody = {
           | undefined
         support_email?: string | undefined
         support_phone?: string | undefined
-        support_url?: (string | "" | UnknownEnumStringValue) | undefined
+        support_url?: (string | "") | undefined
         url?: string | undefined
       }
     | undefined
@@ -18159,7 +18135,6 @@ export type t_PostAccountsAccountRequestBody = {
                   year: number
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         registration_number?: string | undefined
@@ -18262,7 +18237,7 @@ export type t_PostAccountsAccountRequestBody = {
   external_account?: string | undefined
   groups?:
     | {
-        payments_pricing?: (string | "" | UnknownEnumStringValue) | undefined
+        payments_pricing?: (string | "") | undefined
       }
     | undefined
   individual?:
@@ -18307,14 +18282,13 @@ export type t_PostAccountsAccountRequestBody = {
                   year: number
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         email?: string | undefined
         first_name?: string | undefined
         first_name_kana?: string | undefined
         first_name_kanji?: string | undefined
-        full_name_aliases?: (string[] | "" | UnknownEnumStringValue) | undefined
+        full_name_aliases?: (string[] | "") | undefined
         gender?: string | undefined
         id_number?: string | undefined
         id_number_secondary?: string | undefined
@@ -18322,9 +18296,7 @@ export type t_PostAccountsAccountRequestBody = {
         last_name_kana?: string | undefined
         last_name_kanji?: string | undefined
         maiden_name?: string | undefined
-        metadata?:
-          | (Record<string, string> | "" | UnknownEnumStringValue)
-          | undefined
+        metadata?: (Record<string, string> | "") | undefined
         phone?: string | undefined
         political_exposure?:
           | ("existing" | "none" | UnknownEnumStringValue)
@@ -18344,9 +18316,7 @@ export type t_PostAccountsAccountRequestBody = {
               director?: boolean | undefined
               executive?: boolean | undefined
               owner?: boolean | undefined
-              percent_ownership?:
-                | (number | "" | UnknownEnumStringValue)
-                | undefined
+              percent_ownership?: (number | "") | undefined
               title?: string | undefined
             }
           | undefined
@@ -18369,7 +18339,7 @@ export type t_PostAccountsAccountRequestBody = {
           | undefined
       }
     | undefined
-  metadata?: (Record<string, string> | "" | UnknownEnumStringValue) | undefined
+  metadata?: (Record<string, string> | "") | undefined
   settings?:
     | {
         bacs_debit_payments?:
@@ -18391,9 +18361,7 @@ export type t_PostAccountsAccountRequestBody = {
                 | {
                     date?: number | undefined
                     ip?: string | undefined
-                    user_agent?:
-                      | (string | "" | UnknownEnumStringValue)
-                      | undefined
+                    user_agent?: (string | "") | undefined
                   }
                 | undefined
             }
@@ -18407,19 +18375,13 @@ export type t_PostAccountsAccountRequestBody = {
                   }
                 | undefined
               statement_descriptor_prefix?: string | undefined
-              statement_descriptor_prefix_kana?:
-                | (string | "" | UnknownEnumStringValue)
-                | undefined
-              statement_descriptor_prefix_kanji?:
-                | (string | "" | UnknownEnumStringValue)
-                | undefined
+              statement_descriptor_prefix_kana?: (string | "") | undefined
+              statement_descriptor_prefix_kanji?: (string | "") | undefined
             }
           | undefined
         invoices?:
           | {
-              default_account_tax_ids?:
-                | (string[] | "" | UnknownEnumStringValue)
-                | undefined
+              default_account_tax_ids?: (string[] | "") | undefined
               hosted_payment_method_save?:
                 | ("always" | "never" | "offer" | UnknownEnumStringValue)
                 | undefined
@@ -18437,9 +18399,7 @@ export type t_PostAccountsAccountRequestBody = {
               debit_negative_balances?: boolean | undefined
               schedule?:
                 | {
-                    delay_days?:
-                      | ("minimum" | UnknownEnumStringValue | number)
-                      | undefined
+                    delay_days?: ("minimum" | number) | undefined
                     interval?:
                       | (
                           | "daily"
@@ -18486,9 +18446,7 @@ export type t_PostAccountsAccountRequestBody = {
                 | {
                     date?: number | undefined
                     ip?: string | undefined
-                    user_agent?:
-                      | (string | "" | UnknownEnumStringValue)
-                      | undefined
+                    user_agent?: (string | "") | undefined
                   }
                 | undefined
             }
@@ -18534,7 +18492,7 @@ export type t_PostAccountsAccountBankAccountsRequestBody = {
                     | undefined
                 }
               | undefined
-            object?: ("bank_account" | UnknownEnumStringValue) | undefined
+            object?: "bank_account" | undefined
             routing_number?: string | undefined
           }
         | string
@@ -18573,7 +18531,7 @@ export type t_PostAccountsAccountBankAccountsIdRequestBody = {
   exp_month?: string | undefined
   exp_year?: string | undefined
   expand?: string[] | undefined
-  metadata?: (Record<string, string> | "" | UnknownEnumStringValue) | undefined
+  metadata?: (Record<string, string> | "") | undefined
   name?: string | undefined
 }
 
@@ -18611,7 +18569,7 @@ export type t_PostAccountsAccountExternalAccountsRequestBody = {
                     | undefined
                 }
               | undefined
-            object?: ("bank_account" | UnknownEnumStringValue) | undefined
+            object?: "bank_account" | undefined
             routing_number?: string | undefined
           }
         | string
@@ -18650,7 +18608,7 @@ export type t_PostAccountsAccountExternalAccountsIdRequestBody = {
   exp_month?: string | undefined
   exp_year?: string | undefined
   expand?: string[] | undefined
-  metadata?: (Record<string, string> | "" | UnknownEnumStringValue) | undefined
+  metadata?: (Record<string, string> | "") | undefined
   name?: string | undefined
 }
 
@@ -18665,7 +18623,7 @@ export type t_PostAccountsAccountPeopleRequestBody = {
           | {
               date?: number | undefined
               ip?: string | undefined
-              user_agent?: (string | "" | UnknownEnumStringValue) | undefined
+              user_agent?: (string | "") | undefined
             }
           | undefined
       }
@@ -18710,24 +18668,23 @@ export type t_PostAccountsAccountPeopleRequestBody = {
             year: number
           }
         | ""
-        | UnknownEnumStringValue
       )
     | undefined
   documents?:
     | {
         company_authorization?:
           | {
-              files?: (string | "" | UnknownEnumStringValue)[] | undefined
+              files?: (string | "")[] | undefined
             }
           | undefined
         passport?:
           | {
-              files?: (string | "" | UnknownEnumStringValue)[] | undefined
+              files?: (string | "")[] | undefined
             }
           | undefined
         visa?:
           | {
-              files?: (string | "" | UnknownEnumStringValue)[] | undefined
+              files?: (string | "")[] | undefined
             }
           | undefined
       }
@@ -18737,7 +18694,7 @@ export type t_PostAccountsAccountPeopleRequestBody = {
   first_name?: string | undefined
   first_name_kana?: string | undefined
   first_name_kanji?: string | undefined
-  full_name_aliases?: (string[] | "" | UnknownEnumStringValue) | undefined
+  full_name_aliases?: (string[] | "") | undefined
   gender?: string | undefined
   id_number?: string | undefined
   id_number_secondary?: string | undefined
@@ -18745,7 +18702,7 @@ export type t_PostAccountsAccountPeopleRequestBody = {
   last_name_kana?: string | undefined
   last_name_kanji?: string | undefined
   maiden_name?: string | undefined
-  metadata?: (Record<string, string> | "" | UnknownEnumStringValue) | undefined
+  metadata?: (Record<string, string> | "") | undefined
   nationality?: string | undefined
   person_token?: string | undefined
   phone?: string | undefined
@@ -18769,7 +18726,7 @@ export type t_PostAccountsAccountPeopleRequestBody = {
         executive?: boolean | undefined
         legal_guardian?: boolean | undefined
         owner?: boolean | undefined
-        percent_ownership?: (number | "" | UnknownEnumStringValue) | undefined
+        percent_ownership?: (number | "") | undefined
         representative?: boolean | undefined
         title?: string | undefined
       }
@@ -18856,7 +18813,7 @@ export type t_PostAccountsAccountPeoplePersonRequestBody = {
           | {
               date?: number | undefined
               ip?: string | undefined
-              user_agent?: (string | "" | UnknownEnumStringValue) | undefined
+              user_agent?: (string | "") | undefined
             }
           | undefined
       }
@@ -18901,24 +18858,23 @@ export type t_PostAccountsAccountPeoplePersonRequestBody = {
             year: number
           }
         | ""
-        | UnknownEnumStringValue
       )
     | undefined
   documents?:
     | {
         company_authorization?:
           | {
-              files?: (string | "" | UnknownEnumStringValue)[] | undefined
+              files?: (string | "")[] | undefined
             }
           | undefined
         passport?:
           | {
-              files?: (string | "" | UnknownEnumStringValue)[] | undefined
+              files?: (string | "")[] | undefined
             }
           | undefined
         visa?:
           | {
-              files?: (string | "" | UnknownEnumStringValue)[] | undefined
+              files?: (string | "")[] | undefined
             }
           | undefined
       }
@@ -18928,7 +18884,7 @@ export type t_PostAccountsAccountPeoplePersonRequestBody = {
   first_name?: string | undefined
   first_name_kana?: string | undefined
   first_name_kanji?: string | undefined
-  full_name_aliases?: (string[] | "" | UnknownEnumStringValue) | undefined
+  full_name_aliases?: (string[] | "") | undefined
   gender?: string | undefined
   id_number?: string | undefined
   id_number_secondary?: string | undefined
@@ -18936,7 +18892,7 @@ export type t_PostAccountsAccountPeoplePersonRequestBody = {
   last_name_kana?: string | undefined
   last_name_kanji?: string | undefined
   maiden_name?: string | undefined
-  metadata?: (Record<string, string> | "" | UnknownEnumStringValue) | undefined
+  metadata?: (Record<string, string> | "") | undefined
   nationality?: string | undefined
   person_token?: string | undefined
   phone?: string | undefined
@@ -18960,7 +18916,7 @@ export type t_PostAccountsAccountPeoplePersonRequestBody = {
         executive?: boolean | undefined
         legal_guardian?: boolean | undefined
         owner?: boolean | undefined
-        percent_ownership?: (number | "" | UnknownEnumStringValue) | undefined
+        percent_ownership?: (number | "") | undefined
         representative?: boolean | undefined
         title?: string | undefined
       }
@@ -19047,7 +19003,7 @@ export type t_PostAccountsAccountPersonsRequestBody = {
           | {
               date?: number | undefined
               ip?: string | undefined
-              user_agent?: (string | "" | UnknownEnumStringValue) | undefined
+              user_agent?: (string | "") | undefined
             }
           | undefined
       }
@@ -19092,24 +19048,23 @@ export type t_PostAccountsAccountPersonsRequestBody = {
             year: number
           }
         | ""
-        | UnknownEnumStringValue
       )
     | undefined
   documents?:
     | {
         company_authorization?:
           | {
-              files?: (string | "" | UnknownEnumStringValue)[] | undefined
+              files?: (string | "")[] | undefined
             }
           | undefined
         passport?:
           | {
-              files?: (string | "" | UnknownEnumStringValue)[] | undefined
+              files?: (string | "")[] | undefined
             }
           | undefined
         visa?:
           | {
-              files?: (string | "" | UnknownEnumStringValue)[] | undefined
+              files?: (string | "")[] | undefined
             }
           | undefined
       }
@@ -19119,7 +19074,7 @@ export type t_PostAccountsAccountPersonsRequestBody = {
   first_name?: string | undefined
   first_name_kana?: string | undefined
   first_name_kanji?: string | undefined
-  full_name_aliases?: (string[] | "" | UnknownEnumStringValue) | undefined
+  full_name_aliases?: (string[] | "") | undefined
   gender?: string | undefined
   id_number?: string | undefined
   id_number_secondary?: string | undefined
@@ -19127,7 +19082,7 @@ export type t_PostAccountsAccountPersonsRequestBody = {
   last_name_kana?: string | undefined
   last_name_kanji?: string | undefined
   maiden_name?: string | undefined
-  metadata?: (Record<string, string> | "" | UnknownEnumStringValue) | undefined
+  metadata?: (Record<string, string> | "") | undefined
   nationality?: string | undefined
   person_token?: string | undefined
   phone?: string | undefined
@@ -19151,7 +19106,7 @@ export type t_PostAccountsAccountPersonsRequestBody = {
         executive?: boolean | undefined
         legal_guardian?: boolean | undefined
         owner?: boolean | undefined
-        percent_ownership?: (number | "" | UnknownEnumStringValue) | undefined
+        percent_ownership?: (number | "") | undefined
         representative?: boolean | undefined
         title?: string | undefined
       }
@@ -19238,7 +19193,7 @@ export type t_PostAccountsAccountPersonsPersonRequestBody = {
           | {
               date?: number | undefined
               ip?: string | undefined
-              user_agent?: (string | "" | UnknownEnumStringValue) | undefined
+              user_agent?: (string | "") | undefined
             }
           | undefined
       }
@@ -19283,24 +19238,23 @@ export type t_PostAccountsAccountPersonsPersonRequestBody = {
             year: number
           }
         | ""
-        | UnknownEnumStringValue
       )
     | undefined
   documents?:
     | {
         company_authorization?:
           | {
-              files?: (string | "" | UnknownEnumStringValue)[] | undefined
+              files?: (string | "")[] | undefined
             }
           | undefined
         passport?:
           | {
-              files?: (string | "" | UnknownEnumStringValue)[] | undefined
+              files?: (string | "")[] | undefined
             }
           | undefined
         visa?:
           | {
-              files?: (string | "" | UnknownEnumStringValue)[] | undefined
+              files?: (string | "")[] | undefined
             }
           | undefined
       }
@@ -19310,7 +19264,7 @@ export type t_PostAccountsAccountPersonsPersonRequestBody = {
   first_name?: string | undefined
   first_name_kana?: string | undefined
   first_name_kanji?: string | undefined
-  full_name_aliases?: (string[] | "" | UnknownEnumStringValue) | undefined
+  full_name_aliases?: (string[] | "") | undefined
   gender?: string | undefined
   id_number?: string | undefined
   id_number_secondary?: string | undefined
@@ -19318,7 +19272,7 @@ export type t_PostAccountsAccountPersonsPersonRequestBody = {
   last_name_kana?: string | undefined
   last_name_kanji?: string | undefined
   maiden_name?: string | undefined
-  metadata?: (Record<string, string> | "" | UnknownEnumStringValue) | undefined
+  metadata?: (Record<string, string> | "") | undefined
   nationality?: string | undefined
   person_token?: string | undefined
   phone?: string | undefined
@@ -19342,7 +19296,7 @@ export type t_PostAccountsAccountPersonsPersonRequestBody = {
         executive?: boolean | undefined
         legal_guardian?: boolean | undefined
         owner?: boolean | undefined
-        percent_ownership?: (number | "" | UnknownEnumStringValue) | undefined
+        percent_ownership?: (number | "") | undefined
         representative?: boolean | undefined
         title?: string | undefined
       }
@@ -19434,7 +19388,7 @@ export type t_PostApplePayDomainsRequestBody = {
 
 export type t_PostApplicationFeesFeeRefundsIdRequestBody = {
   expand?: string[] | undefined
-  metadata?: (Record<string, string> | "" | UnknownEnumStringValue) | undefined
+  metadata?: (Record<string, string> | "") | undefined
 }
 
 export type t_PostApplicationFeesIdRefundRequestBody = {
@@ -19470,7 +19424,7 @@ export type t_PostAppsSecretsDeleteRequestBody = {
 }
 
 export type t_PostBillingAlertsRequestBody = {
-  alert_type: "usage_threshold" | UnknownEnumStringValue
+  alert_type: "usage_threshold"
   expand?: string[] | undefined
   title: string
   usage_threshold?:
@@ -19478,12 +19432,12 @@ export type t_PostBillingAlertsRequestBody = {
         filters?:
           | {
               customer?: string | undefined
-              type: "customer" | UnknownEnumStringValue
+              type: "customer"
             }[]
           | undefined
         gte: number
         meter: string
-        recurrence: "one_time" | UnknownEnumStringValue
+        recurrence: "one_time"
       }
     | undefined
 }
@@ -19508,11 +19462,11 @@ export type t_PostBillingCreditGrantsRequestBody = {
           value: number
         }
       | undefined
-    type: "monetary" | UnknownEnumStringValue
+    type: "monetary"
   }
   applicability_config: {
     scope: {
-      price_type?: ("metered" | UnknownEnumStringValue) | undefined
+      price_type?: "metered" | undefined
       prices?:
         | {
             id: string
@@ -19532,7 +19486,7 @@ export type t_PostBillingCreditGrantsRequestBody = {
 
 export type t_PostBillingCreditGrantsIdRequestBody = {
   expand?: string[] | undefined
-  expires_at?: (number | "" | UnknownEnumStringValue) | undefined
+  expires_at?: (number | "") | undefined
   metadata?: Record<string, string> | undefined
 }
 
@@ -19552,7 +19506,7 @@ export type t_PostBillingMeterEventAdjustmentsRequestBody = {
     | undefined
   event_name: string
   expand?: string[] | undefined
-  type: "cancel" | UnknownEnumStringValue
+  type: "cancel"
 }
 
 export type t_PostBillingMeterEventsRequestBody = {
@@ -19567,7 +19521,7 @@ export type t_PostBillingMetersRequestBody = {
   customer_mapping?:
     | {
         event_payload_key: string
-        type: "by_id" | UnknownEnumStringValue
+        type: "by_id"
       }
     | undefined
   default_aggregation: {
@@ -19600,12 +19554,12 @@ export type t_PostBillingMetersIdReactivateRequestBody = {
 export type t_PostBillingPortalConfigurationsRequestBody = {
   business_profile?:
     | {
-        headline?: (string | "" | UnknownEnumStringValue) | undefined
+        headline?: (string | "") | undefined
         privacy_policy_url?: string | undefined
         terms_of_service_url?: string | undefined
       }
     | undefined
-  default_return_url?: (string | "" | UnknownEnumStringValue) | undefined
+  default_return_url?: (string | "") | undefined
   expand?: string[] | undefined
   features: {
     customer_update?:
@@ -19622,7 +19576,6 @@ export type t_PostBillingPortalConfigurationsRequestBody = {
                     | UnknownEnumStringValue
                   )[]
                 | ""
-                | UnknownEnumStringValue
               )
             | undefined
           enabled: boolean
@@ -19656,7 +19609,6 @@ export type t_PostBillingPortalConfigurationsRequestBody = {
                       | UnknownEnumStringValue
                     )[]
                   | ""
-                  | UnknownEnumStringValue
               }
             | undefined
           enabled: boolean
@@ -19684,7 +19636,6 @@ export type t_PostBillingPortalConfigurationsRequestBody = {
                     | UnknownEnumStringValue
                   )[]
                 | ""
-                | UnknownEnumStringValue
               )
             | undefined
           enabled: boolean
@@ -19702,7 +19653,6 @@ export type t_PostBillingPortalConfigurationsRequestBody = {
                     product: string
                   }[]
                 | ""
-                | UnknownEnumStringValue
               )
             | undefined
           proration_behavior?:
@@ -19740,14 +19690,12 @@ export type t_PostBillingPortalConfigurationsConfigurationRequestBody = {
   active?: boolean | undefined
   business_profile?:
     | {
-        headline?: (string | "" | UnknownEnumStringValue) | undefined
-        privacy_policy_url?: (string | "" | UnknownEnumStringValue) | undefined
-        terms_of_service_url?:
-          | (string | "" | UnknownEnumStringValue)
-          | undefined
+        headline?: (string | "") | undefined
+        privacy_policy_url?: (string | "") | undefined
+        terms_of_service_url?: (string | "") | undefined
       }
     | undefined
-  default_return_url?: (string | "" | UnknownEnumStringValue) | undefined
+  default_return_url?: (string | "") | undefined
   expand?: string[] | undefined
   features?:
     | {
@@ -19765,7 +19713,6 @@ export type t_PostBillingPortalConfigurationsConfigurationRequestBody = {
                         | UnknownEnumStringValue
                       )[]
                     | ""
-                    | UnknownEnumStringValue
                   )
                 | undefined
               enabled?: boolean | undefined
@@ -19800,7 +19747,6 @@ export type t_PostBillingPortalConfigurationsConfigurationRequestBody = {
                               | UnknownEnumStringValue
                             )[]
                           | ""
-                          | UnknownEnumStringValue
                         )
                       | undefined
                   }
@@ -19830,7 +19776,6 @@ export type t_PostBillingPortalConfigurationsConfigurationRequestBody = {
                         | UnknownEnumStringValue
                       )[]
                     | ""
-                    | UnknownEnumStringValue
                   )
                 | undefined
               enabled?: boolean | undefined
@@ -19848,7 +19793,6 @@ export type t_PostBillingPortalConfigurationsConfigurationRequestBody = {
                         product: string
                       }[]
                     | ""
-                    | UnknownEnumStringValue
                   )
                 | undefined
               proration_behavior?:
@@ -19870,7 +19814,6 @@ export type t_PostBillingPortalConfigurationsConfigurationRequestBody = {
                                 | UnknownEnumStringValue
                             }[]
                           | ""
-                          | UnknownEnumStringValue
                         )
                       | undefined
                   }
@@ -19884,7 +19827,7 @@ export type t_PostBillingPortalConfigurationsConfigurationRequestBody = {
         enabled: boolean
       }
     | undefined
-  metadata?: (Record<string, string> | "" | UnknownEnumStringValue) | undefined
+  metadata?: (Record<string, string> | "") | undefined
 }
 
 export type t_PostBillingPortalSessionsRequestBody = {
@@ -19919,7 +19862,7 @@ export type t_PostBillingPortalSessionsRequestBody = {
                     coupon_offer: {
                       coupon: string
                     }
-                    type: "coupon_offer" | UnknownEnumStringValue
+                    type: "coupon_offer"
                   }
                 | undefined
               subscription: string
@@ -20030,7 +19973,7 @@ export type t_PostChargesRequestBody = {
             metadata?: Record<string, string> | undefined
             name?: string | undefined
             number: string
-            object?: ("card" | UnknownEnumStringValue) | undefined
+            object?: "card" | undefined
           }
         | string
       )
@@ -20048,7 +19991,7 @@ export type t_PostChargesRequestBody = {
       )
     | undefined
   expand?: string[] | undefined
-  metadata?: (Record<string, string> | "" | UnknownEnumStringValue) | undefined
+  metadata?: (Record<string, string> | "") | undefined
   on_behalf_of?: string | undefined
   radar_options?:
     | {
@@ -20093,7 +20036,7 @@ export type t_PostChargesChargeRequestBody = {
         user_report: "" | "fraudulent" | "safe" | UnknownEnumStringValue
       }
     | undefined
-  metadata?: (Record<string, string> | "" | UnknownEnumStringValue) | undefined
+  metadata?: (Record<string, string> | "") | undefined
   receipt_email?: string | undefined
   shipping?:
     | {
@@ -20153,21 +20096,13 @@ export type t_PostChargesChargeDisputeRequestBody = {
                     | {
                         disputed_transaction?:
                           | {
-                              customer_account_id?:
-                                | (string | "" | UnknownEnumStringValue)
-                                | undefined
+                              customer_account_id?: (string | "") | undefined
                               customer_device_fingerprint?:
-                                | (string | "" | UnknownEnumStringValue)
+                                | (string | "")
                                 | undefined
-                              customer_device_id?:
-                                | (string | "" | UnknownEnumStringValue)
-                                | undefined
-                              customer_email_address?:
-                                | (string | "" | UnknownEnumStringValue)
-                                | undefined
-                              customer_purchase_ip?:
-                                | (string | "" | UnknownEnumStringValue)
-                                | undefined
+                              customer_device_id?: (string | "") | undefined
+                              customer_email_address?: (string | "") | undefined
+                              customer_purchase_ip?: (string | "") | undefined
                               merchandise_or_services?:
                                 | (
                                     | "merchandise"
@@ -20175,29 +20110,15 @@ export type t_PostChargesChargeDisputeRequestBody = {
                                     | UnknownEnumStringValue
                                   )
                                 | undefined
-                              product_description?:
-                                | (string | "" | UnknownEnumStringValue)
-                                | undefined
+                              product_description?: (string | "") | undefined
                               shipping_address?:
                                 | {
-                                    city?:
-                                      | (string | "" | UnknownEnumStringValue)
-                                      | undefined
-                                    country?:
-                                      | (string | "" | UnknownEnumStringValue)
-                                      | undefined
-                                    line1?:
-                                      | (string | "" | UnknownEnumStringValue)
-                                      | undefined
-                                    line2?:
-                                      | (string | "" | UnknownEnumStringValue)
-                                      | undefined
-                                    postal_code?:
-                                      | (string | "" | UnknownEnumStringValue)
-                                      | undefined
-                                    state?:
-                                      | (string | "" | UnknownEnumStringValue)
-                                      | undefined
+                                    city?: (string | "") | undefined
+                                    country?: (string | "") | undefined
+                                    line1?: (string | "") | undefined
+                                    line2?: (string | "") | undefined
+                                    postal_code?: (string | "") | undefined
+                                    state?: (string | "") | undefined
                                   }
                                 | undefined
                             }
@@ -20205,44 +20126,22 @@ export type t_PostChargesChargeDisputeRequestBody = {
                         prior_undisputed_transactions?:
                           | {
                               charge: string
-                              customer_account_id?:
-                                | (string | "" | UnknownEnumStringValue)
-                                | undefined
+                              customer_account_id?: (string | "") | undefined
                               customer_device_fingerprint?:
-                                | (string | "" | UnknownEnumStringValue)
+                                | (string | "")
                                 | undefined
-                              customer_device_id?:
-                                | (string | "" | UnknownEnumStringValue)
-                                | undefined
-                              customer_email_address?:
-                                | (string | "" | UnknownEnumStringValue)
-                                | undefined
-                              customer_purchase_ip?:
-                                | (string | "" | UnknownEnumStringValue)
-                                | undefined
-                              product_description?:
-                                | (string | "" | UnknownEnumStringValue)
-                                | undefined
+                              customer_device_id?: (string | "") | undefined
+                              customer_email_address?: (string | "") | undefined
+                              customer_purchase_ip?: (string | "") | undefined
+                              product_description?: (string | "") | undefined
                               shipping_address?:
                                 | {
-                                    city?:
-                                      | (string | "" | UnknownEnumStringValue)
-                                      | undefined
-                                    country?:
-                                      | (string | "" | UnknownEnumStringValue)
-                                      | undefined
-                                    line1?:
-                                      | (string | "" | UnknownEnumStringValue)
-                                      | undefined
-                                    line2?:
-                                      | (string | "" | UnknownEnumStringValue)
-                                      | undefined
-                                    postal_code?:
-                                      | (string | "" | UnknownEnumStringValue)
-                                      | undefined
-                                    state?:
-                                      | (string | "" | UnknownEnumStringValue)
-                                      | undefined
+                                    city?: (string | "") | undefined
+                                    country?: (string | "") | undefined
+                                    line1?: (string | "") | undefined
+                                    line2?: (string | "") | undefined
+                                    postal_code?: (string | "") | undefined
+                                    state?: (string | "") | undefined
                                   }
                                 | undefined
                             }[]
@@ -20256,7 +20155,6 @@ export type t_PostChargesChargeDisputeRequestBody = {
                     | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         product_description?: string | undefined
@@ -20276,7 +20174,7 @@ export type t_PostChargesChargeDisputeRequestBody = {
       }
     | undefined
   expand?: string[] | undefined
-  metadata?: (Record<string, string> | "" | UnknownEnumStringValue) | undefined
+  metadata?: (Record<string, string> | "") | undefined
   submit?: boolean | undefined
 }
 
@@ -20288,7 +20186,7 @@ export type t_PostChargesChargeRefundRequestBody = {
   amount?: number | undefined
   expand?: string[] | undefined
   instructions_email?: string | undefined
-  metadata?: (Record<string, string> | "" | UnknownEnumStringValue) | undefined
+  metadata?: (Record<string, string> | "") | undefined
   payment_intent?: string | undefined
   reason?:
     | (
@@ -20308,8 +20206,8 @@ export type t_PostChargesChargeRefundsRequestBody = {
   customer?: string | undefined
   expand?: string[] | undefined
   instructions_email?: string | undefined
-  metadata?: (Record<string, string> | "" | UnknownEnumStringValue) | undefined
-  origin?: ("customer_balance" | UnknownEnumStringValue) | undefined
+  metadata?: (Record<string, string> | "") | undefined
+  origin?: "customer_balance" | undefined
   payment_intent?: string | undefined
   reason?:
     | (
@@ -20325,7 +20223,7 @@ export type t_PostChargesChargeRefundsRequestBody = {
 
 export type t_PostChargesChargeRefundsRefundRequestBody = {
   expand?: string[] | undefined
-  metadata?: (Record<string, string> | "" | UnknownEnumStringValue) | undefined
+  metadata?: (Record<string, string> | "") | undefined
 }
 
 export type t_PostCheckoutSessionsRequestBody = {
@@ -20389,7 +20287,7 @@ export type t_PostCheckoutSessionsRequestBody = {
         key: string
         label: {
           custom: string
-          type: "custom" | UnknownEnumStringValue
+          type: "custom"
         }
         numeric?:
           | {
@@ -20417,7 +20315,6 @@ export type t_PostCheckoutSessionsRequestBody = {
                   message: string
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         shipping_address?:
@@ -20426,7 +20323,6 @@ export type t_PostCheckoutSessionsRequestBody = {
                   message: string
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         submit?:
@@ -20435,7 +20331,6 @@ export type t_PostCheckoutSessionsRequestBody = {
                   message: string
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         terms_of_service_acceptance?:
@@ -20444,7 +20339,6 @@ export type t_PostCheckoutSessionsRequestBody = {
                   message: string
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
       }
@@ -20474,9 +20368,7 @@ export type t_PostCheckoutSessionsRequestBody = {
         enabled: boolean
         invoice_data?:
           | {
-              account_tax_ids?:
-                | (string[] | "" | UnknownEnumStringValue)
-                | undefined
+              account_tax_ids?: (string[] | "") | undefined
               custom_fields?:
                 | (
                     | {
@@ -20484,7 +20376,6 @@ export type t_PostCheckoutSessionsRequestBody = {
                         value: string
                       }[]
                     | ""
-                    | UnknownEnumStringValue
                   )
                 | undefined
               description?: string | undefined
@@ -20510,7 +20401,6 @@ export type t_PostCheckoutSessionsRequestBody = {
                         template?: string | undefined
                       }
                     | ""
-                    | UnknownEnumStringValue
                   )
                 | undefined
             }
@@ -20695,9 +20585,7 @@ export type t_PostCheckoutSessionsRequestBody = {
               currency?: ("cad" | "usd" | UnknownEnumStringValue) | undefined
               mandate_options?:
                 | {
-                    custom_mandate_url?:
-                      | (string | "" | UnknownEnumStringValue)
-                      | undefined
+                    custom_mandate_url?: (string | "") | undefined
                     default_for?:
                       | ("invoice" | "subscription" | UnknownEnumStringValue)[]
                       | undefined
@@ -20736,17 +20624,17 @@ export type t_PostCheckoutSessionsRequestBody = {
           | undefined
         affirm?:
           | {
-              setup_future_usage?: ("none" | UnknownEnumStringValue) | undefined
+              setup_future_usage?: "none" | undefined
             }
           | undefined
         afterpay_clearpay?:
           | {
-              setup_future_usage?: ("none" | UnknownEnumStringValue) | undefined
+              setup_future_usage?: "none" | undefined
             }
           | undefined
         alipay?:
           | {
-              setup_future_usage?: ("none" | UnknownEnumStringValue) | undefined
+              setup_future_usage?: "none" | undefined
             }
           | undefined
         amazon_pay?:
@@ -20758,7 +20646,7 @@ export type t_PostCheckoutSessionsRequestBody = {
           | undefined
         au_becs_debit?:
           | {
-              setup_future_usage?: ("none" | UnknownEnumStringValue) | undefined
+              setup_future_usage?: "none" | undefined
               target_date?: string | undefined
             }
           | undefined
@@ -20766,9 +20654,7 @@ export type t_PostCheckoutSessionsRequestBody = {
           | {
               mandate_options?:
                 | {
-                    reference_prefix?:
-                      | (string | "" | UnknownEnumStringValue)
-                      | undefined
+                    reference_prefix?: (string | "") | undefined
                   }
                 | undefined
               setup_future_usage?:
@@ -20784,7 +20670,7 @@ export type t_PostCheckoutSessionsRequestBody = {
           | undefined
         bancontact?:
           | {
-              setup_future_usage?: ("none" | UnknownEnumStringValue) | undefined
+              setup_future_usage?: "none" | undefined
             }
           | undefined
         boleto?:
@@ -20884,40 +20770,38 @@ export type t_PostCheckoutSessionsRequestBody = {
                       | UnknownEnumStringValue
                   }
                 | undefined
-              funding_type?:
-                | ("bank_transfer" | UnknownEnumStringValue)
-                | undefined
-              setup_future_usage?: ("none" | UnknownEnumStringValue) | undefined
+              funding_type?: "bank_transfer" | undefined
+              setup_future_usage?: "none" | undefined
             }
           | undefined
         eps?:
           | {
-              setup_future_usage?: ("none" | UnknownEnumStringValue) | undefined
+              setup_future_usage?: "none" | undefined
             }
           | undefined
         fpx?:
           | {
-              setup_future_usage?: ("none" | UnknownEnumStringValue) | undefined
+              setup_future_usage?: "none" | undefined
             }
           | undefined
         giropay?:
           | {
-              setup_future_usage?: ("none" | UnknownEnumStringValue) | undefined
+              setup_future_usage?: "none" | undefined
             }
           | undefined
         grabpay?:
           | {
-              setup_future_usage?: ("none" | UnknownEnumStringValue) | undefined
+              setup_future_usage?: "none" | undefined
             }
           | undefined
         ideal?:
           | {
-              setup_future_usage?: ("none" | UnknownEnumStringValue) | undefined
+              setup_future_usage?: "none" | undefined
             }
           | undefined
         kakao_pay?:
           | {
-              capture_method?: ("manual" | UnknownEnumStringValue) | undefined
+              capture_method?: "manual" | undefined
               setup_future_usage?:
                 | ("none" | "off_session" | UnknownEnumStringValue)
                 | undefined
@@ -20925,7 +20809,7 @@ export type t_PostCheckoutSessionsRequestBody = {
           | undefined
         klarna?:
           | {
-              setup_future_usage?: ("none" | UnknownEnumStringValue) | undefined
+              setup_future_usage?: "none" | undefined
               subscriptions?:
                 | (
                     | {
@@ -20944,7 +20828,6 @@ export type t_PostCheckoutSessionsRequestBody = {
                         reference: string
                       }[]
                     | ""
-                    | UnknownEnumStringValue
                   )
                 | undefined
             }
@@ -20952,12 +20835,12 @@ export type t_PostCheckoutSessionsRequestBody = {
         konbini?:
           | {
               expires_after_days?: number | undefined
-              setup_future_usage?: ("none" | UnknownEnumStringValue) | undefined
+              setup_future_usage?: "none" | undefined
             }
           | undefined
         kr_card?:
           | {
-              capture_method?: ("manual" | UnknownEnumStringValue) | undefined
+              capture_method?: "manual" | undefined
               setup_future_usage?:
                 | ("none" | "off_session" | UnknownEnumStringValue)
                 | undefined
@@ -20972,17 +20855,17 @@ export type t_PostCheckoutSessionsRequestBody = {
           | undefined
         mobilepay?:
           | {
-              setup_future_usage?: ("none" | UnknownEnumStringValue) | undefined
+              setup_future_usage?: "none" | undefined
             }
           | undefined
         multibanco?:
           | {
-              setup_future_usage?: ("none" | UnknownEnumStringValue) | undefined
+              setup_future_usage?: "none" | undefined
             }
           | undefined
         naver_pay?:
           | {
-              capture_method?: ("manual" | UnknownEnumStringValue) | undefined
+              capture_method?: "manual" | undefined
               setup_future_usage?:
                 | ("none" | "off_session" | UnknownEnumStringValue)
                 | undefined
@@ -20991,24 +20874,24 @@ export type t_PostCheckoutSessionsRequestBody = {
         oxxo?:
           | {
               expires_after_days?: number | undefined
-              setup_future_usage?: ("none" | UnknownEnumStringValue) | undefined
+              setup_future_usage?: "none" | undefined
             }
           | undefined
         p24?:
           | {
-              setup_future_usage?: ("none" | UnknownEnumStringValue) | undefined
+              setup_future_usage?: "none" | undefined
               tos_shown_and_accepted?: boolean | undefined
             }
           | undefined
         pay_by_bank?: Record<string, unknown> | undefined
         payco?:
           | {
-              capture_method?: ("manual" | UnknownEnumStringValue) | undefined
+              capture_method?: "manual" | undefined
             }
           | undefined
         paynow?:
           | {
-              setup_future_usage?: ("none" | UnknownEnumStringValue) | undefined
+              setup_future_usage?: "none" | undefined
             }
           | undefined
         paypal?:
@@ -21052,7 +20935,7 @@ export type t_PostCheckoutSessionsRequestBody = {
         pix?:
           | {
               expires_after_seconds?: number | undefined
-              setup_future_usage?: ("none" | UnknownEnumStringValue) | undefined
+              setup_future_usage?: "none" | undefined
             }
           | undefined
         revolut_pay?:
@@ -21064,16 +20947,14 @@ export type t_PostCheckoutSessionsRequestBody = {
           | undefined
         samsung_pay?:
           | {
-              capture_method?: ("manual" | UnknownEnumStringValue) | undefined
+              capture_method?: "manual" | undefined
             }
           | undefined
         sepa_debit?:
           | {
               mandate_options?:
                 | {
-                    reference_prefix?:
-                      | (string | "" | UnknownEnumStringValue)
-                      | undefined
+                    reference_prefix?: (string | "") | undefined
                   }
                 | undefined
               setup_future_usage?:
@@ -21089,7 +20970,7 @@ export type t_PostCheckoutSessionsRequestBody = {
           | undefined
         sofort?:
           | {
-              setup_future_usage?: ("none" | UnknownEnumStringValue) | undefined
+              setup_future_usage?: "none" | undefined
             }
           | undefined
         swish?:
@@ -21138,7 +21019,7 @@ export type t_PostCheckoutSessionsRequestBody = {
           | {
               app_id?: string | undefined
               client: "android" | "ios" | "web" | UnknownEnumStringValue
-              setup_future_usage?: ("none" | UnknownEnumStringValue) | undefined
+              setup_future_usage?: "none" | undefined
             }
           | undefined
       }
@@ -21543,7 +21424,7 @@ export type t_PostCheckoutSessionsRequestBody = {
                   )
                 | undefined
               tax_code?: string | undefined
-              type?: ("fixed_amount" | UnknownEnumStringValue) | undefined
+              type?: "fixed_amount" | undefined
             }
           | undefined
       }[]
@@ -21647,7 +21528,7 @@ export type t_PostCheckoutSessionsSessionRequestBody = {
       }
     | undefined
   expand?: string[] | undefined
-  metadata?: (Record<string, string> | "" | UnknownEnumStringValue) | undefined
+  metadata?: (Record<string, string> | "") | undefined
   shipping_options?:
     | (
         | {
@@ -21715,12 +21596,11 @@ export type t_PostCheckoutSessionsSessionRequestBody = {
                       )
                     | undefined
                   tax_code?: string | undefined
-                  type?: ("fixed_amount" | UnknownEnumStringValue) | undefined
+                  type?: "fixed_amount" | undefined
                 }
               | undefined
           }[]
         | ""
-        | UnknownEnumStringValue
       )
     | undefined
 }
@@ -21747,10 +21627,9 @@ export type t_PostClimateOrdersOrderRequestBody = {
   beneficiary?:
     | (
         | {
-            public_name: string | "" | UnknownEnumStringValue
+            public_name: string | ""
           }
         | ""
-        | UnknownEnumStringValue
       )
     | undefined
   expand?: string[] | undefined
@@ -21784,7 +21663,7 @@ export type t_PostCouponsRequestBody = {
   expand?: string[] | undefined
   id?: string | undefined
   max_redemptions?: number | undefined
-  metadata?: (Record<string, string> | "" | UnknownEnumStringValue) | undefined
+  metadata?: (Record<string, string> | "") | undefined
   name?: string | undefined
   percent_off?: number | undefined
   redeem_by?: number | undefined
@@ -21800,7 +21679,7 @@ export type t_PostCouponsCouponRequestBody = {
       >
     | undefined
   expand?: string[] | undefined
-  metadata?: (Record<string, string> | "" | UnknownEnumStringValue) | undefined
+  metadata?: (Record<string, string> | "") | undefined
   name?: string | undefined
 }
 
@@ -21825,10 +21704,9 @@ export type t_PostCreditNotesRequestBody = {
                   taxable_amount: number
                 }[]
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
-        tax_rates?: (string[] | "" | UnknownEnumStringValue) | undefined
+        tax_rates?: (string[] | "") | undefined
         type: "custom_line_item" | "invoice_line_item" | UnknownEnumStringValue
         unit_amount?: number | undefined
         unit_amount_decimal?: string | undefined
@@ -21929,7 +21807,6 @@ export type t_PostCustomersRequestBody = {
             state?: string | undefined
           }
         | ""
-        | UnknownEnumStringValue
       )
     | undefined
   balance?: number | undefined
@@ -21962,7 +21839,6 @@ export type t_PostCustomersRequestBody = {
                   value: string
                 }[]
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         default_payment_method?: string | undefined
@@ -21981,12 +21857,11 @@ export type t_PostCustomersRequestBody = {
                   template?: string | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
       }
     | undefined
-  metadata?: (Record<string, string> | "" | UnknownEnumStringValue) | undefined
+  metadata?: (Record<string, string> | "") | undefined
   name?: string | undefined
   next_invoice_sequence?: number | undefined
   payment_method?: string | undefined
@@ -22007,13 +21882,12 @@ export type t_PostCustomersRequestBody = {
             phone?: string | undefined
           }
         | ""
-        | UnknownEnumStringValue
       )
     | undefined
   source?: string | undefined
   tax?:
     | {
-        ip_address?: (string | "" | UnknownEnumStringValue) | undefined
+        ip_address?: (string | "") | undefined
         validate_location?:
           | ("deferred" | "immediately" | UnknownEnumStringValue)
           | undefined
@@ -22154,7 +22028,6 @@ export type t_PostCustomersCustomerRequestBody = {
             state?: string | undefined
           }
         | ""
-        | UnknownEnumStringValue
       )
     | undefined
   balance?: number | undefined
@@ -22168,7 +22041,7 @@ export type t_PostCustomersCustomerRequestBody = {
             account_number: string
             country: string
             currency?: string | undefined
-            object?: ("bank_account" | UnknownEnumStringValue) | undefined
+            object?: "bank_account" | undefined
             routing_number?: string | undefined
           }
         | string
@@ -22189,7 +22062,7 @@ export type t_PostCustomersCustomerRequestBody = {
             metadata?: Record<string, string> | undefined
             name?: string | undefined
             number: string
-            object?: ("card" | UnknownEnumStringValue) | undefined
+            object?: "card" | undefined
           }
         | string
       )
@@ -22227,7 +22100,6 @@ export type t_PostCustomersCustomerRequestBody = {
                   value: string
                 }[]
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         default_payment_method?: string | undefined
@@ -22246,12 +22118,11 @@ export type t_PostCustomersCustomerRequestBody = {
                   template?: string | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
       }
     | undefined
-  metadata?: (Record<string, string> | "" | UnknownEnumStringValue) | undefined
+  metadata?: (Record<string, string> | "") | undefined
   name?: string | undefined
   next_invoice_sequence?: number | undefined
   phone?: string | undefined
@@ -22271,13 +22142,12 @@ export type t_PostCustomersCustomerRequestBody = {
             phone?: string | undefined
           }
         | ""
-        | UnknownEnumStringValue
       )
     | undefined
   source?: string | undefined
   tax?:
     | {
-        ip_address?: (string | "" | UnknownEnumStringValue) | undefined
+        ip_address?: (string | "") | undefined
         validate_location?:
           | ("auto" | "deferred" | "immediately" | UnknownEnumStringValue)
           | undefined
@@ -22293,13 +22163,13 @@ export type t_PostCustomersCustomerBalanceTransactionsRequestBody = {
   currency: string
   description?: string | undefined
   expand?: string[] | undefined
-  metadata?: (Record<string, string> | "" | UnknownEnumStringValue) | undefined
+  metadata?: (Record<string, string> | "") | undefined
 }
 
 export type t_PostCustomersCustomerBalanceTransactionsTransactionRequestBody = {
   description?: string | undefined
   expand?: string[] | undefined
-  metadata?: (Record<string, string> | "" | UnknownEnumStringValue) | undefined
+  metadata?: (Record<string, string> | "") | undefined
 }
 
 export type t_PostCustomersCustomerBankAccountsRequestBody = {
@@ -22314,7 +22184,7 @@ export type t_PostCustomersCustomerBankAccountsRequestBody = {
             account_number: string
             country: string
             currency?: string | undefined
-            object?: ("bank_account" | UnknownEnumStringValue) | undefined
+            object?: "bank_account" | undefined
             routing_number?: string | undefined
           }
         | string
@@ -22335,7 +22205,7 @@ export type t_PostCustomersCustomerBankAccountsRequestBody = {
             metadata?: Record<string, string> | undefined
             name?: string | undefined
             number: string
-            object?: ("card" | UnknownEnumStringValue) | undefined
+            object?: "card" | undefined
           }
         | string
       )
@@ -22359,7 +22229,7 @@ export type t_PostCustomersCustomerBankAccountsIdRequestBody = {
   exp_month?: string | undefined
   exp_year?: string | undefined
   expand?: string[] | undefined
-  metadata?: (Record<string, string> | "" | UnknownEnumStringValue) | undefined
+  metadata?: (Record<string, string> | "") | undefined
   name?: string | undefined
   owner?:
     | {
@@ -22397,7 +22267,7 @@ export type t_PostCustomersCustomerCardsRequestBody = {
             account_number: string
             country: string
             currency?: string | undefined
-            object?: ("bank_account" | UnknownEnumStringValue) | undefined
+            object?: "bank_account" | undefined
             routing_number?: string | undefined
           }
         | string
@@ -22418,7 +22288,7 @@ export type t_PostCustomersCustomerCardsRequestBody = {
             metadata?: Record<string, string> | undefined
             name?: string | undefined
             number: string
-            object?: ("card" | UnknownEnumStringValue) | undefined
+            object?: "card" | undefined
           }
         | string
       )
@@ -22442,7 +22312,7 @@ export type t_PostCustomersCustomerCardsIdRequestBody = {
   exp_month?: string | undefined
   exp_year?: string | undefined
   expand?: string[] | undefined
-  metadata?: (Record<string, string> | "" | UnknownEnumStringValue) | undefined
+  metadata?: (Record<string, string> | "") | undefined
   name?: string | undefined
   owner?:
     | {
@@ -22499,7 +22369,7 @@ export type t_PostCustomersCustomerFundingInstructionsRequestBody = {
   }
   currency: string
   expand?: string[] | undefined
-  funding_type: "bank_transfer" | UnknownEnumStringValue
+  funding_type: "bank_transfer"
 }
 
 export type t_PostCustomersCustomerSourcesRequestBody = {
@@ -22514,7 +22384,7 @@ export type t_PostCustomersCustomerSourcesRequestBody = {
             account_number: string
             country: string
             currency?: string | undefined
-            object?: ("bank_account" | UnknownEnumStringValue) | undefined
+            object?: "bank_account" | undefined
             routing_number?: string | undefined
           }
         | string
@@ -22535,7 +22405,7 @@ export type t_PostCustomersCustomerSourcesRequestBody = {
             metadata?: Record<string, string> | undefined
             name?: string | undefined
             number: string
-            object?: ("card" | UnknownEnumStringValue) | undefined
+            object?: "card" | undefined
           }
         | string
       )
@@ -22559,7 +22429,7 @@ export type t_PostCustomersCustomerSourcesIdRequestBody = {
   exp_month?: string | undefined
   exp_year?: string | undefined
   expand?: string[] | undefined
-  metadata?: (Record<string, string> | "" | UnknownEnumStringValue) | undefined
+  metadata?: (Record<string, string> | "") | undefined
   name?: string | undefined
   owner?:
     | {
@@ -22613,10 +22483,10 @@ export type t_PostCustomersCustomerSubscriptionsRequestBody = {
             }
           | undefined
         quantity?: number | undefined
-        tax_rates?: (string[] | "" | UnknownEnumStringValue) | undefined
+        tax_rates?: (string[] | "") | undefined
       }[]
     | undefined
-  application_fee_percent?: (number | "" | UnknownEnumStringValue) | undefined
+  application_fee_percent?: (number | "") | undefined
   automatic_tax?:
     | {
         enabled: boolean
@@ -22637,7 +22507,6 @@ export type t_PostCustomersCustomerSubscriptionsRequestBody = {
             reset_billing_cycle_anchor?: boolean | undefined
           }
         | ""
-        | UnknownEnumStringValue
       )
     | undefined
   cancel_at?:
@@ -22651,7 +22520,7 @@ export type t_PostCustomersCustomerSubscriptionsRequestBody = {
   days_until_due?: number | undefined
   default_payment_method?: string | undefined
   default_source?: string | undefined
-  default_tax_rates?: (string[] | "" | UnknownEnumStringValue) | undefined
+  default_tax_rates?: (string[] | "") | undefined
   discounts?:
     | (
         | {
@@ -22660,13 +22529,12 @@ export type t_PostCustomersCustomerSubscriptionsRequestBody = {
             promotion_code?: string | undefined
           }[]
         | ""
-        | UnknownEnumStringValue
       )
     | undefined
   expand?: string[] | undefined
   invoice_settings?:
     | {
-        account_tax_ids?: (string[] | "" | UnknownEnumStringValue) | undefined
+        account_tax_ids?: (string[] | "") | undefined
         issuer?:
           | {
               account?: string | undefined
@@ -22683,7 +22551,6 @@ export type t_PostCustomersCustomerSubscriptionsRequestBody = {
                   usage_gte: number
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         discounts?:
@@ -22694,7 +22561,6 @@ export type t_PostCustomersCustomerSubscriptionsRequestBody = {
                   promotion_code?: string | undefined
                 }[]
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         metadata?: Record<string, string> | undefined
@@ -22725,10 +22591,10 @@ export type t_PostCustomersCustomerSubscriptionsRequestBody = {
             }
           | undefined
         quantity?: number | undefined
-        tax_rates?: (string[] | "" | UnknownEnumStringValue) | undefined
+        tax_rates?: (string[] | "") | undefined
       }[]
     | undefined
-  metadata?: (Record<string, string> | "" | UnknownEnumStringValue) | undefined
+  metadata?: (Record<string, string> | "") | undefined
   off_session?: boolean | undefined
   payment_behavior?:
     | (
@@ -22767,7 +22633,6 @@ export type t_PostCustomersCustomerSubscriptionsRequestBody = {
                           | undefined
                       }
                     | ""
-                    | UnknownEnumStringValue
                   )
                 | undefined
               bancontact?:
@@ -22778,7 +22643,6 @@ export type t_PostCustomersCustomerSubscriptionsRequestBody = {
                           | undefined
                       }
                     | ""
-                    | UnknownEnumStringValue
                   )
                 | undefined
               card?:
@@ -22821,7 +22685,6 @@ export type t_PostCustomersCustomerSubscriptionsRequestBody = {
                           | undefined
                       }
                     | ""
-                    | UnknownEnumStringValue
                   )
                 | undefined
               customer_balance?:
@@ -22840,15 +22703,10 @@ export type t_PostCustomersCustomerSubscriptionsRequestBody = {
                         funding_type?: string | undefined
                       }
                     | ""
-                    | UnknownEnumStringValue
                   )
                 | undefined
-              konbini?:
-                | (Record<string, unknown> | "" | UnknownEnumStringValue)
-                | undefined
-              sepa_debit?:
-                | (Record<string, unknown> | "" | UnknownEnumStringValue)
-                | undefined
+              konbini?: (Record<string, unknown> | "") | undefined
+              sepa_debit?: (Record<string, unknown> | "") | undefined
               us_bank_account?:
                 | (
                     | {
@@ -22894,7 +22752,6 @@ export type t_PostCustomersCustomerSubscriptionsRequestBody = {
                           | undefined
                       }
                     | ""
-                    | UnknownEnumStringValue
                   )
                 | undefined
             }
@@ -22944,7 +22801,6 @@ export type t_PostCustomersCustomerSubscriptionsRequestBody = {
                   | UnknownEnumStringValue
                 )[]
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         save_default_payment_method?:
@@ -22959,7 +22815,6 @@ export type t_PostCustomersCustomerSubscriptionsRequestBody = {
             interval_count?: number | undefined
           }
         | ""
-        | UnknownEnumStringValue
       )
     | undefined
   proration_behavior?:
@@ -22971,7 +22826,7 @@ export type t_PostCustomersCustomerSubscriptionsRequestBody = {
         destination: string
       }
     | undefined
-  trial_end?: ("now" | UnknownEnumStringValue | number) | undefined
+  trial_end?: ("now" | number) | undefined
   trial_from_plan?: boolean | undefined
   trial_period_days?: number | undefined
   trial_settings?:
@@ -23016,10 +22871,10 @@ export type t_PostCustomersCustomerSubscriptionsSubscriptionExposedIdRequestBody
               }
             | undefined
           quantity?: number | undefined
-          tax_rates?: (string[] | "" | UnknownEnumStringValue) | undefined
+          tax_rates?: (string[] | "") | undefined
         }[]
       | undefined
-    application_fee_percent?: (number | "" | UnknownEnumStringValue) | undefined
+    application_fee_percent?: (number | "") | undefined
     automatic_tax?:
       | {
           enabled: boolean
@@ -23041,22 +22896,21 @@ export type t_PostCustomersCustomerSubscriptionsSubscriptionExposedIdRequestBody
               reset_billing_cycle_anchor?: boolean | undefined
             }
           | ""
-          | UnknownEnumStringValue
         )
       | undefined
     cancel_at?:
       | (
           | number
           | ""
-          | UnknownEnumStringValue
           | "max_period_end"
           | "min_period_end"
+          | UnknownEnumStringValue
         )
       | undefined
     cancel_at_period_end?: boolean | undefined
     cancellation_details?:
       | {
-          comment?: (string | "" | UnknownEnumStringValue) | undefined
+          comment?: (string | "") | undefined
           feedback?:
             | (
                 | ""
@@ -23078,8 +22932,8 @@ export type t_PostCustomersCustomerSubscriptionsSubscriptionExposedIdRequestBody
       | undefined
     days_until_due?: number | undefined
     default_payment_method?: string | undefined
-    default_source?: (string | "" | UnknownEnumStringValue) | undefined
-    default_tax_rates?: (string[] | "" | UnknownEnumStringValue) | undefined
+    default_source?: (string | "") | undefined
+    default_tax_rates?: (string[] | "") | undefined
     discounts?:
       | (
           | {
@@ -23088,13 +22942,12 @@ export type t_PostCustomersCustomerSubscriptionsSubscriptionExposedIdRequestBody
               promotion_code?: string | undefined
             }[]
           | ""
-          | UnknownEnumStringValue
         )
       | undefined
     expand?: string[] | undefined
     invoice_settings?:
       | {
-          account_tax_ids?: (string[] | "" | UnknownEnumStringValue) | undefined
+          account_tax_ids?: (string[] | "") | undefined
           issuer?:
             | {
                 account?: string | undefined
@@ -23111,7 +22964,6 @@ export type t_PostCustomersCustomerSubscriptionsSubscriptionExposedIdRequestBody
                     usage_gte: number
                   }
                 | ""
-                | UnknownEnumStringValue
               )
             | undefined
           clear_usage?: boolean | undefined
@@ -23124,13 +22976,10 @@ export type t_PostCustomersCustomerSubscriptionsSubscriptionExposedIdRequestBody
                     promotion_code?: string | undefined
                   }[]
                 | ""
-                | UnknownEnumStringValue
               )
             | undefined
           id?: string | undefined
-          metadata?:
-            | (Record<string, string> | "" | UnknownEnumStringValue)
-            | undefined
+          metadata?: (Record<string, string> | "") | undefined
           price?: string | undefined
           price_data?:
             | {
@@ -23158,12 +23007,10 @@ export type t_PostCustomersCustomerSubscriptionsSubscriptionExposedIdRequestBody
               }
             | undefined
           quantity?: number | undefined
-          tax_rates?: (string[] | "" | UnknownEnumStringValue) | undefined
+          tax_rates?: (string[] | "") | undefined
         }[]
       | undefined
-    metadata?:
-      | (Record<string, string> | "" | UnknownEnumStringValue)
-      | undefined
+    metadata?: (Record<string, string> | "") | undefined
     off_session?: boolean | undefined
     pause_collection?:
       | (
@@ -23176,7 +23023,6 @@ export type t_PostCustomersCustomerSubscriptionsSubscriptionExposedIdRequestBody
               resumes_at?: number | undefined
             }
           | ""
-          | UnknownEnumStringValue
         )
       | undefined
     payment_behavior?:
@@ -23216,7 +23062,6 @@ export type t_PostCustomersCustomerSubscriptionsSubscriptionExposedIdRequestBody
                             | undefined
                         }
                       | ""
-                      | UnknownEnumStringValue
                     )
                   | undefined
                 bancontact?:
@@ -23233,7 +23078,6 @@ export type t_PostCustomersCustomerSubscriptionsSubscriptionExposedIdRequestBody
                             | undefined
                         }
                       | ""
-                      | UnknownEnumStringValue
                     )
                   | undefined
                 card?:
@@ -23280,7 +23124,6 @@ export type t_PostCustomersCustomerSubscriptionsSubscriptionExposedIdRequestBody
                             | undefined
                         }
                       | ""
-                      | UnknownEnumStringValue
                     )
                   | undefined
                 customer_balance?:
@@ -23299,15 +23142,10 @@ export type t_PostCustomersCustomerSubscriptionsSubscriptionExposedIdRequestBody
                           funding_type?: string | undefined
                         }
                       | ""
-                      | UnknownEnumStringValue
                     )
                   | undefined
-                konbini?:
-                  | (Record<string, unknown> | "" | UnknownEnumStringValue)
-                  | undefined
-                sepa_debit?:
-                  | (Record<string, unknown> | "" | UnknownEnumStringValue)
-                  | undefined
+                konbini?: (Record<string, unknown> | "") | undefined
+                sepa_debit?: (Record<string, unknown> | "") | undefined
                 us_bank_account?:
                   | (
                       | {
@@ -23353,7 +23191,6 @@ export type t_PostCustomersCustomerSubscriptionsSubscriptionExposedIdRequestBody
                             | undefined
                         }
                       | ""
-                      | UnknownEnumStringValue
                     )
                   | undefined
               }
@@ -23403,7 +23240,6 @@ export type t_PostCustomersCustomerSubscriptionsSubscriptionExposedIdRequestBody
                     | UnknownEnumStringValue
                   )[]
                 | ""
-                | UnknownEnumStringValue
               )
             | undefined
           save_default_payment_method?:
@@ -23423,7 +23259,6 @@ export type t_PostCustomersCustomerSubscriptionsSubscriptionExposedIdRequestBody
               interval_count?: number | undefined
             }
           | ""
-          | UnknownEnumStringValue
         )
       | undefined
     proration_behavior?:
@@ -23442,10 +23277,9 @@ export type t_PostCustomersCustomerSubscriptionsSubscriptionExposedIdRequestBody
               destination: string
             }
           | ""
-          | UnknownEnumStringValue
         )
       | undefined
-    trial_end?: ("now" | UnknownEnumStringValue | number) | undefined
+    trial_end?: ("now" | number) | undefined
     trial_from_plan?: boolean | undefined
     trial_settings?:
       | {
@@ -23600,21 +23434,13 @@ export type t_PostDisputesDisputeRequestBody = {
                     | {
                         disputed_transaction?:
                           | {
-                              customer_account_id?:
-                                | (string | "" | UnknownEnumStringValue)
-                                | undefined
+                              customer_account_id?: (string | "") | undefined
                               customer_device_fingerprint?:
-                                | (string | "" | UnknownEnumStringValue)
+                                | (string | "")
                                 | undefined
-                              customer_device_id?:
-                                | (string | "" | UnknownEnumStringValue)
-                                | undefined
-                              customer_email_address?:
-                                | (string | "" | UnknownEnumStringValue)
-                                | undefined
-                              customer_purchase_ip?:
-                                | (string | "" | UnknownEnumStringValue)
-                                | undefined
+                              customer_device_id?: (string | "") | undefined
+                              customer_email_address?: (string | "") | undefined
+                              customer_purchase_ip?: (string | "") | undefined
                               merchandise_or_services?:
                                 | (
                                     | "merchandise"
@@ -23622,29 +23448,15 @@ export type t_PostDisputesDisputeRequestBody = {
                                     | UnknownEnumStringValue
                                   )
                                 | undefined
-                              product_description?:
-                                | (string | "" | UnknownEnumStringValue)
-                                | undefined
+                              product_description?: (string | "") | undefined
                               shipping_address?:
                                 | {
-                                    city?:
-                                      | (string | "" | UnknownEnumStringValue)
-                                      | undefined
-                                    country?:
-                                      | (string | "" | UnknownEnumStringValue)
-                                      | undefined
-                                    line1?:
-                                      | (string | "" | UnknownEnumStringValue)
-                                      | undefined
-                                    line2?:
-                                      | (string | "" | UnknownEnumStringValue)
-                                      | undefined
-                                    postal_code?:
-                                      | (string | "" | UnknownEnumStringValue)
-                                      | undefined
-                                    state?:
-                                      | (string | "" | UnknownEnumStringValue)
-                                      | undefined
+                                    city?: (string | "") | undefined
+                                    country?: (string | "") | undefined
+                                    line1?: (string | "") | undefined
+                                    line2?: (string | "") | undefined
+                                    postal_code?: (string | "") | undefined
+                                    state?: (string | "") | undefined
                                   }
                                 | undefined
                             }
@@ -23652,44 +23464,22 @@ export type t_PostDisputesDisputeRequestBody = {
                         prior_undisputed_transactions?:
                           | {
                               charge: string
-                              customer_account_id?:
-                                | (string | "" | UnknownEnumStringValue)
-                                | undefined
+                              customer_account_id?: (string | "") | undefined
                               customer_device_fingerprint?:
-                                | (string | "" | UnknownEnumStringValue)
+                                | (string | "")
                                 | undefined
-                              customer_device_id?:
-                                | (string | "" | UnknownEnumStringValue)
-                                | undefined
-                              customer_email_address?:
-                                | (string | "" | UnknownEnumStringValue)
-                                | undefined
-                              customer_purchase_ip?:
-                                | (string | "" | UnknownEnumStringValue)
-                                | undefined
-                              product_description?:
-                                | (string | "" | UnknownEnumStringValue)
-                                | undefined
+                              customer_device_id?: (string | "") | undefined
+                              customer_email_address?: (string | "") | undefined
+                              customer_purchase_ip?: (string | "") | undefined
+                              product_description?: (string | "") | undefined
                               shipping_address?:
                                 | {
-                                    city?:
-                                      | (string | "" | UnknownEnumStringValue)
-                                      | undefined
-                                    country?:
-                                      | (string | "" | UnknownEnumStringValue)
-                                      | undefined
-                                    line1?:
-                                      | (string | "" | UnknownEnumStringValue)
-                                      | undefined
-                                    line2?:
-                                      | (string | "" | UnknownEnumStringValue)
-                                      | undefined
-                                    postal_code?:
-                                      | (string | "" | UnknownEnumStringValue)
-                                      | undefined
-                                    state?:
-                                      | (string | "" | UnknownEnumStringValue)
-                                      | undefined
+                                    city?: (string | "") | undefined
+                                    country?: (string | "") | undefined
+                                    line1?: (string | "") | undefined
+                                    line2?: (string | "") | undefined
+                                    postal_code?: (string | "") | undefined
+                                    state?: (string | "") | undefined
                                   }
                                 | undefined
                             }[]
@@ -23703,7 +23493,6 @@ export type t_PostDisputesDisputeRequestBody = {
                     | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         product_description?: string | undefined
@@ -23723,7 +23512,7 @@ export type t_PostDisputesDisputeRequestBody = {
       }
     | undefined
   expand?: string[] | undefined
-  metadata?: (Record<string, string> | "" | UnknownEnumStringValue) | undefined
+  metadata?: (Record<string, string> | "") | undefined
   submit?: boolean | undefined
 }
 
@@ -23741,7 +23530,7 @@ export type t_PostEntitlementsFeaturesRequestBody = {
 export type t_PostEntitlementsFeaturesIdRequestBody = {
   active?: boolean | undefined
   expand?: string[] | undefined
-  metadata?: (Record<string, string> | "" | UnknownEnumStringValue) | undefined
+  metadata?: (Record<string, string> | "") | undefined
   name?: string | undefined
 }
 
@@ -23780,7 +23569,7 @@ export type t_PostExternalAccountsIdRequestBody = {
   exp_month?: string | undefined
   exp_year?: string | undefined
   expand?: string[] | undefined
-  metadata?: (Record<string, string> | "" | UnknownEnumStringValue) | undefined
+  metadata?: (Record<string, string> | "") | undefined
   name?: string | undefined
 }
 
@@ -23788,13 +23577,13 @@ export type t_PostFileLinksRequestBody = {
   expand?: string[] | undefined
   expires_at?: number | undefined
   file: string
-  metadata?: (Record<string, string> | "" | UnknownEnumStringValue) | undefined
+  metadata?: (Record<string, string> | "") | undefined
 }
 
 export type t_PostFileLinksLinkRequestBody = {
   expand?: string[] | undefined
-  expires_at?: ("now" | UnknownEnumStringValue | number | "") | undefined
-  metadata?: (Record<string, string> | "" | UnknownEnumStringValue) | undefined
+  expires_at?: ("now" | number | "") | undefined
+  metadata?: (Record<string, string> | "") | undefined
 }
 
 export type t_PostFinancialConnectionsAccountsAccountDisconnectRequestBody = {
@@ -23813,12 +23602,12 @@ export type t_PostFinancialConnectionsAccountsAccountRefreshRequestBody = {
 
 export type t_PostFinancialConnectionsAccountsAccountSubscribeRequestBody = {
   expand?: string[] | undefined
-  features: ("transactions" | UnknownEnumStringValue)[]
+  features: "transactions"[]
 }
 
 export type t_PostFinancialConnectionsAccountsAccountUnsubscribeRequestBody = {
   expand?: string[] | undefined
-  features: ("transactions" | UnknownEnumStringValue)[]
+  features: "transactions"[]
 }
 
 export type t_PostFinancialConnectionsSessionsRequestBody = {
@@ -23904,7 +23693,6 @@ export type t_PostIdentityVerificationSessionsRequestBody = {
                   require_matching_selfie?: boolean | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
       }
@@ -23948,7 +23736,6 @@ export type t_PostIdentityVerificationSessionsSessionRequestBody = {
                   require_matching_selfie?: boolean | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
       }
@@ -23992,12 +23779,11 @@ export type t_PostInvoiceitemsRequestBody = {
             promotion_code?: string | undefined
           }[]
         | ""
-        | UnknownEnumStringValue
       )
     | undefined
   expand?: string[] | undefined
   invoice?: string | undefined
-  metadata?: (Record<string, string> | "" | UnknownEnumStringValue) | undefined
+  metadata?: (Record<string, string> | "") | undefined
   period?:
     | {
         end: number
@@ -24025,7 +23811,7 @@ export type t_PostInvoiceitemsRequestBody = {
   tax_behavior?:
     | ("exclusive" | "inclusive" | "unspecified" | UnknownEnumStringValue)
     | undefined
-  tax_code?: (string | "" | UnknownEnumStringValue) | undefined
+  tax_code?: (string | "") | undefined
   tax_rates?: string[] | undefined
   unit_amount_decimal?: string | undefined
 }
@@ -24042,11 +23828,10 @@ export type t_PostInvoiceitemsInvoiceitemRequestBody = {
             promotion_code?: string | undefined
           }[]
         | ""
-        | UnknownEnumStringValue
       )
     | undefined
   expand?: string[] | undefined
-  metadata?: (Record<string, string> | "" | UnknownEnumStringValue) | undefined
+  metadata?: (Record<string, string> | "") | undefined
   period?:
     | {
         end: number
@@ -24073,13 +23858,13 @@ export type t_PostInvoiceitemsInvoiceitemRequestBody = {
   tax_behavior?:
     | ("exclusive" | "inclusive" | "unspecified" | UnknownEnumStringValue)
     | undefined
-  tax_code?: (string | "" | UnknownEnumStringValue) | undefined
-  tax_rates?: (string[] | "" | UnknownEnumStringValue) | undefined
+  tax_code?: (string | "") | undefined
+  tax_rates?: (string[] | "") | undefined
   unit_amount_decimal?: string | undefined
 }
 
 export type t_PostInvoicesRequestBody = {
-  account_tax_ids?: (string[] | "" | UnknownEnumStringValue) | undefined
+  account_tax_ids?: (string[] | "") | undefined
   application_fee_amount?: number | undefined
   auto_advance?: boolean | undefined
   automatic_tax?:
@@ -24105,7 +23890,6 @@ export type t_PostInvoicesRequestBody = {
             value: string
           }[]
         | ""
-        | UnknownEnumStringValue
       )
     | undefined
   customer?: string | undefined
@@ -24122,7 +23906,6 @@ export type t_PostInvoicesRequestBody = {
             promotion_code?: string | undefined
           }[]
         | ""
-        | UnknownEnumStringValue
       )
     | undefined
   due_date?: number | undefined
@@ -24131,7 +23914,7 @@ export type t_PostInvoicesRequestBody = {
   footer?: string | undefined
   from_invoice?:
     | {
-        action: "revision" | UnknownEnumStringValue
+        action: "revision"
         invoice: string
       }
     | undefined
@@ -24141,12 +23924,12 @@ export type t_PostInvoicesRequestBody = {
         type: "account" | "self" | UnknownEnumStringValue
       }
     | undefined
-  metadata?: (Record<string, string> | "" | UnknownEnumStringValue) | undefined
+  metadata?: (Record<string, string> | "") | undefined
   number?: string | undefined
   on_behalf_of?: string | undefined
   payment_settings?:
     | {
-        default_mandate?: (string | "" | UnknownEnumStringValue) | undefined
+        default_mandate?: (string | "") | undefined
         payment_method_options?:
           | {
               acss_debit?:
@@ -24173,7 +23956,6 @@ export type t_PostInvoicesRequestBody = {
                           | undefined
                       }
                     | ""
-                    | UnknownEnumStringValue
                   )
                 | undefined
               bancontact?:
@@ -24184,7 +23966,6 @@ export type t_PostInvoicesRequestBody = {
                           | undefined
                       }
                     | ""
-                    | UnknownEnumStringValue
                   )
                 | undefined
               card?:
@@ -24197,9 +23978,7 @@ export type t_PostInvoicesRequestBody = {
                                 | (
                                     | {
                                         count?: number | undefined
-                                        interval?:
-                                          | ("month" | UnknownEnumStringValue)
-                                          | undefined
+                                        interval?: "month" | undefined
                                         type:
                                           | "bonus"
                                           | "fixed_count"
@@ -24207,7 +23986,6 @@ export type t_PostInvoicesRequestBody = {
                                           | UnknownEnumStringValue
                                       }
                                     | ""
-                                    | UnknownEnumStringValue
                                   )
                                 | undefined
                             }
@@ -24222,7 +24000,6 @@ export type t_PostInvoicesRequestBody = {
                           | undefined
                       }
                     | ""
-                    | UnknownEnumStringValue
                   )
                 | undefined
               customer_balance?:
@@ -24241,15 +24018,10 @@ export type t_PostInvoicesRequestBody = {
                         funding_type?: string | undefined
                       }
                     | ""
-                    | UnknownEnumStringValue
                   )
                 | undefined
-              konbini?:
-                | (Record<string, unknown> | "" | UnknownEnumStringValue)
-                | undefined
-              sepa_debit?:
-                | (Record<string, unknown> | "" | UnknownEnumStringValue)
-                | undefined
+              konbini?: (Record<string, unknown> | "") | undefined
+              sepa_debit?: (Record<string, unknown> | "") | undefined
               us_bank_account?:
                 | (
                     | {
@@ -24295,7 +24067,6 @@ export type t_PostInvoicesRequestBody = {
                           | undefined
                       }
                     | ""
-                    | UnknownEnumStringValue
                   )
                 | undefined
             }
@@ -24345,7 +24116,6 @@ export type t_PostInvoicesRequestBody = {
                   | UnknownEnumStringValue
                 )[]
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
       }
@@ -24371,7 +24141,7 @@ export type t_PostInvoicesRequestBody = {
             }
           | undefined
         template?: string | undefined
-        template_version?: (number | "" | UnknownEnumStringValue) | undefined
+        template_version?: (number | "") | undefined
       }
     | undefined
   shipping_cost?:
@@ -24440,7 +24210,7 @@ export type t_PostInvoicesRequestBody = {
                   )
                 | undefined
               tax_code?: string | undefined
-              type?: ("fixed_amount" | UnknownEnumStringValue) | undefined
+              type?: "fixed_amount" | undefined
             }
           | undefined
       }
@@ -24456,7 +24226,7 @@ export type t_PostInvoicesRequestBody = {
           state?: string | undefined
         }
         name: string
-        phone?: (string | "" | UnknownEnumStringValue) | undefined
+        phone?: (string | "") | undefined
       }
     | undefined
   statement_descriptor?: string | undefined
@@ -24496,7 +24266,6 @@ export type t_PostInvoicesCreatePreviewRequestBody = {
                   state?: string | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         shipping?:
@@ -24514,12 +24283,11 @@ export type t_PostInvoicesCreatePreviewRequestBody = {
                   phone?: string | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         tax?:
           | {
-              ip_address?: (string | "" | UnknownEnumStringValue) | undefined
+              ip_address?: (string | "") | undefined
             }
           | undefined
         tax_exempt?:
@@ -24652,7 +24420,6 @@ export type t_PostInvoicesCreatePreviewRequestBody = {
             promotion_code?: string | undefined
           }[]
         | ""
-        | UnknownEnumStringValue
       )
     | undefined
   expand?: string[] | undefined
@@ -24670,13 +24437,10 @@ export type t_PostInvoicesCreatePreviewRequestBody = {
                   promotion_code?: string | undefined
                 }[]
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         invoiceitem?: string | undefined
-        metadata?:
-          | (Record<string, string> | "" | UnknownEnumStringValue)
-          | undefined
+        metadata?: (Record<string, string> | "") | undefined
         period?:
           | {
               end: number
@@ -24704,8 +24468,8 @@ export type t_PostInvoicesCreatePreviewRequestBody = {
         tax_behavior?:
           | ("exclusive" | "inclusive" | "unspecified" | UnknownEnumStringValue)
           | undefined
-        tax_code?: (string | "" | UnknownEnumStringValue) | undefined
-        tax_rates?: (string[] | "" | UnknownEnumStringValue) | undefined
+        tax_code?: (string | "") | undefined
+        tax_rates?: (string[] | "") | undefined
         unit_amount?: number | undefined
         unit_amount_decimal?: string | undefined
       }[]
@@ -24716,7 +24480,7 @@ export type t_PostInvoicesCreatePreviewRequestBody = {
         type: "account" | "self" | UnknownEnumStringValue
       }
     | undefined
-  on_behalf_of?: (string | "" | UnknownEnumStringValue) | undefined
+  on_behalf_of?: (string | "") | undefined
   preview_mode?: ("next" | "recurring" | UnknownEnumStringValue) | undefined
   schedule?: string | undefined
   schedule_details?:
@@ -24758,9 +24522,7 @@ export type t_PostInvoicesCreatePreviewRequestBody = {
                         }
                       | undefined
                     quantity?: number | undefined
-                    tax_rates?:
-                      | (string[] | "" | UnknownEnumStringValue)
-                      | undefined
+                    tax_rates?: (string[] | "") | undefined
                   }[]
                 | undefined
               application_fee_percent?: number | undefined
@@ -24785,7 +24547,6 @@ export type t_PostInvoicesCreatePreviewRequestBody = {
                         reset_billing_cycle_anchor?: boolean | undefined
                       }
                     | ""
-                    | UnknownEnumStringValue
                   )
                 | undefined
               collection_method?:
@@ -24796,10 +24557,8 @@ export type t_PostInvoicesCreatePreviewRequestBody = {
                   )
                 | undefined
               default_payment_method?: string | undefined
-              default_tax_rates?:
-                | (string[] | "" | UnknownEnumStringValue)
-                | undefined
-              description?: (string | "" | UnknownEnumStringValue) | undefined
+              default_tax_rates?: (string[] | "") | undefined
+              description?: (string | "") | undefined
               discounts?:
                 | (
                     | {
@@ -24808,7 +24567,6 @@ export type t_PostInvoicesCreatePreviewRequestBody = {
                         promotion_code?: string | undefined
                       }[]
                     | ""
-                    | UnknownEnumStringValue
                   )
                 | undefined
               duration?:
@@ -24822,12 +24580,10 @@ export type t_PostInvoicesCreatePreviewRequestBody = {
                     interval_count?: number | undefined
                   }
                 | undefined
-              end_date?: (number | "now" | UnknownEnumStringValue) | undefined
+              end_date?: (number | "now") | undefined
               invoice_settings?:
                 | {
-                    account_tax_ids?:
-                      | (string[] | "" | UnknownEnumStringValue)
-                      | undefined
+                    account_tax_ids?: (string[] | "") | undefined
                     days_until_due?: number | undefined
                     issuer?:
                       | {
@@ -24844,7 +24600,6 @@ export type t_PostInvoicesCreatePreviewRequestBody = {
                           usage_gte: number
                         }
                       | ""
-                      | UnknownEnumStringValue
                     )
                   | undefined
                 discounts?:
@@ -24855,7 +24610,6 @@ export type t_PostInvoicesCreatePreviewRequestBody = {
                           promotion_code?: string | undefined
                         }[]
                       | ""
-                      | UnknownEnumStringValue
                     )
                   | undefined
                 metadata?: Record<string, string> | undefined
@@ -24886,7 +24640,7 @@ export type t_PostInvoicesCreatePreviewRequestBody = {
                     }
                   | undefined
                 quantity?: number | undefined
-                tax_rates?: (string[] | "" | UnknownEnumStringValue) | undefined
+                tax_rates?: (string[] | "") | undefined
               }[]
               iterations?: number | undefined
               metadata?: Record<string, string> | undefined
@@ -24899,7 +24653,7 @@ export type t_PostInvoicesCreatePreviewRequestBody = {
                     | UnknownEnumStringValue
                   )
                 | undefined
-              start_date?: (number | "now" | UnknownEnumStringValue) | undefined
+              start_date?: (number | "now") | undefined
               transfer_data?:
                 | {
                     amount_percent?: number | undefined
@@ -24907,7 +24661,7 @@ export type t_PostInvoicesCreatePreviewRequestBody = {
                   }
                 | undefined
               trial?: boolean | undefined
-              trial_end?: (number | "now" | UnknownEnumStringValue) | undefined
+              trial_end?: (number | "now") | undefined
             }[]
           | undefined
         proration_behavior?:
@@ -24935,14 +24689,14 @@ export type t_PostInvoicesCreatePreviewRequestBody = {
           | (
               | number
               | ""
-              | UnknownEnumStringValue
               | "max_period_end"
               | "min_period_end"
+              | UnknownEnumStringValue
             )
           | undefined
         cancel_at_period_end?: boolean | undefined
         cancel_now?: boolean | undefined
-        default_tax_rates?: (string[] | "" | UnknownEnumStringValue) | undefined
+        default_tax_rates?: (string[] | "") | undefined
         items?:
           | {
               billing_thresholds?:
@@ -24951,7 +24705,6 @@ export type t_PostInvoicesCreatePreviewRequestBody = {
                         usage_gte: number
                       }
                     | ""
-                    | UnknownEnumStringValue
                   )
                 | undefined
               clear_usage?: boolean | undefined
@@ -24964,13 +24717,10 @@ export type t_PostInvoicesCreatePreviewRequestBody = {
                         promotion_code?: string | undefined
                       }[]
                     | ""
-                    | UnknownEnumStringValue
                   )
                 | undefined
               id?: string | undefined
-              metadata?:
-                | (Record<string, string> | "" | UnknownEnumStringValue)
-                | undefined
+              metadata?: (Record<string, string> | "") | undefined
               price?: string | undefined
               price_data?:
                 | {
@@ -24998,7 +24748,7 @@ export type t_PostInvoicesCreatePreviewRequestBody = {
                   }
                 | undefined
               quantity?: number | undefined
-              tax_rates?: (string[] | "" | UnknownEnumStringValue) | undefined
+              tax_rates?: (string[] | "") | undefined
             }[]
           | undefined
         proration_behavior?:
@@ -25010,15 +24760,15 @@ export type t_PostInvoicesCreatePreviewRequestBody = {
             )
           | undefined
         proration_date?: number | undefined
-        resume_at?: ("now" | UnknownEnumStringValue) | undefined
+        resume_at?: "now" | undefined
         start_date?: number | undefined
-        trial_end?: ("now" | UnknownEnumStringValue | number) | undefined
+        trial_end?: ("now" | number) | undefined
       }
     | undefined
 }
 
 export type t_PostInvoicesInvoiceRequestBody = {
-  account_tax_ids?: (string[] | "" | UnknownEnumStringValue) | undefined
+  account_tax_ids?: (string[] | "") | undefined
   application_fee_amount?: number | undefined
   auto_advance?: boolean | undefined
   automatic_tax?:
@@ -25043,13 +24793,12 @@ export type t_PostInvoicesInvoiceRequestBody = {
             value: string
           }[]
         | ""
-        | UnknownEnumStringValue
       )
     | undefined
   days_until_due?: number | undefined
   default_payment_method?: string | undefined
-  default_source?: (string | "" | UnknownEnumStringValue) | undefined
-  default_tax_rates?: (string[] | "" | UnknownEnumStringValue) | undefined
+  default_source?: (string | "") | undefined
+  default_tax_rates?: (string[] | "") | undefined
   description?: string | undefined
   discounts?:
     | (
@@ -25059,11 +24808,10 @@ export type t_PostInvoicesInvoiceRequestBody = {
             promotion_code?: string | undefined
           }[]
         | ""
-        | UnknownEnumStringValue
       )
     | undefined
   due_date?: number | undefined
-  effective_at?: (number | "" | UnknownEnumStringValue) | undefined
+  effective_at?: (number | "") | undefined
   expand?: string[] | undefined
   footer?: string | undefined
   issuer?:
@@ -25072,12 +24820,12 @@ export type t_PostInvoicesInvoiceRequestBody = {
         type: "account" | "self" | UnknownEnumStringValue
       }
     | undefined
-  metadata?: (Record<string, string> | "" | UnknownEnumStringValue) | undefined
-  number?: (string | "" | UnknownEnumStringValue) | undefined
-  on_behalf_of?: (string | "" | UnknownEnumStringValue) | undefined
+  metadata?: (Record<string, string> | "") | undefined
+  number?: (string | "") | undefined
+  on_behalf_of?: (string | "") | undefined
   payment_settings?:
     | {
-        default_mandate?: (string | "" | UnknownEnumStringValue) | undefined
+        default_mandate?: (string | "") | undefined
         payment_method_options?:
           | {
               acss_debit?:
@@ -25104,7 +24852,6 @@ export type t_PostInvoicesInvoiceRequestBody = {
                           | undefined
                       }
                     | ""
-                    | UnknownEnumStringValue
                   )
                 | undefined
               bancontact?:
@@ -25115,7 +24862,6 @@ export type t_PostInvoicesInvoiceRequestBody = {
                           | undefined
                       }
                     | ""
-                    | UnknownEnumStringValue
                   )
                 | undefined
               card?:
@@ -25128,9 +24874,7 @@ export type t_PostInvoicesInvoiceRequestBody = {
                                 | (
                                     | {
                                         count?: number | undefined
-                                        interval?:
-                                          | ("month" | UnknownEnumStringValue)
-                                          | undefined
+                                        interval?: "month" | undefined
                                         type:
                                           | "bonus"
                                           | "fixed_count"
@@ -25138,7 +24882,6 @@ export type t_PostInvoicesInvoiceRequestBody = {
                                           | UnknownEnumStringValue
                                       }
                                     | ""
-                                    | UnknownEnumStringValue
                                   )
                                 | undefined
                             }
@@ -25153,7 +24896,6 @@ export type t_PostInvoicesInvoiceRequestBody = {
                           | undefined
                       }
                     | ""
-                    | UnknownEnumStringValue
                   )
                 | undefined
               customer_balance?:
@@ -25172,15 +24914,10 @@ export type t_PostInvoicesInvoiceRequestBody = {
                         funding_type?: string | undefined
                       }
                     | ""
-                    | UnknownEnumStringValue
                   )
                 | undefined
-              konbini?:
-                | (Record<string, unknown> | "" | UnknownEnumStringValue)
-                | undefined
-              sepa_debit?:
-                | (Record<string, unknown> | "" | UnknownEnumStringValue)
-                | undefined
+              konbini?: (Record<string, unknown> | "") | undefined
+              sepa_debit?: (Record<string, unknown> | "") | undefined
               us_bank_account?:
                 | (
                     | {
@@ -25226,7 +24963,6 @@ export type t_PostInvoicesInvoiceRequestBody = {
                           | undefined
                       }
                     | ""
-                    | UnknownEnumStringValue
                   )
                 | undefined
             }
@@ -25276,7 +25012,6 @@ export type t_PostInvoicesInvoiceRequestBody = {
                   | UnknownEnumStringValue
                 )[]
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
       }
@@ -25299,7 +25034,7 @@ export type t_PostInvoicesInvoiceRequestBody = {
             }
           | undefined
         template?: string | undefined
-        template_version?: (number | "" | UnknownEnumStringValue) | undefined
+        template_version?: (number | "") | undefined
       }
     | undefined
   shipping_cost?:
@@ -25369,12 +25104,11 @@ export type t_PostInvoicesInvoiceRequestBody = {
                       )
                     | undefined
                   tax_code?: string | undefined
-                  type?: ("fixed_amount" | UnknownEnumStringValue) | undefined
+                  type?: "fixed_amount" | undefined
                 }
               | undefined
           }
         | ""
-        | UnknownEnumStringValue
       )
     | undefined
   shipping_details?:
@@ -25389,10 +25123,9 @@ export type t_PostInvoicesInvoiceRequestBody = {
               state?: string | undefined
             }
             name: string
-            phone?: (string | "" | UnknownEnumStringValue) | undefined
+            phone?: (string | "") | undefined
           }
         | ""
-        | UnknownEnumStringValue
       )
     | undefined
   statement_descriptor?: string | undefined
@@ -25403,16 +25136,13 @@ export type t_PostInvoicesInvoiceRequestBody = {
             destination: string
           }
         | ""
-        | UnknownEnumStringValue
       )
     | undefined
 }
 
 export type t_PostInvoicesInvoiceAddLinesRequestBody = {
   expand?: string[] | undefined
-  invoice_metadata?:
-    | (Record<string, string> | "" | UnknownEnumStringValue)
-    | undefined
+  invoice_metadata?: (Record<string, string> | "") | undefined
   lines: {
     amount?: number | undefined
     description?: string | undefined
@@ -25425,13 +25155,10 @@ export type t_PostInvoicesInvoiceAddLinesRequestBody = {
               promotion_code?: string | undefined
             }[]
           | ""
-          | UnknownEnumStringValue
         )
       | undefined
     invoice_item?: string | undefined
-    metadata?:
-      | (Record<string, string> | "" | UnknownEnumStringValue)
-      | undefined
+    metadata?: (Record<string, string> | "") | undefined
     period?:
       | {
           end: number
@@ -25535,10 +25262,9 @@ export type t_PostInvoicesInvoiceAddLinesRequestBody = {
               taxable_amount: number
             }[]
           | ""
-          | UnknownEnumStringValue
         )
       | undefined
-    tax_rates?: (string[] | "" | UnknownEnumStringValue) | undefined
+    tax_rates?: (string[] | "") | undefined
   }[]
 }
 
@@ -25564,11 +25290,10 @@ export type t_PostInvoicesInvoiceLinesLineItemIdRequestBody = {
             promotion_code?: string | undefined
           }[]
         | ""
-        | UnknownEnumStringValue
       )
     | undefined
   expand?: string[] | undefined
-  metadata?: (Record<string, string> | "" | UnknownEnumStringValue) | undefined
+  metadata?: (Record<string, string> | "") | undefined
   period?:
     | {
         end: number
@@ -25667,10 +25392,9 @@ export type t_PostInvoicesInvoiceLinesLineItemIdRequestBody = {
             taxable_amount: number
           }[]
         | ""
-        | UnknownEnumStringValue
       )
     | undefined
-  tax_rates?: (string[] | "" | UnknownEnumStringValue) | undefined
+  tax_rates?: (string[] | "") | undefined
 }
 
 export type t_PostInvoicesInvoiceMarkUncollectibleRequestBody = {
@@ -25680,7 +25404,7 @@ export type t_PostInvoicesInvoiceMarkUncollectibleRequestBody = {
 export type t_PostInvoicesInvoicePayRequestBody = {
   expand?: string[] | undefined
   forgive?: boolean | undefined
-  mandate?: (string | "" | UnknownEnumStringValue) | undefined
+  mandate?: (string | "") | undefined
   off_session?: boolean | undefined
   paid_out_of_band?: boolean | undefined
   payment_method?: string | undefined
@@ -25689,9 +25413,7 @@ export type t_PostInvoicesInvoicePayRequestBody = {
 
 export type t_PostInvoicesInvoiceRemoveLinesRequestBody = {
   expand?: string[] | undefined
-  invoice_metadata?:
-    | (Record<string, string> | "" | UnknownEnumStringValue)
-    | undefined
+  invoice_metadata?: (Record<string, string> | "") | undefined
   lines: {
     behavior: "delete" | "unassign" | UnknownEnumStringValue
     id: string
@@ -25704,9 +25426,7 @@ export type t_PostInvoicesInvoiceSendRequestBody = {
 
 export type t_PostInvoicesInvoiceUpdateLinesRequestBody = {
   expand?: string[] | undefined
-  invoice_metadata?:
-    | (Record<string, string> | "" | UnknownEnumStringValue)
-    | undefined
+  invoice_metadata?: (Record<string, string> | "") | undefined
   lines: {
     amount?: number | undefined
     description?: string | undefined
@@ -25719,13 +25439,10 @@ export type t_PostInvoicesInvoiceUpdateLinesRequestBody = {
               promotion_code?: string | undefined
             }[]
           | ""
-          | UnknownEnumStringValue
         )
       | undefined
     id: string
-    metadata?:
-      | (Record<string, string> | "" | UnknownEnumStringValue)
-      | undefined
+    metadata?: (Record<string, string> | "") | undefined
     period?:
       | {
           end: number
@@ -25829,10 +25546,9 @@ export type t_PostInvoicesInvoiceUpdateLinesRequestBody = {
               taxable_amount: number
             }[]
           | ""
-          | UnknownEnumStringValue
         )
       | undefined
-    tax_rates?: (string[] | "" | UnknownEnumStringValue) | undefined
+    tax_rates?: (string[] | "") | undefined
   }[]
 }
 
@@ -25842,18 +25558,18 @@ export type t_PostInvoicesInvoiceVoidRequestBody = {
 
 export type t_PostIssuingAuthorizationsAuthorizationRequestBody = {
   expand?: string[] | undefined
-  metadata?: (Record<string, string> | "" | UnknownEnumStringValue) | undefined
+  metadata?: (Record<string, string> | "") | undefined
 }
 
 export type t_PostIssuingAuthorizationsAuthorizationApproveRequestBody = {
   amount?: number | undefined
   expand?: string[] | undefined
-  metadata?: (Record<string, string> | "" | UnknownEnumStringValue) | undefined
+  metadata?: (Record<string, string> | "") | undefined
 }
 
 export type t_PostIssuingAuthorizationsAuthorizationDeclineRequestBody = {
   expand?: string[] | undefined
-  metadata?: (Record<string, string> | "" | UnknownEnumStringValue) | undefined
+  metadata?: (Record<string, string> | "") | undefined
 }
 
 export type t_PostIssuingCardholdersRequestBody = {
@@ -25882,9 +25598,7 @@ export type t_PostIssuingCardholdersRequestBody = {
                 | {
                     date?: number | undefined
                     ip?: string | undefined
-                    user_agent?:
-                      | (string | "" | UnknownEnumStringValue)
-                      | undefined
+                    user_agent?: (string | "") | undefined
                   }
                 | undefined
             }
@@ -26868,9 +26582,7 @@ export type t_PostIssuingCardholdersCardholderRequestBody = {
                 | {
                     date?: number | undefined
                     ip?: string | undefined
-                    user_agent?:
-                      | (string | "" | UnknownEnumStringValue)
-                      | undefined
+                    user_agent?: (string | "") | undefined
                   }
                 | undefined
             }
@@ -27840,7 +27552,7 @@ export type t_PostIssuingCardsRequestBody = {
   replacement_reason?:
     | ("damaged" | "expired" | "lost" | "stolen" | UnknownEnumStringValue)
     | undefined
-  second_line?: (string | "" | UnknownEnumStringValue) | undefined
+  second_line?: (string | "") | undefined
   shipping?:
     | {
         address: {
@@ -28800,7 +28512,7 @@ export type t_PostIssuingCardsRequestBody = {
 export type t_PostIssuingCardsCardRequestBody = {
   cancellation_reason?: ("lost" | "stolen" | UnknownEnumStringValue) | undefined
   expand?: string[] | undefined
-  metadata?: (Record<string, string> | "" | UnknownEnumStringValue) | undefined
+  metadata?: (Record<string, string> | "") | undefined
   personalization_design?: string | undefined
   pin?:
     | {
@@ -29771,27 +29483,13 @@ export type t_PostIssuingDisputesRequestBody = {
         canceled?:
           | (
               | {
-                  additional_documentation?:
-                    | (string | "" | UnknownEnumStringValue)
-                    | undefined
-                  canceled_at?:
-                    | (number | "" | UnknownEnumStringValue)
-                    | undefined
-                  cancellation_policy_provided?:
-                    | (boolean | "" | UnknownEnumStringValue)
-                    | undefined
-                  cancellation_reason?:
-                    | (string | "" | UnknownEnumStringValue)
-                    | undefined
-                  expected_at?:
-                    | (number | "" | UnknownEnumStringValue)
-                    | undefined
-                  explanation?:
-                    | (string | "" | UnknownEnumStringValue)
-                    | undefined
-                  product_description?:
-                    | (string | "" | UnknownEnumStringValue)
-                    | undefined
+                  additional_documentation?: (string | "") | undefined
+                  canceled_at?: (number | "") | undefined
+                  cancellation_policy_provided?: (boolean | "") | undefined
+                  cancellation_reason?: (string | "") | undefined
+                  expected_at?: (number | "") | undefined
+                  explanation?: (string | "") | undefined
+                  product_description?: (string | "") | undefined
                   product_type?:
                     | ("" | "merchandise" | "service" | UnknownEnumStringValue)
                     | undefined
@@ -29803,67 +29501,40 @@ export type t_PostIssuingDisputesRequestBody = {
                         | UnknownEnumStringValue
                       )
                     | undefined
-                  returned_at?:
-                    | (number | "" | UnknownEnumStringValue)
-                    | undefined
+                  returned_at?: (number | "") | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         duplicate?:
           | (
               | {
-                  additional_documentation?:
-                    | (string | "" | UnknownEnumStringValue)
-                    | undefined
-                  card_statement?:
-                    | (string | "" | UnknownEnumStringValue)
-                    | undefined
-                  cash_receipt?:
-                    | (string | "" | UnknownEnumStringValue)
-                    | undefined
-                  check_image?:
-                    | (string | "" | UnknownEnumStringValue)
-                    | undefined
-                  explanation?:
-                    | (string | "" | UnknownEnumStringValue)
-                    | undefined
+                  additional_documentation?: (string | "") | undefined
+                  card_statement?: (string | "") | undefined
+                  cash_receipt?: (string | "") | undefined
+                  check_image?: (string | "") | undefined
+                  explanation?: (string | "") | undefined
                   original_transaction?: string | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         fraudulent?:
           | (
               | {
-                  additional_documentation?:
-                    | (string | "" | UnknownEnumStringValue)
-                    | undefined
-                  explanation?:
-                    | (string | "" | UnknownEnumStringValue)
-                    | undefined
+                  additional_documentation?: (string | "") | undefined
+                  explanation?: (string | "") | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         merchandise_not_as_described?:
           | (
               | {
-                  additional_documentation?:
-                    | (string | "" | UnknownEnumStringValue)
-                    | undefined
-                  explanation?:
-                    | (string | "" | UnknownEnumStringValue)
-                    | undefined
-                  received_at?:
-                    | (number | "" | UnknownEnumStringValue)
-                    | undefined
-                  return_description?:
-                    | (string | "" | UnknownEnumStringValue)
-                    | undefined
+                  additional_documentation?: (string | "") | undefined
+                  explanation?: (string | "") | undefined
+                  received_at?: (number | "") | undefined
+                  return_description?: (string | "") | undefined
                   return_status?:
                     | (
                         | ""
@@ -29872,69 +29543,45 @@ export type t_PostIssuingDisputesRequestBody = {
                         | UnknownEnumStringValue
                       )
                     | undefined
-                  returned_at?:
-                    | (number | "" | UnknownEnumStringValue)
-                    | undefined
+                  returned_at?: (number | "") | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         no_valid_authorization?:
           | (
               | {
-                  additional_documentation?:
-                    | (string | "" | UnknownEnumStringValue)
-                    | undefined
-                  explanation?:
-                    | (string | "" | UnknownEnumStringValue)
-                    | undefined
+                  additional_documentation?: (string | "") | undefined
+                  explanation?: (string | "") | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         not_received?:
           | (
               | {
-                  additional_documentation?:
-                    | (string | "" | UnknownEnumStringValue)
-                    | undefined
-                  expected_at?:
-                    | (number | "" | UnknownEnumStringValue)
-                    | undefined
-                  explanation?:
-                    | (string | "" | UnknownEnumStringValue)
-                    | undefined
-                  product_description?:
-                    | (string | "" | UnknownEnumStringValue)
-                    | undefined
+                  additional_documentation?: (string | "") | undefined
+                  expected_at?: (number | "") | undefined
+                  explanation?: (string | "") | undefined
+                  product_description?: (string | "") | undefined
                   product_type?:
                     | ("" | "merchandise" | "service" | UnknownEnumStringValue)
                     | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         other?:
           | (
               | {
-                  additional_documentation?:
-                    | (string | "" | UnknownEnumStringValue)
-                    | undefined
-                  explanation?:
-                    | (string | "" | UnknownEnumStringValue)
-                    | undefined
-                  product_description?:
-                    | (string | "" | UnknownEnumStringValue)
-                    | undefined
+                  additional_documentation?: (string | "") | undefined
+                  explanation?: (string | "") | undefined
+                  product_description?: (string | "") | undefined
                   product_type?:
                     | ("" | "merchandise" | "service" | UnknownEnumStringValue)
                     | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         reason?:
@@ -29953,24 +29600,13 @@ export type t_PostIssuingDisputesRequestBody = {
         service_not_as_described?:
           | (
               | {
-                  additional_documentation?:
-                    | (string | "" | UnknownEnumStringValue)
-                    | undefined
-                  canceled_at?:
-                    | (number | "" | UnknownEnumStringValue)
-                    | undefined
-                  cancellation_reason?:
-                    | (string | "" | UnknownEnumStringValue)
-                    | undefined
-                  explanation?:
-                    | (string | "" | UnknownEnumStringValue)
-                    | undefined
-                  received_at?:
-                    | (number | "" | UnknownEnumStringValue)
-                    | undefined
+                  additional_documentation?: (string | "") | undefined
+                  canceled_at?: (number | "") | undefined
+                  cancellation_reason?: (string | "") | undefined
+                  explanation?: (string | "") | undefined
+                  received_at?: (number | "") | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
       }
@@ -29992,27 +29628,13 @@ export type t_PostIssuingDisputesDisputeRequestBody = {
         canceled?:
           | (
               | {
-                  additional_documentation?:
-                    | (string | "" | UnknownEnumStringValue)
-                    | undefined
-                  canceled_at?:
-                    | (number | "" | UnknownEnumStringValue)
-                    | undefined
-                  cancellation_policy_provided?:
-                    | (boolean | "" | UnknownEnumStringValue)
-                    | undefined
-                  cancellation_reason?:
-                    | (string | "" | UnknownEnumStringValue)
-                    | undefined
-                  expected_at?:
-                    | (number | "" | UnknownEnumStringValue)
-                    | undefined
-                  explanation?:
-                    | (string | "" | UnknownEnumStringValue)
-                    | undefined
-                  product_description?:
-                    | (string | "" | UnknownEnumStringValue)
-                    | undefined
+                  additional_documentation?: (string | "") | undefined
+                  canceled_at?: (number | "") | undefined
+                  cancellation_policy_provided?: (boolean | "") | undefined
+                  cancellation_reason?: (string | "") | undefined
+                  expected_at?: (number | "") | undefined
+                  explanation?: (string | "") | undefined
+                  product_description?: (string | "") | undefined
                   product_type?:
                     | ("" | "merchandise" | "service" | UnknownEnumStringValue)
                     | undefined
@@ -30024,67 +29646,40 @@ export type t_PostIssuingDisputesDisputeRequestBody = {
                         | UnknownEnumStringValue
                       )
                     | undefined
-                  returned_at?:
-                    | (number | "" | UnknownEnumStringValue)
-                    | undefined
+                  returned_at?: (number | "") | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         duplicate?:
           | (
               | {
-                  additional_documentation?:
-                    | (string | "" | UnknownEnumStringValue)
-                    | undefined
-                  card_statement?:
-                    | (string | "" | UnknownEnumStringValue)
-                    | undefined
-                  cash_receipt?:
-                    | (string | "" | UnknownEnumStringValue)
-                    | undefined
-                  check_image?:
-                    | (string | "" | UnknownEnumStringValue)
-                    | undefined
-                  explanation?:
-                    | (string | "" | UnknownEnumStringValue)
-                    | undefined
+                  additional_documentation?: (string | "") | undefined
+                  card_statement?: (string | "") | undefined
+                  cash_receipt?: (string | "") | undefined
+                  check_image?: (string | "") | undefined
+                  explanation?: (string | "") | undefined
                   original_transaction?: string | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         fraudulent?:
           | (
               | {
-                  additional_documentation?:
-                    | (string | "" | UnknownEnumStringValue)
-                    | undefined
-                  explanation?:
-                    | (string | "" | UnknownEnumStringValue)
-                    | undefined
+                  additional_documentation?: (string | "") | undefined
+                  explanation?: (string | "") | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         merchandise_not_as_described?:
           | (
               | {
-                  additional_documentation?:
-                    | (string | "" | UnknownEnumStringValue)
-                    | undefined
-                  explanation?:
-                    | (string | "" | UnknownEnumStringValue)
-                    | undefined
-                  received_at?:
-                    | (number | "" | UnknownEnumStringValue)
-                    | undefined
-                  return_description?:
-                    | (string | "" | UnknownEnumStringValue)
-                    | undefined
+                  additional_documentation?: (string | "") | undefined
+                  explanation?: (string | "") | undefined
+                  received_at?: (number | "") | undefined
+                  return_description?: (string | "") | undefined
                   return_status?:
                     | (
                         | ""
@@ -30093,69 +29688,45 @@ export type t_PostIssuingDisputesDisputeRequestBody = {
                         | UnknownEnumStringValue
                       )
                     | undefined
-                  returned_at?:
-                    | (number | "" | UnknownEnumStringValue)
-                    | undefined
+                  returned_at?: (number | "") | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         no_valid_authorization?:
           | (
               | {
-                  additional_documentation?:
-                    | (string | "" | UnknownEnumStringValue)
-                    | undefined
-                  explanation?:
-                    | (string | "" | UnknownEnumStringValue)
-                    | undefined
+                  additional_documentation?: (string | "") | undefined
+                  explanation?: (string | "") | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         not_received?:
           | (
               | {
-                  additional_documentation?:
-                    | (string | "" | UnknownEnumStringValue)
-                    | undefined
-                  expected_at?:
-                    | (number | "" | UnknownEnumStringValue)
-                    | undefined
-                  explanation?:
-                    | (string | "" | UnknownEnumStringValue)
-                    | undefined
-                  product_description?:
-                    | (string | "" | UnknownEnumStringValue)
-                    | undefined
+                  additional_documentation?: (string | "") | undefined
+                  expected_at?: (number | "") | undefined
+                  explanation?: (string | "") | undefined
+                  product_description?: (string | "") | undefined
                   product_type?:
                     | ("" | "merchandise" | "service" | UnknownEnumStringValue)
                     | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         other?:
           | (
               | {
-                  additional_documentation?:
-                    | (string | "" | UnknownEnumStringValue)
-                    | undefined
-                  explanation?:
-                    | (string | "" | UnknownEnumStringValue)
-                    | undefined
-                  product_description?:
-                    | (string | "" | UnknownEnumStringValue)
-                    | undefined
+                  additional_documentation?: (string | "") | undefined
+                  explanation?: (string | "") | undefined
+                  product_description?: (string | "") | undefined
                   product_type?:
                     | ("" | "merchandise" | "service" | UnknownEnumStringValue)
                     | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         reason?:
@@ -30174,45 +29745,34 @@ export type t_PostIssuingDisputesDisputeRequestBody = {
         service_not_as_described?:
           | (
               | {
-                  additional_documentation?:
-                    | (string | "" | UnknownEnumStringValue)
-                    | undefined
-                  canceled_at?:
-                    | (number | "" | UnknownEnumStringValue)
-                    | undefined
-                  cancellation_reason?:
-                    | (string | "" | UnknownEnumStringValue)
-                    | undefined
-                  explanation?:
-                    | (string | "" | UnknownEnumStringValue)
-                    | undefined
-                  received_at?:
-                    | (number | "" | UnknownEnumStringValue)
-                    | undefined
+                  additional_documentation?: (string | "") | undefined
+                  canceled_at?: (number | "") | undefined
+                  cancellation_reason?: (string | "") | undefined
+                  explanation?: (string | "") | undefined
+                  received_at?: (number | "") | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
       }
     | undefined
   expand?: string[] | undefined
-  metadata?: (Record<string, string> | "" | UnknownEnumStringValue) | undefined
+  metadata?: (Record<string, string> | "") | undefined
 }
 
 export type t_PostIssuingDisputesDisputeSubmitRequestBody = {
   expand?: string[] | undefined
-  metadata?: (Record<string, string> | "" | UnknownEnumStringValue) | undefined
+  metadata?: (Record<string, string> | "") | undefined
 }
 
 export type t_PostIssuingPersonalizationDesignsRequestBody = {
   card_logo?: string | undefined
   carrier_text?:
     | {
-        footer_body?: (string | "" | UnknownEnumStringValue) | undefined
-        footer_title?: (string | "" | UnknownEnumStringValue) | undefined
-        header_body?: (string | "" | UnknownEnumStringValue) | undefined
-        header_title?: (string | "" | UnknownEnumStringValue) | undefined
+        footer_body?: (string | "") | undefined
+        footer_title?: (string | "") | undefined
+        header_body?: (string | "") | undefined
+        header_title?: (string | "") | undefined
       }
     | undefined
   expand?: string[] | undefined
@@ -30230,23 +29790,22 @@ export type t_PostIssuingPersonalizationDesignsRequestBody = {
 
 export type t_PostIssuingPersonalizationDesignsPersonalizationDesignRequestBody =
   {
-    card_logo?: (string | "" | UnknownEnumStringValue) | undefined
+    card_logo?: (string | "") | undefined
     carrier_text?:
       | (
           | {
-              footer_body?: (string | "" | UnknownEnumStringValue) | undefined
-              footer_title?: (string | "" | UnknownEnumStringValue) | undefined
-              header_body?: (string | "" | UnknownEnumStringValue) | undefined
-              header_title?: (string | "" | UnknownEnumStringValue) | undefined
+              footer_body?: (string | "") | undefined
+              footer_title?: (string | "") | undefined
+              header_body?: (string | "") | undefined
+              header_title?: (string | "") | undefined
             }
           | ""
-          | UnknownEnumStringValue
         )
       | undefined
     expand?: string[] | undefined
-    lookup_key?: (string | "" | UnknownEnumStringValue) | undefined
+    lookup_key?: (string | "") | undefined
     metadata?: Record<string, string> | undefined
-    name?: (string | "" | UnknownEnumStringValue) | undefined
+    name?: (string | "") | undefined
     physical_bundle?: string | undefined
     preferences?:
       | {
@@ -30268,7 +29827,7 @@ export type t_PostIssuingTokensTokenRequestBody = {
 
 export type t_PostIssuingTransactionsTransactionRequestBody = {
   expand?: string[] | undefined
-  metadata?: (Record<string, string> | "" | UnknownEnumStringValue) | undefined
+  metadata?: (Record<string, string> | "") | undefined
 }
 
 export type t_PostLinkAccountSessionsRequestBody = {
@@ -30361,7 +29920,6 @@ export type t_PostPaymentIntentsRequestBody = {
             }
           }
         | ""
-        | UnknownEnumStringValue
       )
     | undefined
   metadata?: Record<string, string> | undefined
@@ -30415,12 +29973,11 @@ export type t_PostPaymentIntentsRequestBody = {
                         state?: string | undefined
                       }
                     | ""
-                    | UnknownEnumStringValue
                   )
                 | undefined
-              email?: (string | "" | UnknownEnumStringValue) | undefined
-              name?: (string | "" | UnknownEnumStringValue) | undefined
-              phone?: (string | "" | UnknownEnumStringValue) | undefined
+              email?: (string | "") | undefined
+              name?: (string | "") | undefined
+              phone?: (string | "") | undefined
               tax_id?: string | undefined
             }
           | undefined
@@ -30702,9 +30259,7 @@ export type t_PostPaymentIntentsRequestBody = {
               | {
                   mandate_options?:
                     | {
-                        custom_mandate_url?:
-                          | (string | "" | UnknownEnumStringValue)
-                          | undefined
+                        custom_mandate_url?: (string | "") | undefined
                         interval_description?: string | undefined
                         payment_schedule?:
                           | (
@@ -30739,7 +30294,6 @@ export type t_PostPaymentIntentsRequestBody = {
                     | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         affirm?:
@@ -30749,12 +30303,9 @@ export type t_PostPaymentIntentsRequestBody = {
                     | ("" | "manual" | UnknownEnumStringValue)
                     | undefined
                   preferred_locale?: string | undefined
-                  setup_future_usage?:
-                    | ("none" | UnknownEnumStringValue)
-                    | undefined
+                  setup_future_usage?: "none" | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         afterpay_clearpay?:
@@ -30764,12 +30315,9 @@ export type t_PostPaymentIntentsRequestBody = {
                     | ("" | "manual" | UnknownEnumStringValue)
                     | undefined
                   reference?: string | undefined
-                  setup_future_usage?:
-                    | ("none" | UnknownEnumStringValue)
-                    | undefined
+                  setup_future_usage?: "none" | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         alipay?:
@@ -30780,7 +30328,6 @@ export type t_PostPaymentIntentsRequestBody = {
                     | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         alma?:
@@ -30791,7 +30338,6 @@ export type t_PostPaymentIntentsRequestBody = {
                     | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         amazon_pay?:
@@ -30805,7 +30351,6 @@ export type t_PostPaymentIntentsRequestBody = {
                     | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         au_becs_debit?:
@@ -30823,7 +30368,6 @@ export type t_PostPaymentIntentsRequestBody = {
                   target_date?: string | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         bacs_debit?:
@@ -30831,9 +30375,7 @@ export type t_PostPaymentIntentsRequestBody = {
               | {
                   mandate_options?:
                     | {
-                        reference_prefix?:
-                          | (string | "" | UnknownEnumStringValue)
-                          | undefined
+                        reference_prefix?: (string | "") | undefined
                       }
                     | undefined
                   setup_future_usage?:
@@ -30848,7 +30390,6 @@ export type t_PostPaymentIntentsRequestBody = {
                   target_date?: string | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         bancontact?:
@@ -30862,7 +30403,6 @@ export type t_PostPaymentIntentsRequestBody = {
                     | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         billie?:
@@ -30873,7 +30413,6 @@ export type t_PostPaymentIntentsRequestBody = {
                     | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         blik?:
@@ -30885,7 +30424,6 @@ export type t_PostPaymentIntentsRequestBody = {
                     | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         boleto?:
@@ -30903,7 +30441,6 @@ export type t_PostPaymentIntentsRequestBody = {
                     | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         card?:
@@ -30920,9 +30457,7 @@ export type t_PostPaymentIntentsRequestBody = {
                           | (
                               | {
                                   count?: number | undefined
-                                  interval?:
-                                    | ("month" | UnknownEnumStringValue)
-                                    | undefined
+                                  interval?: "month" | undefined
                                   type:
                                     | "bonus"
                                     | "fixed_count"
@@ -30930,7 +30465,6 @@ export type t_PostPaymentIntentsRequestBody = {
                                     | UnknownEnumStringValue
                                 }
                               | ""
-                              | UnknownEnumStringValue
                             )
                           | undefined
                       }
@@ -30954,9 +30488,7 @@ export type t_PostPaymentIntentsRequestBody = {
                         interval_count?: number | undefined
                         reference: string
                         start_date: number
-                        supported_types?:
-                          | ("india" | UnknownEnumStringValue)[]
-                          | undefined
+                        supported_types?: "india"[] | undefined
                       }
                     | undefined
                   network?:
@@ -31007,12 +30539,8 @@ export type t_PostPaymentIntentsRequestBody = {
                         | UnknownEnumStringValue
                       )
                     | undefined
-                  statement_descriptor_suffix_kana?:
-                    | (string | "" | UnknownEnumStringValue)
-                    | undefined
-                  statement_descriptor_suffix_kanji?:
-                    | (string | "" | UnknownEnumStringValue)
-                    | undefined
+                  statement_descriptor_suffix_kana?: (string | "") | undefined
+                  statement_descriptor_suffix_kanji?: (string | "") | undefined
                   three_d_secure?:
                     | {
                         ares_trans_status?:
@@ -31070,7 +30598,6 @@ export type t_PostPaymentIntentsRequestBody = {
                     | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         card_present?:
@@ -31093,7 +30620,6 @@ export type t_PostPaymentIntentsRequestBody = {
                     | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         cashapp?:
@@ -31113,18 +30639,14 @@ export type t_PostPaymentIntentsRequestBody = {
                     | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         crypto?:
           | (
               | {
-                  setup_future_usage?:
-                    | ("none" | UnknownEnumStringValue)
-                    | undefined
+                  setup_future_usage?: "none" | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         customer_balance?:
@@ -31158,59 +30680,42 @@ export type t_PostPaymentIntentsRequestBody = {
                           | UnknownEnumStringValue
                       }
                     | undefined
-                  funding_type?:
-                    | ("bank_transfer" | UnknownEnumStringValue)
-                    | undefined
-                  setup_future_usage?:
-                    | ("none" | UnknownEnumStringValue)
-                    | undefined
+                  funding_type?: "bank_transfer" | undefined
+                  setup_future_usage?: "none" | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         eps?:
           | (
               | {
-                  setup_future_usage?:
-                    | ("none" | UnknownEnumStringValue)
-                    | undefined
+                  setup_future_usage?: "none" | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         fpx?:
           | (
               | {
-                  setup_future_usage?:
-                    | ("none" | UnknownEnumStringValue)
-                    | undefined
+                  setup_future_usage?: "none" | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         giropay?:
           | (
               | {
-                  setup_future_usage?:
-                    | ("none" | UnknownEnumStringValue)
-                    | undefined
+                  setup_future_usage?: "none" | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         grabpay?:
           | (
               | {
-                  setup_future_usage?:
-                    | ("none" | UnknownEnumStringValue)
-                    | undefined
+                  setup_future_usage?: "none" | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         ideal?:
@@ -31221,12 +30726,9 @@ export type t_PostPaymentIntentsRequestBody = {
                     | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
-        interac_present?:
-          | (Record<string, unknown> | "" | UnknownEnumStringValue)
-          | undefined
+        interac_present?: (Record<string, unknown> | "") | undefined
         kakao_pay?:
           | (
               | {
@@ -31238,7 +30740,6 @@ export type t_PostPaymentIntentsRequestBody = {
                     | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         klarna?:
@@ -31343,35 +30844,22 @@ export type t_PostPaymentIntentsRequestBody = {
                             reference: string
                           }[]
                         | ""
-                        | UnknownEnumStringValue
                       )
                     | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         konbini?:
           | (
               | {
-                  confirmation_number?:
-                    | (string | "" | UnknownEnumStringValue)
-                    | undefined
-                  expires_after_days?:
-                    | (number | "" | UnknownEnumStringValue)
-                    | undefined
-                  expires_at?:
-                    | (number | "" | UnknownEnumStringValue)
-                    | undefined
-                  product_description?:
-                    | (string | "" | UnknownEnumStringValue)
-                    | undefined
-                  setup_future_usage?:
-                    | ("none" | UnknownEnumStringValue)
-                    | undefined
+                  confirmation_number?: (string | "") | undefined
+                  expires_after_days?: (number | "") | undefined
+                  expires_at?: (number | "") | undefined
+                  product_description?: (string | "") | undefined
+                  setup_future_usage?: "none" | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         kr_card?:
@@ -31385,7 +30873,6 @@ export type t_PostPaymentIntentsRequestBody = {
                     | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         link?:
@@ -31399,7 +30886,6 @@ export type t_PostPaymentIntentsRequestBody = {
                     | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         mobilepay?:
@@ -31408,23 +30894,17 @@ export type t_PostPaymentIntentsRequestBody = {
                   capture_method?:
                     | ("" | "manual" | UnknownEnumStringValue)
                     | undefined
-                  setup_future_usage?:
-                    | ("none" | UnknownEnumStringValue)
-                    | undefined
+                  setup_future_usage?: "none" | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         multibanco?:
           | (
               | {
-                  setup_future_usage?:
-                    | ("none" | UnknownEnumStringValue)
-                    | undefined
+                  setup_future_usage?: "none" | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         naver_pay?:
@@ -31438,7 +30918,6 @@ export type t_PostPaymentIntentsRequestBody = {
                     | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         nz_bank_account?:
@@ -31456,36 +30935,27 @@ export type t_PostPaymentIntentsRequestBody = {
                   target_date?: string | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         oxxo?:
           | (
               | {
                   expires_after_days?: number | undefined
-                  setup_future_usage?:
-                    | ("none" | UnknownEnumStringValue)
-                    | undefined
+                  setup_future_usage?: "none" | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         p24?:
           | (
               | {
-                  setup_future_usage?:
-                    | ("none" | UnknownEnumStringValue)
-                    | undefined
+                  setup_future_usage?: "none" | undefined
                   tos_shown_and_accepted?: boolean | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
-        pay_by_bank?:
-          | (Record<string, unknown> | "" | UnknownEnumStringValue)
-          | undefined
+        pay_by_bank?: (Record<string, unknown> | "") | undefined
         payco?:
           | (
               | {
@@ -31494,18 +30964,14 @@ export type t_PostPaymentIntentsRequestBody = {
                     | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         paynow?:
           | (
               | {
-                  setup_future_usage?:
-                    | ("none" | UnknownEnumStringValue)
-                    | undefined
+                  setup_future_usage?: "none" | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         paypal?:
@@ -31547,7 +31013,6 @@ export type t_PostPaymentIntentsRequestBody = {
                     | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         pix?:
@@ -31555,23 +31020,17 @@ export type t_PostPaymentIntentsRequestBody = {
               | {
                   expires_after_seconds?: number | undefined
                   expires_at?: number | undefined
-                  setup_future_usage?:
-                    | ("none" | UnknownEnumStringValue)
-                    | undefined
+                  setup_future_usage?: "none" | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         promptpay?:
           | (
               | {
-                  setup_future_usage?:
-                    | ("none" | UnknownEnumStringValue)
-                    | undefined
+                  setup_future_usage?: "none" | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         revolut_pay?:
@@ -31585,7 +31044,6 @@ export type t_PostPaymentIntentsRequestBody = {
                     | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         samsung_pay?:
@@ -31596,7 +31054,6 @@ export type t_PostPaymentIntentsRequestBody = {
                     | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         satispay?:
@@ -31607,7 +31064,6 @@ export type t_PostPaymentIntentsRequestBody = {
                     | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         sepa_debit?:
@@ -31615,9 +31071,7 @@ export type t_PostPaymentIntentsRequestBody = {
               | {
                   mandate_options?:
                     | {
-                        reference_prefix?:
-                          | (string | "" | UnknownEnumStringValue)
-                          | undefined
+                        reference_prefix?: (string | "") | undefined
                       }
                     | undefined
                   setup_future_usage?:
@@ -31632,7 +31086,6 @@ export type t_PostPaymentIntentsRequestBody = {
                   target_date?: string | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         sofort?:
@@ -31656,30 +31109,23 @@ export type t_PostPaymentIntentsRequestBody = {
                     | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         swish?:
           | (
               | {
-                  reference?: (string | "" | UnknownEnumStringValue) | undefined
-                  setup_future_usage?:
-                    | ("none" | UnknownEnumStringValue)
-                    | undefined
+                  reference?: (string | "") | undefined
+                  setup_future_usage?: "none" | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         twint?:
           | (
               | {
-                  setup_future_usage?:
-                    | ("none" | UnknownEnumStringValue)
-                    | undefined
+                  setup_future_usage?: "none" | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         us_bank_account?:
@@ -31759,7 +31205,6 @@ export type t_PostPaymentIntentsRequestBody = {
                     | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         wechat_pay?:
@@ -31769,23 +31214,17 @@ export type t_PostPaymentIntentsRequestBody = {
                   client?:
                     | ("android" | "ios" | "web" | UnknownEnumStringValue)
                     | undefined
-                  setup_future_usage?:
-                    | ("none" | UnknownEnumStringValue)
-                    | undefined
+                  setup_future_usage?: "none" | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         zip?:
           | (
               | {
-                  setup_future_usage?:
-                    | ("none" | UnknownEnumStringValue)
-                    | undefined
+                  setup_future_usage?: "none" | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
       }
@@ -31831,7 +31270,7 @@ export type t_PostPaymentIntentsRequestBody = {
 
 export type t_PostPaymentIntentsIntentRequestBody = {
   amount?: number | undefined
-  application_fee_amount?: (number | "" | UnknownEnumStringValue) | undefined
+  application_fee_amount?: (number | "") | undefined
   capture_method?:
     | ("automatic" | "automatic_async" | "manual" | UnknownEnumStringValue)
     | undefined
@@ -31839,7 +31278,7 @@ export type t_PostPaymentIntentsIntentRequestBody = {
   customer?: string | undefined
   description?: string | undefined
   expand?: string[] | undefined
-  metadata?: (Record<string, string> | "" | UnknownEnumStringValue) | undefined
+  metadata?: (Record<string, string> | "") | undefined
   payment_method?: string | undefined
   payment_method_configuration?: string | undefined
   payment_method_data?:
@@ -31886,12 +31325,11 @@ export type t_PostPaymentIntentsIntentRequestBody = {
                         state?: string | undefined
                       }
                     | ""
-                    | UnknownEnumStringValue
                   )
                 | undefined
-              email?: (string | "" | UnknownEnumStringValue) | undefined
-              name?: (string | "" | UnknownEnumStringValue) | undefined
-              phone?: (string | "" | UnknownEnumStringValue) | undefined
+              email?: (string | "") | undefined
+              name?: (string | "") | undefined
+              phone?: (string | "") | undefined
               tax_id?: string | undefined
             }
           | undefined
@@ -32173,9 +31611,7 @@ export type t_PostPaymentIntentsIntentRequestBody = {
               | {
                   mandate_options?:
                     | {
-                        custom_mandate_url?:
-                          | (string | "" | UnknownEnumStringValue)
-                          | undefined
+                        custom_mandate_url?: (string | "") | undefined
                         interval_description?: string | undefined
                         payment_schedule?:
                           | (
@@ -32210,7 +31646,6 @@ export type t_PostPaymentIntentsIntentRequestBody = {
                     | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         affirm?:
@@ -32220,12 +31655,9 @@ export type t_PostPaymentIntentsIntentRequestBody = {
                     | ("" | "manual" | UnknownEnumStringValue)
                     | undefined
                   preferred_locale?: string | undefined
-                  setup_future_usage?:
-                    | ("none" | UnknownEnumStringValue)
-                    | undefined
+                  setup_future_usage?: "none" | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         afterpay_clearpay?:
@@ -32235,12 +31667,9 @@ export type t_PostPaymentIntentsIntentRequestBody = {
                     | ("" | "manual" | UnknownEnumStringValue)
                     | undefined
                   reference?: string | undefined
-                  setup_future_usage?:
-                    | ("none" | UnknownEnumStringValue)
-                    | undefined
+                  setup_future_usage?: "none" | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         alipay?:
@@ -32251,7 +31680,6 @@ export type t_PostPaymentIntentsIntentRequestBody = {
                     | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         alma?:
@@ -32262,7 +31690,6 @@ export type t_PostPaymentIntentsIntentRequestBody = {
                     | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         amazon_pay?:
@@ -32276,7 +31703,6 @@ export type t_PostPaymentIntentsIntentRequestBody = {
                     | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         au_becs_debit?:
@@ -32294,7 +31720,6 @@ export type t_PostPaymentIntentsIntentRequestBody = {
                   target_date?: string | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         bacs_debit?:
@@ -32302,9 +31727,7 @@ export type t_PostPaymentIntentsIntentRequestBody = {
               | {
                   mandate_options?:
                     | {
-                        reference_prefix?:
-                          | (string | "" | UnknownEnumStringValue)
-                          | undefined
+                        reference_prefix?: (string | "") | undefined
                       }
                     | undefined
                   setup_future_usage?:
@@ -32319,7 +31742,6 @@ export type t_PostPaymentIntentsIntentRequestBody = {
                   target_date?: string | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         bancontact?:
@@ -32333,7 +31755,6 @@ export type t_PostPaymentIntentsIntentRequestBody = {
                     | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         billie?:
@@ -32344,7 +31765,6 @@ export type t_PostPaymentIntentsIntentRequestBody = {
                     | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         blik?:
@@ -32356,7 +31776,6 @@ export type t_PostPaymentIntentsIntentRequestBody = {
                     | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         boleto?:
@@ -32374,7 +31793,6 @@ export type t_PostPaymentIntentsIntentRequestBody = {
                     | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         card?:
@@ -32391,9 +31809,7 @@ export type t_PostPaymentIntentsIntentRequestBody = {
                           | (
                               | {
                                   count?: number | undefined
-                                  interval?:
-                                    | ("month" | UnknownEnumStringValue)
-                                    | undefined
+                                  interval?: "month" | undefined
                                   type:
                                     | "bonus"
                                     | "fixed_count"
@@ -32401,7 +31817,6 @@ export type t_PostPaymentIntentsIntentRequestBody = {
                                     | UnknownEnumStringValue
                                 }
                               | ""
-                              | UnknownEnumStringValue
                             )
                           | undefined
                       }
@@ -32425,9 +31840,7 @@ export type t_PostPaymentIntentsIntentRequestBody = {
                         interval_count?: number | undefined
                         reference: string
                         start_date: number
-                        supported_types?:
-                          | ("india" | UnknownEnumStringValue)[]
-                          | undefined
+                        supported_types?: "india"[] | undefined
                       }
                     | undefined
                   network?:
@@ -32478,12 +31891,8 @@ export type t_PostPaymentIntentsIntentRequestBody = {
                         | UnknownEnumStringValue
                       )
                     | undefined
-                  statement_descriptor_suffix_kana?:
-                    | (string | "" | UnknownEnumStringValue)
-                    | undefined
-                  statement_descriptor_suffix_kanji?:
-                    | (string | "" | UnknownEnumStringValue)
-                    | undefined
+                  statement_descriptor_suffix_kana?: (string | "") | undefined
+                  statement_descriptor_suffix_kanji?: (string | "") | undefined
                   three_d_secure?:
                     | {
                         ares_trans_status?:
@@ -32541,7 +31950,6 @@ export type t_PostPaymentIntentsIntentRequestBody = {
                     | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         card_present?:
@@ -32564,7 +31972,6 @@ export type t_PostPaymentIntentsIntentRequestBody = {
                     | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         cashapp?:
@@ -32584,18 +31991,14 @@ export type t_PostPaymentIntentsIntentRequestBody = {
                     | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         crypto?:
           | (
               | {
-                  setup_future_usage?:
-                    | ("none" | UnknownEnumStringValue)
-                    | undefined
+                  setup_future_usage?: "none" | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         customer_balance?:
@@ -32629,59 +32032,42 @@ export type t_PostPaymentIntentsIntentRequestBody = {
                           | UnknownEnumStringValue
                       }
                     | undefined
-                  funding_type?:
-                    | ("bank_transfer" | UnknownEnumStringValue)
-                    | undefined
-                  setup_future_usage?:
-                    | ("none" | UnknownEnumStringValue)
-                    | undefined
+                  funding_type?: "bank_transfer" | undefined
+                  setup_future_usage?: "none" | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         eps?:
           | (
               | {
-                  setup_future_usage?:
-                    | ("none" | UnknownEnumStringValue)
-                    | undefined
+                  setup_future_usage?: "none" | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         fpx?:
           | (
               | {
-                  setup_future_usage?:
-                    | ("none" | UnknownEnumStringValue)
-                    | undefined
+                  setup_future_usage?: "none" | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         giropay?:
           | (
               | {
-                  setup_future_usage?:
-                    | ("none" | UnknownEnumStringValue)
-                    | undefined
+                  setup_future_usage?: "none" | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         grabpay?:
           | (
               | {
-                  setup_future_usage?:
-                    | ("none" | UnknownEnumStringValue)
-                    | undefined
+                  setup_future_usage?: "none" | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         ideal?:
@@ -32692,12 +32078,9 @@ export type t_PostPaymentIntentsIntentRequestBody = {
                     | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
-        interac_present?:
-          | (Record<string, unknown> | "" | UnknownEnumStringValue)
-          | undefined
+        interac_present?: (Record<string, unknown> | "") | undefined
         kakao_pay?:
           | (
               | {
@@ -32709,7 +32092,6 @@ export type t_PostPaymentIntentsIntentRequestBody = {
                     | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         klarna?:
@@ -32814,35 +32196,22 @@ export type t_PostPaymentIntentsIntentRequestBody = {
                             reference: string
                           }[]
                         | ""
-                        | UnknownEnumStringValue
                       )
                     | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         konbini?:
           | (
               | {
-                  confirmation_number?:
-                    | (string | "" | UnknownEnumStringValue)
-                    | undefined
-                  expires_after_days?:
-                    | (number | "" | UnknownEnumStringValue)
-                    | undefined
-                  expires_at?:
-                    | (number | "" | UnknownEnumStringValue)
-                    | undefined
-                  product_description?:
-                    | (string | "" | UnknownEnumStringValue)
-                    | undefined
-                  setup_future_usage?:
-                    | ("none" | UnknownEnumStringValue)
-                    | undefined
+                  confirmation_number?: (string | "") | undefined
+                  expires_after_days?: (number | "") | undefined
+                  expires_at?: (number | "") | undefined
+                  product_description?: (string | "") | undefined
+                  setup_future_usage?: "none" | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         kr_card?:
@@ -32856,7 +32225,6 @@ export type t_PostPaymentIntentsIntentRequestBody = {
                     | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         link?:
@@ -32870,7 +32238,6 @@ export type t_PostPaymentIntentsIntentRequestBody = {
                     | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         mobilepay?:
@@ -32879,23 +32246,17 @@ export type t_PostPaymentIntentsIntentRequestBody = {
                   capture_method?:
                     | ("" | "manual" | UnknownEnumStringValue)
                     | undefined
-                  setup_future_usage?:
-                    | ("none" | UnknownEnumStringValue)
-                    | undefined
+                  setup_future_usage?: "none" | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         multibanco?:
           | (
               | {
-                  setup_future_usage?:
-                    | ("none" | UnknownEnumStringValue)
-                    | undefined
+                  setup_future_usage?: "none" | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         naver_pay?:
@@ -32909,7 +32270,6 @@ export type t_PostPaymentIntentsIntentRequestBody = {
                     | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         nz_bank_account?:
@@ -32927,36 +32287,27 @@ export type t_PostPaymentIntentsIntentRequestBody = {
                   target_date?: string | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         oxxo?:
           | (
               | {
                   expires_after_days?: number | undefined
-                  setup_future_usage?:
-                    | ("none" | UnknownEnumStringValue)
-                    | undefined
+                  setup_future_usage?: "none" | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         p24?:
           | (
               | {
-                  setup_future_usage?:
-                    | ("none" | UnknownEnumStringValue)
-                    | undefined
+                  setup_future_usage?: "none" | undefined
                   tos_shown_and_accepted?: boolean | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
-        pay_by_bank?:
-          | (Record<string, unknown> | "" | UnknownEnumStringValue)
-          | undefined
+        pay_by_bank?: (Record<string, unknown> | "") | undefined
         payco?:
           | (
               | {
@@ -32965,18 +32316,14 @@ export type t_PostPaymentIntentsIntentRequestBody = {
                     | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         paynow?:
           | (
               | {
-                  setup_future_usage?:
-                    | ("none" | UnknownEnumStringValue)
-                    | undefined
+                  setup_future_usage?: "none" | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         paypal?:
@@ -33018,7 +32365,6 @@ export type t_PostPaymentIntentsIntentRequestBody = {
                     | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         pix?:
@@ -33026,23 +32372,17 @@ export type t_PostPaymentIntentsIntentRequestBody = {
               | {
                   expires_after_seconds?: number | undefined
                   expires_at?: number | undefined
-                  setup_future_usage?:
-                    | ("none" | UnknownEnumStringValue)
-                    | undefined
+                  setup_future_usage?: "none" | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         promptpay?:
           | (
               | {
-                  setup_future_usage?:
-                    | ("none" | UnknownEnumStringValue)
-                    | undefined
+                  setup_future_usage?: "none" | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         revolut_pay?:
@@ -33056,7 +32396,6 @@ export type t_PostPaymentIntentsIntentRequestBody = {
                     | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         samsung_pay?:
@@ -33067,7 +32406,6 @@ export type t_PostPaymentIntentsIntentRequestBody = {
                     | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         satispay?:
@@ -33078,7 +32416,6 @@ export type t_PostPaymentIntentsIntentRequestBody = {
                     | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         sepa_debit?:
@@ -33086,9 +32423,7 @@ export type t_PostPaymentIntentsIntentRequestBody = {
               | {
                   mandate_options?:
                     | {
-                        reference_prefix?:
-                          | (string | "" | UnknownEnumStringValue)
-                          | undefined
+                        reference_prefix?: (string | "") | undefined
                       }
                     | undefined
                   setup_future_usage?:
@@ -33103,7 +32438,6 @@ export type t_PostPaymentIntentsIntentRequestBody = {
                   target_date?: string | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         sofort?:
@@ -33127,30 +32461,23 @@ export type t_PostPaymentIntentsIntentRequestBody = {
                     | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         swish?:
           | (
               | {
-                  reference?: (string | "" | UnknownEnumStringValue) | undefined
-                  setup_future_usage?:
-                    | ("none" | UnknownEnumStringValue)
-                    | undefined
+                  reference?: (string | "") | undefined
+                  setup_future_usage?: "none" | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         twint?:
           | (
               | {
-                  setup_future_usage?:
-                    | ("none" | UnknownEnumStringValue)
-                    | undefined
+                  setup_future_usage?: "none" | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         us_bank_account?:
@@ -33230,7 +32557,6 @@ export type t_PostPaymentIntentsIntentRequestBody = {
                     | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         wechat_pay?:
@@ -33240,29 +32566,23 @@ export type t_PostPaymentIntentsIntentRequestBody = {
                   client?:
                     | ("android" | "ios" | "web" | UnknownEnumStringValue)
                     | undefined
-                  setup_future_usage?:
-                    | ("none" | UnknownEnumStringValue)
-                    | undefined
+                  setup_future_usage?: "none" | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         zip?:
           | (
               | {
-                  setup_future_usage?:
-                    | ("none" | UnknownEnumStringValue)
-                    | undefined
+                  setup_future_usage?: "none" | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
       }
     | undefined
   payment_method_types?: string[] | undefined
-  receipt_email?: (string | "" | UnknownEnumStringValue) | undefined
+  receipt_email?: (string | "") | undefined
   setup_future_usage?:
     | ("" | "off_session" | "on_session" | UnknownEnumStringValue)
     | undefined
@@ -33283,7 +32603,6 @@ export type t_PostPaymentIntentsIntentRequestBody = {
             tracking_number?: string | undefined
           }
         | ""
-        | UnknownEnumStringValue
       )
     | undefined
   statement_descriptor?: string | undefined
@@ -33320,7 +32639,7 @@ export type t_PostPaymentIntentsIntentCaptureRequestBody = {
   application_fee_amount?: number | undefined
   expand?: string[] | undefined
   final_capture?: boolean | undefined
-  metadata?: (Record<string, string> | "" | UnknownEnumStringValue) | undefined
+  metadata?: (Record<string, string> | "") | undefined
   statement_descriptor?: string | undefined
   statement_descriptor_suffix?: string | undefined
   transfer_data?:
@@ -33355,14 +32674,13 @@ export type t_PostPaymentIntentsIntentConfirmRequestBody = {
             }
           }
         | ""
-        | UnknownEnumStringValue
         | {
             customer_acceptance: {
               online: {
                 ip_address?: string | undefined
                 user_agent?: string | undefined
               }
-              type: "online" | UnknownEnumStringValue
+              type: "online"
             }
           }
       )
@@ -33415,12 +32733,11 @@ export type t_PostPaymentIntentsIntentConfirmRequestBody = {
                         state?: string | undefined
                       }
                     | ""
-                    | UnknownEnumStringValue
                   )
                 | undefined
-              email?: (string | "" | UnknownEnumStringValue) | undefined
-              name?: (string | "" | UnknownEnumStringValue) | undefined
-              phone?: (string | "" | UnknownEnumStringValue) | undefined
+              email?: (string | "") | undefined
+              name?: (string | "") | undefined
+              phone?: (string | "") | undefined
               tax_id?: string | undefined
             }
           | undefined
@@ -33702,9 +33019,7 @@ export type t_PostPaymentIntentsIntentConfirmRequestBody = {
               | {
                   mandate_options?:
                     | {
-                        custom_mandate_url?:
-                          | (string | "" | UnknownEnumStringValue)
-                          | undefined
+                        custom_mandate_url?: (string | "") | undefined
                         interval_description?: string | undefined
                         payment_schedule?:
                           | (
@@ -33739,7 +33054,6 @@ export type t_PostPaymentIntentsIntentConfirmRequestBody = {
                     | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         affirm?:
@@ -33749,12 +33063,9 @@ export type t_PostPaymentIntentsIntentConfirmRequestBody = {
                     | ("" | "manual" | UnknownEnumStringValue)
                     | undefined
                   preferred_locale?: string | undefined
-                  setup_future_usage?:
-                    | ("none" | UnknownEnumStringValue)
-                    | undefined
+                  setup_future_usage?: "none" | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         afterpay_clearpay?:
@@ -33764,12 +33075,9 @@ export type t_PostPaymentIntentsIntentConfirmRequestBody = {
                     | ("" | "manual" | UnknownEnumStringValue)
                     | undefined
                   reference?: string | undefined
-                  setup_future_usage?:
-                    | ("none" | UnknownEnumStringValue)
-                    | undefined
+                  setup_future_usage?: "none" | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         alipay?:
@@ -33780,7 +33088,6 @@ export type t_PostPaymentIntentsIntentConfirmRequestBody = {
                     | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         alma?:
@@ -33791,7 +33098,6 @@ export type t_PostPaymentIntentsIntentConfirmRequestBody = {
                     | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         amazon_pay?:
@@ -33805,7 +33111,6 @@ export type t_PostPaymentIntentsIntentConfirmRequestBody = {
                     | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         au_becs_debit?:
@@ -33823,7 +33128,6 @@ export type t_PostPaymentIntentsIntentConfirmRequestBody = {
                   target_date?: string | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         bacs_debit?:
@@ -33831,9 +33135,7 @@ export type t_PostPaymentIntentsIntentConfirmRequestBody = {
               | {
                   mandate_options?:
                     | {
-                        reference_prefix?:
-                          | (string | "" | UnknownEnumStringValue)
-                          | undefined
+                        reference_prefix?: (string | "") | undefined
                       }
                     | undefined
                   setup_future_usage?:
@@ -33848,7 +33150,6 @@ export type t_PostPaymentIntentsIntentConfirmRequestBody = {
                   target_date?: string | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         bancontact?:
@@ -33862,7 +33163,6 @@ export type t_PostPaymentIntentsIntentConfirmRequestBody = {
                     | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         billie?:
@@ -33873,7 +33173,6 @@ export type t_PostPaymentIntentsIntentConfirmRequestBody = {
                     | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         blik?:
@@ -33885,7 +33184,6 @@ export type t_PostPaymentIntentsIntentConfirmRequestBody = {
                     | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         boleto?:
@@ -33903,7 +33201,6 @@ export type t_PostPaymentIntentsIntentConfirmRequestBody = {
                     | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         card?:
@@ -33920,9 +33217,7 @@ export type t_PostPaymentIntentsIntentConfirmRequestBody = {
                           | (
                               | {
                                   count?: number | undefined
-                                  interval?:
-                                    | ("month" | UnknownEnumStringValue)
-                                    | undefined
+                                  interval?: "month" | undefined
                                   type:
                                     | "bonus"
                                     | "fixed_count"
@@ -33930,7 +33225,6 @@ export type t_PostPaymentIntentsIntentConfirmRequestBody = {
                                     | UnknownEnumStringValue
                                 }
                               | ""
-                              | UnknownEnumStringValue
                             )
                           | undefined
                       }
@@ -33954,9 +33248,7 @@ export type t_PostPaymentIntentsIntentConfirmRequestBody = {
                         interval_count?: number | undefined
                         reference: string
                         start_date: number
-                        supported_types?:
-                          | ("india" | UnknownEnumStringValue)[]
-                          | undefined
+                        supported_types?: "india"[] | undefined
                       }
                     | undefined
                   network?:
@@ -34007,12 +33299,8 @@ export type t_PostPaymentIntentsIntentConfirmRequestBody = {
                         | UnknownEnumStringValue
                       )
                     | undefined
-                  statement_descriptor_suffix_kana?:
-                    | (string | "" | UnknownEnumStringValue)
-                    | undefined
-                  statement_descriptor_suffix_kanji?:
-                    | (string | "" | UnknownEnumStringValue)
-                    | undefined
+                  statement_descriptor_suffix_kana?: (string | "") | undefined
+                  statement_descriptor_suffix_kanji?: (string | "") | undefined
                   three_d_secure?:
                     | {
                         ares_trans_status?:
@@ -34070,7 +33358,6 @@ export type t_PostPaymentIntentsIntentConfirmRequestBody = {
                     | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         card_present?:
@@ -34093,7 +33380,6 @@ export type t_PostPaymentIntentsIntentConfirmRequestBody = {
                     | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         cashapp?:
@@ -34113,18 +33399,14 @@ export type t_PostPaymentIntentsIntentConfirmRequestBody = {
                     | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         crypto?:
           | (
               | {
-                  setup_future_usage?:
-                    | ("none" | UnknownEnumStringValue)
-                    | undefined
+                  setup_future_usage?: "none" | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         customer_balance?:
@@ -34158,59 +33440,42 @@ export type t_PostPaymentIntentsIntentConfirmRequestBody = {
                           | UnknownEnumStringValue
                       }
                     | undefined
-                  funding_type?:
-                    | ("bank_transfer" | UnknownEnumStringValue)
-                    | undefined
-                  setup_future_usage?:
-                    | ("none" | UnknownEnumStringValue)
-                    | undefined
+                  funding_type?: "bank_transfer" | undefined
+                  setup_future_usage?: "none" | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         eps?:
           | (
               | {
-                  setup_future_usage?:
-                    | ("none" | UnknownEnumStringValue)
-                    | undefined
+                  setup_future_usage?: "none" | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         fpx?:
           | (
               | {
-                  setup_future_usage?:
-                    | ("none" | UnknownEnumStringValue)
-                    | undefined
+                  setup_future_usage?: "none" | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         giropay?:
           | (
               | {
-                  setup_future_usage?:
-                    | ("none" | UnknownEnumStringValue)
-                    | undefined
+                  setup_future_usage?: "none" | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         grabpay?:
           | (
               | {
-                  setup_future_usage?:
-                    | ("none" | UnknownEnumStringValue)
-                    | undefined
+                  setup_future_usage?: "none" | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         ideal?:
@@ -34221,12 +33486,9 @@ export type t_PostPaymentIntentsIntentConfirmRequestBody = {
                     | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
-        interac_present?:
-          | (Record<string, unknown> | "" | UnknownEnumStringValue)
-          | undefined
+        interac_present?: (Record<string, unknown> | "") | undefined
         kakao_pay?:
           | (
               | {
@@ -34238,7 +33500,6 @@ export type t_PostPaymentIntentsIntentConfirmRequestBody = {
                     | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         klarna?:
@@ -34343,35 +33604,22 @@ export type t_PostPaymentIntentsIntentConfirmRequestBody = {
                             reference: string
                           }[]
                         | ""
-                        | UnknownEnumStringValue
                       )
                     | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         konbini?:
           | (
               | {
-                  confirmation_number?:
-                    | (string | "" | UnknownEnumStringValue)
-                    | undefined
-                  expires_after_days?:
-                    | (number | "" | UnknownEnumStringValue)
-                    | undefined
-                  expires_at?:
-                    | (number | "" | UnknownEnumStringValue)
-                    | undefined
-                  product_description?:
-                    | (string | "" | UnknownEnumStringValue)
-                    | undefined
-                  setup_future_usage?:
-                    | ("none" | UnknownEnumStringValue)
-                    | undefined
+                  confirmation_number?: (string | "") | undefined
+                  expires_after_days?: (number | "") | undefined
+                  expires_at?: (number | "") | undefined
+                  product_description?: (string | "") | undefined
+                  setup_future_usage?: "none" | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         kr_card?:
@@ -34385,7 +33633,6 @@ export type t_PostPaymentIntentsIntentConfirmRequestBody = {
                     | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         link?:
@@ -34399,7 +33646,6 @@ export type t_PostPaymentIntentsIntentConfirmRequestBody = {
                     | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         mobilepay?:
@@ -34408,23 +33654,17 @@ export type t_PostPaymentIntentsIntentConfirmRequestBody = {
                   capture_method?:
                     | ("" | "manual" | UnknownEnumStringValue)
                     | undefined
-                  setup_future_usage?:
-                    | ("none" | UnknownEnumStringValue)
-                    | undefined
+                  setup_future_usage?: "none" | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         multibanco?:
           | (
               | {
-                  setup_future_usage?:
-                    | ("none" | UnknownEnumStringValue)
-                    | undefined
+                  setup_future_usage?: "none" | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         naver_pay?:
@@ -34438,7 +33678,6 @@ export type t_PostPaymentIntentsIntentConfirmRequestBody = {
                     | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         nz_bank_account?:
@@ -34456,36 +33695,27 @@ export type t_PostPaymentIntentsIntentConfirmRequestBody = {
                   target_date?: string | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         oxxo?:
           | (
               | {
                   expires_after_days?: number | undefined
-                  setup_future_usage?:
-                    | ("none" | UnknownEnumStringValue)
-                    | undefined
+                  setup_future_usage?: "none" | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         p24?:
           | (
               | {
-                  setup_future_usage?:
-                    | ("none" | UnknownEnumStringValue)
-                    | undefined
+                  setup_future_usage?: "none" | undefined
                   tos_shown_and_accepted?: boolean | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
-        pay_by_bank?:
-          | (Record<string, unknown> | "" | UnknownEnumStringValue)
-          | undefined
+        pay_by_bank?: (Record<string, unknown> | "") | undefined
         payco?:
           | (
               | {
@@ -34494,18 +33724,14 @@ export type t_PostPaymentIntentsIntentConfirmRequestBody = {
                     | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         paynow?:
           | (
               | {
-                  setup_future_usage?:
-                    | ("none" | UnknownEnumStringValue)
-                    | undefined
+                  setup_future_usage?: "none" | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         paypal?:
@@ -34547,7 +33773,6 @@ export type t_PostPaymentIntentsIntentConfirmRequestBody = {
                     | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         pix?:
@@ -34555,23 +33780,17 @@ export type t_PostPaymentIntentsIntentConfirmRequestBody = {
               | {
                   expires_after_seconds?: number | undefined
                   expires_at?: number | undefined
-                  setup_future_usage?:
-                    | ("none" | UnknownEnumStringValue)
-                    | undefined
+                  setup_future_usage?: "none" | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         promptpay?:
           | (
               | {
-                  setup_future_usage?:
-                    | ("none" | UnknownEnumStringValue)
-                    | undefined
+                  setup_future_usage?: "none" | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         revolut_pay?:
@@ -34585,7 +33804,6 @@ export type t_PostPaymentIntentsIntentConfirmRequestBody = {
                     | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         samsung_pay?:
@@ -34596,7 +33814,6 @@ export type t_PostPaymentIntentsIntentConfirmRequestBody = {
                     | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         satispay?:
@@ -34607,7 +33824,6 @@ export type t_PostPaymentIntentsIntentConfirmRequestBody = {
                     | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         sepa_debit?:
@@ -34615,9 +33831,7 @@ export type t_PostPaymentIntentsIntentConfirmRequestBody = {
               | {
                   mandate_options?:
                     | {
-                        reference_prefix?:
-                          | (string | "" | UnknownEnumStringValue)
-                          | undefined
+                        reference_prefix?: (string | "") | undefined
                       }
                     | undefined
                   setup_future_usage?:
@@ -34632,7 +33846,6 @@ export type t_PostPaymentIntentsIntentConfirmRequestBody = {
                   target_date?: string | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         sofort?:
@@ -34656,30 +33869,23 @@ export type t_PostPaymentIntentsIntentConfirmRequestBody = {
                     | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         swish?:
           | (
               | {
-                  reference?: (string | "" | UnknownEnumStringValue) | undefined
-                  setup_future_usage?:
-                    | ("none" | UnknownEnumStringValue)
-                    | undefined
+                  reference?: (string | "") | undefined
+                  setup_future_usage?: "none" | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         twint?:
           | (
               | {
-                  setup_future_usage?:
-                    | ("none" | UnknownEnumStringValue)
-                    | undefined
+                  setup_future_usage?: "none" | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         us_bank_account?:
@@ -34759,7 +33965,6 @@ export type t_PostPaymentIntentsIntentConfirmRequestBody = {
                     | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         wechat_pay?:
@@ -34769,23 +33974,17 @@ export type t_PostPaymentIntentsIntentConfirmRequestBody = {
                   client?:
                     | ("android" | "ios" | "web" | UnknownEnumStringValue)
                     | undefined
-                  setup_future_usage?:
-                    | ("none" | UnknownEnumStringValue)
-                    | undefined
+                  setup_future_usage?: "none" | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         zip?:
           | (
               | {
-                  setup_future_usage?:
-                    | ("none" | UnknownEnumStringValue)
-                    | undefined
+                  setup_future_usage?: "none" | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
       }
@@ -34796,7 +33995,7 @@ export type t_PostPaymentIntentsIntentConfirmRequestBody = {
         session?: string | undefined
       }
     | undefined
-  receipt_email?: (string | "" | UnknownEnumStringValue) | undefined
+  receipt_email?: (string | "") | undefined
   return_url?: string | undefined
   setup_future_usage?:
     | ("" | "off_session" | "on_session" | UnknownEnumStringValue)
@@ -34818,7 +34017,6 @@ export type t_PostPaymentIntentsIntentConfirmRequestBody = {
             tracking_number?: string | undefined
           }
         | ""
-        | UnknownEnumStringValue
       )
     | undefined
   use_stripe_sdk?: boolean | undefined
@@ -34906,7 +34104,7 @@ export type t_PostPaymentLinksRequestBody = {
         key: string
         label: {
           custom: string
-          type: "custom" | UnknownEnumStringValue
+          type: "custom"
         }
         numeric?:
           | {
@@ -34934,7 +34132,6 @@ export type t_PostPaymentLinksRequestBody = {
                   message: string
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         shipping_address?:
@@ -34943,7 +34140,6 @@ export type t_PostPaymentLinksRequestBody = {
                   message: string
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         submit?:
@@ -34952,7 +34148,6 @@ export type t_PostPaymentLinksRequestBody = {
                   message: string
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         terms_of_service_acceptance?:
@@ -34961,7 +34156,6 @@ export type t_PostPaymentLinksRequestBody = {
                   message: string
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
       }
@@ -34976,9 +34170,7 @@ export type t_PostPaymentLinksRequestBody = {
         enabled: boolean
         invoice_data?:
           | {
-              account_tax_ids?:
-                | (string[] | "" | UnknownEnumStringValue)
-                | undefined
+              account_tax_ids?: (string[] | "") | undefined
               custom_fields?:
                 | (
                     | {
@@ -34986,7 +34178,6 @@ export type t_PostPaymentLinksRequestBody = {
                         value: string
                       }[]
                     | ""
-                    | UnknownEnumStringValue
                   )
                 | undefined
               description?: string | undefined
@@ -34997,9 +34188,7 @@ export type t_PostPaymentLinksRequestBody = {
                     type: "account" | "self" | UnknownEnumStringValue
                   }
                 | undefined
-              metadata?:
-                | (Record<string, string> | "" | UnknownEnumStringValue)
-                | undefined
+              metadata?: (Record<string, string> | "") | undefined
               rendering_options?:
                 | (
                     | {
@@ -35014,7 +34203,6 @@ export type t_PostPaymentLinksRequestBody = {
                         template?: string | undefined
                       }
                     | ""
-                    | UnknownEnumStringValue
                   )
                 | undefined
             }
@@ -35511,7 +34699,7 @@ export type t_PostPaymentLinksPaymentLinkRequestBody = {
             key: string
             label: {
               custom: string
-              type: "custom" | UnknownEnumStringValue
+              type: "custom"
             }
             numeric?:
               | {
@@ -35531,7 +34719,6 @@ export type t_PostPaymentLinksPaymentLinkRequestBody = {
             type: "dropdown" | "numeric" | "text" | UnknownEnumStringValue
           }[]
         | ""
-        | UnknownEnumStringValue
       )
     | undefined
   custom_text?:
@@ -35542,7 +34729,6 @@ export type t_PostPaymentLinksPaymentLinkRequestBody = {
                   message: string
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         shipping_address?:
@@ -35551,7 +34737,6 @@ export type t_PostPaymentLinksPaymentLinkRequestBody = {
                   message: string
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         submit?:
@@ -35560,7 +34745,6 @@ export type t_PostPaymentLinksPaymentLinkRequestBody = {
                   message: string
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         terms_of_service_acceptance?:
@@ -35569,7 +34753,6 @@ export type t_PostPaymentLinksPaymentLinkRequestBody = {
                   message: string
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
       }
@@ -35578,15 +34761,13 @@ export type t_PostPaymentLinksPaymentLinkRequestBody = {
     | ("always" | "if_required" | UnknownEnumStringValue)
     | undefined
   expand?: string[] | undefined
-  inactive_message?: (string | "" | UnknownEnumStringValue) | undefined
+  inactive_message?: (string | "") | undefined
   invoice_creation?:
     | {
         enabled: boolean
         invoice_data?:
           | {
-              account_tax_ids?:
-                | (string[] | "" | UnknownEnumStringValue)
-                | undefined
+              account_tax_ids?: (string[] | "") | undefined
               custom_fields?:
                 | (
                     | {
@@ -35594,7 +34775,6 @@ export type t_PostPaymentLinksPaymentLinkRequestBody = {
                         value: string
                       }[]
                     | ""
-                    | UnknownEnumStringValue
                   )
                 | undefined
               description?: string | undefined
@@ -35605,9 +34785,7 @@ export type t_PostPaymentLinksPaymentLinkRequestBody = {
                     type: "account" | "self" | UnknownEnumStringValue
                   }
                 | undefined
-              metadata?:
-                | (Record<string, string> | "" | UnknownEnumStringValue)
-                | undefined
+              metadata?: (Record<string, string> | "") | undefined
               rendering_options?:
                 | (
                     | {
@@ -35622,7 +34800,6 @@ export type t_PostPaymentLinksPaymentLinkRequestBody = {
                         template?: string | undefined
                       }
                     | ""
-                    | UnknownEnumStringValue
                   )
                 | undefined
             }
@@ -35645,17 +34822,11 @@ export type t_PostPaymentLinksPaymentLinkRequestBody = {
   metadata?: Record<string, string> | undefined
   payment_intent_data?:
     | {
-        description?: (string | "" | UnknownEnumStringValue) | undefined
-        metadata?:
-          | (Record<string, string> | "" | UnknownEnumStringValue)
-          | undefined
-        statement_descriptor?:
-          | (string | "" | UnknownEnumStringValue)
-          | undefined
-        statement_descriptor_suffix?:
-          | (string | "" | UnknownEnumStringValue)
-          | undefined
-        transfer_group?: (string | "" | UnknownEnumStringValue) | undefined
+        description?: (string | "") | undefined
+        metadata?: (Record<string, string> | "") | undefined
+        statement_descriptor?: (string | "") | undefined
+        statement_descriptor_suffix?: (string | "") | undefined
+        transfer_group?: (string | "") | undefined
       }
     | undefined
   payment_method_collection?:
@@ -35704,7 +34875,6 @@ export type t_PostPaymentLinksPaymentLinkRequestBody = {
             | UnknownEnumStringValue
           )[]
         | ""
-        | UnknownEnumStringValue
       )
     | undefined
   phone_number_collection?:
@@ -35720,7 +34890,6 @@ export type t_PostPaymentLinksPaymentLinkRequestBody = {
             }
           }
         | ""
-        | UnknownEnumStringValue
       )
     | undefined
   shipping_address_collection?:
@@ -35969,7 +35138,6 @@ export type t_PostPaymentLinksPaymentLinkRequestBody = {
             )[]
           }
         | ""
-        | UnknownEnumStringValue
       )
     | undefined
   submit_type?:
@@ -35994,10 +35162,8 @@ export type t_PostPaymentLinksPaymentLinkRequestBody = {
                 | undefined
             }
           | undefined
-        metadata?:
-          | (Record<string, string> | "" | UnknownEnumStringValue)
-          | undefined
-        trial_period_days?: (number | "" | UnknownEnumStringValue) | undefined
+        metadata?: (Record<string, string> | "") | undefined
+        trial_period_days?: (number | "") | undefined
         trial_settings?:
           | (
               | {
@@ -36010,7 +35176,6 @@ export type t_PostPaymentLinksPaymentLinkRequestBody = {
                   }
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
       }
@@ -37239,12 +36404,11 @@ export type t_PostPaymentMethodsRequestBody = {
                   state?: string | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
-        email?: (string | "" | UnknownEnumStringValue) | undefined
-        name?: (string | "" | UnknownEnumStringValue) | undefined
-        phone?: (string | "" | UnknownEnumStringValue) | undefined
+        email?: (string | "") | undefined
+        name?: (string | "") | undefined
+        phone?: (string | "") | undefined
         tax_id?: string | undefined
       }
     | undefined
@@ -37568,12 +36732,11 @@ export type t_PostPaymentMethodsPaymentMethodRequestBody = {
                   state?: string | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
-        email?: (string | "" | UnknownEnumStringValue) | undefined
-        name?: (string | "" | UnknownEnumStringValue) | undefined
-        phone?: (string | "" | UnknownEnumStringValue) | undefined
+        email?: (string | "") | undefined
+        name?: (string | "") | undefined
+        phone?: (string | "") | undefined
         tax_id?: string | undefined
       }
     | undefined
@@ -37598,7 +36761,7 @@ export type t_PostPaymentMethodsPaymentMethodRequestBody = {
     | undefined
   expand?: string[] | undefined
   link?: Record<string, unknown> | undefined
-  metadata?: (Record<string, string> | "" | UnknownEnumStringValue) | undefined
+  metadata?: (Record<string, string> | "") | undefined
   pay_by_bank?: Record<string, unknown> | undefined
   us_bank_account?:
     | {
@@ -37637,7 +36800,7 @@ export type t_PostPayoutsRequestBody = {
 
 export type t_PostPayoutsPayoutRequestBody = {
   expand?: string[] | undefined
-  metadata?: (Record<string, string> | "" | UnknownEnumStringValue) | undefined
+  metadata?: (Record<string, string> | "") | undefined
 }
 
 export type t_PostPayoutsPayoutCancelRequestBody = {
@@ -37659,7 +36822,7 @@ export type t_PostPlansRequestBody = {
   id?: string | undefined
   interval: "day" | "month" | "week" | "year" | UnknownEnumStringValue
   interval_count?: number | undefined
-  metadata?: (Record<string, string> | "" | UnknownEnumStringValue) | undefined
+  metadata?: (Record<string, string> | "") | undefined
   meter?: string | undefined
   nickname?: string | undefined
   product?:
@@ -37682,7 +36845,7 @@ export type t_PostPlansRequestBody = {
         flat_amount_decimal?: string | undefined
         unit_amount?: number | undefined
         unit_amount_decimal?: string | undefined
-        up_to: "inf" | UnknownEnumStringValue | number
+        up_to: "inf" | number
       }[]
     | undefined
   tiers_mode?: ("graduated" | "volume" | UnknownEnumStringValue) | undefined
@@ -37699,7 +36862,7 @@ export type t_PostPlansRequestBody = {
 export type t_PostPlansPlanRequestBody = {
   active?: boolean | undefined
   expand?: string[] | undefined
-  metadata?: (Record<string, string> | "" | UnknownEnumStringValue) | undefined
+  metadata?: (Record<string, string> | "") | undefined
   nickname?: string | undefined
   product?: string | undefined
   trial_period_days?: number | undefined
@@ -37735,7 +36898,7 @@ export type t_PostPricesRequestBody = {
                 flat_amount_decimal?: string | undefined
                 unit_amount?: number | undefined
                 unit_amount_decimal?: string | undefined
-                up_to: "inf" | UnknownEnumStringValue | number
+                up_to: "inf" | number
               }[]
             | undefined
           unit_amount?: number | undefined
@@ -37786,7 +36949,7 @@ export type t_PostPricesRequestBody = {
         flat_amount_decimal?: string | undefined
         unit_amount?: number | undefined
         unit_amount_decimal?: string | undefined
-        up_to: "inf" | UnknownEnumStringValue | number
+        up_to: "inf" | number
       }[]
     | undefined
   tiers_mode?: ("graduated" | "volume" | UnknownEnumStringValue) | undefined
@@ -37830,7 +36993,7 @@ export type t_PostPricesPriceRequestBody = {
                     flat_amount_decimal?: string | undefined
                     unit_amount?: number | undefined
                     unit_amount_decimal?: string | undefined
-                    up_to: "inf" | UnknownEnumStringValue | number
+                    up_to: "inf" | number
                   }[]
                 | undefined
               unit_amount?: number | undefined
@@ -37838,12 +37001,11 @@ export type t_PostPricesPriceRequestBody = {
             }
           >
         | ""
-        | UnknownEnumStringValue
       )
     | undefined
   expand?: string[] | undefined
   lookup_key?: string | undefined
-  metadata?: (Record<string, string> | "" | UnknownEnumStringValue) | undefined
+  metadata?: (Record<string, string> | "") | undefined
   nickname?: string | undefined
   tax_behavior?:
     | ("exclusive" | "inclusive" | "unspecified" | UnknownEnumStringValue)
@@ -37882,7 +37044,7 @@ export type t_PostProductsRequestBody = {
                       flat_amount_decimal?: string | undefined
                       unit_amount?: number | undefined
                       unit_amount_decimal?: string | undefined
-                      up_to: "inf" | UnknownEnumStringValue | number
+                      up_to: "inf" | number
                     }[]
                   | undefined
                 unit_amount?: number | undefined
@@ -37946,19 +37108,18 @@ export type t_PostProductsRequestBody = {
 export type t_PostProductsIdRequestBody = {
   active?: boolean | undefined
   default_price?: string | undefined
-  description?: (string | "" | UnknownEnumStringValue) | undefined
+  description?: (string | "") | undefined
   expand?: string[] | undefined
-  images?: (string[] | "" | UnknownEnumStringValue) | undefined
+  images?: (string[] | "") | undefined
   marketing_features?:
     | (
         | {
             name: string
           }[]
         | ""
-        | UnknownEnumStringValue
       )
     | undefined
-  metadata?: (Record<string, string> | "" | UnknownEnumStringValue) | undefined
+  metadata?: (Record<string, string> | "") | undefined
   name?: string | undefined
   package_dimensions?:
     | (
@@ -37969,14 +37130,13 @@ export type t_PostProductsIdRequestBody = {
             width: number
           }
         | ""
-        | UnknownEnumStringValue
       )
     | undefined
   shippable?: boolean | undefined
   statement_descriptor?: string | undefined
-  tax_code?: (string | "" | UnknownEnumStringValue) | undefined
-  unit_label?: (string | "" | UnknownEnumStringValue) | undefined
-  url?: (string | "" | UnknownEnumStringValue) | undefined
+  tax_code?: (string | "") | undefined
+  unit_label?: (string | "") | undefined
+  url?: (string | "") | undefined
 }
 
 export type t_PostProductsProductFeaturesRequestBody = {
@@ -38013,7 +37173,7 @@ export type t_PostPromotionCodesRequestBody = {
 export type t_PostPromotionCodesPromotionCodeRequestBody = {
   active?: boolean | undefined
   expand?: string[] | undefined
-  metadata?: (Record<string, string> | "" | UnknownEnumStringValue) | undefined
+  metadata?: (Record<string, string> | "") | undefined
   restrictions?:
     | {
         currency_options?:
@@ -38029,8 +37189,8 @@ export type t_PostPromotionCodesPromotionCodeRequestBody = {
 }
 
 export type t_PostQuotesRequestBody = {
-  application_fee_amount?: (number | "" | UnknownEnumStringValue) | undefined
-  application_fee_percent?: (number | "" | UnknownEnumStringValue) | undefined
+  application_fee_amount?: (number | "") | undefined
+  application_fee_percent?: (number | "") | undefined
   automatic_tax?:
     | {
         enabled: boolean
@@ -38046,8 +37206,8 @@ export type t_PostQuotesRequestBody = {
     | ("charge_automatically" | "send_invoice" | UnknownEnumStringValue)
     | undefined
   customer?: string | undefined
-  default_tax_rates?: (string[] | "" | UnknownEnumStringValue) | undefined
-  description?: (string | "" | UnknownEnumStringValue) | undefined
+  default_tax_rates?: (string[] | "") | undefined
+  description?: (string | "") | undefined
   discounts?:
     | (
         | {
@@ -38056,19 +37216,18 @@ export type t_PostQuotesRequestBody = {
             promotion_code?: string | undefined
           }[]
         | ""
-        | UnknownEnumStringValue
       )
     | undefined
   expand?: string[] | undefined
   expires_at?: number | undefined
-  footer?: (string | "" | UnknownEnumStringValue) | undefined
+  footer?: (string | "") | undefined
   from_quote?:
     | {
         is_revision?: boolean | undefined
         quote: string
       }
     | undefined
-  header?: (string | "" | UnknownEnumStringValue) | undefined
+  header?: (string | "") | undefined
   invoice_settings?:
     | {
         days_until_due?: number | undefined
@@ -38090,7 +37249,6 @@ export type t_PostQuotesRequestBody = {
                   promotion_code?: string | undefined
                 }[]
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         price?: string | undefined
@@ -38122,11 +37280,11 @@ export type t_PostQuotesRequestBody = {
             }
           | undefined
         quantity?: number | undefined
-        tax_rates?: (string[] | "" | UnknownEnumStringValue) | undefined
+        tax_rates?: (string[] | "") | undefined
       }[]
     | undefined
   metadata?: Record<string, string> | undefined
-  on_behalf_of?: (string | "" | UnknownEnumStringValue) | undefined
+  on_behalf_of?: (string | "") | undefined
   subscription_data?:
     | {
         billing_mode?:
@@ -38135,11 +37293,9 @@ export type t_PostQuotesRequestBody = {
             }
           | undefined
         description?: string | undefined
-        effective_date?:
-          | ("current_period_end" | UnknownEnumStringValue | number | "")
-          | undefined
+        effective_date?: ("current_period_end" | number | "") | undefined
         metadata?: Record<string, string> | undefined
-        trial_period_days?: (number | "" | UnknownEnumStringValue) | undefined
+        trial_period_days?: (number | "") | undefined
       }
     | undefined
   test_clock?: string | undefined
@@ -38151,14 +37307,13 @@ export type t_PostQuotesRequestBody = {
             destination: string
           }
         | ""
-        | UnknownEnumStringValue
       )
     | undefined
 }
 
 export type t_PostQuotesQuoteRequestBody = {
-  application_fee_amount?: (number | "" | UnknownEnumStringValue) | undefined
-  application_fee_percent?: (number | "" | UnknownEnumStringValue) | undefined
+  application_fee_amount?: (number | "") | undefined
+  application_fee_percent?: (number | "") | undefined
   automatic_tax?:
     | {
         enabled: boolean
@@ -38174,8 +37329,8 @@ export type t_PostQuotesQuoteRequestBody = {
     | ("charge_automatically" | "send_invoice" | UnknownEnumStringValue)
     | undefined
   customer?: string | undefined
-  default_tax_rates?: (string[] | "" | UnknownEnumStringValue) | undefined
-  description?: (string | "" | UnknownEnumStringValue) | undefined
+  default_tax_rates?: (string[] | "") | undefined
+  description?: (string | "") | undefined
   discounts?:
     | (
         | {
@@ -38184,13 +37339,12 @@ export type t_PostQuotesQuoteRequestBody = {
             promotion_code?: string | undefined
           }[]
         | ""
-        | UnknownEnumStringValue
       )
     | undefined
   expand?: string[] | undefined
   expires_at?: number | undefined
-  footer?: (string | "" | UnknownEnumStringValue) | undefined
-  header?: (string | "" | UnknownEnumStringValue) | undefined
+  footer?: (string | "") | undefined
+  header?: (string | "") | undefined
   invoice_settings?:
     | {
         days_until_due?: number | undefined
@@ -38212,7 +37366,6 @@ export type t_PostQuotesQuoteRequestBody = {
                   promotion_code?: string | undefined
                 }[]
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         id?: string | undefined
@@ -38245,19 +37398,17 @@ export type t_PostQuotesQuoteRequestBody = {
             }
           | undefined
         quantity?: number | undefined
-        tax_rates?: (string[] | "" | UnknownEnumStringValue) | undefined
+        tax_rates?: (string[] | "") | undefined
       }[]
     | undefined
   metadata?: Record<string, string> | undefined
-  on_behalf_of?: (string | "" | UnknownEnumStringValue) | undefined
+  on_behalf_of?: (string | "") | undefined
   subscription_data?:
     | {
-        description?: (string | "" | UnknownEnumStringValue) | undefined
-        effective_date?:
-          | ("current_period_end" | UnknownEnumStringValue | number | "")
-          | undefined
+        description?: (string | "") | undefined
+        effective_date?: ("current_period_end" | number | "") | undefined
         metadata?: Record<string, string> | undefined
-        trial_period_days?: (number | "" | UnknownEnumStringValue) | undefined
+        trial_period_days?: (number | "") | undefined
       }
     | undefined
   transfer_data?:
@@ -38268,7 +37419,6 @@ export type t_PostQuotesQuoteRequestBody = {
             destination: string
           }
         | ""
-        | UnknownEnumStringValue
       )
     | undefined
 }
@@ -38328,8 +37478,8 @@ export type t_PostRefundsRequestBody = {
   customer?: string | undefined
   expand?: string[] | undefined
   instructions_email?: string | undefined
-  metadata?: (Record<string, string> | "" | UnknownEnumStringValue) | undefined
-  origin?: ("customer_balance" | UnknownEnumStringValue) | undefined
+  metadata?: (Record<string, string> | "") | undefined
+  origin?: "customer_balance" | undefined
   payment_intent?: string | undefined
   reason?:
     | (
@@ -38345,7 +37495,7 @@ export type t_PostRefundsRequestBody = {
 
 export type t_PostRefundsRefundRequestBody = {
   expand?: string[] | undefined
-  metadata?: (Record<string, string> | "" | UnknownEnumStringValue) | undefined
+  metadata?: (Record<string, string> | "") | undefined
 }
 
 export type t_PostRefundsRefundCancelRequestBody = {
@@ -39051,7 +38201,6 @@ export type t_PostSetupIntentsRequestBody = {
             }
           }
         | ""
-        | UnknownEnumStringValue
       )
     | undefined
   metadata?: Record<string, string> | undefined
@@ -39102,12 +38251,11 @@ export type t_PostSetupIntentsRequestBody = {
                         state?: string | undefined
                       }
                     | ""
-                    | UnknownEnumStringValue
                   )
                 | undefined
-              email?: (string | "" | UnknownEnumStringValue) | undefined
-              name?: (string | "" | UnknownEnumStringValue) | undefined
-              phone?: (string | "" | UnknownEnumStringValue) | undefined
+              email?: (string | "") | undefined
+              name?: (string | "") | undefined
+              phone?: (string | "") | undefined
               tax_id?: string | undefined
             }
           | undefined
@@ -39389,9 +38537,7 @@ export type t_PostSetupIntentsRequestBody = {
               currency?: ("cad" | "usd" | UnknownEnumStringValue) | undefined
               mandate_options?:
                 | {
-                    custom_mandate_url?:
-                      | (string | "" | UnknownEnumStringValue)
-                      | undefined
+                    custom_mandate_url?: (string | "") | undefined
                     default_for?:
                       | ("invoice" | "subscription" | UnknownEnumStringValue)[]
                       | undefined
@@ -39424,9 +38570,7 @@ export type t_PostSetupIntentsRequestBody = {
           | {
               mandate_options?:
                 | {
-                    reference_prefix?:
-                      | (string | "" | UnknownEnumStringValue)
-                      | undefined
+                    reference_prefix?: (string | "") | undefined
                   }
                 | undefined
             }
@@ -39450,9 +38594,7 @@ export type t_PostSetupIntentsRequestBody = {
                     interval_count?: number | undefined
                     reference: string
                     start_date: number
-                    supported_types?:
-                      | ("india" | UnknownEnumStringValue)[]
-                      | undefined
+                    supported_types?: "india"[] | undefined
                   }
                 | undefined
               network?:
@@ -39618,7 +38760,6 @@ export type t_PostSetupIntentsRequestBody = {
                         reference: string
                       }[]
                     | ""
-                    | UnknownEnumStringValue
                   )
                 | undefined
             }
@@ -39633,9 +38774,7 @@ export type t_PostSetupIntentsRequestBody = {
           | {
               mandate_options?:
                 | {
-                    reference_prefix?:
-                      | (string | "" | UnknownEnumStringValue)
-                      | undefined
+                    reference_prefix?: (string | "") | undefined
                   }
                 | undefined
             }
@@ -39721,7 +38860,7 @@ export type t_PostSetupIntentsIntentRequestBody = {
   flow_directions?:
     | ("inbound" | "outbound" | UnknownEnumStringValue)[]
     | undefined
-  metadata?: (Record<string, string> | "" | UnknownEnumStringValue) | undefined
+  metadata?: (Record<string, string> | "") | undefined
   payment_method?: string | undefined
   payment_method_configuration?: string | undefined
   payment_method_data?:
@@ -39768,12 +38907,11 @@ export type t_PostSetupIntentsIntentRequestBody = {
                         state?: string | undefined
                       }
                     | ""
-                    | UnknownEnumStringValue
                   )
                 | undefined
-              email?: (string | "" | UnknownEnumStringValue) | undefined
-              name?: (string | "" | UnknownEnumStringValue) | undefined
-              phone?: (string | "" | UnknownEnumStringValue) | undefined
+              email?: (string | "") | undefined
+              name?: (string | "") | undefined
+              phone?: (string | "") | undefined
               tax_id?: string | undefined
             }
           | undefined
@@ -40055,9 +39193,7 @@ export type t_PostSetupIntentsIntentRequestBody = {
               currency?: ("cad" | "usd" | UnknownEnumStringValue) | undefined
               mandate_options?:
                 | {
-                    custom_mandate_url?:
-                      | (string | "" | UnknownEnumStringValue)
-                      | undefined
+                    custom_mandate_url?: (string | "") | undefined
                     default_for?:
                       | ("invoice" | "subscription" | UnknownEnumStringValue)[]
                       | undefined
@@ -40090,9 +39226,7 @@ export type t_PostSetupIntentsIntentRequestBody = {
           | {
               mandate_options?:
                 | {
-                    reference_prefix?:
-                      | (string | "" | UnknownEnumStringValue)
-                      | undefined
+                    reference_prefix?: (string | "") | undefined
                   }
                 | undefined
             }
@@ -40116,9 +39250,7 @@ export type t_PostSetupIntentsIntentRequestBody = {
                     interval_count?: number | undefined
                     reference: string
                     start_date: number
-                    supported_types?:
-                      | ("india" | UnknownEnumStringValue)[]
-                      | undefined
+                    supported_types?: "india"[] | undefined
                   }
                 | undefined
               network?:
@@ -40284,7 +39416,6 @@ export type t_PostSetupIntentsIntentRequestBody = {
                         reference: string
                       }[]
                     | ""
-                    | UnknownEnumStringValue
                   )
                 | undefined
             }
@@ -40299,9 +39430,7 @@ export type t_PostSetupIntentsIntentRequestBody = {
           | {
               mandate_options?:
                 | {
-                    reference_prefix?:
-                      | (string | "" | UnknownEnumStringValue)
-                      | undefined
+                    reference_prefix?: (string | "") | undefined
                   }
                 | undefined
             }
@@ -40402,14 +39531,13 @@ export type t_PostSetupIntentsIntentConfirmRequestBody = {
             }
           }
         | ""
-        | UnknownEnumStringValue
         | {
             customer_acceptance: {
               online: {
                 ip_address?: string | undefined
                 user_agent?: string | undefined
               }
-              type: "online" | UnknownEnumStringValue
+              type: "online"
             }
           }
       )
@@ -40459,12 +39587,11 @@ export type t_PostSetupIntentsIntentConfirmRequestBody = {
                         state?: string | undefined
                       }
                     | ""
-                    | UnknownEnumStringValue
                   )
                 | undefined
-              email?: (string | "" | UnknownEnumStringValue) | undefined
-              name?: (string | "" | UnknownEnumStringValue) | undefined
-              phone?: (string | "" | UnknownEnumStringValue) | undefined
+              email?: (string | "") | undefined
+              name?: (string | "") | undefined
+              phone?: (string | "") | undefined
               tax_id?: string | undefined
             }
           | undefined
@@ -40746,9 +39873,7 @@ export type t_PostSetupIntentsIntentConfirmRequestBody = {
               currency?: ("cad" | "usd" | UnknownEnumStringValue) | undefined
               mandate_options?:
                 | {
-                    custom_mandate_url?:
-                      | (string | "" | UnknownEnumStringValue)
-                      | undefined
+                    custom_mandate_url?: (string | "") | undefined
                     default_for?:
                       | ("invoice" | "subscription" | UnknownEnumStringValue)[]
                       | undefined
@@ -40781,9 +39906,7 @@ export type t_PostSetupIntentsIntentConfirmRequestBody = {
           | {
               mandate_options?:
                 | {
-                    reference_prefix?:
-                      | (string | "" | UnknownEnumStringValue)
-                      | undefined
+                    reference_prefix?: (string | "") | undefined
                   }
                 | undefined
             }
@@ -40807,9 +39930,7 @@ export type t_PostSetupIntentsIntentConfirmRequestBody = {
                     interval_count?: number | undefined
                     reference: string
                     start_date: number
-                    supported_types?:
-                      | ("india" | UnknownEnumStringValue)[]
-                      | undefined
+                    supported_types?: "india"[] | undefined
                   }
                 | undefined
               network?:
@@ -40975,7 +40096,6 @@ export type t_PostSetupIntentsIntentConfirmRequestBody = {
                         reference: string
                       }[]
                     | ""
-                    | UnknownEnumStringValue
                   )
                 | undefined
             }
@@ -40990,9 +40110,7 @@ export type t_PostSetupIntentsIntentConfirmRequestBody = {
           | {
               mandate_options?:
                 | {
-                    reference_prefix?:
-                      | (string | "" | UnknownEnumStringValue)
-                      | undefined
+                    reference_prefix?: (string | "") | undefined
                   }
                 | undefined
             }
@@ -41127,7 +40245,7 @@ export type t_PostShippingRatesRequestBody = {
     | ("exclusive" | "inclusive" | "unspecified" | UnknownEnumStringValue)
     | undefined
   tax_code?: string | undefined
-  type?: ("fixed_amount" | UnknownEnumStringValue) | undefined
+  type?: "fixed_amount" | undefined
 }
 
 export type t_PostShippingRatesShippingRateTokenRequestBody = {
@@ -41153,7 +40271,7 @@ export type t_PostShippingRatesShippingRateTokenRequestBody = {
           | undefined
       }
     | undefined
-  metadata?: (Record<string, string> | "" | UnknownEnumStringValue) | undefined
+  metadata?: (Record<string, string> | "") | undefined
   tax_behavior?:
     | ("exclusive" | "inclusive" | "unspecified" | UnknownEnumStringValue)
     | undefined
@@ -41207,7 +40325,7 @@ export type t_PostSourcesRequestBody = {
               user_agent?: string | undefined
             }
           | undefined
-        amount?: (number | "" | UnknownEnumStringValue) | undefined
+        amount?: (number | "") | undefined
         currency?: string | undefined
         interval?:
           | ("one_time" | "scheduled" | "variable" | UnknownEnumStringValue)
@@ -41330,7 +40448,7 @@ export type t_PostSourcesSourceRequestBody = {
               user_agent?: string | undefined
             }
           | undefined
-        amount?: (number | "" | UnknownEnumStringValue) | undefined
+        amount?: (number | "") | undefined
         currency?: string | undefined
         interval?:
           | ("one_time" | "scheduled" | "variable" | UnknownEnumStringValue)
@@ -41347,7 +40465,7 @@ export type t_PostSourcesSourceRequestBody = {
           | undefined
       }
     | undefined
-  metadata?: (Record<string, string> | "" | UnknownEnumStringValue) | undefined
+  metadata?: (Record<string, string> | "") | undefined
   owner?:
     | {
         address?:
@@ -41417,7 +40535,6 @@ export type t_PostSubscriptionItemsRequestBody = {
             usage_gte: number
           }
         | ""
-        | UnknownEnumStringValue
       )
     | undefined
   discounts?:
@@ -41428,7 +40545,6 @@ export type t_PostSubscriptionItemsRequestBody = {
             promotion_code?: string | undefined
           }[]
         | ""
-        | UnknownEnumStringValue
       )
     | undefined
   expand?: string[] | undefined
@@ -41464,7 +40580,7 @@ export type t_PostSubscriptionItemsRequestBody = {
   proration_date?: number | undefined
   quantity?: number | undefined
   subscription: string
-  tax_rates?: (string[] | "" | UnknownEnumStringValue) | undefined
+  tax_rates?: (string[] | "") | undefined
 }
 
 export type t_PostSubscriptionItemsItemRequestBody = {
@@ -41474,7 +40590,6 @@ export type t_PostSubscriptionItemsItemRequestBody = {
             usage_gte: number
           }
         | ""
-        | UnknownEnumStringValue
       )
     | undefined
   discounts?:
@@ -41485,11 +40600,10 @@ export type t_PostSubscriptionItemsItemRequestBody = {
             promotion_code?: string | undefined
           }[]
         | ""
-        | UnknownEnumStringValue
       )
     | undefined
   expand?: string[] | undefined
-  metadata?: (Record<string, string> | "" | UnknownEnumStringValue) | undefined
+  metadata?: (Record<string, string> | "") | undefined
   off_session?: boolean | undefined
   payment_behavior?:
     | (
@@ -41521,7 +40635,7 @@ export type t_PostSubscriptionItemsItemRequestBody = {
     | undefined
   proration_date?: number | undefined
   quantity?: number | undefined
-  tax_rates?: (string[] | "" | UnknownEnumStringValue) | undefined
+  tax_rates?: (string[] | "") | undefined
 }
 
 export type t_PostSubscriptionSchedulesRequestBody = {
@@ -41555,19 +40669,16 @@ export type t_PostSubscriptionSchedulesRequestBody = {
                   reset_billing_cycle_anchor?: boolean | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         collection_method?:
           | ("charge_automatically" | "send_invoice" | UnknownEnumStringValue)
           | undefined
         default_payment_method?: string | undefined
-        description?: (string | "" | UnknownEnumStringValue) | undefined
+        description?: (string | "") | undefined
         invoice_settings?:
           | {
-              account_tax_ids?:
-                | (string[] | "" | UnknownEnumStringValue)
-                | undefined
+              account_tax_ids?: (string[] | "") | undefined
               days_until_due?: number | undefined
               issuer?:
                 | {
@@ -41577,7 +40688,7 @@ export type t_PostSubscriptionSchedulesRequestBody = {
                 | undefined
             }
           | undefined
-        on_behalf_of?: (string | "" | UnknownEnumStringValue) | undefined
+        on_behalf_of?: (string | "") | undefined
         transfer_data?:
           | (
               | {
@@ -41585,7 +40696,6 @@ export type t_PostSubscriptionSchedulesRequestBody = {
                   destination: string
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
       }
@@ -41595,7 +40705,7 @@ export type t_PostSubscriptionSchedulesRequestBody = {
     | undefined
   expand?: string[] | undefined
   from_subscription?: string | undefined
-  metadata?: (Record<string, string> | "" | UnknownEnumStringValue) | undefined
+  metadata?: (Record<string, string> | "") | undefined
   phases?:
     | {
         add_invoice_items?:
@@ -41625,7 +40735,7 @@ export type t_PostSubscriptionSchedulesRequestBody = {
                   }
                 | undefined
               quantity?: number | undefined
-              tax_rates?: (string[] | "" | UnknownEnumStringValue) | undefined
+              tax_rates?: (string[] | "") | undefined
             }[]
           | undefined
         application_fee_percent?: number | undefined
@@ -41650,7 +40760,6 @@ export type t_PostSubscriptionSchedulesRequestBody = {
                   reset_billing_cycle_anchor?: boolean | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         collection_method?:
@@ -41658,8 +40767,8 @@ export type t_PostSubscriptionSchedulesRequestBody = {
           | undefined
         currency?: string | undefined
         default_payment_method?: string | undefined
-        default_tax_rates?: (string[] | "" | UnknownEnumStringValue) | undefined
-        description?: (string | "" | UnknownEnumStringValue) | undefined
+        default_tax_rates?: (string[] | "") | undefined
+        description?: (string | "") | undefined
         discounts?:
           | (
               | {
@@ -41668,7 +40777,6 @@ export type t_PostSubscriptionSchedulesRequestBody = {
                   promotion_code?: string | undefined
                 }[]
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         duration?:
@@ -41685,9 +40793,7 @@ export type t_PostSubscriptionSchedulesRequestBody = {
         end_date?: number | undefined
         invoice_settings?:
           | {
-              account_tax_ids?:
-                | (string[] | "" | UnknownEnumStringValue)
-                | undefined
+              account_tax_ids?: (string[] | "") | undefined
               days_until_due?: number | undefined
               issuer?:
                 | {
@@ -41704,7 +40810,6 @@ export type t_PostSubscriptionSchedulesRequestBody = {
                     usage_gte: number
                   }
                 | ""
-                | UnknownEnumStringValue
               )
             | undefined
           discounts?:
@@ -41715,7 +40820,6 @@ export type t_PostSubscriptionSchedulesRequestBody = {
                     promotion_code?: string | undefined
                   }[]
                 | ""
-                | UnknownEnumStringValue
               )
             | undefined
           metadata?: Record<string, string> | undefined
@@ -41746,7 +40850,7 @@ export type t_PostSubscriptionSchedulesRequestBody = {
               }
             | undefined
           quantity?: number | undefined
-          tax_rates?: (string[] | "" | UnknownEnumStringValue) | undefined
+          tax_rates?: (string[] | "") | undefined
         }[]
         iterations?: number | undefined
         metadata?: Record<string, string> | undefined
@@ -41769,7 +40873,7 @@ export type t_PostSubscriptionSchedulesRequestBody = {
         trial_end?: number | undefined
       }[]
     | undefined
-  start_date?: (number | "now" | UnknownEnumStringValue) | undefined
+  start_date?: (number | "now") | undefined
 }
 
 export type t_PostSubscriptionSchedulesScheduleRequestBody = {
@@ -41797,19 +40901,16 @@ export type t_PostSubscriptionSchedulesScheduleRequestBody = {
                   reset_billing_cycle_anchor?: boolean | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         collection_method?:
           | ("charge_automatically" | "send_invoice" | UnknownEnumStringValue)
           | undefined
         default_payment_method?: string | undefined
-        description?: (string | "" | UnknownEnumStringValue) | undefined
+        description?: (string | "") | undefined
         invoice_settings?:
           | {
-              account_tax_ids?:
-                | (string[] | "" | UnknownEnumStringValue)
-                | undefined
+              account_tax_ids?: (string[] | "") | undefined
               days_until_due?: number | undefined
               issuer?:
                 | {
@@ -41819,7 +40920,7 @@ export type t_PostSubscriptionSchedulesScheduleRequestBody = {
                 | undefined
             }
           | undefined
-        on_behalf_of?: (string | "" | UnknownEnumStringValue) | undefined
+        on_behalf_of?: (string | "") | undefined
         transfer_data?:
           | (
               | {
@@ -41827,7 +40928,6 @@ export type t_PostSubscriptionSchedulesScheduleRequestBody = {
                   destination: string
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
       }
@@ -41836,7 +40936,7 @@ export type t_PostSubscriptionSchedulesScheduleRequestBody = {
     | ("cancel" | "none" | "release" | "renew" | UnknownEnumStringValue)
     | undefined
   expand?: string[] | undefined
-  metadata?: (Record<string, string> | "" | UnknownEnumStringValue) | undefined
+  metadata?: (Record<string, string> | "") | undefined
   phases?:
     | {
         add_invoice_items?:
@@ -41866,7 +40966,7 @@ export type t_PostSubscriptionSchedulesScheduleRequestBody = {
                   }
                 | undefined
               quantity?: number | undefined
-              tax_rates?: (string[] | "" | UnknownEnumStringValue) | undefined
+              tax_rates?: (string[] | "") | undefined
             }[]
           | undefined
         application_fee_percent?: number | undefined
@@ -41891,15 +40991,14 @@ export type t_PostSubscriptionSchedulesScheduleRequestBody = {
                   reset_billing_cycle_anchor?: boolean | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         collection_method?:
           | ("charge_automatically" | "send_invoice" | UnknownEnumStringValue)
           | undefined
         default_payment_method?: string | undefined
-        default_tax_rates?: (string[] | "" | UnknownEnumStringValue) | undefined
-        description?: (string | "" | UnknownEnumStringValue) | undefined
+        default_tax_rates?: (string[] | "") | undefined
+        description?: (string | "") | undefined
         discounts?:
           | (
               | {
@@ -41908,7 +41007,6 @@ export type t_PostSubscriptionSchedulesScheduleRequestBody = {
                   promotion_code?: string | undefined
                 }[]
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         duration?:
@@ -41922,12 +41020,10 @@ export type t_PostSubscriptionSchedulesScheduleRequestBody = {
               interval_count?: number | undefined
             }
           | undefined
-        end_date?: (number | "now" | UnknownEnumStringValue) | undefined
+        end_date?: (number | "now") | undefined
         invoice_settings?:
           | {
-              account_tax_ids?:
-                | (string[] | "" | UnknownEnumStringValue)
-                | undefined
+              account_tax_ids?: (string[] | "") | undefined
               days_until_due?: number | undefined
               issuer?:
                 | {
@@ -41944,7 +41040,6 @@ export type t_PostSubscriptionSchedulesScheduleRequestBody = {
                     usage_gte: number
                   }
                 | ""
-                | UnknownEnumStringValue
               )
             | undefined
           discounts?:
@@ -41955,7 +41050,6 @@ export type t_PostSubscriptionSchedulesScheduleRequestBody = {
                     promotion_code?: string | undefined
                   }[]
                 | ""
-                | UnknownEnumStringValue
               )
             | undefined
           metadata?: Record<string, string> | undefined
@@ -41986,7 +41080,7 @@ export type t_PostSubscriptionSchedulesScheduleRequestBody = {
               }
             | undefined
           quantity?: number | undefined
-          tax_rates?: (string[] | "" | UnknownEnumStringValue) | undefined
+          tax_rates?: (string[] | "") | undefined
         }[]
         iterations?: number | undefined
         metadata?: Record<string, string> | undefined
@@ -41999,7 +41093,7 @@ export type t_PostSubscriptionSchedulesScheduleRequestBody = {
               | UnknownEnumStringValue
             )
           | undefined
-        start_date?: (number | "now" | UnknownEnumStringValue) | undefined
+        start_date?: (number | "now") | undefined
         transfer_data?:
           | {
               amount_percent?: number | undefined
@@ -42007,7 +41101,7 @@ export type t_PostSubscriptionSchedulesScheduleRequestBody = {
             }
           | undefined
         trial?: boolean | undefined
-        trial_end?: (number | "now" | UnknownEnumStringValue) | undefined
+        trial_end?: (number | "now") | undefined
       }[]
     | undefined
   proration_behavior?:
@@ -42054,10 +41148,10 @@ export type t_PostSubscriptionsRequestBody = {
             }
           | undefined
         quantity?: number | undefined
-        tax_rates?: (string[] | "" | UnknownEnumStringValue) | undefined
+        tax_rates?: (string[] | "") | undefined
       }[]
     | undefined
-  application_fee_percent?: (number | "" | UnknownEnumStringValue) | undefined
+  application_fee_percent?: (number | "") | undefined
   automatic_tax?:
     | {
         enabled: boolean
@@ -42092,7 +41186,6 @@ export type t_PostSubscriptionsRequestBody = {
             reset_billing_cycle_anchor?: boolean | undefined
           }
         | ""
-        | UnknownEnumStringValue
       )
     | undefined
   cancel_at?:
@@ -42107,7 +41200,7 @@ export type t_PostSubscriptionsRequestBody = {
   days_until_due?: number | undefined
   default_payment_method?: string | undefined
   default_source?: string | undefined
-  default_tax_rates?: (string[] | "" | UnknownEnumStringValue) | undefined
+  default_tax_rates?: (string[] | "") | undefined
   description?: string | undefined
   discounts?:
     | (
@@ -42117,13 +41210,12 @@ export type t_PostSubscriptionsRequestBody = {
             promotion_code?: string | undefined
           }[]
         | ""
-        | UnknownEnumStringValue
       )
     | undefined
   expand?: string[] | undefined
   invoice_settings?:
     | {
-        account_tax_ids?: (string[] | "" | UnknownEnumStringValue) | undefined
+        account_tax_ids?: (string[] | "") | undefined
         issuer?:
           | {
               account?: string | undefined
@@ -42140,7 +41232,6 @@ export type t_PostSubscriptionsRequestBody = {
                   usage_gte: number
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         discounts?:
@@ -42151,7 +41242,6 @@ export type t_PostSubscriptionsRequestBody = {
                   promotion_code?: string | undefined
                 }[]
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         metadata?: Record<string, string> | undefined
@@ -42182,12 +41272,12 @@ export type t_PostSubscriptionsRequestBody = {
             }
           | undefined
         quantity?: number | undefined
-        tax_rates?: (string[] | "" | UnknownEnumStringValue) | undefined
+        tax_rates?: (string[] | "") | undefined
       }[]
     | undefined
-  metadata?: (Record<string, string> | "" | UnknownEnumStringValue) | undefined
+  metadata?: (Record<string, string> | "") | undefined
   off_session?: boolean | undefined
-  on_behalf_of?: (string | "" | UnknownEnumStringValue) | undefined
+  on_behalf_of?: (string | "") | undefined
   payment_behavior?:
     | (
         | "allow_incomplete"
@@ -42225,7 +41315,6 @@ export type t_PostSubscriptionsRequestBody = {
                           | undefined
                       }
                     | ""
-                    | UnknownEnumStringValue
                   )
                 | undefined
               bancontact?:
@@ -42236,7 +41325,6 @@ export type t_PostSubscriptionsRequestBody = {
                           | undefined
                       }
                     | ""
-                    | UnknownEnumStringValue
                   )
                 | undefined
               card?:
@@ -42279,7 +41367,6 @@ export type t_PostSubscriptionsRequestBody = {
                           | undefined
                       }
                     | ""
-                    | UnknownEnumStringValue
                   )
                 | undefined
               customer_balance?:
@@ -42298,15 +41385,10 @@ export type t_PostSubscriptionsRequestBody = {
                         funding_type?: string | undefined
                       }
                     | ""
-                    | UnknownEnumStringValue
                   )
                 | undefined
-              konbini?:
-                | (Record<string, unknown> | "" | UnknownEnumStringValue)
-                | undefined
-              sepa_debit?:
-                | (Record<string, unknown> | "" | UnknownEnumStringValue)
-                | undefined
+              konbini?: (Record<string, unknown> | "") | undefined
+              sepa_debit?: (Record<string, unknown> | "") | undefined
               us_bank_account?:
                 | (
                     | {
@@ -42352,7 +41434,6 @@ export type t_PostSubscriptionsRequestBody = {
                           | undefined
                       }
                     | ""
-                    | UnknownEnumStringValue
                   )
                 | undefined
             }
@@ -42402,7 +41483,6 @@ export type t_PostSubscriptionsRequestBody = {
                   | UnknownEnumStringValue
                 )[]
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         save_default_payment_method?:
@@ -42417,7 +41497,6 @@ export type t_PostSubscriptionsRequestBody = {
             interval_count?: number | undefined
           }
         | ""
-        | UnknownEnumStringValue
       )
     | undefined
   proration_behavior?:
@@ -42429,7 +41508,7 @@ export type t_PostSubscriptionsRequestBody = {
         destination: string
       }
     | undefined
-  trial_end?: ("now" | UnknownEnumStringValue | number) | undefined
+  trial_end?: ("now" | number) | undefined
   trial_from_plan?: boolean | undefined
   trial_period_days?: number | undefined
   trial_settings?:
@@ -42473,10 +41552,10 @@ export type t_PostSubscriptionsSubscriptionExposedIdRequestBody = {
             }
           | undefined
         quantity?: number | undefined
-        tax_rates?: (string[] | "" | UnknownEnumStringValue) | undefined
+        tax_rates?: (string[] | "") | undefined
       }[]
     | undefined
-  application_fee_percent?: (number | "" | UnknownEnumStringValue) | undefined
+  application_fee_percent?: (number | "") | undefined
   automatic_tax?:
     | {
         enabled: boolean
@@ -42498,22 +41577,21 @@ export type t_PostSubscriptionsSubscriptionExposedIdRequestBody = {
             reset_billing_cycle_anchor?: boolean | undefined
           }
         | ""
-        | UnknownEnumStringValue
       )
     | undefined
   cancel_at?:
     | (
         | number
         | ""
-        | UnknownEnumStringValue
         | "max_period_end"
         | "min_period_end"
+        | UnknownEnumStringValue
       )
     | undefined
   cancel_at_period_end?: boolean | undefined
   cancellation_details?:
     | {
-        comment?: (string | "" | UnknownEnumStringValue) | undefined
+        comment?: (string | "") | undefined
         feedback?:
           | (
               | ""
@@ -42535,9 +41613,9 @@ export type t_PostSubscriptionsSubscriptionExposedIdRequestBody = {
     | undefined
   days_until_due?: number | undefined
   default_payment_method?: string | undefined
-  default_source?: (string | "" | UnknownEnumStringValue) | undefined
-  default_tax_rates?: (string[] | "" | UnknownEnumStringValue) | undefined
-  description?: (string | "" | UnknownEnumStringValue) | undefined
+  default_source?: (string | "") | undefined
+  default_tax_rates?: (string[] | "") | undefined
+  description?: (string | "") | undefined
   discounts?:
     | (
         | {
@@ -42546,13 +41624,12 @@ export type t_PostSubscriptionsSubscriptionExposedIdRequestBody = {
             promotion_code?: string | undefined
           }[]
         | ""
-        | UnknownEnumStringValue
       )
     | undefined
   expand?: string[] | undefined
   invoice_settings?:
     | {
-        account_tax_ids?: (string[] | "" | UnknownEnumStringValue) | undefined
+        account_tax_ids?: (string[] | "") | undefined
         issuer?:
           | {
               account?: string | undefined
@@ -42569,7 +41646,6 @@ export type t_PostSubscriptionsSubscriptionExposedIdRequestBody = {
                   usage_gte: number
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         clear_usage?: boolean | undefined
@@ -42582,13 +41658,10 @@ export type t_PostSubscriptionsSubscriptionExposedIdRequestBody = {
                   promotion_code?: string | undefined
                 }[]
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         id?: string | undefined
-        metadata?:
-          | (Record<string, string> | "" | UnknownEnumStringValue)
-          | undefined
+        metadata?: (Record<string, string> | "") | undefined
         price?: string | undefined
         price_data?:
           | {
@@ -42616,12 +41689,12 @@ export type t_PostSubscriptionsSubscriptionExposedIdRequestBody = {
             }
           | undefined
         quantity?: number | undefined
-        tax_rates?: (string[] | "" | UnknownEnumStringValue) | undefined
+        tax_rates?: (string[] | "") | undefined
       }[]
     | undefined
-  metadata?: (Record<string, string> | "" | UnknownEnumStringValue) | undefined
+  metadata?: (Record<string, string> | "") | undefined
   off_session?: boolean | undefined
-  on_behalf_of?: (string | "" | UnknownEnumStringValue) | undefined
+  on_behalf_of?: (string | "") | undefined
   pause_collection?:
     | (
         | {
@@ -42633,7 +41706,6 @@ export type t_PostSubscriptionsSubscriptionExposedIdRequestBody = {
             resumes_at?: number | undefined
           }
         | ""
-        | UnknownEnumStringValue
       )
     | undefined
   payment_behavior?:
@@ -42673,7 +41745,6 @@ export type t_PostSubscriptionsSubscriptionExposedIdRequestBody = {
                           | undefined
                       }
                     | ""
-                    | UnknownEnumStringValue
                   )
                 | undefined
               bancontact?:
@@ -42684,7 +41755,6 @@ export type t_PostSubscriptionsSubscriptionExposedIdRequestBody = {
                           | undefined
                       }
                     | ""
-                    | UnknownEnumStringValue
                   )
                 | undefined
               card?:
@@ -42727,7 +41797,6 @@ export type t_PostSubscriptionsSubscriptionExposedIdRequestBody = {
                           | undefined
                       }
                     | ""
-                    | UnknownEnumStringValue
                   )
                 | undefined
               customer_balance?:
@@ -42746,15 +41815,10 @@ export type t_PostSubscriptionsSubscriptionExposedIdRequestBody = {
                         funding_type?: string | undefined
                       }
                     | ""
-                    | UnknownEnumStringValue
                   )
                 | undefined
-              konbini?:
-                | (Record<string, unknown> | "" | UnknownEnumStringValue)
-                | undefined
-              sepa_debit?:
-                | (Record<string, unknown> | "" | UnknownEnumStringValue)
-                | undefined
+              konbini?: (Record<string, unknown> | "") | undefined
+              sepa_debit?: (Record<string, unknown> | "") | undefined
               us_bank_account?:
                 | (
                     | {
@@ -42800,7 +41864,6 @@ export type t_PostSubscriptionsSubscriptionExposedIdRequestBody = {
                           | undefined
                       }
                     | ""
-                    | UnknownEnumStringValue
                   )
                 | undefined
             }
@@ -42850,7 +41913,6 @@ export type t_PostSubscriptionsSubscriptionExposedIdRequestBody = {
                   | UnknownEnumStringValue
                 )[]
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         save_default_payment_method?:
@@ -42865,7 +41927,6 @@ export type t_PostSubscriptionsSubscriptionExposedIdRequestBody = {
             interval_count?: number | undefined
           }
         | ""
-        | UnknownEnumStringValue
       )
     | undefined
   proration_behavior?:
@@ -42879,10 +41940,9 @@ export type t_PostSubscriptionsSubscriptionExposedIdRequestBody = {
             destination: string
           }
         | ""
-        | UnknownEnumStringValue
       )
     | undefined
-  trial_end?: ("now" | UnknownEnumStringValue | number) | undefined
+  trial_end?: ("now" | number) | undefined
   trial_from_plan?: boolean | undefined
   trial_settings?:
     | {
@@ -42899,7 +41959,7 @@ export type t_PostSubscriptionsSubscriptionExposedIdRequestBody = {
 
 export type t_PostSubscriptionsSubscriptionMigrateRequestBody = {
   billing_mode: {
-    type: "flexible" | UnknownEnumStringValue
+    type: "flexible"
   }
   expand?: string[] | undefined
 }
@@ -42922,12 +41982,12 @@ export type t_PostTaxCalculationsRequestBody = {
     | {
         address?:
           | {
-              city?: (string | "" | UnknownEnumStringValue) | undefined
+              city?: (string | "") | undefined
               country: string
-              line1?: (string | "" | UnknownEnumStringValue) | undefined
-              line2?: (string | "" | UnknownEnumStringValue) | undefined
-              postal_code?: (string | "" | UnknownEnumStringValue) | undefined
-              state?: (string | "" | UnknownEnumStringValue) | undefined
+              line1?: (string | "") | undefined
+              line2?: (string | "") | undefined
+              postal_code?: (string | "") | undefined
+              state?: (string | "") | undefined
             }
           | undefined
         address_source?:
@@ -43076,12 +42136,12 @@ export type t_PostTaxCalculationsRequestBody = {
   ship_from_details?:
     | {
         address: {
-          city?: (string | "" | UnknownEnumStringValue) | undefined
+          city?: (string | "") | undefined
           country: string
-          line1?: (string | "" | UnknownEnumStringValue) | undefined
-          line2?: (string | "" | UnknownEnumStringValue) | undefined
-          postal_code?: (string | "" | UnknownEnumStringValue) | undefined
-          state?: (string | "" | UnknownEnumStringValue) | undefined
+          line1?: (string | "") | undefined
+          line2?: (string | "") | undefined
+          postal_code?: (string | "") | undefined
+          state?: (string | "") | undefined
         }
       }
     | undefined
@@ -43266,7 +42326,7 @@ export type t_PostTaxRatesTaxRateRequestBody = {
   display_name?: string | undefined
   expand?: string[] | undefined
   jurisdiction?: string | undefined
-  metadata?: (Record<string, string> | "" | UnknownEnumStringValue) | undefined
+  metadata?: (Record<string, string> | "") | undefined
   state?: string | undefined
   tax_type?:
     | (
@@ -43290,7 +42350,7 @@ export type t_PostTaxRatesTaxRateRequestBody = {
 }
 
 export type t_PostTaxRegistrationsRequestBody = {
-  active_from: "now" | UnknownEnumStringValue | number
+  active_from: "now" | number
   country: string
   country_options: {
     ae?:
@@ -43302,7 +42362,7 @@ export type t_PostTaxRegistrationsRequestBody = {
                   | undefined
               }
             | undefined
-          type: "standard" | UnknownEnumStringValue
+          type: "standard"
         }
       | undefined
     al?:
@@ -43314,12 +42374,12 @@ export type t_PostTaxRegistrationsRequestBody = {
                   | undefined
               }
             | undefined
-          type: "standard" | UnknownEnumStringValue
+          type: "standard"
         }
       | undefined
     am?:
       | {
-          type: "simplified" | UnknownEnumStringValue
+          type: "simplified"
         }
       | undefined
     ao?:
@@ -43331,7 +42391,7 @@ export type t_PostTaxRegistrationsRequestBody = {
                   | undefined
               }
             | undefined
-          type: "standard" | UnknownEnumStringValue
+          type: "standard"
         }
       | undefined
     at?:
@@ -43362,7 +42422,7 @@ export type t_PostTaxRegistrationsRequestBody = {
                   | undefined
               }
             | undefined
-          type: "standard" | UnknownEnumStringValue
+          type: "standard"
         }
       | undefined
     aw?:
@@ -43374,12 +42434,12 @@ export type t_PostTaxRegistrationsRequestBody = {
                   | undefined
               }
             | undefined
-          type: "standard" | UnknownEnumStringValue
+          type: "standard"
         }
       | undefined
     az?:
       | {
-          type: "simplified" | UnknownEnumStringValue
+          type: "simplified"
         }
       | undefined
     ba?:
@@ -43391,7 +42451,7 @@ export type t_PostTaxRegistrationsRequestBody = {
                   | undefined
               }
             | undefined
-          type: "standard" | UnknownEnumStringValue
+          type: "standard"
         }
       | undefined
     bb?:
@@ -43403,7 +42463,7 @@ export type t_PostTaxRegistrationsRequestBody = {
                   | undefined
               }
             | undefined
-          type: "standard" | UnknownEnumStringValue
+          type: "standard"
         }
       | undefined
     bd?:
@@ -43415,7 +42475,7 @@ export type t_PostTaxRegistrationsRequestBody = {
                   | undefined
               }
             | undefined
-          type: "standard" | UnknownEnumStringValue
+          type: "standard"
         }
       | undefined
     be?:
@@ -43446,7 +42506,7 @@ export type t_PostTaxRegistrationsRequestBody = {
                   | undefined
               }
             | undefined
-          type: "standard" | UnknownEnumStringValue
+          type: "standard"
         }
       | undefined
     bg?:
@@ -43477,12 +42537,12 @@ export type t_PostTaxRegistrationsRequestBody = {
                   | undefined
               }
             | undefined
-          type: "standard" | UnknownEnumStringValue
+          type: "standard"
         }
       | undefined
     bj?:
       | {
-          type: "simplified" | UnknownEnumStringValue
+          type: "simplified"
         }
       | undefined
     bs?:
@@ -43494,12 +42554,12 @@ export type t_PostTaxRegistrationsRequestBody = {
                   | undefined
               }
             | undefined
-          type: "standard" | UnknownEnumStringValue
+          type: "standard"
         }
       | undefined
     by?:
       | {
-          type: "simplified" | UnknownEnumStringValue
+          type: "simplified"
         }
       | undefined
     ca?:
@@ -43525,7 +42585,7 @@ export type t_PostTaxRegistrationsRequestBody = {
                   | undefined
               }
             | undefined
-          type: "standard" | UnknownEnumStringValue
+          type: "standard"
         }
       | undefined
     ch?:
@@ -43537,32 +42597,32 @@ export type t_PostTaxRegistrationsRequestBody = {
                   | undefined
               }
             | undefined
-          type: "standard" | UnknownEnumStringValue
+          type: "standard"
         }
       | undefined
     cl?:
       | {
-          type: "simplified" | UnknownEnumStringValue
+          type: "simplified"
         }
       | undefined
     cm?:
       | {
-          type: "simplified" | UnknownEnumStringValue
+          type: "simplified"
         }
       | undefined
     co?:
       | {
-          type: "simplified" | UnknownEnumStringValue
+          type: "simplified"
         }
       | undefined
     cr?:
       | {
-          type: "simplified" | UnknownEnumStringValue
+          type: "simplified"
         }
       | undefined
     cv?:
       | {
-          type: "simplified" | UnknownEnumStringValue
+          type: "simplified"
         }
       | undefined
     cy?:
@@ -43643,7 +42703,7 @@ export type t_PostTaxRegistrationsRequestBody = {
       | undefined
     ec?:
       | {
-          type: "simplified" | UnknownEnumStringValue
+          type: "simplified"
         }
       | undefined
     ee?:
@@ -43667,7 +42727,7 @@ export type t_PostTaxRegistrationsRequestBody = {
       | undefined
     eg?:
       | {
-          type: "simplified" | UnknownEnumStringValue
+          type: "simplified"
         }
       | undefined
     es?:
@@ -43698,7 +42758,7 @@ export type t_PostTaxRegistrationsRequestBody = {
                   | undefined
               }
             | undefined
-          type: "standard" | UnknownEnumStringValue
+          type: "standard"
         }
       | undefined
     fi?:
@@ -43748,12 +42808,12 @@ export type t_PostTaxRegistrationsRequestBody = {
                   | undefined
               }
             | undefined
-          type: "standard" | UnknownEnumStringValue
+          type: "standard"
         }
       | undefined
     ge?:
       | {
-          type: "simplified" | UnknownEnumStringValue
+          type: "simplified"
         }
       | undefined
     gn?:
@@ -43765,7 +42825,7 @@ export type t_PostTaxRegistrationsRequestBody = {
                   | undefined
               }
             | undefined
-          type: "standard" | UnknownEnumStringValue
+          type: "standard"
         }
       | undefined
     gr?:
@@ -43827,7 +42887,7 @@ export type t_PostTaxRegistrationsRequestBody = {
       | undefined
     id?:
       | {
-          type: "simplified" | UnknownEnumStringValue
+          type: "simplified"
         }
       | undefined
     ie?:
@@ -43851,7 +42911,7 @@ export type t_PostTaxRegistrationsRequestBody = {
       | undefined
     in?:
       | {
-          type: "simplified" | UnknownEnumStringValue
+          type: "simplified"
         }
       | undefined
     is?:
@@ -43863,7 +42923,7 @@ export type t_PostTaxRegistrationsRequestBody = {
                   | undefined
               }
             | undefined
-          type: "standard" | UnknownEnumStringValue
+          type: "standard"
         }
       | undefined
     it?:
@@ -43894,37 +42954,37 @@ export type t_PostTaxRegistrationsRequestBody = {
                   | undefined
               }
             | undefined
-          type: "standard" | UnknownEnumStringValue
+          type: "standard"
         }
       | undefined
     ke?:
       | {
-          type: "simplified" | UnknownEnumStringValue
+          type: "simplified"
         }
       | undefined
     kg?:
       | {
-          type: "simplified" | UnknownEnumStringValue
+          type: "simplified"
         }
       | undefined
     kh?:
       | {
-          type: "simplified" | UnknownEnumStringValue
+          type: "simplified"
         }
       | undefined
     kr?:
       | {
-          type: "simplified" | UnknownEnumStringValue
+          type: "simplified"
         }
       | undefined
     kz?:
       | {
-          type: "simplified" | UnknownEnumStringValue
+          type: "simplified"
         }
       | undefined
     la?:
       | {
-          type: "simplified" | UnknownEnumStringValue
+          type: "simplified"
         }
       | undefined
     lt?:
@@ -43986,12 +43046,12 @@ export type t_PostTaxRegistrationsRequestBody = {
       | undefined
     ma?:
       | {
-          type: "simplified" | UnknownEnumStringValue
+          type: "simplified"
         }
       | undefined
     md?:
       | {
-          type: "simplified" | UnknownEnumStringValue
+          type: "simplified"
         }
       | undefined
     me?:
@@ -44003,7 +43063,7 @@ export type t_PostTaxRegistrationsRequestBody = {
                   | undefined
               }
             | undefined
-          type: "standard" | UnknownEnumStringValue
+          type: "standard"
         }
       | undefined
     mk?:
@@ -44015,7 +43075,7 @@ export type t_PostTaxRegistrationsRequestBody = {
                   | undefined
               }
             | undefined
-          type: "standard" | UnknownEnumStringValue
+          type: "standard"
         }
       | undefined
     mr?:
@@ -44027,7 +43087,7 @@ export type t_PostTaxRegistrationsRequestBody = {
                   | undefined
               }
             | undefined
-          type: "standard" | UnknownEnumStringValue
+          type: "standard"
         }
       | undefined
     mt?:
@@ -44051,17 +43111,17 @@ export type t_PostTaxRegistrationsRequestBody = {
       | undefined
     mx?:
       | {
-          type: "simplified" | UnknownEnumStringValue
+          type: "simplified"
         }
       | undefined
     my?:
       | {
-          type: "simplified" | UnknownEnumStringValue
+          type: "simplified"
         }
       | undefined
     ng?:
       | {
-          type: "simplified" | UnknownEnumStringValue
+          type: "simplified"
         }
       | undefined
     nl?:
@@ -44092,12 +43152,12 @@ export type t_PostTaxRegistrationsRequestBody = {
                   | undefined
               }
             | undefined
-          type: "standard" | UnknownEnumStringValue
+          type: "standard"
         }
       | undefined
     np?:
       | {
-          type: "simplified" | UnknownEnumStringValue
+          type: "simplified"
         }
       | undefined
     nz?:
@@ -44109,7 +43169,7 @@ export type t_PostTaxRegistrationsRequestBody = {
                   | undefined
               }
             | undefined
-          type: "standard" | UnknownEnumStringValue
+          type: "standard"
         }
       | undefined
     om?:
@@ -44121,17 +43181,17 @@ export type t_PostTaxRegistrationsRequestBody = {
                   | undefined
               }
             | undefined
-          type: "standard" | UnknownEnumStringValue
+          type: "standard"
         }
       | undefined
     pe?:
       | {
-          type: "simplified" | UnknownEnumStringValue
+          type: "simplified"
         }
       | undefined
     ph?:
       | {
-          type: "simplified" | UnknownEnumStringValue
+          type: "simplified"
         }
       | undefined
     pl?:
@@ -44200,17 +43260,17 @@ export type t_PostTaxRegistrationsRequestBody = {
                   | undefined
               }
             | undefined
-          type: "standard" | UnknownEnumStringValue
+          type: "standard"
         }
       | undefined
     ru?:
       | {
-          type: "simplified" | UnknownEnumStringValue
+          type: "simplified"
         }
       | undefined
     sa?:
       | {
-          type: "simplified" | UnknownEnumStringValue
+          type: "simplified"
         }
       | undefined
     se?:
@@ -44241,7 +43301,7 @@ export type t_PostTaxRegistrationsRequestBody = {
                   | undefined
               }
             | undefined
-          type: "standard" | UnknownEnumStringValue
+          type: "standard"
         }
       | undefined
     si?:
@@ -44284,7 +43344,7 @@ export type t_PostTaxRegistrationsRequestBody = {
       | undefined
     sn?:
       | {
-          type: "simplified" | UnknownEnumStringValue
+          type: "simplified"
         }
       | undefined
     sr?:
@@ -44296,37 +43356,37 @@ export type t_PostTaxRegistrationsRequestBody = {
                   | undefined
               }
             | undefined
-          type: "standard" | UnknownEnumStringValue
+          type: "standard"
         }
       | undefined
     th?:
       | {
-          type: "simplified" | UnknownEnumStringValue
+          type: "simplified"
         }
       | undefined
     tj?:
       | {
-          type: "simplified" | UnknownEnumStringValue
+          type: "simplified"
         }
       | undefined
     tr?:
       | {
-          type: "simplified" | UnknownEnumStringValue
+          type: "simplified"
         }
       | undefined
     tz?:
       | {
-          type: "simplified" | UnknownEnumStringValue
+          type: "simplified"
         }
       | undefined
     ua?:
       | {
-          type: "simplified" | UnknownEnumStringValue
+          type: "simplified"
         }
       | undefined
     ug?:
       | {
-          type: "simplified" | UnknownEnumStringValue
+          type: "simplified"
         }
       | undefined
     us?:
@@ -44372,17 +43432,17 @@ export type t_PostTaxRegistrationsRequestBody = {
                   | undefined
               }
             | undefined
-          type: "standard" | UnknownEnumStringValue
+          type: "standard"
         }
       | undefined
     uz?:
       | {
-          type: "simplified" | UnknownEnumStringValue
+          type: "simplified"
         }
       | undefined
     vn?:
       | {
-          type: "simplified" | UnknownEnumStringValue
+          type: "simplified"
         }
       | undefined
     za?:
@@ -44394,12 +43454,12 @@ export type t_PostTaxRegistrationsRequestBody = {
                   | undefined
               }
             | undefined
-          type: "standard" | UnknownEnumStringValue
+          type: "standard"
         }
       | undefined
     zm?:
       | {
-          type: "simplified" | UnknownEnumStringValue
+          type: "simplified"
         }
       | undefined
     zw?:
@@ -44411,7 +43471,7 @@ export type t_PostTaxRegistrationsRequestBody = {
                   | undefined
               }
             | undefined
-          type: "standard" | UnknownEnumStringValue
+          type: "standard"
         }
       | undefined
   }
@@ -44420,9 +43480,9 @@ export type t_PostTaxRegistrationsRequestBody = {
 }
 
 export type t_PostTaxRegistrationsIdRequestBody = {
-  active_from?: ("now" | UnknownEnumStringValue | number) | undefined
+  active_from?: ("now" | number) | undefined
   expand?: string[] | undefined
-  expires_at?: ("now" | UnknownEnumStringValue | number | "") | undefined
+  expires_at?: ("now" | number | "") | undefined
 }
 
 export type t_PostTaxSettingsRequestBody = {
@@ -44490,7 +43550,7 @@ export type t_PostTaxTransactionsCreateReversalRequestBody = {
 export type t_PostTerminalConfigurationsRequestBody = {
   bbpos_wisepos_e?:
     | {
-        splashscreen?: (string | "" | UnknownEnumStringValue) | undefined
+        splashscreen?: (string | "") | undefined
       }
     | undefined
   expand?: string[] | undefined
@@ -44501,7 +43561,6 @@ export type t_PostTerminalConfigurationsRequestBody = {
             enabled: boolean
           }
         | ""
-        | UnknownEnumStringValue
       )
     | undefined
   reboot_window?:
@@ -44512,7 +43571,7 @@ export type t_PostTerminalConfigurationsRequestBody = {
     | undefined
   stripe_s700?:
     | {
-        splashscreen?: (string | "" | UnknownEnumStringValue) | undefined
+        splashscreen?: (string | "") | undefined
       }
     | undefined
   tipping?:
@@ -44660,12 +43719,11 @@ export type t_PostTerminalConfigurationsRequestBody = {
               | undefined
           }
         | ""
-        | UnknownEnumStringValue
       )
     | undefined
   verifone_p400?:
     | {
-        splashscreen?: (string | "" | UnknownEnumStringValue) | undefined
+        splashscreen?: (string | "") | undefined
       }
     | undefined
   wifi?:
@@ -44701,7 +43759,6 @@ export type t_PostTerminalConfigurationsRequestBody = {
               | UnknownEnumStringValue
           }
         | ""
-        | UnknownEnumStringValue
       )
     | undefined
 }
@@ -44710,10 +43767,9 @@ export type t_PostTerminalConfigurationsConfigurationRequestBody = {
   bbpos_wisepos_e?:
     | (
         | {
-            splashscreen?: (string | "" | UnknownEnumStringValue) | undefined
+            splashscreen?: (string | "") | undefined
           }
         | ""
-        | UnknownEnumStringValue
       )
     | undefined
   expand?: string[] | undefined
@@ -44724,7 +43780,6 @@ export type t_PostTerminalConfigurationsConfigurationRequestBody = {
             enabled: boolean
           }
         | ""
-        | UnknownEnumStringValue
       )
     | undefined
   reboot_window?:
@@ -44734,16 +43789,14 @@ export type t_PostTerminalConfigurationsConfigurationRequestBody = {
             start_hour: number
           }
         | ""
-        | UnknownEnumStringValue
       )
     | undefined
   stripe_s700?:
     | (
         | {
-            splashscreen?: (string | "" | UnknownEnumStringValue) | undefined
+            splashscreen?: (string | "") | undefined
           }
         | ""
-        | UnknownEnumStringValue
       )
     | undefined
   tipping?:
@@ -44891,16 +43944,14 @@ export type t_PostTerminalConfigurationsConfigurationRequestBody = {
               | undefined
           }
         | ""
-        | UnknownEnumStringValue
       )
     | undefined
   verifone_p400?:
     | (
         | {
-            splashscreen?: (string | "" | UnknownEnumStringValue) | undefined
+            splashscreen?: (string | "") | undefined
           }
         | ""
-        | UnknownEnumStringValue
       )
     | undefined
   wifi?:
@@ -44936,7 +43987,6 @@ export type t_PostTerminalConfigurationsConfigurationRequestBody = {
               | UnknownEnumStringValue
           }
         | ""
-        | UnknownEnumStringValue
       )
     | undefined
 }
@@ -44958,7 +44008,7 @@ export type t_PostTerminalLocationsRequestBody = {
   configuration_overrides?: string | undefined
   display_name: string
   expand?: string[] | undefined
-  metadata?: (Record<string, string> | "" | UnknownEnumStringValue) | undefined
+  metadata?: (Record<string, string> | "") | undefined
 }
 
 export type t_PostTerminalLocationsLocationRequestBody = {
@@ -44972,24 +44022,24 @@ export type t_PostTerminalLocationsLocationRequestBody = {
         state?: string | undefined
       }
     | undefined
-  configuration_overrides?: (string | "" | UnknownEnumStringValue) | undefined
-  display_name?: (string | "" | UnknownEnumStringValue) | undefined
+  configuration_overrides?: (string | "") | undefined
+  display_name?: (string | "") | undefined
   expand?: string[] | undefined
-  metadata?: (Record<string, string> | "" | UnknownEnumStringValue) | undefined
+  metadata?: (Record<string, string> | "") | undefined
 }
 
 export type t_PostTerminalReadersRequestBody = {
   expand?: string[] | undefined
   label?: string | undefined
   location?: string | undefined
-  metadata?: (Record<string, string> | "" | UnknownEnumStringValue) | undefined
+  metadata?: (Record<string, string> | "") | undefined
   registration_code: string
 }
 
 export type t_PostTerminalReadersReaderRequestBody = {
   expand?: string[] | undefined
-  label?: (string | "" | UnknownEnumStringValue) | undefined
-  metadata?: (Record<string, string> | "" | UnknownEnumStringValue) | undefined
+  label?: (string | "") | undefined
+  metadata?: (Record<string, string> | "") | undefined
 }
 
 export type t_PostTerminalReadersReaderCancelActionRequestBody = {
@@ -45127,7 +44177,7 @@ export type t_PostTerminalReadersReaderSetReaderDisplayRequestBody = {
       }
     | undefined
   expand?: string[] | undefined
-  type: "cart" | UnknownEnumStringValue
+  type: "cart"
 }
 
 export type t_PostTestHelpersConfirmationTokensRequestBody = {
@@ -45177,12 +44227,11 @@ export type t_PostTestHelpersConfirmationTokensRequestBody = {
                         state?: string | undefined
                       }
                     | ""
-                    | UnknownEnumStringValue
                   )
                 | undefined
-              email?: (string | "" | UnknownEnumStringValue) | undefined
-              name?: (string | "" | UnknownEnumStringValue) | undefined
-              phone?: (string | "" | UnknownEnumStringValue) | undefined
+              email?: (string | "") | undefined
+              name?: (string | "") | undefined
+              phone?: (string | "") | undefined
               tax_id?: string | undefined
             }
           | undefined
@@ -45465,7 +44514,7 @@ export type t_PostTestHelpersConfirmationTokensRequestBody = {
                 | {
                     plan: {
                       count?: number | undefined
-                      interval?: ("month" | UnknownEnumStringValue) | undefined
+                      interval?: "month" | undefined
                       type:
                         | "bonus"
                         | "fixed_count"
@@ -45493,7 +44542,7 @@ export type t_PostTestHelpersConfirmationTokensRequestBody = {
           state?: string | undefined
         }
         name: string
-        phone?: (string | "" | UnknownEnumStringValue) | undefined
+        phone?: (string | "") | undefined
       }
     | undefined
 }
@@ -47344,7 +46393,7 @@ export type t_PostTestHelpersTreasuryReceivedCreditsRequestBody = {
   financial_account: string
   initiating_payment_method_details?:
     | {
-        type: "us_bank_account" | UnknownEnumStringValue
+        type: "us_bank_account"
         us_bank_account?:
           | {
               account_holder_name?: string | undefined
@@ -47365,7 +46414,7 @@ export type t_PostTestHelpersTreasuryReceivedDebitsRequestBody = {
   financial_account: string
   initiating_payment_method_details?:
     | {
-        type: "us_bank_account" | UnknownEnumStringValue
+        type: "us_bank_account"
         us_bank_account?:
           | {
               account_holder_name?: string | undefined
@@ -47375,7 +46424,7 @@ export type t_PostTestHelpersTreasuryReceivedDebitsRequestBody = {
           | undefined
       }
     | undefined
-  network: "ach" | UnknownEnumStringValue
+  network: "ach"
 }
 
 export type t_PostTokensRequestBody = {
@@ -47464,7 +46513,6 @@ export type t_PostTokensRequestBody = {
                         year: number
                       }
                     | ""
-                    | UnknownEnumStringValue
                   )
                 | undefined
               registration_number?: string | undefined
@@ -47554,16 +46602,13 @@ export type t_PostTokensRequestBody = {
                         year: number
                       }
                     | ""
-                    | UnknownEnumStringValue
                   )
                 | undefined
               email?: string | undefined
               first_name?: string | undefined
               first_name_kana?: string | undefined
               first_name_kanji?: string | undefined
-              full_name_aliases?:
-                | (string[] | "" | UnknownEnumStringValue)
-                | undefined
+              full_name_aliases?: (string[] | "") | undefined
               gender?: string | undefined
               id_number?: string | undefined
               id_number_secondary?: string | undefined
@@ -47571,9 +46616,7 @@ export type t_PostTokensRequestBody = {
               last_name_kana?: string | undefined
               last_name_kanji?: string | undefined
               maiden_name?: string | undefined
-              metadata?:
-                | (Record<string, string> | "" | UnknownEnumStringValue)
-                | undefined
+              metadata?: (Record<string, string> | "") | undefined
               phone?: string | undefined
               political_exposure?:
                 | ("existing" | "none" | UnknownEnumStringValue)
@@ -47593,9 +46636,7 @@ export type t_PostTokensRequestBody = {
                     director?: boolean | undefined
                     executive?: boolean | undefined
                     owner?: boolean | undefined
-                    percent_ownership?:
-                      | (number | "" | UnknownEnumStringValue)
-                      | undefined
+                    percent_ownership?: (number | "") | undefined
                     title?: string | undefined
                   }
                 | undefined
@@ -47683,9 +46724,7 @@ export type t_PostTokensRequestBody = {
                 | {
                     date?: number | undefined
                     ip?: string | undefined
-                    user_agent?:
-                      | (string | "" | UnknownEnumStringValue)
-                      | undefined
+                    user_agent?: (string | "") | undefined
                   }
                 | undefined
             }
@@ -47730,24 +46769,23 @@ export type t_PostTokensRequestBody = {
                   year: number
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
         documents?:
           | {
               company_authorization?:
                 | {
-                    files?: (string | "" | UnknownEnumStringValue)[] | undefined
+                    files?: (string | "")[] | undefined
                   }
                 | undefined
               passport?:
                 | {
-                    files?: (string | "" | UnknownEnumStringValue)[] | undefined
+                    files?: (string | "")[] | undefined
                   }
                 | undefined
               visa?:
                 | {
-                    files?: (string | "" | UnknownEnumStringValue)[] | undefined
+                    files?: (string | "")[] | undefined
                   }
                 | undefined
             }
@@ -47756,7 +46794,7 @@ export type t_PostTokensRequestBody = {
         first_name?: string | undefined
         first_name_kana?: string | undefined
         first_name_kanji?: string | undefined
-        full_name_aliases?: (string[] | "" | UnknownEnumStringValue) | undefined
+        full_name_aliases?: (string[] | "") | undefined
         gender?: string | undefined
         id_number?: string | undefined
         id_number_secondary?: string | undefined
@@ -47764,9 +46802,7 @@ export type t_PostTokensRequestBody = {
         last_name_kana?: string | undefined
         last_name_kanji?: string | undefined
         maiden_name?: string | undefined
-        metadata?:
-          | (Record<string, string> | "" | UnknownEnumStringValue)
-          | undefined
+        metadata?: (Record<string, string> | "") | undefined
         nationality?: string | undefined
         phone?: string | undefined
         political_exposure?:
@@ -47789,9 +46825,7 @@ export type t_PostTokensRequestBody = {
               executive?: boolean | undefined
               legal_guardian?: boolean | undefined
               owner?: boolean | undefined
-              percent_ownership?:
-                | (number | "" | UnknownEnumStringValue)
-                | undefined
+              percent_ownership?: (number | "") | undefined
               representative?: boolean | undefined
               title?: string | undefined
             }
@@ -47883,7 +46917,7 @@ export type t_PostTopupsRequestBody = {
   currency: string
   description?: string | undefined
   expand?: string[] | undefined
-  metadata?: (Record<string, string> | "" | UnknownEnumStringValue) | undefined
+  metadata?: (Record<string, string> | "") | undefined
   source?: string | undefined
   statement_descriptor?: string | undefined
   transfer_group?: string | undefined
@@ -47892,7 +46926,7 @@ export type t_PostTopupsRequestBody = {
 export type t_PostTopupsTopupRequestBody = {
   description?: string | undefined
   expand?: string[] | undefined
-  metadata?: (Record<string, string> | "" | UnknownEnumStringValue) | undefined
+  metadata?: (Record<string, string> | "") | undefined
 }
 
 export type t_PostTopupsTopupCancelRequestBody = {
@@ -47917,19 +46951,19 @@ export type t_PostTransfersIdReversalsRequestBody = {
   amount?: number | undefined
   description?: string | undefined
   expand?: string[] | undefined
-  metadata?: (Record<string, string> | "" | UnknownEnumStringValue) | undefined
+  metadata?: (Record<string, string> | "") | undefined
   refund_application_fee?: boolean | undefined
 }
 
 export type t_PostTransfersTransferRequestBody = {
   description?: string | undefined
   expand?: string[] | undefined
-  metadata?: (Record<string, string> | "" | UnknownEnumStringValue) | undefined
+  metadata?: (Record<string, string> | "") | undefined
 }
 
 export type t_PostTransfersTransferReversalsIdRequestBody = {
   expand?: string[] | undefined
-  metadata?: (Record<string, string> | "" | UnknownEnumStringValue) | undefined
+  metadata?: (Record<string, string> | "") | undefined
 }
 
 export type t_PostTreasuryCreditReversalsRequestBody = {
@@ -48012,7 +47046,7 @@ export type t_PostTreasuryFinancialAccountsRequestBody = {
       }
     | undefined
   metadata?: Record<string, string> | undefined
-  nickname?: (string | "" | UnknownEnumStringValue) | undefined
+  nickname?: (string | "") | undefined
   platform_restrictions?:
     | {
         inbound_flows?:
@@ -48101,7 +47135,7 @@ export type t_PostTreasuryFinancialAccountsFinancialAccountRequestBody = {
       }
     | undefined
   metadata?: Record<string, string> | undefined
-  nickname?: (string | "" | UnknownEnumStringValue) | undefined
+  nickname?: (string | "") | undefined
   platform_restrictions?:
     | {
         inbound_flows?:
@@ -48227,12 +47261,11 @@ export type t_PostTreasuryOutboundPaymentsRequestBody = {
                         state?: string | undefined
                       }
                     | ""
-                    | UnknownEnumStringValue
                   )
                 | undefined
-              email?: (string | "" | UnknownEnumStringValue) | undefined
-              name?: (string | "" | UnknownEnumStringValue) | undefined
-              phone?: (string | "" | UnknownEnumStringValue) | undefined
+              email?: (string | "") | undefined
+              name?: (string | "") | undefined
+              phone?: (string | "") | undefined
             }
           | undefined
         financial_account?: string | undefined
@@ -48263,7 +47296,6 @@ export type t_PostTreasuryOutboundPaymentsRequestBody = {
                     | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
       }
@@ -48292,7 +47324,7 @@ export type t_PostTreasuryOutboundTransfersRequestBody = {
   destination_payment_method_data?:
     | {
         financial_account?: string | undefined
-        type: "financial_account" | UnknownEnumStringValue
+        type: "financial_account"
       }
     | undefined
   destination_payment_method_options?:
@@ -48305,7 +47337,6 @@ export type t_PostTreasuryOutboundTransfersRequestBody = {
                     | undefined
                 }
               | ""
-              | UnknownEnumStringValue
             )
           | undefined
       }
@@ -48441,7 +47472,7 @@ export type t_PostWebhookEndpointsRequestBody = {
       )
     | undefined
   connect?: boolean | undefined
-  description?: (string | "" | UnknownEnumStringValue) | undefined
+  description?: (string | "") | undefined
   enabled_events: (
     | "*"
     | "account.application.authorized"
@@ -48689,12 +47720,12 @@ export type t_PostWebhookEndpointsRequestBody = {
     | UnknownEnumStringValue
   )[]
   expand?: string[] | undefined
-  metadata?: (Record<string, string> | "" | UnknownEnumStringValue) | undefined
+  metadata?: (Record<string, string> | "") | undefined
   url: string
 }
 
 export type t_PostWebhookEndpointsWebhookEndpointRequestBody = {
-  description?: (string | "" | UnknownEnumStringValue) | undefined
+  description?: (string | "") | undefined
   disabled?: boolean | undefined
   enabled_events?:
     | (
@@ -48945,6 +47976,6 @@ export type t_PostWebhookEndpointsWebhookEndpointRequestBody = {
       )[]
     | undefined
   expand?: string[] | undefined
-  metadata?: (Record<string, string> | "" | UnknownEnumStringValue) | undefined
+  metadata?: (Record<string, string> | "") | undefined
   url?: string | undefined
 }

--- a/integration-tests/typescript-express/src/generated/api.github.com.yaml/generated.ts
+++ b/integration-tests/typescript-express/src/generated/api.github.com.yaml/generated.ts
@@ -24428,7 +24428,7 @@ export function createRouter(
     ecosystem: z.string().optional(),
     package: z.string().optional(),
     epss_percentage: z.string().optional(),
-    has: z.union([z.string(), z.array(z.enum(["patch"]))]).optional(),
+    has: z.union([z.string(), z.array(z.literal("patch"))]).optional(),
     scope: z.enum(["development", "runtime"]).optional(),
     sort: z
       .enum(["created", "updated", "epss_percentage"])
@@ -35269,7 +35269,7 @@ export function createRouter(
     ecosystem: z.string().optional(),
     package: z.string().optional(),
     epss_percentage: z.string().optional(),
-    has: z.union([z.string(), z.array(z.enum(["patch"]))]).optional(),
+    has: z.union([z.string(), z.array(z.literal("patch"))]).optional(),
     scope: z.enum(["development", "runtime"]).optional(),
     sort: z
       .enum(["created", "updated", "epss_percentage"])
@@ -38756,7 +38756,7 @@ export function createRouter(
     exclude: z
       .preprocess(
         (it: unknown) => (Array.isArray(it) || it === undefined ? it : [it]),
-        z.array(z.enum(["repositories"])),
+        z.array(z.literal("repositories")),
       )
       .optional(),
   })
@@ -38870,7 +38870,7 @@ export function createRouter(
     exclude: z
       .preprocess(
         (it: unknown) => (Array.isArray(it) || it === undefined ? it : [it]),
-        z.array(z.enum(["repositories"])),
+        z.array(z.literal("repositories")),
       )
       .optional(),
   })
@@ -40507,7 +40507,7 @@ export function createRouter(
   const orgsListPatGrantRequestsQuerySchema = z.object({
     per_page: z.coerce.number().optional().default(30),
     page: z.coerce.number().optional().default(1),
-    sort: z.enum(["created_at"]).optional().default("created_at"),
+    sort: z.literal("created_at").optional().default("created_at"),
     direction: z.enum(["asc", "desc"]).optional().default("desc"),
     owner: z
       .preprocess(
@@ -40815,7 +40815,7 @@ export function createRouter(
   const orgsListPatGrantsQuerySchema = z.object({
     per_page: z.coerce.number().optional().default(30),
     page: z.coerce.number().optional().default(1),
-    sort: z.enum(["created_at"]).optional().default("created_at"),
+    sort: z.literal("created_at").optional().default("created_at"),
     direction: z.enum(["asc", "desc"]).optional().default("desc"),
     owner: z
       .preprocess(
@@ -55975,7 +55975,7 @@ export function createRouter(
     ref: s_code_scanning_ref.optional(),
     sarif_id: s_code_scanning_analysis_sarif_id.optional(),
     direction: z.enum(["asc", "desc"]).optional().default("desc"),
-    sort: z.enum(["created"]).optional().default("created"),
+    sort: z.literal("created").optional().default("created"),
   })
 
   const codeScanningListRecentAnalysesResponseBodyValidator =
@@ -59900,7 +59900,7 @@ export function createRouter(
     package: z.string().optional(),
     manifest: z.string().optional(),
     epss_percentage: z.string().optional(),
-    has: z.union([z.string(), z.array(z.enum(["patch"]))]).optional(),
+    has: z.union([z.string(), z.array(z.literal("patch"))]).optional(),
     scope: z.enum(["development", "runtime"]).optional(),
     sort: z
       .enum(["created", "updated", "epss_percentage"])
@@ -75887,7 +75887,7 @@ export function createRouter(
 
   const searchCodeQuerySchema = z.object({
     q: z.string(),
-    sort: z.enum(["indexed"]).optional(),
+    sort: z.literal("indexed").optional(),
     order: z.enum(["desc", "asc"]).optional().default("desc"),
     per_page: z.coerce.number().optional().default(30),
     page: z.coerce.number().optional().default(1),

--- a/integration-tests/typescript-express/src/generated/api.github.com.yaml/schemas.ts
+++ b/integration-tests/typescript-express/src/generated/api.github.com.yaml/schemas.ts
@@ -267,21 +267,21 @@ export const s_app_permissions = z.object({
   single_file: z.enum(["read", "write"]).optional(),
   statuses: z.enum(["read", "write"]).optional(),
   vulnerability_alerts: z.enum(["read", "write"]).optional(),
-  workflows: z.enum(["write"]).optional(),
+  workflows: z.literal("write").optional(),
   members: z.enum(["read", "write"]).optional(),
   organization_administration: z.enum(["read", "write"]).optional(),
   organization_custom_roles: z.enum(["read", "write"]).optional(),
   organization_custom_org_roles: z.enum(["read", "write"]).optional(),
   organization_custom_properties: z.enum(["read", "write", "admin"]).optional(),
-  organization_copilot_seat_management: z.enum(["write"]).optional(),
+  organization_copilot_seat_management: z.literal("write").optional(),
   organization_announcement_banners: z.enum(["read", "write"]).optional(),
-  organization_events: z.enum(["read"]).optional(),
+  organization_events: z.literal("read").optional(),
   organization_hooks: z.enum(["read", "write"]).optional(),
   organization_personal_access_tokens: z.enum(["read", "write"]).optional(),
   organization_personal_access_token_requests: z
     .enum(["read", "write"])
     .optional(),
-  organization_plan: z.enum(["read"]).optional(),
+  organization_plan: z.literal("read").optional(),
   organization_projects: z.enum(["read", "write", "admin"]).optional(),
   organization_packages: z.enum(["read", "write"]).optional(),
   organization_secrets: z.enum(["read", "write"]).optional(),
@@ -293,7 +293,7 @@ export const s_app_permissions = z.object({
   git_ssh_keys: z.enum(["read", "write"]).optional(),
   gpg_keys: z.enum(["read", "write"]).optional(),
   interaction_limits: z.enum(["read", "write"]).optional(),
-  profile: z.enum(["write"]).optional(),
+  profile: z.literal("write").optional(),
   starring: z.enum(["read", "write"]).optional(),
 })
 
@@ -705,7 +705,7 @@ export const s_code_scanning_default_setup = z.object({
   query_suite: z.enum(["default", "extended"]).optional(),
   threat_model: z.enum(["remote", "remote_and_local"]).optional(),
   updated_at: z.iso.datetime({offset: true}).nullable().optional(),
-  schedule: z.enum(["weekly"]).nullable().optional(),
+  schedule: z.literal("weekly").nullable().optional(),
 })
 
 export const s_code_scanning_default_setup_options = z
@@ -1004,7 +1004,7 @@ export const s_content_directory = z.array(
 )
 
 export const s_content_file = z.object({
-  type: z.enum(["file"]),
+  type: z.literal("file"),
   encoding: z.string(),
   size: z.coerce.number(),
   name: z.string(),
@@ -1025,7 +1025,7 @@ export const s_content_file = z.object({
 })
 
 export const s_content_submodule = z.object({
-  type: z.enum(["submodule"]),
+  type: z.literal("submodule"),
   submodule_git_url: z.string(),
   size: z.coerce.number(),
   name: z.string(),
@@ -1043,7 +1043,7 @@ export const s_content_submodule = z.object({
 })
 
 export const s_content_symlink = z.object({
-  type: z.enum(["symlink"]),
+  type: z.literal("symlink"),
   target: z.string(),
   size: z.coerce.number(),
   name: z.string(),
@@ -2777,7 +2777,7 @@ export const s_repo_codespaces_secret = z.object({
 })
 
 export const s_repository_rule_branch_name_pattern = z.object({
-  type: z.enum(["branch_name_pattern"]),
+  type: z.literal("branch_name_pattern"),
   parameters: z
     .object({
       name: z.string().optional(),
@@ -2789,7 +2789,7 @@ export const s_repository_rule_branch_name_pattern = z.object({
 })
 
 export const s_repository_rule_commit_author_email_pattern = z.object({
-  type: z.enum(["commit_author_email_pattern"]),
+  type: z.literal("commit_author_email_pattern"),
   parameters: z
     .object({
       name: z.string().optional(),
@@ -2801,7 +2801,7 @@ export const s_repository_rule_commit_author_email_pattern = z.object({
 })
 
 export const s_repository_rule_commit_message_pattern = z.object({
-  type: z.enum(["commit_message_pattern"]),
+  type: z.literal("commit_message_pattern"),
   parameters: z
     .object({
       name: z.string().optional(),
@@ -2813,7 +2813,7 @@ export const s_repository_rule_commit_message_pattern = z.object({
 })
 
 export const s_repository_rule_committer_email_pattern = z.object({
-  type: z.enum(["committer_email_pattern"]),
+  type: z.literal("committer_email_pattern"),
   parameters: z
     .object({
       name: z.string().optional(),
@@ -2824,9 +2824,13 @@ export const s_repository_rule_committer_email_pattern = z.object({
     .optional(),
 })
 
-export const s_repository_rule_creation = z.object({type: z.enum(["creation"])})
+export const s_repository_rule_creation = z.object({
+  type: z.literal("creation"),
+})
 
-export const s_repository_rule_deletion = z.object({type: z.enum(["deletion"])})
+export const s_repository_rule_deletion = z.object({
+  type: z.literal("deletion"),
+})
 
 export const s_repository_rule_enforcement = z.enum([
   "disabled",
@@ -2835,33 +2839,33 @@ export const s_repository_rule_enforcement = z.enum([
 ])
 
 export const s_repository_rule_file_extension_restriction = z.object({
-  type: z.enum(["file_extension_restriction"]),
+  type: z.literal("file_extension_restriction"),
   parameters: z
     .object({restricted_file_extensions: z.array(z.string())})
     .optional(),
 })
 
 export const s_repository_rule_file_path_restriction = z.object({
-  type: z.enum(["file_path_restriction"]),
+  type: z.literal("file_path_restriction"),
   parameters: z.object({restricted_file_paths: z.array(z.string())}).optional(),
 })
 
 export const s_repository_rule_max_file_path_length = z.object({
-  type: z.enum(["max_file_path_length"]),
+  type: z.literal("max_file_path_length"),
   parameters: z
     .object({max_file_path_length: z.coerce.number().min(1).max(32767)})
     .optional(),
 })
 
 export const s_repository_rule_max_file_size = z.object({
-  type: z.enum(["max_file_size"]),
+  type: z.literal("max_file_size"),
   parameters: z
     .object({max_file_size: z.coerce.number().min(1).max(100)})
     .optional(),
 })
 
 export const s_repository_rule_merge_queue = z.object({
-  type: z.enum(["merge_queue"]),
+  type: z.literal("merge_queue"),
   parameters: z
     .object({
       check_response_timeout_minutes: z.coerce.number().min(1).max(360),
@@ -2876,7 +2880,7 @@ export const s_repository_rule_merge_queue = z.object({
 })
 
 export const s_repository_rule_non_fast_forward = z.object({
-  type: z.enum(["non_fast_forward"]),
+  type: z.literal("non_fast_forward"),
 })
 
 export const s_repository_rule_params_code_scanning_tool = z.object({
@@ -2904,7 +2908,7 @@ export const s_repository_rule_params_workflow_file_reference = z.object({
 })
 
 export const s_repository_rule_pull_request = z.object({
-  type: z.enum(["pull_request"]),
+  type: z.literal("pull_request"),
   parameters: z
     .object({
       allowed_merge_methods: z
@@ -2921,18 +2925,18 @@ export const s_repository_rule_pull_request = z.object({
 })
 
 export const s_repository_rule_required_deployments = z.object({
-  type: z.enum(["required_deployments"]),
+  type: z.literal("required_deployments"),
   parameters: z
     .object({required_deployment_environments: z.array(z.string())})
     .optional(),
 })
 
 export const s_repository_rule_required_linear_history = z.object({
-  type: z.enum(["required_linear_history"]),
+  type: z.literal("required_linear_history"),
 })
 
 export const s_repository_rule_required_signatures = z.object({
-  type: z.enum(["required_signatures"]),
+  type: z.literal("required_signatures"),
 })
 
 export const s_repository_rule_ruleset_info = z.object({
@@ -2942,7 +2946,7 @@ export const s_repository_rule_ruleset_info = z.object({
 })
 
 export const s_repository_rule_tag_name_pattern = z.object({
-  type: z.enum(["tag_name_pattern"]),
+  type: z.literal("tag_name_pattern"),
   parameters: z
     .object({
       name: z.string().optional(),
@@ -2954,7 +2958,7 @@ export const s_repository_rule_tag_name_pattern = z.object({
 })
 
 export const s_repository_rule_update = z.object({
-  type: z.enum(["update"]),
+  type: z.literal("update"),
   parameters: z
     .object({update_allows_fetch_and_merge: PermissiveBoolean})
     .optional(),
@@ -5341,7 +5345,7 @@ export const s_repository_collaborator_permission = z.object({
 })
 
 export const s_repository_rule_code_scanning = z.object({
-  type: z.enum(["code_scanning"]),
+  type: z.literal("code_scanning"),
   parameters: z
     .object({
       code_scanning_tools: z.array(s_repository_rule_params_code_scanning_tool),
@@ -5350,7 +5354,7 @@ export const s_repository_rule_code_scanning = z.object({
 })
 
 export const s_repository_rule_required_status_checks = z.object({
-  type: z.enum(["required_status_checks"]),
+  type: z.literal("required_status_checks"),
   parameters: z
     .object({
       do_not_enforce_on_create: PermissiveBoolean.optional(),
@@ -5386,7 +5390,7 @@ export const s_repository_rule_violation_error = z.object({
 })
 
 export const s_repository_rule_workflows = z.object({
-  type: z.enum(["workflows"]),
+  type: z.literal("workflows"),
   parameters: z
     .object({
       do_not_enforce_on_create: PermissiveBoolean.optional(),
@@ -9057,7 +9061,7 @@ export const s_MigrationsStartForOrgRequestBody = z.object({
   exclude_releases: PermissiveBoolean.optional().default(false),
   exclude_owner_projects: PermissiveBoolean.optional().default(false),
   org_metadata_only: PermissiveBoolean.optional().default(false),
-  exclude: z.array(z.enum(["repositories"])).optional(),
+  exclude: z.array(z.literal("repositories")).optional(),
 })
 
 export const s_OrgsConvertMemberToOutsideCollaboratorRequestBody = z.object({
@@ -9076,12 +9080,12 @@ export const s_OrgsReviewPatGrantRequestRequestBody = z.object({
 })
 
 export const s_OrgsUpdatePatAccessesRequestBody = z.object({
-  action: z.enum(["revoke"]),
+  action: z.literal("revoke"),
   pat_ids: z.array(z.coerce.number()).min(1).max(100),
 })
 
 export const s_OrgsUpdatePatAccessRequestBody = z.object({
-  action: z.enum(["revoke"]),
+  action: z.literal("revoke"),
 })
 
 export const s_PrivateRegistriesCreateOrgPrivateRegistryRequestBody = z.object({
@@ -9706,7 +9710,7 @@ export const s_ChecksCreateRequestBody = z.intersection(
   z.union([
     z.intersection(
       z.object({
-        status: z.enum(["completed"]),
+        status: z.literal("completed"),
         conclusion: z.enum([
           "action_required",
           "cancelled",
@@ -9802,7 +9806,7 @@ export const s_ChecksUpdateRequestBody = z.intersection(
   z.union([
     z.intersection(
       z.object({
-        status: z.enum(["completed"]).optional(),
+        status: z.literal("completed").optional(),
         conclusion: z.enum([
           "action_required",
           "cancelled",
@@ -10559,7 +10563,7 @@ export const s_PullsUpdateReviewRequestBody = z.object({body: z.string()})
 
 export const s_PullsDismissReviewRequestBody = z.object({
   message: z.string(),
-  event: z.enum(["DISMISS"]).optional(),
+  event: z.literal("DISMISS").optional(),
 })
 
 export const s_PullsSubmitReviewRequestBody = z.object({
@@ -10844,7 +10848,7 @@ export const s_UsersCreatePublicSshKeyForAuthenticatedUserRequestBody =
   })
 
 export const s_OrgsUpdateMembershipForAuthenticatedUserRequestBody = z.object({
-  state: z.enum(["active"]),
+  state: z.literal("active"),
 })
 
 export const s_MigrationsStartForAuthenticatedUserRequestBody = z.object({
@@ -10855,7 +10859,7 @@ export const s_MigrationsStartForAuthenticatedUserRequestBody = z.object({
   exclude_releases: PermissiveBoolean.optional(),
   exclude_owner_projects: PermissiveBoolean.optional(),
   org_metadata_only: PermissiveBoolean.optional().default(false),
-  exclude: z.array(z.enum(["repositories"])).optional(),
+  exclude: z.array(z.literal("repositories")).optional(),
   repositories: z.array(z.string()),
 })
 

--- a/integration-tests/typescript-express/src/generated/azure-core-data-plane-service.tsp/schemas.ts
+++ b/integration-tests/typescript-express/src/generated/azure-core-data-plane-service.tsp/schemas.ts
@@ -19,7 +19,7 @@ export const s_Azure_Core_eTag = z.string()
 export const s_Azure_Core_uuid = z.string()
 
 export const s_WidgetAnalytics = z.object({
-  id: z.enum(["current"]),
+  id: z.literal("current"),
   useCount: z.coerce.number(),
   repairCount: z.coerce.number(),
 })

--- a/integration-tests/typescript-express/src/generated/azure-resource-manager.tsp/schemas.ts
+++ b/integration-tests/typescript-express/src/generated/azure-resource-manager.tsp/schemas.ts
@@ -24,7 +24,7 @@ export const s_Azure_Core_azureLocation = z.string()
 export const s_Azure_Core_uuid = z.string()
 
 export const s_Azure_ResourceManager_CommonTypes_ActionType = z.union([
-  z.enum(["Internal"]),
+  z.literal("Internal"),
   z.string(),
 ])
 

--- a/integration-tests/typescript-express/src/generated/okta.idp.yaml/generated.ts
+++ b/integration-tests/typescript-express/src/generated/okta.idp.yaml/generated.ts
@@ -1570,11 +1570,11 @@ export function createRouter(
           _links: z.object({
             verify: z.object({
               href: z.string().min(1),
-              hints: z.object({allow: z.array(z.enum(["POST"]))}),
+              hints: z.object({allow: z.array(z.literal("POST"))}),
             }),
             poll: z.object({
               href: z.string().min(1),
-              hints: z.object({allow: z.array(z.enum(["GET"]))}),
+              hints: z.object({allow: z.array(z.literal("GET"))}),
             }),
           }),
         }),
@@ -2326,7 +2326,7 @@ export function createRouter(
               verify: z
                 .object({
                   href: z.string().min(1),
-                  hints: z.object({allow: z.array(z.enum(["GET"]))}),
+                  hints: z.object({allow: z.array(z.literal("GET"))}),
                 })
                 .optional(),
             })

--- a/integration-tests/typescript-express/src/generated/okta.idp.yaml/schemas.ts
+++ b/integration-tests/typescript-express/src/generated/okta.idp.yaml/schemas.ts
@@ -19,7 +19,7 @@ export const s_AppAuthenticatorEnrollment = z.object({
   device: z
     .object({
       id: z.string().optional(),
-      status: z.enum(["ACTIVE"]).optional(),
+      status: z.literal("ACTIVE").optional(),
       createdDate: z.iso.datetime({offset: true}).optional(),
       lastUpdated: z.iso.datetime({offset: true}).optional(),
       clientInstanceId: z.string().optional(),
@@ -52,7 +52,7 @@ export const s_AppAuthenticatorEnrollment = z.object({
                 .object({
                   href: z.string().min(1).optional(),
                   hints: z
-                    .object({allow: z.array(z.enum(["GET"])).optional()})
+                    .object({allow: z.array(z.literal("GET")).optional()})
                     .optional(),
                 })
                 .optional(),
@@ -159,9 +159,9 @@ export const s_Error = z.object({
 export const s_HttpMethod = z.enum(["DELETE", "GET", "POST", "PUT"])
 
 export const s_KeyEC = z.object({
-  crv: z.enum(["P-256"]),
+  crv: z.literal("P-256"),
   kid: z.string(),
-  kty: z.enum(["EC"]),
+  kty: z.literal("EC"),
   "okta:kpr": z.enum(["HARDWARE", "SOFTWARE"]),
   x: z.string(),
   y: z.string(),
@@ -170,7 +170,7 @@ export const s_KeyEC = z.object({
 export const s_KeyRSA = z.object({
   e: z.string(),
   kid: z.string(),
-  kty: z.enum(["RSA"]),
+  kty: z.literal("RSA"),
   n: z.string(),
   "okta:kpr": z.enum(["HARDWARE", "SOFTWARE"]),
 })
@@ -192,7 +192,7 @@ export const s_Organization = z.object({
         .object({
           href: z.string().min(1).optional(),
           hints: z
-            .object({allow: z.array(z.enum(["GET"])).optional()})
+            .object({allow: z.array(z.literal("GET")).optional()})
             .optional(),
         })
         .optional(),
@@ -279,12 +279,12 @@ export const s_Profile = z.object({
 
 export const s_PushNotificationChallenge = z.object({
   challenge: z.string().optional(),
-  payloadVersion: z.enum(["IDXv1"]).optional(),
+  payloadVersion: z.literal("IDXv1").optional(),
 })
 
 export const s_PushNotificationVerification = z.object({
   challengeResponse: z.string().optional(),
-  method: z.enum(["push"]).optional(),
+  method: z.literal("push").optional(),
 })
 
 export const s_Schema = z.object({

--- a/integration-tests/typescript-express/src/generated/okta.oauth.yaml/schemas.ts
+++ b/integration-tests/typescript-express/src/generated/okta.oauth.yaml/schemas.ts
@@ -71,7 +71,7 @@ export const s_Channel = z.enum(["push", "sms", "voice"])
 
 export const s_Claim = z.string()
 
-export const s_CodeChallengeMethod = z.enum(["S256"])
+export const s_CodeChallengeMethod = z.literal("S256")
 
 export const s_DeviceAuthorizeRequest = z.object({
   client_id: z.string().optional(),
@@ -228,7 +228,7 @@ export const s_SigningAlgorithm = z.enum([
 
 export const s_SubjectType = z.enum(["pairwise", "public"])
 
-export const s_TokenDeliveryMode = z.enum(["poll"])
+export const s_TokenDeliveryMode = z.literal("poll")
 
 export const s_TokenResponseTokenType = z.enum(["Bearer", "N_A"])
 
@@ -262,7 +262,7 @@ export const s_UserInfo = z.intersection(
 )
 
 export const s_sub_id = z.object({
-  format: z.enum(["opaque"]).optional(),
+  format: z.literal("opaque").optional(),
   id: z.string().optional(),
 })
 

--- a/integration-tests/typescript-express/src/generated/stripe.yaml/generated.ts
+++ b/integration-tests/typescript-express/src/generated/stripe.yaml/generated.ts
@@ -12409,7 +12409,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_account)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000).regex(new RegExp("^/v1/accounts")),
         }),
       ],
@@ -12968,7 +12968,7 @@ export function createRouter(
           z.object({
             data: z.array(z.lazy(() => s_capability)),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z.string().max(5000),
           }),
         ],
@@ -13206,7 +13206,7 @@ export function createRouter(
               z.union([z.lazy(() => s_bank_account), z.lazy(() => s_card)]),
             ),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z.string().max(5000),
           }),
         ],
@@ -13640,7 +13640,7 @@ export function createRouter(
           z.object({
             data: z.array(z.lazy(() => s_person)),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z.string().max(5000),
           }),
         ],
@@ -14006,7 +14006,7 @@ export function createRouter(
           z.object({
             data: z.array(z.lazy(() => s_person)),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z.string().max(5000),
           }),
         ],
@@ -14412,7 +14412,7 @@ export function createRouter(
         z.object({
           data: z.array(s_apple_pay_domain),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000).regex(new RegExp("^/v1/apple_pay/domains")),
         }),
       ],
@@ -14691,7 +14691,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_application_fee)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000).regex(new RegExp("^/v1/application_fees")),
         }),
       ],
@@ -15065,7 +15065,7 @@ export function createRouter(
           z.object({
             data: z.array(z.lazy(() => s_fee_refund)),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z.string().max(5000),
           }),
         ],
@@ -15230,7 +15230,7 @@ export function createRouter(
         z.object({
           data: z.array(s_apps_secret),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000).regex(new RegExp("^/v1/apps/secrets")),
         }),
       ],
@@ -15588,7 +15588,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_balance_transaction)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z
             .string()
             .max(5000)
@@ -15810,7 +15810,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_balance_transaction)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z
             .string()
             .max(5000)
@@ -16003,7 +16003,7 @@ export function createRouter(
   )
 
   const getBillingAlertsQuerySchema = z.object({
-    alert_type: z.enum(["usage_threshold"]).optional(),
+    alert_type: z.literal("usage_threshold").optional(),
     ending_before: z.string().max(5000).optional(),
     expand: z
       .preprocess(
@@ -16023,7 +16023,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_billing_alert)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000).regex(new RegExp("^/v1/billing/alerts")),
         }),
       ],
@@ -16398,7 +16398,7 @@ export function createRouter(
     filter: z.object({
       applicability_scope: z
         .object({
-          price_type: z.enum(["metered"]).optional(),
+          price_type: z.literal("metered").optional(),
           prices: z.array(z.object({id: z.string().max(5000)})).optional(),
         })
         .optional(),
@@ -16521,7 +16521,7 @@ export function createRouter(
           z.object({
             data: z.array(z.lazy(() => s_billing_credit_balance_transaction)),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z
               .string()
               .max(5000)
@@ -16724,7 +16724,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_billing_credit_grant)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z
             .string()
             .max(5000)
@@ -17202,7 +17202,7 @@ export function createRouter(
         z.object({
           data: z.array(s_billing_meter),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000).regex(new RegExp("^/v1/billing/meters")),
         }),
       ],
@@ -17529,7 +17529,7 @@ export function createRouter(
           z.object({
             data: z.array(s_billing_meter_event_summary),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z
               .string()
               .max(5000)
@@ -17720,7 +17720,7 @@ export function createRouter(
           z.object({
             data: z.array(s_billing_portal_configuration),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z
               .string()
               .max(5000)
@@ -18095,7 +18095,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_charge)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000).regex(new RegExp("^/v1/charges")),
         }),
       ],
@@ -18269,7 +18269,7 @@ export function createRouter(
           data: z.array(z.lazy(() => s_charge)),
           has_more: PermissiveBoolean,
           next_page: z.string().max(5000).nullable().optional(),
-          object: z.enum(["search_result"]),
+          object: z.literal("search_result"),
           total_count: z.coerce.number().optional(),
           url: z.string().max(5000),
         }),
@@ -18767,7 +18767,7 @@ export function createRouter(
           z.object({
             data: z.array(z.lazy(() => s_refund)),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z.string().max(5000),
           }),
         ],
@@ -19068,7 +19068,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_checkout_session)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000),
         }),
       ],
@@ -19448,7 +19448,7 @@ export function createRouter(
           z.object({
             data: z.array(z.lazy(() => s_item)),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z.string().max(5000),
           }),
         ],
@@ -19555,7 +19555,7 @@ export function createRouter(
         z.object({
           data: z.array(s_climate_order),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000).regex(new RegExp("^/v1/climate/orders")),
         }),
       ],
@@ -19873,7 +19873,7 @@ export function createRouter(
         z.object({
           data: z.array(s_climate_product),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000).regex(new RegExp("^/v1/climate/products")),
         }),
       ],
@@ -20041,7 +20041,7 @@ export function createRouter(
         z.object({
           data: z.array(s_climate_supplier),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000).regex(new RegExp("^/v1/climate/suppliers")),
         }),
       ],
@@ -20291,7 +20291,7 @@ export function createRouter(
         z.object({
           data: z.array(s_country_spec),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000).regex(new RegExp("^/v1/country_specs")),
         }),
       ],
@@ -20472,7 +20472,7 @@ export function createRouter(
         z.object({
           data: z.array(s_coupon),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000).regex(new RegExp("^/v1/coupons")),
         }),
       ],
@@ -20804,7 +20804,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_credit_note)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000),
         }),
       ],
@@ -20982,11 +20982,11 @@ export function createRouter(
                     taxable_amount: z.coerce.number(),
                   }),
                 ),
-                z.enum([""]),
+                z.literal(""),
               ])
               .optional(),
             tax_rates: z
-              .union([z.array(z.string().max(5000)), z.enum([""])])
+              .union([z.array(z.string().max(5000)), z.literal("")])
               .optional(),
             type: z.enum(["custom_line_item", "invoice_line_item"]),
             unit_amount: z.coerce.number().optional(),
@@ -21224,11 +21224,11 @@ export function createRouter(
                     taxable_amount: z.coerce.number(),
                   }),
                 ),
-                z.enum([""]),
+                z.literal(""),
               ])
               .optional(),
             tax_rates: z
-              .union([z.array(z.string().max(5000)), z.enum([""])])
+              .union([z.array(z.string().max(5000)), z.literal("")])
               .optional(),
             type: z.enum(["custom_line_item", "invoice_line_item"]),
             unit_amount: z.coerce.number().optional(),
@@ -21274,7 +21274,7 @@ export function createRouter(
           z.object({
             data: z.array(z.lazy(() => s_credit_note_line_item)),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z.string().max(5000),
           }),
         ],
@@ -21498,7 +21498,7 @@ export function createRouter(
           z.object({
             data: z.array(z.lazy(() => s_credit_note_line_item)),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z.string().max(5000),
           }),
         ],
@@ -21827,7 +21827,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_customer)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000).regex(new RegExp("^/v1/customers")),
         }),
       ],
@@ -21995,7 +21995,7 @@ export function createRouter(
           data: z.array(z.lazy(() => s_customer)),
           has_more: PermissiveBoolean,
           next_page: z.string().max(5000).nullable().optional(),
-          object: z.enum(["search_result"]),
+          object: z.literal("search_result"),
           total_count: z.coerce.number().optional(),
           url: z.string().max(5000),
         }),
@@ -22271,7 +22271,7 @@ export function createRouter(
           z.object({
             data: z.array(z.lazy(() => s_customer_balance_transaction)),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z.string().max(5000),
           }),
         ],
@@ -22605,7 +22605,7 @@ export function createRouter(
           z.object({
             data: z.array(z.lazy(() => s_bank_account)),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z.string().max(5000),
           }),
         ],
@@ -23046,7 +23046,7 @@ export function createRouter(
           z.object({
             data: z.array(z.lazy(() => s_card)),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z.string().max(5000),
           }),
         ],
@@ -23544,7 +23544,7 @@ export function createRouter(
           z.object({
             data: z.array(z.lazy(() => s_customer_cash_balance_transaction)),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z.string().max(5000),
           }),
         ],
@@ -23982,7 +23982,7 @@ export function createRouter(
           z.object({
             data: z.array(z.lazy(() => s_payment_method)),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z.string().max(5000),
           }),
         ],
@@ -24193,7 +24193,7 @@ export function createRouter(
               ]),
             ),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z.string().max(5000),
           }),
         ],
@@ -24634,7 +24634,7 @@ export function createRouter(
           z.object({
             data: z.array(z.lazy(() => s_subscription)),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z.string().max(5000),
           }),
         ],
@@ -25146,7 +25146,7 @@ export function createRouter(
           z.object({
             data: z.array(z.lazy(() => s_tax_id)),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z.string().max(5000),
           }),
         ],
@@ -25445,7 +25445,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_dispute)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000).regex(new RegExp("^/v1/disputes")),
         }),
       ],
@@ -25743,7 +25743,7 @@ export function createRouter(
           z.object({
             data: z.array(s_entitlements_active_entitlement),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z.string().max(5000),
           }),
         ],
@@ -25933,7 +25933,7 @@ export function createRouter(
           z.object({
             data: z.array(s_entitlements_feature),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z
               .string()
               .max(5000)
@@ -26330,7 +26330,7 @@ export function createRouter(
         z.object({
           data: z.array(s_event),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000).regex(new RegExp("^/v1/events")),
         }),
       ],
@@ -26528,7 +26528,7 @@ export function createRouter(
         z.object({
           data: z.array(s_exchange_rate),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000).regex(new RegExp("^/v1/exchange_rates")),
         }),
       ],
@@ -26762,7 +26762,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_file_link)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000).regex(new RegExp("^/v1/file_links")),
         }),
       ],
@@ -27078,7 +27078,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_file)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000).regex(new RegExp("^/v1/files")),
         }),
       ],
@@ -27316,7 +27316,7 @@ export function createRouter(
           z.object({
             data: z.array(z.lazy(() => s_financial_connections_account)),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z
               .string()
               .max(5000)
@@ -27595,7 +27595,7 @@ export function createRouter(
           z.object({
             data: z.array(s_financial_connections_account_owner),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z.string().max(5000),
           }),
         ],
@@ -28057,7 +28057,7 @@ export function createRouter(
           z.object({
             data: z.array(s_financial_connections_transaction),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z
               .string()
               .max(5000)
@@ -28284,7 +28284,7 @@ export function createRouter(
         z.object({
           data: z.array(s_forwarding_request),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000),
         }),
       ],
@@ -28526,7 +28526,7 @@ export function createRouter(
           z.object({
             data: z.array(s_identity_verification_report),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z
               .string()
               .max(5000)
@@ -28765,7 +28765,7 @@ export function createRouter(
           z.object({
             data: z.array(s_identity_verification_session),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z
               .string()
               .max(5000)
@@ -29227,7 +29227,7 @@ export function createRouter(
     payment: z
       .object({
         payment_intent: z.string().max(5000).optional(),
-        type: z.enum(["payment_intent"]),
+        type: z.literal("payment_intent"),
       })
       .optional(),
     starting_after: z.string().max(5000).optional(),
@@ -29241,7 +29241,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_invoice_payment)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000),
         }),
       ],
@@ -29438,7 +29438,7 @@ export function createRouter(
           z.object({
             data: z.array(s_invoice_rendering_template),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z.string().max(5000),
           }),
         ],
@@ -29767,7 +29767,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_invoiceitem)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000).regex(new RegExp("^/v1/invoiceitems")),
         }),
       ],
@@ -30147,7 +30147,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_invoice)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000).regex(new RegExp("^/v1/invoices")),
         }),
       ],
@@ -30384,7 +30384,7 @@ export function createRouter(
           data: z.array(z.lazy(() => s_invoice)),
           has_more: PermissiveBoolean,
           next_page: z.string().max(5000).nullable().optional(),
-          object: z.enum(["search_result"]),
+          object: z.literal("search_result"),
           total_count: z.coerce.number().optional(),
           url: z.string().max(5000),
         }),
@@ -30820,7 +30820,7 @@ export function createRouter(
           z.object({
             data: z.array(z.lazy(() => s_line_item)),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z.string().max(5000),
           }),
         ],
@@ -31317,7 +31317,7 @@ export function createRouter(
           z.object({
             data: z.array(z.lazy(() => s_issuing_authorization)),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z
               .string()
               .max(5000)
@@ -31726,7 +31726,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_issuing_cardholder)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z
             .string()
             .max(5000)
@@ -32055,7 +32055,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_issuing_card)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000).regex(new RegExp("^/v1/issuing/cards")),
         }),
       ],
@@ -32384,7 +32384,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_issuing_dispute)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000).regex(new RegExp("^/v1/issuing/disputes")),
         }),
       ],
@@ -32743,7 +32743,7 @@ export function createRouter(
           z.object({
             data: z.array(z.lazy(() => s_issuing_personalization_design)),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z
               .string()
               .max(5000)
@@ -33075,7 +33075,7 @@ export function createRouter(
           z.object({
             data: z.array(s_issuing_physical_bundle),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z
               .string()
               .max(5000)
@@ -33409,7 +33409,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_issuing_token)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000),
         }),
       ],
@@ -33670,7 +33670,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_issuing_transaction)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z
             .string()
             .max(5000)
@@ -34065,7 +34065,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_financial_connections_account)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z
             .string()
             .max(5000)
@@ -34324,7 +34324,7 @@ export function createRouter(
           z.object({
             data: z.array(s_financial_connections_account_owner),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z.string().max(5000),
           }),
         ],
@@ -34576,7 +34576,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_payment_intent)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000).regex(new RegExp("^/v1/payment_intents")),
         }),
       ],
@@ -34739,7 +34739,7 @@ export function createRouter(
             data: z.array(z.lazy(() => s_payment_intent)),
             has_more: PermissiveBoolean,
             next_page: z.string().max(5000).nullable().optional(),
-            object: z.enum(["search_result"]),
+            object: z.literal("search_result"),
             total_count: z.coerce.number().optional(),
             url: z.string().max(5000),
           }),
@@ -35313,7 +35313,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_payment_link)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000).regex(new RegExp("^/v1/payment_links")),
         }),
       ],
@@ -35592,7 +35592,7 @@ export function createRouter(
           z.object({
             data: z.array(z.lazy(() => s_item)),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z.string().max(5000),
           }),
         ],
@@ -35681,7 +35681,7 @@ export function createRouter(
   )
 
   const getPaymentMethodConfigurationsQuerySchema = z.object({
-    application: z.union([z.string().max(100), z.enum([""])]).optional(),
+    application: z.union([z.string().max(100), z.literal("")]).optional(),
     ending_before: z.string().max(5000).optional(),
     expand: z
       .preprocess(
@@ -35701,7 +35701,7 @@ export function createRouter(
           z.object({
             data: z.array(s_payment_method_configuration),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z
               .string()
               .max(5000)
@@ -36016,7 +36016,7 @@ export function createRouter(
           z.object({
             data: z.array(s_payment_method_domain),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z
               .string()
               .max(5000)
@@ -36425,7 +36425,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_payment_method)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000).regex(new RegExp("^/v1/payment_methods")),
         }),
       ],
@@ -36849,7 +36849,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_payout)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000).regex(new RegExp("^/v1/payouts")),
         }),
       ],
@@ -37262,7 +37262,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_plan)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000).regex(new RegExp("^/v1/plans")),
         }),
       ],
@@ -37619,7 +37619,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_price)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000).regex(new RegExp("^/v1/prices")),
         }),
       ],
@@ -37818,7 +37818,7 @@ export function createRouter(
           data: z.array(z.lazy(() => s_price)),
           has_more: PermissiveBoolean,
           next_page: z.string().max(5000).nullable().optional(),
-          object: z.enum(["search_result"]),
+          object: z.literal("search_result"),
           total_count: z.coerce.number().optional(),
           url: z.string().max(5000),
         }),
@@ -38056,7 +38056,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_product)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000).regex(new RegExp("^/v1/products")),
         }),
       ],
@@ -38236,7 +38236,7 @@ export function createRouter(
           data: z.array(z.lazy(() => s_product)),
           has_more: PermissiveBoolean,
           next_page: z.string().max(5000).nullable().optional(),
-          object: z.enum(["search_result"]),
+          object: z.literal("search_result"),
           total_count: z.coerce.number().optional(),
           url: z.string().max(5000),
         }),
@@ -38504,7 +38504,7 @@ export function createRouter(
           z.object({
             data: z.array(s_product_feature),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z.string().max(5000),
           }),
         ],
@@ -38805,7 +38805,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_promotion_code)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000).regex(new RegExp("^/v1/promotion_codes")),
         }),
       ],
@@ -39114,7 +39114,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_quote)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000).regex(new RegExp("^/v1/quotes")),
         }),
       ],
@@ -39497,7 +39497,7 @@ export function createRouter(
           z.object({
             data: z.array(z.lazy(() => s_item)),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z.string().max(5000),
           }),
         ],
@@ -39666,7 +39666,7 @@ export function createRouter(
           z.object({
             data: z.array(z.lazy(() => s_item)),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z.string().max(5000),
           }),
         ],
@@ -39852,7 +39852,7 @@ export function createRouter(
           z.object({
             data: z.array(z.lazy(() => s_radar_early_fraud_warning)),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z
               .string()
               .max(5000)
@@ -40076,7 +40076,7 @@ export function createRouter(
         z.object({
           data: z.array(s_radar_value_list_item),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z
             .string()
             .max(5000)
@@ -40389,7 +40389,7 @@ export function createRouter(
         z.object({
           data: z.array(s_radar_value_list),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000).regex(new RegExp("^/v1/radar/value_lists")),
         }),
       ],
@@ -40746,7 +40746,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_refund)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000).regex(new RegExp("^/v1/refunds")),
         }),
       ],
@@ -41090,7 +41090,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_reporting_report_run)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z
             .string()
             .max(5000)
@@ -41321,7 +41321,7 @@ export function createRouter(
           z.object({
             data: z.array(s_reporting_report_type),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z.string().max(5000),
           }),
         ],
@@ -41487,7 +41487,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_review)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000),
         }),
       ],
@@ -41730,7 +41730,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_setup_attempt)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000).regex(new RegExp("^/v1/setup_attempts")),
         }),
       ],
@@ -41862,7 +41862,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_setup_intent)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000).regex(new RegExp("^/v1/setup_intents")),
         }),
       ],
@@ -42346,7 +42346,7 @@ export function createRouter(
         z.object({
           data: z.array(s_shipping_rate),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000).regex(new RegExp("^/v1/shipping_rates")),
         }),
       ],
@@ -42692,7 +42692,7 @@ export function createRouter(
           z.object({
             data: z.array(z.lazy(() => s_scheduled_query_run)),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z
               .string()
               .max(5000)
@@ -43133,7 +43133,7 @@ export function createRouter(
           z.object({
             data: z.array(s_source_transaction),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z.string().max(5000),
           }),
         ],
@@ -43374,7 +43374,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_subscription_item)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z
             .string()
             .max(5000)
@@ -43746,7 +43746,7 @@ export function createRouter(
           z.object({
             data: z.array(z.lazy(() => s_subscription_schedule)),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z
               .string()
               .max(5000)
@@ -44261,7 +44261,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_subscription)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000).regex(new RegExp("^/v1/subscriptions")),
         }),
       ],
@@ -44484,7 +44484,7 @@ export function createRouter(
           data: z.array(z.lazy(() => s_subscription)),
           has_more: PermissiveBoolean,
           next_page: z.string().max(5000).nullable().optional(),
-          object: z.enum(["search_result"]),
+          object: z.literal("search_result"),
           total_count: z.coerce.number().optional(),
           url: z.string().max(5000),
         }),
@@ -45077,7 +45077,7 @@ export function createRouter(
           z.object({
             data: z.array(s_tax_calculation_line_item),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z
               .string()
               .max(5000)
@@ -45194,7 +45194,7 @@ export function createRouter(
         z.object({
           data: z.array(s_tax_registration),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000).regex(new RegExp("^/v1/tax/registrations")),
         }),
       ],
@@ -45741,7 +45741,7 @@ export function createRouter(
           z.object({
             data: z.array(s_tax_transaction_line_item),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z
               .string()
               .max(5000)
@@ -45857,7 +45857,7 @@ export function createRouter(
         z.object({
           data: z.array(s_tax_code),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000),
         }),
       ],
@@ -46030,7 +46030,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_tax_id)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000),
         }),
       ],
@@ -46310,7 +46310,7 @@ export function createRouter(
         z.object({
           data: z.array(s_tax_rate),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000).regex(new RegExp("^/v1/tax_rates")),
         }),
       ],
@@ -46600,7 +46600,7 @@ export function createRouter(
           z.object({
             data: z.array(z.lazy(() => s_terminal_configuration)),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z
               .string()
               .max(5000)
@@ -47027,7 +47027,7 @@ export function createRouter(
         z.object({
           data: z.array(s_terminal_location),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z
             .string()
             .max(5000)
@@ -47374,7 +47374,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_terminal_reader)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000),
         }),
       ],
@@ -49719,7 +49719,7 @@ export function createRouter(
           z.object({
             data: z.array(s_test_helpers_test_clock),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z
               .string()
               .max(5000)
@@ -50953,7 +50953,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_topup)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000).regex(new RegExp("^/v1/topups")),
         }),
       ],
@@ -51309,7 +51309,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_transfer)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000).regex(new RegExp("^/v1/transfers")),
         }),
       ],
@@ -51481,7 +51481,7 @@ export function createRouter(
           z.object({
             data: z.array(z.lazy(() => s_transfer_reversal)),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z.string().max(5000),
           }),
         ],
@@ -51890,7 +51890,7 @@ export function createRouter(
           z.object({
             data: z.array(z.lazy(() => s_treasury_credit_reversal)),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z.string().max(5000),
           }),
         ],
@@ -52141,7 +52141,7 @@ export function createRouter(
           z.object({
             data: z.array(z.lazy(() => s_treasury_debit_reversal)),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z.string().max(5000),
           }),
         ],
@@ -52403,7 +52403,7 @@ export function createRouter(
           z.object({
             data: z.array(s_treasury_financial_account),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z
               .string()
               .max(5000)
@@ -52926,7 +52926,7 @@ export function createRouter(
           z.object({
             data: z.array(z.lazy(() => s_treasury_inbound_transfer)),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z.string().max(5000),
           }),
         ],
@@ -53237,7 +53237,7 @@ export function createRouter(
           z.object({
             data: z.array(z.lazy(() => s_treasury_outbound_payment)),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z
               .string()
               .max(5000)
@@ -53559,7 +53559,7 @@ export function createRouter(
           z.object({
             data: z.array(z.lazy(() => s_treasury_outbound_transfer)),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z.string().max(5000),
           }),
         ],
@@ -53872,7 +53872,7 @@ export function createRouter(
           z.object({
             data: z.array(z.lazy(() => s_treasury_received_credit)),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z.string().max(5000),
           }),
         ],
@@ -54072,7 +54072,7 @@ export function createRouter(
           z.object({
             data: z.array(z.lazy(() => s_treasury_received_debit)),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z.string().max(5000),
           }),
         ],
@@ -54283,7 +54283,7 @@ export function createRouter(
           z.object({
             data: z.array(z.lazy(() => s_treasury_transaction_entry)),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z
               .string()
               .max(5000)
@@ -54538,7 +54538,7 @@ export function createRouter(
           z.object({
             data: z.array(z.lazy(() => s_treasury_transaction)),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z.string().max(5000),
           }),
         ],
@@ -54759,7 +54759,7 @@ export function createRouter(
         z.object({
           data: z.array(s_webhook_endpoint),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000).regex(new RegExp("^/v1/webhook_endpoints")),
         }),
       ],

--- a/integration-tests/typescript-express/src/generated/stripe.yaml/schemas.ts
+++ b/integration-tests/typescript-express/src/generated/stripe.yaml/schemas.ts
@@ -327,7 +327,7 @@ export const s_account_group_membership = z.object({
 export const s_account_link = z.object({
   created: z.coerce.number(),
   expires_at: z.coerce.number(),
-  object: z.enum(["account_link"]),
+  object: z.literal("account_link"),
   url: z.string().max(5000),
 })
 
@@ -495,13 +495,13 @@ export const s_apple_pay_domain = z.object({
   domain_name: z.string().max(5000),
   id: z.string().max(5000),
   livemode: PermissiveBoolean,
-  object: z.enum(["apple_pay_domain"]),
+  object: z.literal("apple_pay_domain"),
 })
 
 export const s_application = z.object({
   id: z.string().max(5000),
   name: z.string().max(5000).nullable().optional(),
-  object: z.enum(["application"]),
+  object: z.literal("application"),
 })
 
 export const s_balance_amount_by_source_type = z.object({
@@ -600,7 +600,7 @@ export const s_billing_meter_event = z.object({
   event_name: z.string().max(100),
   identifier: z.string().max(5000),
   livemode: PermissiveBoolean,
-  object: z.enum(["billing.meter_event"]),
+  object: z.literal("billing.meter_event"),
   payload: z.record(z.string(), z.string().max(100)),
   timestamp: z.coerce.number(),
 })
@@ -611,7 +611,7 @@ export const s_billing_meter_event_summary = z.object({
   id: z.string().max(5000),
   livemode: PermissiveBoolean,
   meter: z.string().max(5000),
-  object: z.enum(["billing.meter_event_summary"]),
+  object: z.literal("billing.meter_event_summary"),
   start_time: z.coerce.number(),
 })
 
@@ -631,7 +631,7 @@ export const s_billing_meter_resource_billing_meter_value = z.object({
 
 export const s_billing_meter_resource_customer_mapping_settings = z.object({
   event_payload_key: z.string().max(5000),
-  type: z.enum(["by_id"]),
+  type: z.literal("by_id"),
 })
 
 export const s_cancellation_details = z.object({
@@ -683,15 +683,15 @@ export const s_checkout_acss_debit_mandate_options = z.object({
 })
 
 export const s_checkout_affirm_payment_method_options = z.object({
-  setup_future_usage: z.enum(["none"]).optional(),
+  setup_future_usage: z.literal("none").optional(),
 })
 
 export const s_checkout_afterpay_clearpay_payment_method_options = z.object({
-  setup_future_usage: z.enum(["none"]).optional(),
+  setup_future_usage: z.literal("none").optional(),
 })
 
 export const s_checkout_alipay_payment_method_options = z.object({
-  setup_future_usage: z.enum(["none"]).optional(),
+  setup_future_usage: z.literal("none").optional(),
 })
 
 export const s_checkout_amazon_pay_payment_method_options = z.object({
@@ -699,12 +699,12 @@ export const s_checkout_amazon_pay_payment_method_options = z.object({
 })
 
 export const s_checkout_au_becs_debit_payment_method_options = z.object({
-  setup_future_usage: z.enum(["none"]).optional(),
+  setup_future_usage: z.literal("none").optional(),
   target_date: z.string().max(5000).optional(),
 })
 
 export const s_checkout_bancontact_payment_method_options = z.object({
-  setup_future_usage: z.enum(["none"]).optional(),
+  setup_future_usage: z.literal("none").optional(),
 })
 
 export const s_checkout_boleto_payment_method_options = z.object({
@@ -717,31 +717,31 @@ export const s_checkout_card_installments_options = z.object({
 })
 
 export const s_checkout_cashapp_payment_method_options = z.object({
-  setup_future_usage: z.enum(["none"]).optional(),
+  setup_future_usage: z.literal("none").optional(),
 })
 
 export const s_checkout_eps_payment_method_options = z.object({
-  setup_future_usage: z.enum(["none"]).optional(),
+  setup_future_usage: z.literal("none").optional(),
 })
 
 export const s_checkout_fpx_payment_method_options = z.object({
-  setup_future_usage: z.enum(["none"]).optional(),
+  setup_future_usage: z.literal("none").optional(),
 })
 
 export const s_checkout_giropay_payment_method_options = z.object({
-  setup_future_usage: z.enum(["none"]).optional(),
+  setup_future_usage: z.literal("none").optional(),
 })
 
 export const s_checkout_grab_pay_payment_method_options = z.object({
-  setup_future_usage: z.enum(["none"]).optional(),
+  setup_future_usage: z.literal("none").optional(),
 })
 
 export const s_checkout_ideal_payment_method_options = z.object({
-  setup_future_usage: z.enum(["none"]).optional(),
+  setup_future_usage: z.literal("none").optional(),
 })
 
 export const s_checkout_kakao_pay_payment_method_options = z.object({
-  capture_method: z.enum(["manual"]).optional(),
+  capture_method: z.literal("manual").optional(),
   setup_future_usage: z.enum(["none", "off_session"]).optional(),
 })
 
@@ -751,11 +751,11 @@ export const s_checkout_klarna_payment_method_options = z.object({
 
 export const s_checkout_konbini_payment_method_options = z.object({
   expires_after_days: z.coerce.number().nullable().optional(),
-  setup_future_usage: z.enum(["none"]).optional(),
+  setup_future_usage: z.literal("none").optional(),
 })
 
 export const s_checkout_kr_card_payment_method_options = z.object({
-  capture_method: z.enum(["manual"]).optional(),
+  capture_method: z.literal("manual").optional(),
   setup_future_usage: z.enum(["none", "off_session"]).optional(),
 })
 
@@ -768,29 +768,29 @@ export const s_checkout_link_wallet_options = z.object({
 })
 
 export const s_checkout_mobilepay_payment_method_options = z.object({
-  setup_future_usage: z.enum(["none"]).optional(),
+  setup_future_usage: z.literal("none").optional(),
 })
 
 export const s_checkout_multibanco_payment_method_options = z.object({
-  setup_future_usage: z.enum(["none"]).optional(),
+  setup_future_usage: z.literal("none").optional(),
 })
 
 export const s_checkout_naver_pay_payment_method_options = z.object({
-  capture_method: z.enum(["manual"]).optional(),
+  capture_method: z.literal("manual").optional(),
   setup_future_usage: z.enum(["none", "off_session"]).optional(),
 })
 
 export const s_checkout_oxxo_payment_method_options = z.object({
   expires_after_days: z.coerce.number(),
-  setup_future_usage: z.enum(["none"]).optional(),
+  setup_future_usage: z.literal("none").optional(),
 })
 
 export const s_checkout_p24_payment_method_options = z.object({
-  setup_future_usage: z.enum(["none"]).optional(),
+  setup_future_usage: z.literal("none").optional(),
 })
 
 export const s_checkout_payco_payment_method_options = z.object({
-  capture_method: z.enum(["manual"]).optional(),
+  capture_method: z.literal("manual").optional(),
 })
 
 export const s_checkout_payment_method_options_mandate_options_bacs_debit =
@@ -800,11 +800,11 @@ export const s_checkout_payment_method_options_mandate_options_sepa_debit =
   z.object({reference_prefix: z.string().max(5000).optional()})
 
 export const s_checkout_paynow_payment_method_options = z.object({
-  setup_future_usage: z.enum(["none"]).optional(),
+  setup_future_usage: z.literal("none").optional(),
 })
 
 export const s_checkout_paypal_payment_method_options = z.object({
-  capture_method: z.enum(["manual"]).optional(),
+  capture_method: z.literal("manual").optional(),
   preferred_locale: z.string().max(5000).nullable().optional(),
   reference: z.string().max(5000).nullable().optional(),
   setup_future_usage: z.enum(["none", "off_session"]).optional(),
@@ -812,7 +812,7 @@ export const s_checkout_paypal_payment_method_options = z.object({
 
 export const s_checkout_pix_payment_method_options = z.object({
   expires_after_seconds: z.coerce.number().nullable().optional(),
-  setup_future_usage: z.enum(["none"]).optional(),
+  setup_future_usage: z.literal("none").optional(),
 })
 
 export const s_checkout_revolut_pay_payment_method_options = z.object({
@@ -820,11 +820,11 @@ export const s_checkout_revolut_pay_payment_method_options = z.object({
 })
 
 export const s_checkout_samsung_pay_payment_method_options = z.object({
-  capture_method: z.enum(["manual"]).optional(),
+  capture_method: z.literal("manual").optional(),
 })
 
 export const s_checkout_sofort_payment_method_options = z.object({
-  setup_future_usage: z.enum(["none"]).optional(),
+  setup_future_usage: z.literal("none").optional(),
 })
 
 export const s_checkout_swish_payment_method_options = z.object({
@@ -1010,142 +1010,142 @@ export const s_customer_tax_location = z.object({
 export const s_deleted_account = z.object({
   deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
-  object: z.enum(["account"]),
+  object: z.literal("account"),
 })
 
 export const s_deleted_apple_pay_domain = z.object({
   deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
-  object: z.enum(["apple_pay_domain"]),
+  object: z.literal("apple_pay_domain"),
 })
 
 export const s_deleted_application = z.object({
   deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
   name: z.string().max(5000).nullable().optional(),
-  object: z.enum(["application"]),
+  object: z.literal("application"),
 })
 
 export const s_deleted_bank_account = z.object({
   currency: z.string().max(5000).nullable().optional(),
   deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
-  object: z.enum(["bank_account"]),
+  object: z.literal("bank_account"),
 })
 
 export const s_deleted_card = z.object({
   currency: z.string().max(5000).nullable().optional(),
   deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
-  object: z.enum(["card"]),
+  object: z.literal("card"),
 })
 
 export const s_deleted_coupon = z.object({
   deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
-  object: z.enum(["coupon"]),
+  object: z.literal("coupon"),
 })
 
 export const s_deleted_customer = z.object({
   deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
-  object: z.enum(["customer"]),
+  object: z.literal("customer"),
 })
 
 export const s_deleted_invoice = z.object({
   deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
-  object: z.enum(["invoice"]),
+  object: z.literal("invoice"),
 })
 
 export const s_deleted_invoiceitem = z.object({
   deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
-  object: z.enum(["invoiceitem"]),
+  object: z.literal("invoiceitem"),
 })
 
 export const s_deleted_person = z.object({
   deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
-  object: z.enum(["person"]),
+  object: z.literal("person"),
 })
 
 export const s_deleted_plan = z.object({
   deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
-  object: z.enum(["plan"]),
+  object: z.literal("plan"),
 })
 
 export const s_deleted_price = z.object({
   deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
-  object: z.enum(["price"]),
+  object: z.literal("price"),
 })
 
 export const s_deleted_product = z.object({
   deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
-  object: z.enum(["product"]),
+  object: z.literal("product"),
 })
 
 export const s_deleted_product_feature = z.object({
   deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
-  object: z.enum(["product_feature"]),
+  object: z.literal("product_feature"),
 })
 
 export const s_deleted_radar_value_list = z.object({
   deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
-  object: z.enum(["radar.value_list"]),
+  object: z.literal("radar.value_list"),
 })
 
 export const s_deleted_radar_value_list_item = z.object({
   deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
-  object: z.enum(["radar.value_list_item"]),
+  object: z.literal("radar.value_list_item"),
 })
 
 export const s_deleted_subscription_item = z.object({
   deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
-  object: z.enum(["subscription_item"]),
+  object: z.literal("subscription_item"),
 })
 
 export const s_deleted_tax_id = z.object({
   deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
-  object: z.enum(["tax_id"]),
+  object: z.literal("tax_id"),
 })
 
 export const s_deleted_terminal_configuration = z.object({
   deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
-  object: z.enum(["terminal.configuration"]),
+  object: z.literal("terminal.configuration"),
 })
 
 export const s_deleted_terminal_location = z.object({
   deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
-  object: z.enum(["terminal.location"]),
+  object: z.literal("terminal.location"),
 })
 
 export const s_deleted_terminal_reader = z.object({
   deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
-  object: z.enum(["terminal.reader"]),
+  object: z.literal("terminal.reader"),
 })
 
 export const s_deleted_test_helpers_test_clock = z.object({
   deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
-  object: z.enum(["test_helpers.test_clock"]),
+  object: z.literal("test_helpers.test_clock"),
 })
 
 export const s_deleted_webhook_endpoint = z.object({
   deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
-  object: z.enum(["webhook_endpoint"]),
+  object: z.literal("webhook_endpoint"),
 })
 
 export const s_destination_details_unimplemented = z.record(
@@ -1215,7 +1215,7 @@ export const s_entitlements_feature = z.object({
   lookup_key: z.string().max(5000),
   metadata: z.record(z.string(), z.string().max(500)),
   name: z.string().max(80),
-  object: z.enum(["entitlements.feature"]),
+  object: z.literal("entitlements.feature"),
 })
 
 export const s_ephemeral_key = z.object({
@@ -1223,13 +1223,13 @@ export const s_ephemeral_key = z.object({
   expires: z.coerce.number(),
   id: z.string().max(5000),
   livemode: PermissiveBoolean,
-  object: z.enum(["ephemeral_key"]),
+  object: z.literal("ephemeral_key"),
   secret: z.string().max(5000).optional(),
 })
 
 export const s_exchange_rate = z.object({
   id: z.string().max(5000),
-  object: z.enum(["exchange_rate"]),
+  object: z.literal("exchange_rate"),
   rates: z.record(z.string(), z.coerce.number()),
 })
 
@@ -1245,7 +1245,7 @@ export const s_financial_connections_account_owner = z.object({
   email: z.string().max(5000).nullable().optional(),
   id: z.string().max(5000),
   name: z.string().max(5000),
-  object: z.enum(["financial_connections.account_owner"]),
+  object: z.literal("financial_connections.account_owner"),
   ownership: z.string().max(5000),
   phone: z.string().max(5000).nullable().optional(),
   raw_address: z.string().max(5000).nullable().optional(),
@@ -1502,7 +1502,7 @@ export const s_invoice_rendering_template = z.object({
   livemode: PermissiveBoolean,
   metadata: z.record(z.string(), z.string().max(500)).nullable().optional(),
   nickname: z.string().max(5000).nullable().optional(),
-  object: z.enum(["invoice_rendering_template"]),
+  object: z.literal("invoice_rendering_template"),
   status: z.enum(["active", "archived"]),
   version: z.coerce.number(),
 })
@@ -1693,7 +1693,7 @@ export const s_issuing_authorization_fleet_tax_data = z.object({
 })
 
 export const s_issuing_authorization_fraud_challenge = z.object({
-  channel: z.enum(["sms"]),
+  channel: z.literal("sms"),
   status: z.enum([
     "expired",
     "pending",
@@ -2567,7 +2567,7 @@ export const s_issuing_settlement = z.object({
   network: z.enum(["maestro", "visa"]),
   network_fees_amount: z.coerce.number(),
   network_settlement_identifier: z.string().max(5000),
-  object: z.enum(["issuing.settlement"]),
+  object: z.literal("issuing.settlement"),
   settlement_service: z.string().max(5000),
   status: z.enum(["complete", "pending"]),
   transaction_amount: z.coerce.number(),
@@ -2680,7 +2680,7 @@ export const s_legal_entity_ubo_declaration = z.object({
 
 export const s_login_link = z.object({
   created: z.coerce.number(),
-  object: z.enum(["login_link"]),
+  object: z.literal("login_link"),
   url: z.string().max(5000),
 })
 
@@ -2745,7 +2745,7 @@ export const s_mandate_single_use = z.object({
 })
 
 export const s_mandate_us_bank_account = z.object({
-  collection_method: z.enum(["paper"]).optional(),
+  collection_method: z.literal("paper").optional(),
 })
 
 export const s_networks = z.object({
@@ -2771,10 +2771,10 @@ export const s_online_acceptance = z.object({
 })
 
 export const s_outbound_payments_payment_method_details_financial_account =
-  z.object({id: z.string().max(5000), network: z.enum(["stripe"])})
+  z.object({id: z.string().max(5000), network: z.literal("stripe")})
 
 export const s_outbound_transfers_payment_method_details_financial_account =
-  z.object({id: z.string().max(5000), network: z.enum(["stripe"])})
+  z.object({id: z.string().max(5000), network: z.literal("stripe")})
 
 export const s_package_dimensions = z.object({
   height: z.coerce.number(),
@@ -2841,7 +2841,7 @@ export const s_payment_flows_private_payment_methods_financial_connections_commo
 
 export const s_payment_flows_private_payment_methods_kakao_pay_payment_method_options =
   z.object({
-    capture_method: z.enum(["manual"]).optional(),
+    capture_method: z.literal("manual").optional(),
     setup_future_usage: z.enum(["none", "off_session"]).optional(),
   })
 
@@ -2853,15 +2853,15 @@ export const s_payment_flows_private_payment_methods_klarna_dob = z.object({
 
 export const s_payment_flows_private_payment_methods_naver_pay_payment_method_options =
   z.object({
-    capture_method: z.enum(["manual"]).optional(),
+    capture_method: z.literal("manual").optional(),
     setup_future_usage: z.enum(["none", "off_session"]).optional(),
   })
 
 export const s_payment_flows_private_payment_methods_payco_payment_method_options =
-  z.object({capture_method: z.enum(["manual"]).optional()})
+  z.object({capture_method: z.literal("manual").optional()})
 
 export const s_payment_flows_private_payment_methods_samsung_pay_payment_method_options =
-  z.object({capture_method: z.enum(["manual"]).optional()})
+  z.object({capture_method: z.literal("manual").optional()})
 
 export const s_payment_intent_next_action_alipay_handle_redirect = z.object({
   native_data: z.string().max(5000).nullable().optional(),
@@ -2995,15 +2995,15 @@ export const s_payment_intent_payment_method_options_au_becs_debit = z.object({
 })
 
 export const s_payment_intent_payment_method_options_blik = z.object({
-  setup_future_usage: z.enum(["none"]).optional(),
+  setup_future_usage: z.literal("none").optional(),
 })
 
 export const s_payment_intent_payment_method_options_eps = z.object({
-  setup_future_usage: z.enum(["none"]).optional(),
+  setup_future_usage: z.literal("none").optional(),
 })
 
 export const s_payment_intent_payment_method_options_link = z.object({
-  capture_method: z.enum(["manual"]).optional(),
+  capture_method: z.literal("manual").optional(),
   setup_future_usage: z.enum(["none", "off_session"]).optional(),
 })
 
@@ -3025,8 +3025,8 @@ export const s_payment_intent_payment_method_options_mandate_options_sepa_debit 
   z.object({reference_prefix: z.string().max(5000).optional()})
 
 export const s_payment_intent_payment_method_options_mobilepay = z.object({
-  capture_method: z.enum(["manual"]).optional(),
-  setup_future_usage: z.enum(["none"]).optional(),
+  capture_method: z.literal("manual").optional(),
+  setup_future_usage: z.literal("none").optional(),
 })
 
 export const s_payment_intent_payment_method_options_nz_bank_account = z.object(
@@ -3040,7 +3040,7 @@ export const s_payment_intent_payment_method_options_nz_bank_account = z.object(
 
 export const s_payment_intent_payment_method_options_swish = z.object({
   reference: z.string().max(35).nullable().optional(),
-  setup_future_usage: z.enum(["none"]).optional(),
+  setup_future_usage: z.literal("none").optional(),
 })
 
 export const s_payment_intent_processing_customer_notification = z.object({
@@ -3067,7 +3067,7 @@ export const s_payment_links_resource_custom_fields_dropdown_option = z.object({
 
 export const s_payment_links_resource_custom_fields_label = z.object({
   custom: z.string().max(5000).nullable().optional(),
-  type: z.enum(["custom"]),
+  type: z.literal("custom"),
 })
 
 export const s_payment_links_resource_custom_fields_numeric = z.object({
@@ -3536,7 +3536,7 @@ export const s_payment_method_details_card_checks = z.object({
 
 export const s_payment_method_details_card_installments_plan = z.object({
   count: z.coerce.number().nullable().optional(),
-  interval: z.enum(["month"]).nullable().optional(),
+  interval: z.literal("month").nullable().optional(),
   type: z.enum(["bonus", "fixed_count", "revolving"]),
 })
 
@@ -3546,7 +3546,7 @@ export const s_payment_method_details_card_network_token = z.object({
 
 export const s_payment_method_details_card_present_offline = z.object({
   stored_at: z.coerce.number().nullable().optional(),
-  type: z.enum(["deferred"]).nullable().optional(),
+  type: z.literal("deferred").nullable().optional(),
 })
 
 export const s_payment_method_details_card_present_receipt = z.object({
@@ -4043,15 +4043,15 @@ export const s_payment_method_nz_bank_account = z.object({
 })
 
 export const s_payment_method_options_affirm = z.object({
-  capture_method: z.enum(["manual"]).optional(),
+  capture_method: z.literal("manual").optional(),
   preferred_locale: z.string().max(30).optional(),
-  setup_future_usage: z.enum(["none"]).optional(),
+  setup_future_usage: z.literal("none").optional(),
 })
 
 export const s_payment_method_options_afterpay_clearpay = z.object({
-  capture_method: z.enum(["manual"]).optional(),
+  capture_method: z.literal("manual").optional(),
   reference: z.string().max(5000).nullable().optional(),
-  setup_future_usage: z.enum(["none"]).optional(),
+  setup_future_usage: z.literal("none").optional(),
 })
 
 export const s_payment_method_options_alipay = z.object({
@@ -4059,11 +4059,11 @@ export const s_payment_method_options_alipay = z.object({
 })
 
 export const s_payment_method_options_alma = z.object({
-  capture_method: z.enum(["manual"]).optional(),
+  capture_method: z.literal("manual").optional(),
 })
 
 export const s_payment_method_options_amazon_pay = z.object({
-  capture_method: z.enum(["manual"]).optional(),
+  capture_method: z.literal("manual").optional(),
   setup_future_usage: z.enum(["none", "off_session"]).optional(),
 })
 
@@ -4073,7 +4073,7 @@ export const s_payment_method_options_bancontact = z.object({
 })
 
 export const s_payment_method_options_billie = z.object({
-  capture_method: z.enum(["manual"]).optional(),
+  capture_method: z.literal("manual").optional(),
 })
 
 export const s_payment_method_options_boleto = z.object({
@@ -4090,10 +4090,7 @@ export const s_payment_method_options_card_mandate_options = z.object({
   interval_count: z.coerce.number().nullable().optional(),
   reference: z.string().max(80),
   start_date: z.coerce.number(),
-  supported_types: z
-    .array(z.enum(["india"]))
-    .nullable()
-    .optional(),
+  supported_types: z.array(z.literal("india")).nullable().optional(),
 })
 
 export const s_payment_method_options_card_present_routing = z.object({
@@ -4104,27 +4101,27 @@ export const s_payment_method_options_card_present_routing = z.object({
 })
 
 export const s_payment_method_options_cashapp = z.object({
-  capture_method: z.enum(["manual"]).optional(),
+  capture_method: z.literal("manual").optional(),
   setup_future_usage: z.enum(["none", "off_session", "on_session"]).optional(),
 })
 
 export const s_payment_method_options_crypto = z.object({
-  setup_future_usage: z.enum(["none"]).optional(),
+  setup_future_usage: z.literal("none").optional(),
 })
 
 export const s_payment_method_options_customer_balance_eu_bank_account =
   z.object({country: z.enum(["BE", "DE", "ES", "FR", "IE", "NL"])})
 
 export const s_payment_method_options_fpx = z.object({
-  setup_future_usage: z.enum(["none"]).optional(),
+  setup_future_usage: z.literal("none").optional(),
 })
 
 export const s_payment_method_options_giropay = z.object({
-  setup_future_usage: z.enum(["none"]).optional(),
+  setup_future_usage: z.literal("none").optional(),
 })
 
 export const s_payment_method_options_grabpay = z.object({
-  setup_future_usage: z.enum(["none"]).optional(),
+  setup_future_usage: z.literal("none").optional(),
 })
 
 export const s_payment_method_options_ideal = z.object({
@@ -4137,7 +4134,7 @@ export const s_payment_method_options_interac_present = z.record(
 )
 
 export const s_payment_method_options_klarna = z.object({
-  capture_method: z.enum(["manual"]).optional(),
+  capture_method: z.literal("manual").optional(),
   preferred_locale: z.string().max(5000).nullable().optional(),
   setup_future_usage: z.enum(["none", "off_session", "on_session"]).optional(),
 })
@@ -4147,25 +4144,25 @@ export const s_payment_method_options_konbini = z.object({
   expires_after_days: z.coerce.number().nullable().optional(),
   expires_at: z.coerce.number().nullable().optional(),
   product_description: z.string().max(5000).nullable().optional(),
-  setup_future_usage: z.enum(["none"]).optional(),
+  setup_future_usage: z.literal("none").optional(),
 })
 
 export const s_payment_method_options_kr_card = z.object({
-  capture_method: z.enum(["manual"]).optional(),
+  capture_method: z.literal("manual").optional(),
   setup_future_usage: z.enum(["none", "off_session"]).optional(),
 })
 
 export const s_payment_method_options_multibanco = z.object({
-  setup_future_usage: z.enum(["none"]).optional(),
+  setup_future_usage: z.literal("none").optional(),
 })
 
 export const s_payment_method_options_oxxo = z.object({
   expires_after_days: z.coerce.number(),
-  setup_future_usage: z.enum(["none"]).optional(),
+  setup_future_usage: z.literal("none").optional(),
 })
 
 export const s_payment_method_options_p24 = z.object({
-  setup_future_usage: z.enum(["none"]).optional(),
+  setup_future_usage: z.literal("none").optional(),
 })
 
 export const s_payment_method_options_pay_by_bank = z.record(
@@ -4174,11 +4171,11 @@ export const s_payment_method_options_pay_by_bank = z.record(
 )
 
 export const s_payment_method_options_paynow = z.object({
-  setup_future_usage: z.enum(["none"]).optional(),
+  setup_future_usage: z.literal("none").optional(),
 })
 
 export const s_payment_method_options_paypal = z.object({
-  capture_method: z.enum(["manual"]).optional(),
+  capture_method: z.literal("manual").optional(),
   preferred_locale: z.string().max(5000).nullable().optional(),
   reference: z.string().max(5000).nullable().optional(),
   setup_future_usage: z.enum(["none", "off_session"]).optional(),
@@ -4187,20 +4184,20 @@ export const s_payment_method_options_paypal = z.object({
 export const s_payment_method_options_pix = z.object({
   expires_after_seconds: z.coerce.number().nullable().optional(),
   expires_at: z.coerce.number().nullable().optional(),
-  setup_future_usage: z.enum(["none"]).optional(),
+  setup_future_usage: z.literal("none").optional(),
 })
 
 export const s_payment_method_options_promptpay = z.object({
-  setup_future_usage: z.enum(["none"]).optional(),
+  setup_future_usage: z.literal("none").optional(),
 })
 
 export const s_payment_method_options_revolut_pay = z.object({
-  capture_method: z.enum(["manual"]).optional(),
+  capture_method: z.literal("manual").optional(),
   setup_future_usage: z.enum(["none", "off_session"]).optional(),
 })
 
 export const s_payment_method_options_satispay = z.object({
-  capture_method: z.enum(["manual"]).optional(),
+  capture_method: z.literal("manual").optional(),
 })
 
 export const s_payment_method_options_sofort = z.object({
@@ -4212,20 +4209,20 @@ export const s_payment_method_options_sofort = z.object({
 })
 
 export const s_payment_method_options_twint = z.object({
-  setup_future_usage: z.enum(["none"]).optional(),
+  setup_future_usage: z.literal("none").optional(),
 })
 
 export const s_payment_method_options_us_bank_account_mandate_options =
-  z.object({collection_method: z.enum(["paper"]).optional()})
+  z.object({collection_method: z.literal("paper").optional()})
 
 export const s_payment_method_options_wechat_pay = z.object({
   app_id: z.string().max(5000).nullable().optional(),
   client: z.enum(["android", "ios", "web"]).nullable().optional(),
-  setup_future_usage: z.enum(["none"]).optional(),
+  setup_future_usage: z.literal("none").optional(),
 })
 
 export const s_payment_method_options_zip = z.object({
-  setup_future_usage: z.enum(["none"]).optional(),
+  setup_future_usage: z.literal("none").optional(),
 })
 
 export const s_payment_method_oxxo = z.record(z.string(), z.unknown())
@@ -4343,7 +4340,7 @@ export const s_payment_pages_checkout_session_after_expiration_recovery =
 
 export const s_payment_pages_checkout_session_consent = z.object({
   promotions: z.enum(["opt_in", "opt_out"]).nullable().optional(),
-  terms_of_service: z.enum(["accepted"]).nullable().optional(),
+  terms_of_service: z.literal("accepted").nullable().optional(),
 })
 
 export const s_payment_pages_checkout_session_currency_conversion = z.object({
@@ -4355,7 +4352,7 @@ export const s_payment_pages_checkout_session_currency_conversion = z.object({
 
 export const s_payment_pages_checkout_session_custom_fields_label = z.object({
   custom: z.string().max(5000).nullable().optional(),
-  type: z.enum(["custom"]),
+  type: z.literal("custom"),
 })
 
 export const s_payment_pages_checkout_session_custom_fields_numeric = z.object({
@@ -5020,14 +5017,14 @@ export const s_radar_value_list_item = z.object({
   created_by: z.string().max(5000),
   id: z.string().max(5000),
   livemode: PermissiveBoolean,
-  object: z.enum(["radar.value_list_item"]),
+  object: z.literal("radar.value_list_item"),
   value: z.string().max(5000),
   value_list: z.string().max(5000),
 })
 
 export const s_received_payment_method_details_financial_account = z.object({
   id: z.string().max(5000),
-  network: z.enum(["stripe"]),
+  network: z.literal("stripe"),
 })
 
 export const s_recurring = z.object({
@@ -5112,7 +5109,7 @@ export const s_reporting_report_type = z.object({
   id: z.string().max(5000),
   livemode: PermissiveBoolean,
   name: z.string().max(5000),
-  object: z.enum(["reporting.report_type"]),
+  object: z.literal("reporting.report_type"),
   updated: z.coerce.number(),
   version: z.coerce.number(),
 })
@@ -5122,7 +5119,7 @@ export const s_reserve_transaction = z.object({
   currency: z.string(),
   description: z.string().max(5000).nullable().optional(),
   id: z.string().max(5000),
-  object: z.enum(["reserve_transaction"]),
+  object: z.literal("reserve_transaction"),
 })
 
 export const s_rule = z.object({
@@ -5251,10 +5248,7 @@ export const s_setup_intent_payment_method_options_card_mandate_options =
     interval_count: z.coerce.number().nullable().optional(),
     reference: z.string().max(80),
     start_date: z.coerce.number(),
-    supported_types: z
-      .array(z.enum(["india"]))
-      .nullable()
-      .optional(),
+    supported_types: z.array(z.literal("india")).nullable().optional(),
   })
 
 export const s_setup_intent_payment_method_options_card_present = z.record(
@@ -5320,7 +5314,7 @@ export const s_sigma_sigma_api_query = z.object({
   id: z.string().max(5000),
   livemode: PermissiveBoolean,
   name: z.string().max(5000),
-  object: z.enum(["sigma.sigma_api_query"]),
+  object: z.literal("sigma.sigma_api_query"),
   sql: z.string().max(5000),
 })
 
@@ -5657,12 +5651,12 @@ export const s_tax_code = z.object({
   description: z.string().max(5000),
   id: z.string().max(5000),
   name: z.string().max(5000),
-  object: z.enum(["tax_code"]),
+  object: z.literal("tax_code"),
 })
 
 export const s_tax_deducted_at_source = z.object({
   id: z.string().max(5000),
-  object: z.enum(["tax_deducted_at_source"]),
+  object: z.literal("tax_deducted_at_source"),
   period_end: z.coerce.number(),
   period_start: z.coerce.number(),
   tax_deduction_account_number: z.string().max(5000),
@@ -5678,7 +5672,7 @@ export const s_tax_product_registrations_resource_country_options_ca_province_st
   z.object({province: z.string().max(5000)})
 
 export const s_tax_product_registrations_resource_country_options_default =
-  z.object({type: z.enum(["standard"])})
+  z.object({type: z.literal("standard")})
 
 export const s_tax_product_registrations_resource_country_options_default_standard =
   z.object({place_of_supply_scheme: z.enum(["inbound_goods", "standard"])})
@@ -5693,7 +5687,7 @@ export const s_tax_product_registrations_resource_country_options_eu_standard =
   })
 
 export const s_tax_product_registrations_resource_country_options_simplified =
-  z.object({type: z.enum(["simplified"])})
+  z.object({type: z.literal("simplified")})
 
 export const s_tax_product_registrations_resource_country_options_us_local_amusement_tax =
   z.object({jurisdiction: z.string().max(5000)})
@@ -5937,7 +5931,7 @@ export const s_terminal_configuration_configuration_resource_reboot_window =
 
 export const s_terminal_connection_token = z.object({
   location: z.string().max(5000).optional(),
-  object: z.enum(["terminal.connection_token"]),
+  object: z.literal("terminal.connection_token"),
   secret: z.string().max(5000),
 })
 
@@ -6318,7 +6312,7 @@ export const s_webhook_endpoint = z.object({
   id: z.string().max(5000),
   livemode: PermissiveBoolean,
   metadata: z.record(z.string(), z.string().max(500)),
-  object: z.enum(["webhook_endpoint"]),
+  object: z.literal("webhook_endpoint"),
   secret: z.string().max(5000).optional(),
   status: z.string().max(5000),
   url: z.string().max(5000),
@@ -6505,7 +6499,7 @@ export const s_account_unification_account_controller = z.object({
 
 export const s_amazon_pay_underlying_payment_method_funding_details = z.object({
   card: s_payment_method_details_passthrough_card.optional(),
-  type: z.enum(["card"]).nullable().optional(),
+  type: z.literal("card").nullable().optional(),
 })
 
 export const s_apps_secret = z.object({
@@ -6515,7 +6509,7 @@ export const s_apps_secret = z.object({
   id: z.string().max(5000),
   livemode: PermissiveBoolean,
   name: z.string().max(5000),
-  object: z.enum(["apps.secret"]),
+  object: z.literal("apps.secret"),
   payload: z.string().max(5000).nullable().optional(),
   scope: s_secret_service_resource_scope,
 })
@@ -6547,7 +6541,7 @@ export const s_billing_bill_resource_invoice_item_parents_invoice_item_parent =
       s_billing_bill_resource_invoice_item_parents_invoice_item_subscription_parent
         .nullable()
         .optional(),
-    type: z.enum(["subscription_details"]),
+    type: z.literal("subscription_details"),
   })
 
 export const s_billing_bill_resource_invoicing_lines_common_proration_details =
@@ -6561,7 +6555,7 @@ export const s_billing_bill_resource_invoicing_lines_common_proration_details =
 export const s_billing_bill_resource_invoicing_pricing_pricing = z.object({
   price_details:
     s_billing_bill_resource_invoicing_pricing_pricing_price_details.optional(),
-  type: z.enum(["price_details"]),
+  type: z.literal("price_details"),
   unit_amount_decimal: z.string().nullable().optional(),
 })
 
@@ -6590,7 +6584,7 @@ export const s_billing_bill_resource_invoicing_taxes_tax = z.object({
     "zero_rated",
   ]),
   taxable_amount: z.coerce.number().nullable().optional(),
-  type: z.enum(["tax_rate_details"]),
+  type: z.literal("tax_rate_details"),
 })
 
 export const s_billing_clocks_resource_status_details_status_details = z.object(
@@ -6604,11 +6598,11 @@ export const s_billing_credit_grants_resource_amount = z.object({
   monetary: s_billing_credit_grants_resource_monetary_amount
     .nullable()
     .optional(),
-  type: z.enum(["monetary"]),
+  type: z.literal("monetary"),
 })
 
 export const s_billing_credit_grants_resource_scope = z.object({
-  price_type: z.enum(["metered"]).optional(),
+  price_type: z.literal("metered").optional(),
   prices: z.array(s_billing_credit_grants_resource_applicable_price).optional(),
 })
 
@@ -6629,7 +6623,7 @@ export const s_billing_meter = z.object({
   event_time_window: z.enum(["day", "hour"]).nullable().optional(),
   id: z.string().max(5000),
   livemode: PermissiveBoolean,
-  object: z.enum(["billing.meter"]),
+  object: z.literal("billing.meter"),
   status: z.enum(["active", "inactive"]),
   status_transitions: s_billing_meter_resource_billing_meter_status_transitions,
   updated: z.coerce.number(),
@@ -6642,16 +6636,16 @@ export const s_billing_meter_event_adjustment = z.object({
     .optional(),
   event_name: z.string().max(100),
   livemode: PermissiveBoolean,
-  object: z.enum(["billing.meter_event_adjustment"]),
+  object: z.literal("billing.meter_event_adjustment"),
   status: z.enum(["complete", "pending"]),
-  type: z.enum(["cancel"]),
+  type: z.literal("cancel"),
 })
 
 export const s_cash_balance = z.object({
   available: z.record(z.string(), z.coerce.number()).nullable().optional(),
   customer: z.string().max(5000),
   livemode: PermissiveBoolean,
-  object: z.enum(["cash_balance"]),
+  object: z.literal("cash_balance"),
   settings: s_customer_balance_customer_balance_settings,
 })
 
@@ -6742,7 +6736,7 @@ export const s_climate_supplier = z.object({
   livemode: PermissiveBoolean,
   locations: z.array(s_climate_removals_location),
   name: z.string().max(5000),
-  object: z.enum(["climate.supplier"]),
+  object: z.literal("climate.supplier"),
   removal_pathway: z.enum([
     "biomass_carbon_removal_and_storage",
     "direct_air_capture",
@@ -6842,7 +6836,7 @@ export const s_coupon = z.object({
   max_redemptions: z.coerce.number().nullable().optional(),
   metadata: z.record(z.string(), z.string().max(500)).nullable().optional(),
   name: z.string().max(5000).nullable().optional(),
-  object: z.enum(["coupon"]),
+  object: z.literal("coupon"),
   percent_off: z.coerce.number().nullable().optional(),
   redeem_by: z.coerce.number().nullable().optional(),
   times_redeemed: z.coerce.number(),
@@ -6967,7 +6961,7 @@ export const s_entitlements_active_entitlement = z.object({
   id: z.string().max(5000),
   livemode: PermissiveBoolean,
   lookup_key: z.string().max(5000),
-  object: z.enum(["entitlements.active_entitlement"]),
+  object: z.literal("entitlements.active_entitlement"),
 })
 
 export const s_event = z.object({
@@ -6978,7 +6972,7 @@ export const s_event = z.object({
   data: s_notification_event_data,
   id: z.string().max(5000),
   livemode: PermissiveBoolean,
-  object: z.enum(["event"]),
+  object: z.literal("event"),
   pending_webhooks: z.coerce.number(),
   request: s_notification_event_request.nullable().optional(),
   type: z.string().max(5000),
@@ -6994,11 +6988,11 @@ export const s_external_account_requirements = z.object({
 export const s_financial_connections_account_ownership = z.object({
   created: z.coerce.number(),
   id: z.string().max(5000),
-  object: z.enum(["financial_connections.account_ownership"]),
+  object: z.literal("financial_connections.account_ownership"),
   owners: z.object({
     data: z.array(s_financial_connections_account_owner),
     has_more: PermissiveBoolean,
-    object: z.enum(["list"]),
+    object: z.literal("list"),
     url: z.string().max(5000),
   }),
 })
@@ -7010,7 +7004,7 @@ export const s_financial_connections_transaction = z.object({
   description: z.string().max(5000),
   id: z.string().max(5000),
   livemode: PermissiveBoolean,
-  object: z.enum(["financial_connections.transaction"]),
+  object: z.literal("financial_connections.transaction"),
   status: z.enum(["pending", "posted", "void"]),
   status_transitions:
     s_bank_connections_resource_transaction_resource_status_transitions,
@@ -7022,7 +7016,7 @@ export const s_financial_connections_transaction = z.object({
 export const s_forwarded_request_details = z.object({
   body: z.string().max(5000),
   headers: z.array(s_forwarded_request_header),
-  http_method: z.enum(["POST"]),
+  http_method: z.literal("POST"),
 })
 
 export const s_forwarded_response_details = z.object({
@@ -8605,7 +8599,7 @@ export const s_issuing_physical_bundle = z.object({
   id: z.string().max(5000),
   livemode: PermissiveBoolean,
   name: z.string().max(5000),
-  object: z.enum(["issuing.physical_bundle"]),
+  object: z.literal("issuing.physical_bundle"),
   status: z.enum(["active", "inactive", "review"]),
   type: z.enum(["custom", "standard"]),
 })
@@ -9122,7 +9116,7 @@ export const s_portal_flows_flow_subscription_update_confirm = z.object({
 
 export const s_portal_flows_retention = z.object({
   coupon_offer: s_portal_flows_coupon_offer.nullable().optional(),
-  type: z.enum(["coupon_offer"]),
+  type: z.literal("coupon_offer"),
 })
 
 export const s_portal_resource_schedule_update_at_period_end = z.object({
@@ -9148,7 +9142,7 @@ export const s_product_feature = z.object({
   entitlement_feature: s_entitlements_feature,
   id: z.string().max(5000),
   livemode: PermissiveBoolean,
-  object: z.enum(["product_feature"]),
+  object: z.literal("product_feature"),
 })
 
 export const s_promotion_codes_resource_restrictions = z.object({
@@ -9188,13 +9182,13 @@ export const s_radar_value_list = z.object({
   list_items: z.object({
     data: z.array(s_radar_value_list_item),
     has_more: PermissiveBoolean,
-    object: z.enum(["list"]),
+    object: z.literal("list"),
     url: z.string().max(5000),
   }),
   livemode: PermissiveBoolean,
   metadata: z.record(z.string(), z.string().max(500)),
   name: z.string().max(5000),
-  object: z.enum(["radar.value_list"]),
+  object: z.literal("radar.value_list"),
 })
 
 export const s_refund_destination_details = z.object({
@@ -9241,7 +9235,7 @@ export const s_refund_next_action_display_details = z.object({
 export const s_revolut_pay_underlying_payment_method_funding_details = z.object(
   {
     card: s_payment_method_details_passthrough_card.optional(),
-    type: z.enum(["card"]).nullable().optional(),
+    type: z.literal("card").nullable().optional(),
   },
 )
 
@@ -9339,7 +9333,7 @@ export const s_source_transaction = z.object({
   gbp_credit_transfer: s_source_transaction_gbp_credit_transfer_data.optional(),
   id: z.string().max(5000),
   livemode: PermissiveBoolean,
-  object: z.enum(["source_transaction"]),
+  object: z.literal("source_transaction"),
   paper_check: s_source_transaction_paper_check_data.optional(),
   sepa_credit_transfer:
     s_source_transaction_sepa_credit_transfer_data.optional(),
@@ -9406,7 +9400,7 @@ export const s_tax_product_registrations_resource_country_options_default_inboun
   z.object({
     standard:
       s_tax_product_registrations_resource_country_options_default_standard.optional(),
-    type: z.enum(["standard"]),
+    type: z.literal("standard"),
   })
 
 export const s_tax_product_registrations_resource_country_options_europe =
@@ -9519,7 +9513,7 @@ export const s_tax_rate = z.object({
     .optional(),
   livemode: PermissiveBoolean,
   metadata: z.record(z.string(), z.string().max(500)).nullable().optional(),
-  object: z.enum(["tax_rate"]),
+  object: z.literal("tax_rate"),
   percentage: z.coerce.number(),
   rate_type: z.enum(["flat_amount", "percentage"]).nullable().optional(),
   state: z.string().max(5000).nullable().optional(),
@@ -9550,7 +9544,7 @@ export const s_tax_transaction_line_item = z.object({
   id: z.string().max(5000),
   livemode: PermissiveBoolean,
   metadata: z.record(z.string(), z.string().max(500)).nullable().optional(),
-  object: z.enum(["tax.transaction_line_item"]),
+  object: z.literal("tax.transaction_line_item"),
   product: z.string().max(5000).nullable().optional(),
   quantity: z.coerce.number(),
   reference: z.string().max(5000),
@@ -9605,7 +9599,7 @@ export const s_terminal_location = z.object({
   id: z.string().max(5000),
   livemode: PermissiveBoolean,
   metadata: z.record(z.string(), z.string().max(500)),
-  object: z.enum(["terminal.location"]),
+  object: z.literal("terminal.location"),
 })
 
 export const s_terminal_reader_reader_resource_cart = z.object({
@@ -9647,7 +9641,7 @@ export const s_treasury_financial_accounts_resource_financial_address =
   z.object({
     aba: s_treasury_financial_accounts_resource_aba_record.optional(),
     supported_networks: z.array(z.enum(["ach", "us_domestic_wire"])).optional(),
-    type: z.enum(["aba"]),
+    type: z.literal("aba"),
   })
 
 export const s_treasury_financial_accounts_resource_inbound_ach_toggle_settings =
@@ -9753,8 +9747,8 @@ export const s_card_generated_from_payment_method_details = z.object({
 export const s_checkout_customer_balance_payment_method_options = z.object({
   bank_transfer:
     s_checkout_customer_balance_bank_transfer_payment_method_options.optional(),
-  funding_type: z.enum(["bank_transfer"]).nullable().optional(),
-  setup_future_usage: z.enum(["none"]).optional(),
+  funding_type: z.literal("bank_transfer").nullable().optional(),
+  setup_future_usage: z.literal("none").optional(),
 })
 
 export const s_checkout_us_bank_account_payment_method_options = z.object({
@@ -9775,7 +9769,7 @@ export const s_climate_product = z.object({
   livemode: PermissiveBoolean,
   metric_tons_available: z.string(),
   name: z.string().max(5000),
-  object: z.enum(["climate.product"]),
+  object: z.literal("climate.product"),
   suppliers: z.array(s_climate_supplier),
 })
 
@@ -9825,7 +9819,7 @@ export const s_connect_embedded_account_session_create_components = z.object({
 export const s_country_spec = z.object({
   default_currency: z.string().max(5000),
   id: z.string().max(5000),
-  object: z.enum(["country_spec"]),
+  object: z.literal("country_spec"),
   supported_bank_account_currencies: z.record(
     z.string(),
     z.array(z.string().max(5000)),
@@ -9876,7 +9870,7 @@ export const s_forwarding_request = z.object({
   id: z.string().max(5000),
   livemode: PermissiveBoolean,
   metadata: z.record(z.string(), z.string().max(500)).nullable().optional(),
-  object: z.enum(["forwarding.request"]),
+  object: z.literal("forwarding.request"),
   payment_method: z.string().max(5000),
   replacements: z.array(
     z.enum([
@@ -9925,7 +9919,7 @@ export const s_identity_verification_report = z.object({
   id: z.string().max(5000),
   id_number: s_gelato_id_number_report.optional(),
   livemode: PermissiveBoolean,
-  object: z.enum(["identity.verification_report"]),
+  object: z.literal("identity.verification_report"),
   options: s_gelato_verification_report_options.optional(),
   phone: s_gelato_phone_report.optional(),
   selfie: s_gelato_selfie_report.optional(),
@@ -9937,7 +9931,7 @@ export const s_identity_verification_report = z.object({
 export const s_invoice_payment_method_options_customer_balance = z.object({
   bank_transfer:
     s_invoice_payment_method_options_customer_balance_bank_transfer.optional(),
-  funding_type: z.enum(["bank_transfer"]).nullable().optional(),
+  funding_type: z.literal("bank_transfer").nullable().optional(),
 })
 
 export const s_invoice_payment_method_options_us_bank_account = z.object({
@@ -10046,7 +10040,7 @@ export const s_payment_intent_next_action_konbini = z.object({
 })
 
 export const s_payment_intent_payment_method_options_card = z.object({
-  capture_method: z.enum(["manual"]).optional(),
+  capture_method: z.literal("manual").optional(),
   installments: s_payment_method_options_card_installments
     .nullable()
     .optional(),
@@ -10105,7 +10099,7 @@ export const s_payment_intent_payment_method_options_us_bank_account = z.object(
 
 export const s_payment_intent_processing = z.object({
   card: s_payment_intent_card_processing.optional(),
-  type: z.enum(["card"]),
+  type: z.literal("card"),
 })
 
 export const s_payment_intent_type_specific_payment_method_options_client =
@@ -10214,7 +10208,7 @@ export const s_payment_method_configuration = z.object({
     s_payment_method_config_resource_payment_method_properties.optional(),
   nz_bank_account:
     s_payment_method_config_resource_payment_method_properties.optional(),
-  object: z.enum(["payment_method_configuration"]),
+  object: z.literal("payment_method_configuration"),
   oxxo: s_payment_method_config_resource_payment_method_properties.optional(),
   p24: s_payment_method_config_resource_payment_method_properties.optional(),
   parent: z.string().max(5000).nullable().optional(),
@@ -10290,15 +10284,15 @@ export const s_payment_method_domain = z.object({
   klarna: s_payment_method_domain_resource_payment_method_status,
   link: s_payment_method_domain_resource_payment_method_status,
   livemode: PermissiveBoolean,
-  object: z.enum(["payment_method_domain"]),
+  object: z.literal("payment_method_domain"),
   paypal: s_payment_method_domain_resource_payment_method_status,
 })
 
 export const s_payment_method_options_customer_balance = z.object({
   bank_transfer:
     s_payment_method_options_customer_balance_bank_transfer.optional(),
-  funding_type: z.enum(["bank_transfer"]).nullable().optional(),
-  setup_future_usage: z.enum(["none"]).optional(),
+  funding_type: z.literal("bank_transfer").nullable().optional(),
+  setup_future_usage: z.literal("none").optional(),
 })
 
 export const s_payment_method_us_bank_account = z.object({
@@ -10397,7 +10391,7 @@ export const s_shipping_rate = z.object({
   id: z.string().max(5000),
   livemode: PermissiveBoolean,
   metadata: z.record(z.string(), z.string().max(500)),
-  object: z.enum(["shipping_rate"]),
+  object: z.literal("shipping_rate"),
   tax_behavior: z
     .enum(["exclusive", "inclusive", "unspecified"])
     .nullable()
@@ -10406,7 +10400,7 @@ export const s_shipping_rate = z.object({
     .union([z.string().max(5000), s_tax_code])
     .nullable()
     .optional(),
-  type: z.enum(["fixed_amount"]),
+  type: z.literal("fixed_amount"),
 })
 
 export const s_source_order = z.object({
@@ -10423,7 +10417,7 @@ export const s_tax_calculation_line_item = z.object({
   id: z.string().max(5000),
   livemode: PermissiveBoolean,
   metadata: z.record(z.string(), z.string().max(500)).nullable().optional(),
-  object: z.enum(["tax.calculation_line_item"]),
+  object: z.literal("tax.calculation_line_item"),
   product: z.string().max(5000).nullable().optional(),
   quantity: z.coerce.number(),
   reference: z.string().max(5000),
@@ -10494,7 +10488,7 @@ export const s_tax_settings = z.object({
     .nullable()
     .optional(),
   livemode: PermissiveBoolean,
-  object: z.enum(["tax.settings"]),
+  object: z.literal("tax.settings"),
   status: z.enum(["active", "pending"]),
   status_details: s_tax_product_resource_tax_settings_status_details,
 })
@@ -10509,7 +10503,7 @@ export const s_tax_transaction = z.object({
     .object({
       data: z.array(s_tax_transaction_line_item),
       has_more: PermissiveBoolean,
-      object: z.enum(["list"]),
+      object: z.literal("list"),
       url: z
         .string()
         .max(5000)
@@ -10519,7 +10513,7 @@ export const s_tax_transaction = z.object({
     .optional(),
   livemode: PermissiveBoolean,
   metadata: z.record(z.string(), z.string().max(500)).nullable().optional(),
-  object: z.enum(["tax.transaction"]),
+  object: z.literal("tax.transaction"),
   posted_at: z.coerce.number(),
   reference: z.string().max(5000),
   reversal: s_tax_product_resource_tax_transaction_resource_reversal
@@ -10557,7 +10551,7 @@ export const s_terminal_reader_reader_resource_input = z.object({
 export const s_terminal_reader_reader_resource_set_reader_display_action =
   z.object({
     cart: s_terminal_reader_reader_resource_cart.nullable().optional(),
-    type: z.enum(["cart"]),
+    type: z.literal("cart"),
   })
 
 export const s_test_helpers_test_clock = z.object({
@@ -10567,7 +10561,7 @@ export const s_test_helpers_test_clock = z.object({
   id: z.string().max(5000),
   livemode: PermissiveBoolean,
   name: z.string().max(5000).nullable().optional(),
-  object: z.enum(["test_helpers.test_clock"]),
+  object: z.literal("test_helpers.test_clock"),
   status: z.enum(["advancing", "internal_failure", "ready"]),
   status_details: s_billing_clocks_resource_status_details_status_details,
 })
@@ -10598,7 +10592,7 @@ export const s_treasury_financial_accounts_resource_outbound_transfers =
 
 export const s_treasury_shared_resource_initiating_payment_method_details_initiating_payment_method_details =
   z.object({
-    balance: z.enum(["payments"]).optional(),
+    balance: z.literal("payments").optional(),
     billing_details: s_treasury_shared_resource_billing_details,
     financial_account:
       s_received_payment_method_details_financial_account.optional(),
@@ -10620,7 +10614,7 @@ export const s_account_session = z.object({
   components: s_connect_embedded_account_session_create_components,
   expires_at: z.coerce.number(),
   livemode: PermissiveBoolean,
-  object: z.enum(["account_session"]),
+  object: z.literal("account_session"),
 })
 
 export const s_balance = z.object({
@@ -10629,7 +10623,7 @@ export const s_balance = z.object({
   instant_available: z.array(s_balance_amount_net).optional(),
   issuing: s_balance_detail.optional(),
   livemode: PermissiveBoolean,
-  object: z.enum(["balance"]),
+  object: z.literal("balance"),
   pending: z.array(s_balance_amount),
   refund_and_dispute_prefunding: s_balance_detail_ungated.optional(),
 })
@@ -10711,7 +10705,7 @@ export const s_climate_order = z.object({
   livemode: PermissiveBoolean,
   metadata: z.record(z.string(), z.string().max(500)),
   metric_tons: z.string(),
-  object: z.enum(["climate.order"]),
+  object: z.literal("climate.order"),
   product: z.union([z.string().max(5000), s_climate_product]),
   product_substituted_at: z.coerce.number().nullable().optional(),
   status: z.enum([
@@ -10755,7 +10749,7 @@ export const s_identity_verification_session = z.object({
     .optional(),
   livemode: PermissiveBoolean,
   metadata: z.record(z.string(), z.string().max(500)),
-  object: z.enum(["identity.verification_session"]),
+  object: z.literal("identity.verification_session"),
   options: s_gelato_verification_session_options.nullable().optional(),
   provided_details: s_gelato_provided_details.nullable().optional(),
   redaction: s_verification_session_redaction.nullable().optional(),
@@ -11296,7 +11290,7 @@ export const s_source = z.object({
   livemode: PermissiveBoolean,
   metadata: z.record(z.string(), z.string().max(500)).nullable().optional(),
   multibanco: s_source_type_multibanco.optional(),
-  object: z.enum(["source"]),
+  object: z.literal("source"),
   owner: s_source_owner.nullable().optional(),
   p24: s_source_type_p24.optional(),
   receiver: s_source_receiver_flow.optional(),
@@ -11356,7 +11350,7 @@ export const s_tax_calculation = z.object({
     .object({
       data: z.array(s_tax_calculation_line_item),
       has_more: PermissiveBoolean,
-      object: z.enum(["list"]),
+      object: z.literal("list"),
       url: z
         .string()
         .max(5000)
@@ -11365,7 +11359,7 @@ export const s_tax_calculation = z.object({
     .nullable()
     .optional(),
   livemode: PermissiveBoolean,
-  object: z.enum(["tax.calculation"]),
+  object: z.literal("tax.calculation"),
   ship_from_details: s_tax_product_resource_ship_from_details
     .nullable()
     .optional(),
@@ -11498,7 +11492,7 @@ export const s_treasury_financial_account_features = z.object({
     s_treasury_financial_accounts_resource_inbound_transfers.optional(),
   intra_stripe_flows:
     s_treasury_financial_accounts_resource_toggle_settings.optional(),
-  object: z.enum(["treasury.financial_account_features"]),
+  object: z.literal("treasury.financial_account_features"),
   outbound_payments:
     s_treasury_financial_accounts_resource_outbound_payments.optional(),
   outbound_transfers:
@@ -11520,16 +11514,16 @@ export const s_billing_portal_configuration = z.object({
   livemode: PermissiveBoolean,
   login_page: s_portal_login_page,
   metadata: z.record(z.string(), z.string().max(500)).nullable().optional(),
-  object: z.enum(["billing_portal.configuration"]),
+  object: z.literal("billing_portal.configuration"),
   updated: z.coerce.number(),
 })
 
 export const s_funding_instructions = z.object({
   bank_transfer: s_funding_instructions_bank_transfer,
   currency: z.string().max(5000),
-  funding_type: z.enum(["bank_transfer"]),
+  funding_type: z.literal("bank_transfer"),
   livemode: PermissiveBoolean,
-  object: z.enum(["funding_instructions"]),
+  object: z.literal("funding_instructions"),
 })
 
 export const s_invoices_payment_settings = z.object({
@@ -11628,7 +11622,7 @@ export const s_source_mandate_notification = z.object({
   created: z.coerce.number(),
   id: z.string().max(5000),
   livemode: PermissiveBoolean,
-  object: z.enum(["source_mandate_notification"]),
+  object: z.literal("source_mandate_notification"),
   reason: z.string().max(5000),
   sepa_debit: s_source_mandate_notification_sepa_debit_data.optional(),
   source: s_source,
@@ -11700,7 +11694,7 @@ export const s_tax_registration = z.object({
   expires_at: z.coerce.number().nullable().optional(),
   id: z.string().max(5000),
   livemode: PermissiveBoolean,
-  object: z.enum(["tax.registration"]),
+  object: z.literal("tax.registration"),
   status: z.enum(["active", "expired", "scheduled"]),
 })
 
@@ -11734,7 +11728,7 @@ export const s_treasury_financial_account = z.object({
   livemode: PermissiveBoolean,
   metadata: z.record(z.string(), z.string().max(500)).nullable().optional(),
   nickname: z.string().max(5000).nullable().optional(),
-  object: z.enum(["treasury.financial_account"]),
+  object: z.literal("treasury.financial_account"),
   pending_features: z
     .array(
       z.enum([
@@ -11840,7 +11834,7 @@ export const s_billing_portal_session = z.object({
     ])
     .nullable()
     .optional(),
-  object: z.enum(["billing_portal.session"]),
+  object: z.literal("billing_portal.session"),
   on_behalf_of: z.string().max(5000).nullable().optional(),
   return_url: z.string().max(5000).nullable().optional(),
   url: z.string().max(5000),
@@ -11867,7 +11861,7 @@ export const s_account: z.ZodType<t_account> = z.object({
         z.union([z.lazy(() => s_bank_account), z.lazy(() => s_card)]),
       ),
       has_more: PermissiveBoolean,
-      object: z.enum(["list"]),
+      object: z.literal("list"),
       url: z.string().max(5000),
     })
     .optional(),
@@ -11876,7 +11870,7 @@ export const s_account: z.ZodType<t_account> = z.object({
   id: z.string().max(5000),
   individual: z.lazy(() => s_person.optional()),
   metadata: z.record(z.string(), z.string().max(500)).optional(),
-  object: z.enum(["account"]),
+  object: z.literal("account"),
   payouts_enabled: PermissiveBoolean.optional(),
   requirements: s_account_requirements.optional(),
   settings: z
@@ -12133,7 +12127,7 @@ export const s_PostAccountsRequestBody = z.object({
               .optional(),
           })
           .optional(),
-        object: z.enum(["bank_account"]).optional(),
+        object: z.literal("bank_account").optional(),
         routing_number: z.string().max(5000).optional(),
       }),
       z.string().max(5000),
@@ -12178,7 +12172,7 @@ export const s_PostAccountsRequestBody = z.object({
         .optional(),
       support_email: z.string().optional(),
       support_phone: z.string().max(5000).optional(),
-      support_url: z.union([z.string(), z.enum([""])]).optional(),
+      support_url: z.union([z.string(), z.literal("")]).optional(),
       url: z.string().optional(),
     })
     .optional(),
@@ -12433,7 +12427,7 @@ export const s_PostAccountsRequestBody = z.object({
             month: z.coerce.number(),
             year: z.coerce.number(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       registration_number: z.string().max(5000).optional(),
@@ -12533,7 +12527,7 @@ export const s_PostAccountsRequestBody = z.object({
   groups: z
     .object({
       payments_pricing: z
-        .union([z.string().max(5000), z.enum([""])])
+        .union([z.string().max(5000), z.literal("")])
         .optional(),
     })
     .optional(),
@@ -12578,7 +12572,7 @@ export const s_PostAccountsRequestBody = z.object({
             month: z.coerce.number(),
             year: z.coerce.number(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       email: z.string().optional(),
@@ -12586,7 +12580,7 @@ export const s_PostAccountsRequestBody = z.object({
       first_name_kana: z.string().max(5000).optional(),
       first_name_kanji: z.string().max(5000).optional(),
       full_name_aliases: z
-        .union([z.array(z.string().max(300)), z.enum([""])])
+        .union([z.array(z.string().max(300)), z.literal("")])
         .optional(),
       gender: z.string().optional(),
       id_number: z.string().max(5000).optional(),
@@ -12596,7 +12590,7 @@ export const s_PostAccountsRequestBody = z.object({
       last_name_kanji: z.string().max(5000).optional(),
       maiden_name: z.string().max(5000).optional(),
       metadata: z
-        .union([z.record(z.string(), z.string()), z.enum([""])])
+        .union([z.record(z.string(), z.string()), z.literal("")])
         .optional(),
       phone: z.string().optional(),
       political_exposure: z.enum(["existing", "none"]).optional(),
@@ -12616,7 +12610,7 @@ export const s_PostAccountsRequestBody = z.object({
           executive: PermissiveBoolean.optional(),
           owner: PermissiveBoolean.optional(),
           percent_ownership: z
-            .union([z.coerce.number(), z.enum([""])])
+            .union([z.coerce.number(), z.literal("")])
             .optional(),
           title: z.string().max(5000).optional(),
         })
@@ -12641,7 +12635,7 @@ export const s_PostAccountsRequestBody = z.object({
     })
     .optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   settings: z
     .object({
@@ -12663,7 +12657,7 @@ export const s_PostAccountsRequestBody = z.object({
               date: z.coerce.number().optional(),
               ip: z.string().optional(),
               user_agent: z
-                .union([z.string().max(5000), z.enum([""])])
+                .union([z.string().max(5000), z.literal("")])
                 .optional(),
             })
             .optional(),
@@ -12679,10 +12673,10 @@ export const s_PostAccountsRequestBody = z.object({
             .optional(),
           statement_descriptor_prefix: z.string().max(10).optional(),
           statement_descriptor_prefix_kana: z
-            .union([z.string().max(10), z.enum([""])])
+            .union([z.string().max(10), z.literal("")])
             .optional(),
           statement_descriptor_prefix_kanji: z
-            .union([z.string().max(10), z.enum([""])])
+            .union([z.string().max(10), z.literal("")])
             .optional(),
         })
         .optional(),
@@ -12706,7 +12700,7 @@ export const s_PostAccountsRequestBody = z.object({
           schedule: z
             .object({
               delay_days: z
-                .union([z.enum(["minimum"]), z.coerce.number()])
+                .union([z.literal("minimum"), z.coerce.number()])
                 .optional(),
               interval: z
                 .enum(["daily", "manual", "monthly", "weekly"])
@@ -12749,7 +12743,7 @@ export const s_PostAccountsRequestBody = z.object({
               date: z.coerce.number().optional(),
               ip: z.string().optional(),
               user_agent: z
-                .union([z.string().max(5000), z.enum([""])])
+                .union([z.string().max(5000), z.literal("")])
                 .optional(),
             })
             .optional(),
@@ -12809,7 +12803,7 @@ export const s_PostAccountsAccountRequestBody = z.object({
         .optional(),
       support_email: z.string().optional(),
       support_phone: z.string().max(5000).optional(),
-      support_url: z.union([z.string(), z.enum([""])]).optional(),
+      support_url: z.union([z.string(), z.literal("")]).optional(),
       url: z.string().optional(),
     })
     .optional(),
@@ -13064,7 +13058,7 @@ export const s_PostAccountsAccountRequestBody = z.object({
             month: z.coerce.number(),
             year: z.coerce.number(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       registration_number: z.string().max(5000).optional(),
@@ -13149,7 +13143,7 @@ export const s_PostAccountsAccountRequestBody = z.object({
   groups: z
     .object({
       payments_pricing: z
-        .union([z.string().max(5000), z.enum([""])])
+        .union([z.string().max(5000), z.literal("")])
         .optional(),
     })
     .optional(),
@@ -13194,7 +13188,7 @@ export const s_PostAccountsAccountRequestBody = z.object({
             month: z.coerce.number(),
             year: z.coerce.number(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       email: z.string().optional(),
@@ -13202,7 +13196,7 @@ export const s_PostAccountsAccountRequestBody = z.object({
       first_name_kana: z.string().max(5000).optional(),
       first_name_kanji: z.string().max(5000).optional(),
       full_name_aliases: z
-        .union([z.array(z.string().max(300)), z.enum([""])])
+        .union([z.array(z.string().max(300)), z.literal("")])
         .optional(),
       gender: z.string().optional(),
       id_number: z.string().max(5000).optional(),
@@ -13212,7 +13206,7 @@ export const s_PostAccountsAccountRequestBody = z.object({
       last_name_kanji: z.string().max(5000).optional(),
       maiden_name: z.string().max(5000).optional(),
       metadata: z
-        .union([z.record(z.string(), z.string()), z.enum([""])])
+        .union([z.record(z.string(), z.string()), z.literal("")])
         .optional(),
       phone: z.string().optional(),
       political_exposure: z.enum(["existing", "none"]).optional(),
@@ -13232,7 +13226,7 @@ export const s_PostAccountsAccountRequestBody = z.object({
           executive: PermissiveBoolean.optional(),
           owner: PermissiveBoolean.optional(),
           percent_ownership: z
-            .union([z.coerce.number(), z.enum([""])])
+            .union([z.coerce.number(), z.literal("")])
             .optional(),
           title: z.string().max(5000).optional(),
         })
@@ -13257,7 +13251,7 @@ export const s_PostAccountsAccountRequestBody = z.object({
     })
     .optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   settings: z
     .object({
@@ -13279,7 +13273,7 @@ export const s_PostAccountsAccountRequestBody = z.object({
               date: z.coerce.number().optional(),
               ip: z.string().optional(),
               user_agent: z
-                .union([z.string().max(5000), z.enum([""])])
+                .union([z.string().max(5000), z.literal("")])
                 .optional(),
             })
             .optional(),
@@ -13295,17 +13289,17 @@ export const s_PostAccountsAccountRequestBody = z.object({
             .optional(),
           statement_descriptor_prefix: z.string().max(10).optional(),
           statement_descriptor_prefix_kana: z
-            .union([z.string().max(10), z.enum([""])])
+            .union([z.string().max(10), z.literal("")])
             .optional(),
           statement_descriptor_prefix_kanji: z
-            .union([z.string().max(10), z.enum([""])])
+            .union([z.string().max(10), z.literal("")])
             .optional(),
         })
         .optional(),
       invoices: z
         .object({
           default_account_tax_ids: z
-            .union([z.array(z.string().max(5000)), z.enum([""])])
+            .union([z.array(z.string().max(5000)), z.literal("")])
             .optional(),
           hosted_payment_method_save: z
             .enum(["always", "never", "offer"])
@@ -13325,7 +13319,7 @@ export const s_PostAccountsAccountRequestBody = z.object({
           schedule: z
             .object({
               delay_days: z
-                .union([z.enum(["minimum"]), z.coerce.number()])
+                .union([z.literal("minimum"), z.coerce.number()])
                 .optional(),
               interval: z
                 .enum(["daily", "manual", "monthly", "weekly"])
@@ -13368,7 +13362,7 @@ export const s_PostAccountsAccountRequestBody = z.object({
               date: z.coerce.number().optional(),
               ip: z.string().optional(),
               user_agent: z
-                .union([z.string().max(5000), z.enum([""])])
+                .union([z.string().max(5000), z.literal("")])
                 .optional(),
             })
             .optional(),
@@ -13405,7 +13399,7 @@ export const s_PostAccountsAccountBankAccountsRequestBody = z.object({
               .optional(),
           })
           .optional(),
-        object: z.enum(["bank_account"]).optional(),
+        object: z.literal("bank_account").optional(),
         routing_number: z.string().max(5000).optional(),
       }),
       z.string().max(5000),
@@ -13444,7 +13438,7 @@ export const s_PostAccountsAccountBankAccountsIdRequestBody = z.object({
   exp_year: z.string().max(5000).optional(),
   expand: z.array(z.string().max(5000)).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   name: z.string().max(5000).optional(),
 })
@@ -13453,7 +13447,7 @@ export const s_capability: z.ZodType<t_capability> = z.object({
   account: z.union([z.string().max(5000), z.lazy(() => s_account)]),
   future_requirements: s_account_capability_future_requirements.optional(),
   id: z.string().max(5000),
-  object: z.enum(["capability"]),
+  object: z.literal("capability"),
   requested: PermissiveBoolean,
   requested_at: z.coerce.number().nullable().optional(),
   requirements: s_account_capability_requirements.optional(),
@@ -13490,7 +13484,7 @@ export const s_bank_account: z.ZodType<t_bank_account> = z.object({
   id: z.string().max(5000),
   last4: z.string().max(5000),
   metadata: z.record(z.string(), z.string().max(500)).nullable().optional(),
-  object: z.enum(["bank_account"]),
+  object: z.literal("bank_account"),
   requirements: s_external_account_requirements.nullable().optional(),
   routing_number: z.string().max(5000).nullable().optional(),
   status: z.string().max(5000),
@@ -13537,7 +13531,7 @@ export const s_card: z.ZodType<t_card> = z.object({
   metadata: z.record(z.string(), z.string().max(500)).nullable().optional(),
   name: z.string().max(5000).nullable().optional(),
   networks: s_token_card_networks.optional(),
-  object: z.enum(["card"]),
+  object: z.literal("card"),
   regulated_status: z.enum(["regulated", "unregulated"]).nullable().optional(),
   status: z.string().max(5000).nullable().optional(),
   tokenization_method: z.string().max(5000).nullable().optional(),
@@ -13562,7 +13556,7 @@ export const s_PostAccountsAccountExternalAccountsRequestBody = z.object({
               .optional(),
           })
           .optional(),
-        object: z.enum(["bank_account"]).optional(),
+        object: z.literal("bank_account").optional(),
         routing_number: z.string().max(5000).optional(),
       }),
       z.string().max(5000),
@@ -13596,7 +13590,7 @@ export const s_PostAccountsAccountExternalAccountsIdRequestBody = z.object({
   exp_year: z.string().max(5000).optional(),
   expand: z.array(z.string().max(5000)).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   name: z.string().max(5000).optional(),
 })
@@ -13629,7 +13623,7 @@ export const s_person: z.ZodType<t_person> = z.object({
   maiden_name: z.string().max(5000).nullable().optional(),
   metadata: z.record(z.string(), z.string().max(500)).optional(),
   nationality: z.string().max(5000).nullable().optional(),
-  object: z.enum(["person"]),
+  object: z.literal("person"),
   phone: z.string().max(5000).nullable().optional(),
   political_exposure: z.enum(["existing", "none"]).optional(),
   registered_address: s_address.optional(),
@@ -13647,7 +13641,7 @@ export const s_PostAccountsAccountPeopleRequestBody = z.object({
         .object({
           date: z.coerce.number().optional(),
           ip: z.string().optional(),
-          user_agent: z.union([z.string().max(5000), z.enum([""])]).optional(),
+          user_agent: z.union([z.string().max(5000), z.literal("")]).optional(),
         })
         .optional(),
     })
@@ -13691,7 +13685,7 @@ export const s_PostAccountsAccountPeopleRequestBody = z.object({
         month: z.coerce.number(),
         year: z.coerce.number(),
       }),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   documents: z
@@ -13699,21 +13693,21 @@ export const s_PostAccountsAccountPeopleRequestBody = z.object({
       company_authorization: z
         .object({
           files: z
-            .array(z.union([z.string().max(500), z.enum([""])]))
+            .array(z.union([z.string().max(500), z.literal("")]))
             .optional(),
         })
         .optional(),
       passport: z
         .object({
           files: z
-            .array(z.union([z.string().max(500), z.enum([""])]))
+            .array(z.union([z.string().max(500), z.literal("")]))
             .optional(),
         })
         .optional(),
       visa: z
         .object({
           files: z
-            .array(z.union([z.string().max(500), z.enum([""])]))
+            .array(z.union([z.string().max(500), z.literal("")]))
             .optional(),
         })
         .optional(),
@@ -13725,7 +13719,7 @@ export const s_PostAccountsAccountPeopleRequestBody = z.object({
   first_name_kana: z.string().max(5000).optional(),
   first_name_kanji: z.string().max(5000).optional(),
   full_name_aliases: z
-    .union([z.array(z.string().max(5000)), z.enum([""])])
+    .union([z.array(z.string().max(5000)), z.literal("")])
     .optional(),
   gender: z.string().optional(),
   id_number: z.string().max(5000).optional(),
@@ -13735,7 +13729,7 @@ export const s_PostAccountsAccountPeopleRequestBody = z.object({
   last_name_kanji: z.string().max(5000).optional(),
   maiden_name: z.string().max(5000).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   nationality: z.string().max(5000).optional(),
   person_token: z.string().max(5000).optional(),
@@ -13758,7 +13752,7 @@ export const s_PostAccountsAccountPeopleRequestBody = z.object({
       executive: PermissiveBoolean.optional(),
       legal_guardian: PermissiveBoolean.optional(),
       owner: PermissiveBoolean.optional(),
-      percent_ownership: z.union([z.coerce.number(), z.enum([""])]).optional(),
+      percent_ownership: z.union([z.coerce.number(), z.literal("")]).optional(),
       representative: PermissiveBoolean.optional(),
       title: z.string().max(5000).optional(),
     })
@@ -13847,7 +13841,7 @@ export const s_PostAccountsAccountPeoplePersonRequestBody = z.object({
         .object({
           date: z.coerce.number().optional(),
           ip: z.string().optional(),
-          user_agent: z.union([z.string().max(5000), z.enum([""])]).optional(),
+          user_agent: z.union([z.string().max(5000), z.literal("")]).optional(),
         })
         .optional(),
     })
@@ -13891,7 +13885,7 @@ export const s_PostAccountsAccountPeoplePersonRequestBody = z.object({
         month: z.coerce.number(),
         year: z.coerce.number(),
       }),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   documents: z
@@ -13899,21 +13893,21 @@ export const s_PostAccountsAccountPeoplePersonRequestBody = z.object({
       company_authorization: z
         .object({
           files: z
-            .array(z.union([z.string().max(500), z.enum([""])]))
+            .array(z.union([z.string().max(500), z.literal("")]))
             .optional(),
         })
         .optional(),
       passport: z
         .object({
           files: z
-            .array(z.union([z.string().max(500), z.enum([""])]))
+            .array(z.union([z.string().max(500), z.literal("")]))
             .optional(),
         })
         .optional(),
       visa: z
         .object({
           files: z
-            .array(z.union([z.string().max(500), z.enum([""])]))
+            .array(z.union([z.string().max(500), z.literal("")]))
             .optional(),
         })
         .optional(),
@@ -13925,7 +13919,7 @@ export const s_PostAccountsAccountPeoplePersonRequestBody = z.object({
   first_name_kana: z.string().max(5000).optional(),
   first_name_kanji: z.string().max(5000).optional(),
   full_name_aliases: z
-    .union([z.array(z.string().max(5000)), z.enum([""])])
+    .union([z.array(z.string().max(5000)), z.literal("")])
     .optional(),
   gender: z.string().optional(),
   id_number: z.string().max(5000).optional(),
@@ -13935,7 +13929,7 @@ export const s_PostAccountsAccountPeoplePersonRequestBody = z.object({
   last_name_kanji: z.string().max(5000).optional(),
   maiden_name: z.string().max(5000).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   nationality: z.string().max(5000).optional(),
   person_token: z.string().max(5000).optional(),
@@ -13958,7 +13952,7 @@ export const s_PostAccountsAccountPeoplePersonRequestBody = z.object({
       executive: PermissiveBoolean.optional(),
       legal_guardian: PermissiveBoolean.optional(),
       owner: PermissiveBoolean.optional(),
-      percent_ownership: z.union([z.coerce.number(), z.enum([""])]).optional(),
+      percent_ownership: z.union([z.coerce.number(), z.literal("")]).optional(),
       representative: PermissiveBoolean.optional(),
       title: z.string().max(5000).optional(),
     })
@@ -14047,7 +14041,7 @@ export const s_PostAccountsAccountPersonsRequestBody = z.object({
         .object({
           date: z.coerce.number().optional(),
           ip: z.string().optional(),
-          user_agent: z.union([z.string().max(5000), z.enum([""])]).optional(),
+          user_agent: z.union([z.string().max(5000), z.literal("")]).optional(),
         })
         .optional(),
     })
@@ -14091,7 +14085,7 @@ export const s_PostAccountsAccountPersonsRequestBody = z.object({
         month: z.coerce.number(),
         year: z.coerce.number(),
       }),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   documents: z
@@ -14099,21 +14093,21 @@ export const s_PostAccountsAccountPersonsRequestBody = z.object({
       company_authorization: z
         .object({
           files: z
-            .array(z.union([z.string().max(500), z.enum([""])]))
+            .array(z.union([z.string().max(500), z.literal("")]))
             .optional(),
         })
         .optional(),
       passport: z
         .object({
           files: z
-            .array(z.union([z.string().max(500), z.enum([""])]))
+            .array(z.union([z.string().max(500), z.literal("")]))
             .optional(),
         })
         .optional(),
       visa: z
         .object({
           files: z
-            .array(z.union([z.string().max(500), z.enum([""])]))
+            .array(z.union([z.string().max(500), z.literal("")]))
             .optional(),
         })
         .optional(),
@@ -14125,7 +14119,7 @@ export const s_PostAccountsAccountPersonsRequestBody = z.object({
   first_name_kana: z.string().max(5000).optional(),
   first_name_kanji: z.string().max(5000).optional(),
   full_name_aliases: z
-    .union([z.array(z.string().max(5000)), z.enum([""])])
+    .union([z.array(z.string().max(5000)), z.literal("")])
     .optional(),
   gender: z.string().optional(),
   id_number: z.string().max(5000).optional(),
@@ -14135,7 +14129,7 @@ export const s_PostAccountsAccountPersonsRequestBody = z.object({
   last_name_kanji: z.string().max(5000).optional(),
   maiden_name: z.string().max(5000).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   nationality: z.string().max(5000).optional(),
   person_token: z.string().max(5000).optional(),
@@ -14158,7 +14152,7 @@ export const s_PostAccountsAccountPersonsRequestBody = z.object({
       executive: PermissiveBoolean.optional(),
       legal_guardian: PermissiveBoolean.optional(),
       owner: PermissiveBoolean.optional(),
-      percent_ownership: z.union([z.coerce.number(), z.enum([""])]).optional(),
+      percent_ownership: z.union([z.coerce.number(), z.literal("")]).optional(),
       representative: PermissiveBoolean.optional(),
       title: z.string().max(5000).optional(),
     })
@@ -14247,7 +14241,7 @@ export const s_PostAccountsAccountPersonsPersonRequestBody = z.object({
         .object({
           date: z.coerce.number().optional(),
           ip: z.string().optional(),
-          user_agent: z.union([z.string().max(5000), z.enum([""])]).optional(),
+          user_agent: z.union([z.string().max(5000), z.literal("")]).optional(),
         })
         .optional(),
     })
@@ -14291,7 +14285,7 @@ export const s_PostAccountsAccountPersonsPersonRequestBody = z.object({
         month: z.coerce.number(),
         year: z.coerce.number(),
       }),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   documents: z
@@ -14299,21 +14293,21 @@ export const s_PostAccountsAccountPersonsPersonRequestBody = z.object({
       company_authorization: z
         .object({
           files: z
-            .array(z.union([z.string().max(500), z.enum([""])]))
+            .array(z.union([z.string().max(500), z.literal("")]))
             .optional(),
         })
         .optional(),
       passport: z
         .object({
           files: z
-            .array(z.union([z.string().max(500), z.enum([""])]))
+            .array(z.union([z.string().max(500), z.literal("")]))
             .optional(),
         })
         .optional(),
       visa: z
         .object({
           files: z
-            .array(z.union([z.string().max(500), z.enum([""])]))
+            .array(z.union([z.string().max(500), z.literal("")]))
             .optional(),
         })
         .optional(),
@@ -14325,7 +14319,7 @@ export const s_PostAccountsAccountPersonsPersonRequestBody = z.object({
   first_name_kana: z.string().max(5000).optional(),
   first_name_kanji: z.string().max(5000).optional(),
   full_name_aliases: z
-    .union([z.array(z.string().max(5000)), z.enum([""])])
+    .union([z.array(z.string().max(5000)), z.literal("")])
     .optional(),
   gender: z.string().optional(),
   id_number: z.string().max(5000).optional(),
@@ -14335,7 +14329,7 @@ export const s_PostAccountsAccountPersonsPersonRequestBody = z.object({
   last_name_kanji: z.string().max(5000).optional(),
   maiden_name: z.string().max(5000).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   nationality: z.string().max(5000).optional(),
   person_token: z.string().max(5000).optional(),
@@ -14358,7 +14352,7 @@ export const s_PostAccountsAccountPersonsPersonRequestBody = z.object({
       executive: PermissiveBoolean.optional(),
       legal_guardian: PermissiveBoolean.optional(),
       owner: PermissiveBoolean.optional(),
-      percent_ownership: z.union([z.coerce.number(), z.enum([""])]).optional(),
+      percent_ownership: z.union([z.coerce.number(), z.literal("")]).optional(),
       representative: PermissiveBoolean.optional(),
       title: z.string().max(5000).optional(),
     })
@@ -14465,7 +14459,7 @@ export const s_application_fee: z.ZodType<t_application_fee> = z.object({
   fee_source: s_platform_earning_fee_source.nullable().optional(),
   id: z.string().max(5000),
   livemode: PermissiveBoolean,
-  object: z.enum(["application_fee"]),
+  object: z.literal("application_fee"),
   originating_transaction: z
     .union([z.string().max(5000), z.lazy(() => s_charge)])
     .nullable()
@@ -14474,7 +14468,7 @@ export const s_application_fee: z.ZodType<t_application_fee> = z.object({
   refunds: z.object({
     data: z.array(z.lazy(() => s_fee_refund)),
     has_more: PermissiveBoolean,
-    object: z.enum(["list"]),
+    object: z.literal("list"),
     url: z.string().max(5000),
   }),
 })
@@ -14490,13 +14484,13 @@ export const s_fee_refund: z.ZodType<t_fee_refund> = z.object({
   fee: z.union([z.string().max(5000), z.lazy(() => s_application_fee)]),
   id: z.string().max(5000),
   metadata: z.record(z.string(), z.string().max(500)).nullable().optional(),
-  object: z.enum(["fee_refund"]),
+  object: z.literal("fee_refund"),
 })
 
 export const s_PostApplicationFeesFeeRefundsIdRequestBody = z.object({
   expand: z.array(z.string().max(5000)).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
 })
 
@@ -14547,7 +14541,7 @@ export const s_balance_transaction: z.ZodType<t_balance_transaction> = z.object(
     fee_details: z.array(s_fee),
     id: z.string().max(5000),
     net: z.coerce.number(),
-    object: z.enum(["balance_transaction"]),
+    object: z.literal("balance_transaction"),
     reporting_category: z.string().max(5000),
     source: z
       .union([
@@ -14622,10 +14616,10 @@ export const s_balance_transaction: z.ZodType<t_balance_transaction> = z.object(
 )
 
 export const s_billing_alert: z.ZodType<t_billing_alert> = z.object({
-  alert_type: z.enum(["usage_threshold"]),
+  alert_type: z.literal("usage_threshold"),
   id: z.string().max(5000),
   livemode: PermissiveBoolean,
-  object: z.enum(["billing.alert"]),
+  object: z.literal("billing.alert"),
   status: z.enum(["active", "archived", "inactive"]).nullable().optional(),
   title: z.string().max(5000),
   usage_threshold: z
@@ -14635,7 +14629,7 @@ export const s_billing_alert: z.ZodType<t_billing_alert> = z.object({
 })
 
 export const s_PostBillingAlertsRequestBody = z.object({
-  alert_type: z.enum(["usage_threshold"]),
+  alert_type: z.literal("usage_threshold"),
   expand: z.array(z.string().max(5000)).optional(),
   title: z.string().max(256),
   usage_threshold: z
@@ -14644,13 +14638,13 @@ export const s_PostBillingAlertsRequestBody = z.object({
         .array(
           z.object({
             customer: z.string().max(5000).optional(),
-            type: z.enum(["customer"]),
+            type: z.literal("customer"),
           }),
         )
         .optional(),
       gte: z.coerce.number(),
       meter: z.string().max(5000),
-      recurrence: z.enum(["one_time"]),
+      recurrence: z.literal("one_time"),
     })
     .optional(),
 })
@@ -14676,7 +14670,7 @@ export const s_billing_credit_balance_summary: z.ZodType<t_billing_credit_balanc
       s_deleted_customer,
     ]),
     livemode: PermissiveBoolean,
-    object: z.enum(["billing.credit_balance_summary"]),
+    object: z.literal("billing.credit_balance_summary"),
   })
 
 export const s_billing_credit_balance_transaction: z.ZodType<t_billing_credit_balance_transaction> =
@@ -14697,7 +14691,7 @@ export const s_billing_credit_balance_transaction: z.ZodType<t_billing_credit_ba
     effective_at: z.coerce.number(),
     id: z.string().max(5000),
     livemode: PermissiveBoolean,
-    object: z.enum(["billing.credit_balance_transaction"]),
+    object: z.literal("billing.credit_balance_transaction"),
     test_clock: z
       .union([z.string().max(5000), s_test_helpers_test_clock])
       .nullable()
@@ -14722,7 +14716,7 @@ export const s_billing_credit_grant: z.ZodType<t_billing_credit_grant> =
     livemode: PermissiveBoolean,
     metadata: z.record(z.string(), z.string().max(500)),
     name: z.string().max(5000).nullable().optional(),
-    object: z.enum(["billing.credit_grant"]),
+    object: z.literal("billing.credit_grant"),
     priority: z.coerce.number().nullable().optional(),
     test_clock: z
       .union([z.string().max(5000), s_test_helpers_test_clock])
@@ -14737,11 +14731,11 @@ export const s_PostBillingCreditGrantsRequestBody = z.object({
     monetary: z
       .object({currency: z.string(), value: z.coerce.number()})
       .optional(),
-    type: z.enum(["monetary"]),
+    type: z.literal("monetary"),
   }),
   applicability_config: z.object({
     scope: z.object({
-      price_type: z.enum(["metered"]).optional(),
+      price_type: z.literal("metered").optional(),
       prices: z.array(z.object({id: z.string().max(5000)})).optional(),
     }),
   }),
@@ -14757,7 +14751,7 @@ export const s_PostBillingCreditGrantsRequestBody = z.object({
 
 export const s_PostBillingCreditGrantsIdRequestBody = z.object({
   expand: z.array(z.string().max(5000)).optional(),
-  expires_at: z.union([z.coerce.number(), z.enum([""])]).optional(),
+  expires_at: z.union([z.coerce.number(), z.literal("")]).optional(),
   metadata: z.record(z.string(), z.string()).optional(),
 })
 
@@ -14773,7 +14767,7 @@ export const s_PostBillingMeterEventAdjustmentsRequestBody = z.object({
   cancel: z.object({identifier: z.string().max(100).optional()}).optional(),
   event_name: z.string().max(100),
   expand: z.array(z.string().max(5000)).optional(),
-  type: z.enum(["cancel"]),
+  type: z.literal("cancel"),
 })
 
 export const s_PostBillingMeterEventsRequestBody = z.object({
@@ -14786,7 +14780,7 @@ export const s_PostBillingMeterEventsRequestBody = z.object({
 
 export const s_PostBillingMetersRequestBody = z.object({
   customer_mapping: z
-    .object({event_payload_key: z.string().max(100), type: z.enum(["by_id"])})
+    .object({event_payload_key: z.string().max(100), type: z.literal("by_id")})
     .optional(),
   default_aggregation: z.object({formula: z.enum(["count", "last", "sum"])}),
   display_name: z.string().max(250),
@@ -14812,12 +14806,12 @@ export const s_PostBillingMetersIdReactivateRequestBody = z.object({
 export const s_PostBillingPortalConfigurationsRequestBody = z.object({
   business_profile: z
     .object({
-      headline: z.union([z.string().max(60), z.enum([""])]).optional(),
+      headline: z.union([z.string().max(60), z.literal("")]).optional(),
       privacy_policy_url: z.string().optional(),
       terms_of_service_url: z.string().optional(),
     })
     .optional(),
-  default_return_url: z.union([z.string(), z.enum([""])]).optional(),
+  default_return_url: z.union([z.string(), z.literal("")]).optional(),
   expand: z.array(z.string().max(5000)).optional(),
   features: z.object({
     customer_update: z
@@ -14834,7 +14828,7 @@ export const s_PostBillingPortalConfigurationsRequestBody = z.object({
                 "tax_id",
               ]),
             ),
-            z.enum([""]),
+            z.literal(""),
           ])
           .optional(),
         enabled: PermissiveBoolean,
@@ -14860,7 +14854,7 @@ export const s_PostBillingPortalConfigurationsRequestBody = z.object({
                   "unused",
                 ]),
               ),
-              z.enum([""]),
+              z.literal(""),
             ]),
           })
           .optional(),
@@ -14876,7 +14870,7 @@ export const s_PostBillingPortalConfigurationsRequestBody = z.object({
         default_allowed_updates: z
           .union([
             z.array(z.enum(["price", "promotion_code", "quantity"])),
-            z.enum([""]),
+            z.literal(""),
           ])
           .optional(),
         enabled: PermissiveBoolean,
@@ -14895,7 +14889,7 @@ export const s_PostBillingPortalConfigurationsRequestBody = z.object({
                 product: z.string().max(5000),
               }),
             ),
-            z.enum([""]),
+            z.literal(""),
           ])
           .optional(),
         proration_behavior: z
@@ -14927,12 +14921,12 @@ export const s_PostBillingPortalConfigurationsConfigurationRequestBody =
     active: PermissiveBoolean.optional(),
     business_profile: z
       .object({
-        headline: z.union([z.string().max(60), z.enum([""])]).optional(),
-        privacy_policy_url: z.union([z.string(), z.enum([""])]).optional(),
-        terms_of_service_url: z.union([z.string(), z.enum([""])]).optional(),
+        headline: z.union([z.string().max(60), z.literal("")]).optional(),
+        privacy_policy_url: z.union([z.string(), z.literal("")]).optional(),
+        terms_of_service_url: z.union([z.string(), z.literal("")]).optional(),
       })
       .optional(),
-    default_return_url: z.union([z.string(), z.enum([""])]).optional(),
+    default_return_url: z.union([z.string(), z.literal("")]).optional(),
     expand: z.array(z.string().max(5000)).optional(),
     features: z
       .object({
@@ -14950,7 +14944,7 @@ export const s_PostBillingPortalConfigurationsConfigurationRequestBody =
                     "tax_id",
                   ]),
                 ),
-                z.enum([""]),
+                z.literal(""),
               ])
               .optional(),
             enabled: PermissiveBoolean.optional(),
@@ -14979,7 +14973,7 @@ export const s_PostBillingPortalConfigurationsConfigurationRequestBody =
                         "unused",
                       ]),
                     ),
-                    z.enum([""]),
+                    z.literal(""),
                   ])
                   .optional(),
               })
@@ -14996,7 +14990,7 @@ export const s_PostBillingPortalConfigurationsConfigurationRequestBody =
             default_allowed_updates: z
               .union([
                 z.array(z.enum(["price", "promotion_code", "quantity"])),
-                z.enum([""]),
+                z.literal(""),
               ])
               .optional(),
             enabled: PermissiveBoolean.optional(),
@@ -15015,7 +15009,7 @@ export const s_PostBillingPortalConfigurationsConfigurationRequestBody =
                     product: z.string().max(5000),
                   }),
                 ),
-                z.enum([""]),
+                z.literal(""),
               ])
               .optional(),
             proration_behavior: z
@@ -15033,7 +15027,7 @@ export const s_PostBillingPortalConfigurationsConfigurationRequestBody =
                         ]),
                       }),
                     ),
-                    z.enum([""]),
+                    z.literal(""),
                   ])
                   .optional(),
               })
@@ -15044,7 +15038,7 @@ export const s_PostBillingPortalConfigurationsConfigurationRequestBody =
       .optional(),
     login_page: z.object({enabled: PermissiveBoolean}).optional(),
     metadata: z
-      .union([z.record(z.string(), z.string()), z.enum([""])])
+      .union([z.record(z.string(), z.string()), z.literal("")])
       .optional(),
   })
 
@@ -15068,7 +15062,7 @@ export const s_PostBillingPortalSessionsRequestBody = z.object({
           retention: z
             .object({
               coupon_offer: z.object({coupon: z.string().max(5000)}),
-              type: z.enum(["coupon_offer"]),
+              type: z.literal("coupon_offer"),
             })
             .optional(),
           subscription: z.string().max(5000),
@@ -15198,7 +15192,7 @@ export const s_charge: z.ZodType<t_charge> = z.object({
   id: z.string().max(5000),
   livemode: PermissiveBoolean,
   metadata: z.record(z.string(), z.string().max(500)),
-  object: z.enum(["charge"]),
+  object: z.literal("charge"),
   on_behalf_of: z
     .union([z.string().max(5000), z.lazy(() => s_account)])
     .nullable()
@@ -15225,7 +15219,7 @@ export const s_charge: z.ZodType<t_charge> = z.object({
     .object({
       data: z.array(z.lazy(() => s_refund)),
       has_more: PermissiveBoolean,
-      object: z.enum(["list"]),
+      object: z.literal("list"),
       url: z.string().max(5000),
     })
     .nullable()
@@ -15272,7 +15266,7 @@ export const s_PostChargesRequestBody = z.object({
         metadata: z.record(z.string(), z.string()).optional(),
         name: z.string().max(5000).optional(),
         number: z.string().max(5000),
-        object: z.enum(["card"]).optional(),
+        object: z.literal("card").optional(),
       }),
       z.string().max(5000),
     ])
@@ -15291,7 +15285,7 @@ export const s_PostChargesRequestBody = z.object({
     .optional(),
   expand: z.array(z.string().max(5000)).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   on_behalf_of: z.string().max(5000).optional(),
   radar_options: z
@@ -15334,7 +15328,7 @@ export const s_PostChargesChargeRequestBody = z.object({
     .object({user_report: z.enum(["", "fraudulent", "safe"])})
     .optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   receipt_email: z.string().max(5000).optional(),
   shipping: z
@@ -15383,7 +15377,7 @@ export const s_dispute: z.ZodType<t_dispute> = z.object({
   is_charge_refundable: PermissiveBoolean,
   livemode: PermissiveBoolean,
   metadata: z.record(z.string(), z.string().max(500)),
-  object: z.enum(["dispute"]),
+  object: z.literal("dispute"),
   payment_intent: z
     .union([z.string().max(5000), z.lazy(() => s_payment_intent)])
     .nullable()
@@ -15425,45 +15419,45 @@ export const s_PostChargesChargeDisputeRequestBody = z.object({
                 disputed_transaction: z
                   .object({
                     customer_account_id: z
-                      .union([z.string().max(5000), z.enum([""])])
+                      .union([z.string().max(5000), z.literal("")])
                       .optional(),
                     customer_device_fingerprint: z
-                      .union([z.string().max(5000), z.enum([""])])
+                      .union([z.string().max(5000), z.literal("")])
                       .optional(),
                     customer_device_id: z
-                      .union([z.string().max(5000), z.enum([""])])
+                      .union([z.string().max(5000), z.literal("")])
                       .optional(),
                     customer_email_address: z
-                      .union([z.string().max(5000), z.enum([""])])
+                      .union([z.string().max(5000), z.literal("")])
                       .optional(),
                     customer_purchase_ip: z
-                      .union([z.string().max(5000), z.enum([""])])
+                      .union([z.string().max(5000), z.literal("")])
                       .optional(),
                     merchandise_or_services: z
                       .enum(["merchandise", "services"])
                       .optional(),
                     product_description: z
-                      .union([z.string().max(5000), z.enum([""])])
+                      .union([z.string().max(5000), z.literal("")])
                       .optional(),
                     shipping_address: z
                       .object({
                         city: z
-                          .union([z.string().max(5000), z.enum([""])])
+                          .union([z.string().max(5000), z.literal("")])
                           .optional(),
                         country: z
-                          .union([z.string().max(5000), z.enum([""])])
+                          .union([z.string().max(5000), z.literal("")])
                           .optional(),
                         line1: z
-                          .union([z.string().max(5000), z.enum([""])])
+                          .union([z.string().max(5000), z.literal("")])
                           .optional(),
                         line2: z
-                          .union([z.string().max(5000), z.enum([""])])
+                          .union([z.string().max(5000), z.literal("")])
                           .optional(),
                         postal_code: z
-                          .union([z.string().max(5000), z.enum([""])])
+                          .union([z.string().max(5000), z.literal("")])
                           .optional(),
                         state: z
-                          .union([z.string().max(5000), z.enum([""])])
+                          .union([z.string().max(5000), z.literal("")])
                           .optional(),
                       })
                       .optional(),
@@ -15474,42 +15468,42 @@ export const s_PostChargesChargeDisputeRequestBody = z.object({
                     z.object({
                       charge: z.string().max(5000),
                       customer_account_id: z
-                        .union([z.string().max(5000), z.enum([""])])
+                        .union([z.string().max(5000), z.literal("")])
                         .optional(),
                       customer_device_fingerprint: z
-                        .union([z.string().max(5000), z.enum([""])])
+                        .union([z.string().max(5000), z.literal("")])
                         .optional(),
                       customer_device_id: z
-                        .union([z.string().max(5000), z.enum([""])])
+                        .union([z.string().max(5000), z.literal("")])
                         .optional(),
                       customer_email_address: z
-                        .union([z.string().max(5000), z.enum([""])])
+                        .union([z.string().max(5000), z.literal("")])
                         .optional(),
                       customer_purchase_ip: z
-                        .union([z.string().max(5000), z.enum([""])])
+                        .union([z.string().max(5000), z.literal("")])
                         .optional(),
                       product_description: z
-                        .union([z.string().max(5000), z.enum([""])])
+                        .union([z.string().max(5000), z.literal("")])
                         .optional(),
                       shipping_address: z
                         .object({
                           city: z
-                            .union([z.string().max(5000), z.enum([""])])
+                            .union([z.string().max(5000), z.literal("")])
                             .optional(),
                           country: z
-                            .union([z.string().max(5000), z.enum([""])])
+                            .union([z.string().max(5000), z.literal("")])
                             .optional(),
                           line1: z
-                            .union([z.string().max(5000), z.enum([""])])
+                            .union([z.string().max(5000), z.literal("")])
                             .optional(),
                           line2: z
-                            .union([z.string().max(5000), z.enum([""])])
+                            .union([z.string().max(5000), z.literal("")])
                             .optional(),
                           postal_code: z
-                            .union([z.string().max(5000), z.enum([""])])
+                            .union([z.string().max(5000), z.literal("")])
                             .optional(),
                           state: z
-                            .union([z.string().max(5000), z.enum([""])])
+                            .union([z.string().max(5000), z.literal("")])
                             .optional(),
                         })
                         .optional(),
@@ -15522,7 +15516,7 @@ export const s_PostChargesChargeDisputeRequestBody = z.object({
               .object({fee_acknowledged: PermissiveBoolean.optional()})
               .optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       product_description: z.string().max(20000).optional(),
@@ -15543,7 +15537,7 @@ export const s_PostChargesChargeDisputeRequestBody = z.object({
     .optional(),
   expand: z.array(z.string().max(5000)).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   submit: PermissiveBoolean.optional(),
 })
@@ -15557,7 +15551,7 @@ export const s_PostChargesChargeRefundRequestBody = z.object({
   expand: z.array(z.string().max(5000)).optional(),
   instructions_email: z.string().optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   payment_intent: z.string().max(5000).optional(),
   reason: z
@@ -15589,7 +15583,7 @@ export const s_refund: z.ZodType<t_refund> = z.object({
   instructions_email: z.string().max(5000).optional(),
   metadata: z.record(z.string(), z.string().max(500)).nullable().optional(),
   next_action: s_refund_next_action.optional(),
-  object: z.enum(["refund"]),
+  object: z.literal("refund"),
   payment_intent: z
     .union([z.string().max(5000), z.lazy(() => s_payment_intent)])
     .nullable()
@@ -15627,9 +15621,9 @@ export const s_PostChargesChargeRefundsRequestBody = z.object({
   expand: z.array(z.string().max(5000)).optional(),
   instructions_email: z.string().optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
-  origin: z.enum(["customer_balance"]).optional(),
+  origin: z.literal("customer_balance").optional(),
   payment_intent: z.string().max(5000).optional(),
   reason: z
     .enum(["duplicate", "fraudulent", "requested_by_customer"])
@@ -15641,7 +15635,7 @@ export const s_PostChargesChargeRefundsRequestBody = z.object({
 export const s_PostChargesChargeRefundsRefundRequestBody = z.object({
   expand: z.array(z.string().max(5000)).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
 })
 
@@ -15704,7 +15698,7 @@ export const s_checkout_session: z.ZodType<t_checkout_session> = z.object({
     .object({
       data: z.array(z.lazy(() => s_item)),
       has_more: PermissiveBoolean,
-      object: z.enum(["list"]),
+      object: z.literal("list"),
       url: z.string().max(5000),
     })
     .optional(),
@@ -15757,7 +15751,7 @@ export const s_checkout_session: z.ZodType<t_checkout_session> = z.object({
     .optional(),
   metadata: z.record(z.string(), z.string().max(500)).nullable().optional(),
   mode: z.enum(["payment", "setup", "subscription"]),
-  object: z.enum(["checkout.session"]),
+  object: z.literal("checkout.session"),
   optional_items: z
     .array(s_payment_pages_checkout_session_optional_item)
     .nullable()
@@ -15885,7 +15879,10 @@ export const s_PostCheckoutSessionsRequestBody = z.object({
           })
           .optional(),
         key: z.string().max(200),
-        label: z.object({custom: z.string().max(50), type: z.enum(["custom"])}),
+        label: z.object({
+          custom: z.string().max(50),
+          type: z.literal("custom"),
+        }),
         numeric: z
           .object({
             default_value: z.string().max(255).optional(),
@@ -15908,16 +15905,16 @@ export const s_PostCheckoutSessionsRequestBody = z.object({
   custom_text: z
     .object({
       after_submit: z
-        .union([z.object({message: z.string().max(1200)}), z.enum([""])])
+        .union([z.object({message: z.string().max(1200)}), z.literal("")])
         .optional(),
       shipping_address: z
-        .union([z.object({message: z.string().max(1200)}), z.enum([""])])
+        .union([z.object({message: z.string().max(1200)}), z.literal("")])
         .optional(),
       submit: z
-        .union([z.object({message: z.string().max(1200)}), z.enum([""])])
+        .union([z.object({message: z.string().max(1200)}), z.literal("")])
         .optional(),
       terms_of_service_acceptance: z
-        .union([z.object({message: z.string().max(1200)}), z.enum([""])])
+        .union([z.object({message: z.string().max(1200)}), z.literal("")])
         .optional(),
     })
     .optional(),
@@ -15947,7 +15944,7 @@ export const s_PostCheckoutSessionsRequestBody = z.object({
       invoice_data: z
         .object({
           account_tax_ids: z
-            .union([z.array(z.string().max(5000)), z.enum([""])])
+            .union([z.array(z.string().max(5000)), z.literal("")])
             .optional(),
           custom_fields: z
             .union([
@@ -15957,7 +15954,7 @@ export const s_PostCheckoutSessionsRequestBody = z.object({
                   value: z.string().max(140),
                 }),
               ),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
           description: z.string().max(1500).optional(),
@@ -15977,7 +15974,7 @@ export const s_PostCheckoutSessionsRequestBody = z.object({
                   .optional(),
                 template: z.string().max(5000).optional(),
               }),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
         })
@@ -16140,7 +16137,7 @@ export const s_PostCheckoutSessionsRequestBody = z.object({
           mandate_options: z
             .object({
               custom_mandate_url: z
-                .union([z.string(), z.enum([""])])
+                .union([z.string(), z.literal("")])
                 .optional(),
               default_for: z
                 .array(z.enum(["invoice", "subscription"]))
@@ -16162,13 +16159,13 @@ export const s_PostCheckoutSessionsRequestBody = z.object({
         })
         .optional(),
       affirm: z
-        .object({setup_future_usage: z.enum(["none"]).optional()})
+        .object({setup_future_usage: z.literal("none").optional()})
         .optional(),
       afterpay_clearpay: z
-        .object({setup_future_usage: z.enum(["none"]).optional()})
+        .object({setup_future_usage: z.literal("none").optional()})
         .optional(),
       alipay: z
-        .object({setup_future_usage: z.enum(["none"]).optional()})
+        .object({setup_future_usage: z.literal("none").optional()})
         .optional(),
       amazon_pay: z
         .object({
@@ -16177,7 +16174,7 @@ export const s_PostCheckoutSessionsRequestBody = z.object({
         .optional(),
       au_becs_debit: z
         .object({
-          setup_future_usage: z.enum(["none"]).optional(),
+          setup_future_usage: z.literal("none").optional(),
           target_date: z.string().max(5000).optional(),
         })
         .optional(),
@@ -16186,7 +16183,7 @@ export const s_PostCheckoutSessionsRequestBody = z.object({
           mandate_options: z
             .object({
               reference_prefix: z
-                .union([z.string().max(12), z.enum([""])])
+                .union([z.string().max(12), z.literal("")])
                 .optional(),
             })
             .optional(),
@@ -16197,7 +16194,7 @@ export const s_PostCheckoutSessionsRequestBody = z.object({
         })
         .optional(),
       bancontact: z
-        .object({setup_future_usage: z.enum(["none"]).optional()})
+        .object({setup_future_usage: z.literal("none").optional()})
         .optional(),
       boleto: z
         .object({
@@ -16278,34 +16275,34 @@ export const s_PostCheckoutSessionsRequestBody = z.object({
               ]),
             })
             .optional(),
-          funding_type: z.enum(["bank_transfer"]).optional(),
-          setup_future_usage: z.enum(["none"]).optional(),
+          funding_type: z.literal("bank_transfer").optional(),
+          setup_future_usage: z.literal("none").optional(),
         })
         .optional(),
       eps: z
-        .object({setup_future_usage: z.enum(["none"]).optional()})
+        .object({setup_future_usage: z.literal("none").optional()})
         .optional(),
       fpx: z
-        .object({setup_future_usage: z.enum(["none"]).optional()})
+        .object({setup_future_usage: z.literal("none").optional()})
         .optional(),
       giropay: z
-        .object({setup_future_usage: z.enum(["none"]).optional()})
+        .object({setup_future_usage: z.literal("none").optional()})
         .optional(),
       grabpay: z
-        .object({setup_future_usage: z.enum(["none"]).optional()})
+        .object({setup_future_usage: z.literal("none").optional()})
         .optional(),
       ideal: z
-        .object({setup_future_usage: z.enum(["none"]).optional()})
+        .object({setup_future_usage: z.literal("none").optional()})
         .optional(),
       kakao_pay: z
         .object({
-          capture_method: z.enum(["manual"]).optional(),
+          capture_method: z.literal("manual").optional(),
           setup_future_usage: z.enum(["none", "off_session"]).optional(),
         })
         .optional(),
       klarna: z
         .object({
-          setup_future_usage: z.enum(["none"]).optional(),
+          setup_future_usage: z.literal("none").optional(),
           subscriptions: z
             .union([
               z.array(
@@ -16320,7 +16317,7 @@ export const s_PostCheckoutSessionsRequestBody = z.object({
                   reference: z.string().max(255),
                 }),
               ),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
         })
@@ -16328,12 +16325,12 @@ export const s_PostCheckoutSessionsRequestBody = z.object({
       konbini: z
         .object({
           expires_after_days: z.coerce.number().optional(),
-          setup_future_usage: z.enum(["none"]).optional(),
+          setup_future_usage: z.literal("none").optional(),
         })
         .optional(),
       kr_card: z
         .object({
-          capture_method: z.enum(["manual"]).optional(),
+          capture_method: z.literal("manual").optional(),
           setup_future_usage: z.enum(["none", "off_session"]).optional(),
         })
         .optional(),
@@ -16343,35 +16340,35 @@ export const s_PostCheckoutSessionsRequestBody = z.object({
         })
         .optional(),
       mobilepay: z
-        .object({setup_future_usage: z.enum(["none"]).optional()})
+        .object({setup_future_usage: z.literal("none").optional()})
         .optional(),
       multibanco: z
-        .object({setup_future_usage: z.enum(["none"]).optional()})
+        .object({setup_future_usage: z.literal("none").optional()})
         .optional(),
       naver_pay: z
         .object({
-          capture_method: z.enum(["manual"]).optional(),
+          capture_method: z.literal("manual").optional(),
           setup_future_usage: z.enum(["none", "off_session"]).optional(),
         })
         .optional(),
       oxxo: z
         .object({
           expires_after_days: z.coerce.number().optional(),
-          setup_future_usage: z.enum(["none"]).optional(),
+          setup_future_usage: z.literal("none").optional(),
         })
         .optional(),
       p24: z
         .object({
-          setup_future_usage: z.enum(["none"]).optional(),
+          setup_future_usage: z.literal("none").optional(),
           tos_shown_and_accepted: PermissiveBoolean.optional(),
         })
         .optional(),
       pay_by_bank: z.record(z.string(), z.unknown()).optional(),
       payco: z
-        .object({capture_method: z.enum(["manual"]).optional()})
+        .object({capture_method: z.literal("manual").optional()})
         .optional(),
       paynow: z
-        .object({setup_future_usage: z.enum(["none"]).optional()})
+        .object({setup_future_usage: z.literal("none").optional()})
         .optional(),
       paypal: z
         .object({
@@ -16409,7 +16406,7 @@ export const s_PostCheckoutSessionsRequestBody = z.object({
       pix: z
         .object({
           expires_after_seconds: z.coerce.number().optional(),
-          setup_future_usage: z.enum(["none"]).optional(),
+          setup_future_usage: z.literal("none").optional(),
         })
         .optional(),
       revolut_pay: z
@@ -16418,14 +16415,14 @@ export const s_PostCheckoutSessionsRequestBody = z.object({
         })
         .optional(),
       samsung_pay: z
-        .object({capture_method: z.enum(["manual"]).optional()})
+        .object({capture_method: z.literal("manual").optional()})
         .optional(),
       sepa_debit: z
         .object({
           mandate_options: z
             .object({
               reference_prefix: z
-                .union([z.string().max(12), z.enum([""])])
+                .union([z.string().max(12), z.literal("")])
                 .optional(),
             })
             .optional(),
@@ -16436,7 +16433,7 @@ export const s_PostCheckoutSessionsRequestBody = z.object({
         })
         .optional(),
       sofort: z
-        .object({setup_future_usage: z.enum(["none"]).optional()})
+        .object({setup_future_usage: z.literal("none").optional()})
         .optional(),
       swish: z.object({reference: z.string().max(5000).optional()}).optional(),
       us_bank_account: z
@@ -16469,7 +16466,7 @@ export const s_PostCheckoutSessionsRequestBody = z.object({
         .object({
           app_id: z.string().max(5000).optional(),
           client: z.enum(["android", "ios", "web"]),
-          setup_future_usage: z.enum(["none"]).optional(),
+          setup_future_usage: z.literal("none").optional(),
         })
         .optional(),
     })
@@ -16857,7 +16854,7 @@ export const s_PostCheckoutSessionsRequestBody = z.object({
               .enum(["exclusive", "inclusive", "unspecified"])
               .optional(),
             tax_code: z.string().optional(),
-            type: z.enum(["fixed_amount"]).optional(),
+            type: z.literal("fixed_amount").optional(),
           })
           .optional(),
       }),
@@ -16946,7 +16943,7 @@ export const s_PostCheckoutSessionsSessionRequestBody = z.object({
     .optional(),
   expand: z.array(z.string().max(5000)).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   shipping_options: z
     .union([
@@ -17006,12 +17003,12 @@ export const s_PostCheckoutSessionsSessionRequestBody = z.object({
                 .enum(["exclusive", "inclusive", "unspecified"])
                 .optional(),
               tax_code: z.string().optional(),
-              type: z.enum(["fixed_amount"]).optional(),
+              type: z.literal("fixed_amount").optional(),
             })
             .optional(),
         }),
       ),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
 })
@@ -17029,7 +17026,7 @@ export const s_item: z.ZodType<t_item> = z.object({
   description: z.string().max(5000).nullable().optional(),
   discounts: z.array(z.lazy(() => s_line_items_discount_amount)).optional(),
   id: z.string().max(5000),
-  object: z.enum(["item"]),
+  object: z.literal("item"),
   price: z
     .lazy(() => s_price)
     .nullable()
@@ -17051,8 +17048,8 @@ export const s_PostClimateOrdersRequestBody = z.object({
 export const s_PostClimateOrdersOrderRequestBody = z.object({
   beneficiary: z
     .union([
-      z.object({public_name: z.union([z.string().max(5000), z.enum([""])])}),
-      z.enum([""]),
+      z.object({public_name: z.union([z.string().max(5000), z.literal("")])}),
+      z.literal(""),
     ])
     .optional(),
   expand: z.array(z.string().max(5000)).optional(),
@@ -17071,7 +17068,7 @@ export const s_confirmation_token: z.ZodType<t_confirmation_token> = z.object({
   mandate_data: s_confirmation_tokens_resource_mandate_data
     .nullable()
     .optional(),
-  object: z.enum(["confirmation_token"]),
+  object: z.literal("confirmation_token"),
   payment_intent: z.string().max(5000).nullable().optional(),
   payment_method_options: s_confirmation_tokens_resource_payment_method_options
     .nullable()
@@ -17105,7 +17102,7 @@ export const s_PostCouponsRequestBody = z.object({
   id: z.string().max(5000).optional(),
   max_redemptions: z.coerce.number().optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   name: z.string().max(40).optional(),
   percent_off: z.coerce.number().optional(),
@@ -17118,7 +17115,7 @@ export const s_PostCouponsCouponRequestBody = z.object({
     .optional(),
   expand: z.array(z.string().max(5000)).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   name: z.string().max(40).optional(),
 })
@@ -17145,14 +17142,14 @@ export const s_credit_note: z.ZodType<t_credit_note> = z.object({
   lines: z.object({
     data: z.array(z.lazy(() => s_credit_note_line_item)),
     has_more: PermissiveBoolean,
-    object: z.enum(["list"]),
+    object: z.literal("list"),
     url: z.string().max(5000),
   }),
   livemode: PermissiveBoolean,
   memo: z.string().max(5000).nullable().optional(),
   metadata: z.record(z.string(), z.string().max(500)).nullable().optional(),
   number: z.string().max(5000),
-  object: z.enum(["credit_note"]),
+  object: z.literal("credit_note"),
   out_of_band_amount: z.coerce.number().nullable().optional(),
   pdf: z.string().max(5000),
   post_payment_amount: z.coerce.number(),
@@ -17202,11 +17199,11 @@ export const s_PostCreditNotesRequestBody = z.object({
                 taxable_amount: z.coerce.number(),
               }),
             ),
-            z.enum([""]),
+            z.literal(""),
           ])
           .optional(),
         tax_rates: z
-          .union([z.array(z.string().max(5000)), z.enum([""])])
+          .union([z.array(z.string().max(5000)), z.literal("")])
           .optional(),
         type: z.enum(["custom_line_item", "invoice_line_item"]),
         unit_amount: z.coerce.number().optional(),
@@ -17245,7 +17242,7 @@ export const s_credit_note_line_item: z.ZodType<t_credit_note_line_item> =
     id: z.string().max(5000),
     invoice_line_item: z.string().max(5000).optional(),
     livemode: PermissiveBoolean,
-    object: z.enum(["credit_note_line_item"]),
+    object: z.literal("credit_note_line_item"),
     pretax_credit_amounts: z.array(
       z.lazy(() => s_credit_notes_pretax_credit_amount),
     ),
@@ -17307,7 +17304,7 @@ export const s_customer_session: z.ZodType<t_customer_session> = z.object({
   customer: z.union([z.string().max(5000), z.lazy(() => s_customer)]),
   expires_at: z.coerce.number(),
   livemode: PermissiveBoolean,
-  object: z.enum(["customer_session"]),
+  object: z.literal("customer_session"),
 })
 
 export const s_customer: z.ZodType<t_customer> = z.object({
@@ -17340,7 +17337,7 @@ export const s_customer: z.ZodType<t_customer> = z.object({
   metadata: z.record(z.string(), z.string().max(500)).optional(),
   name: z.string().max(5000).nullable().optional(),
   next_invoice_sequence: z.coerce.number().optional(),
-  object: z.enum(["customer"]),
+  object: z.literal("customer"),
   phone: z.string().max(5000).nullable().optional(),
   preferred_locales: z.array(z.string().max(5000)).nullable().optional(),
   shipping: s_shipping.nullable().optional(),
@@ -17350,7 +17347,7 @@ export const s_customer: z.ZodType<t_customer> = z.object({
         z.union([z.lazy(() => s_bank_account), z.lazy(() => s_card), s_source]),
       ),
       has_more: PermissiveBoolean,
-      object: z.enum(["list"]),
+      object: z.literal("list"),
       url: z.string().max(5000),
     })
     .optional(),
@@ -17358,7 +17355,7 @@ export const s_customer: z.ZodType<t_customer> = z.object({
     .object({
       data: z.array(z.lazy(() => s_subscription)),
       has_more: PermissiveBoolean,
-      object: z.enum(["list"]),
+      object: z.literal("list"),
       url: z.string().max(5000),
     })
     .optional(),
@@ -17368,7 +17365,7 @@ export const s_customer: z.ZodType<t_customer> = z.object({
     .object({
       data: z.array(z.lazy(() => s_tax_id)),
       has_more: PermissiveBoolean,
-      object: z.enum(["list"]),
+      object: z.literal("list"),
       url: z.string().max(5000),
     })
     .optional(),
@@ -17389,7 +17386,7 @@ export const s_PostCustomersRequestBody = z.object({
         postal_code: z.string().max(5000).optional(),
         state: z.string().max(5000).optional(),
       }),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   balance: z.coerce.number().optional(),
@@ -17415,7 +17412,7 @@ export const s_PostCustomersRequestBody = z.object({
           z.array(
             z.object({name: z.string().max(40), value: z.string().max(140)}),
           ),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       default_payment_method: z.string().max(5000).optional(),
@@ -17428,13 +17425,13 @@ export const s_PostCustomersRequestBody = z.object({
               .optional(),
             template: z.string().max(5000).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
     })
     .optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   name: z.string().max(256).optional(),
   next_invoice_sequence: z.coerce.number().optional(),
@@ -17455,13 +17452,13 @@ export const s_PostCustomersRequestBody = z.object({
         name: z.string().max(5000),
         phone: z.string().max(5000).optional(),
       }),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   source: z.string().max(5000).optional(),
   tax: z
     .object({
-      ip_address: z.union([z.string(), z.enum([""])]).optional(),
+      ip_address: z.union([z.string(), z.literal("")]).optional(),
       validate_location: z.enum(["deferred", "immediately"]).optional(),
     })
     .optional(),
@@ -17599,7 +17596,7 @@ export const s_PostCustomersCustomerRequestBody = z.object({
         postal_code: z.string().max(5000).optional(),
         state: z.string().max(5000).optional(),
       }),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   balance: z.coerce.number().optional(),
@@ -17611,7 +17608,7 @@ export const s_PostCustomersCustomerRequestBody = z.object({
         account_number: z.string().max(5000),
         country: z.string().max(5000),
         currency: z.string().optional(),
-        object: z.enum(["bank_account"]).optional(),
+        object: z.literal("bank_account").optional(),
         routing_number: z.string().max(5000).optional(),
       }),
       z.string().max(5000),
@@ -17632,7 +17629,7 @@ export const s_PostCustomersCustomerRequestBody = z.object({
         metadata: z.record(z.string(), z.string()).optional(),
         name: z.string().max(5000).optional(),
         number: z.string().max(5000),
-        object: z.enum(["card"]).optional(),
+        object: z.literal("card").optional(),
       }),
       z.string().max(5000),
     ])
@@ -17663,7 +17660,7 @@ export const s_PostCustomersCustomerRequestBody = z.object({
           z.array(
             z.object({name: z.string().max(40), value: z.string().max(140)}),
           ),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       default_payment_method: z.string().max(5000).optional(),
@@ -17676,13 +17673,13 @@ export const s_PostCustomersCustomerRequestBody = z.object({
               .optional(),
             template: z.string().max(5000).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
     })
     .optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   name: z.string().max(256).optional(),
   next_invoice_sequence: z.coerce.number().optional(),
@@ -17702,13 +17699,13 @@ export const s_PostCustomersCustomerRequestBody = z.object({
         name: z.string().max(5000),
         phone: z.string().max(5000).optional(),
       }),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   source: z.string().max(5000).optional(),
   tax: z
     .object({
-      ip_address: z.union([z.string(), z.enum([""])]).optional(),
+      ip_address: z.union([z.string(), z.literal("")]).optional(),
       validate_location: z.enum(["auto", "deferred", "immediately"]).optional(),
     })
     .optional(),
@@ -17738,7 +17735,7 @@ export const s_customer_balance_transaction: z.ZodType<t_customer_balance_transa
       .optional(),
     livemode: PermissiveBoolean,
     metadata: z.record(z.string(), z.string().max(500)).nullable().optional(),
-    object: z.enum(["customer_balance_transaction"]),
+    object: z.literal("customer_balance_transaction"),
     type: z.enum([
       "adjustment",
       "applied_to_invoice",
@@ -17761,7 +17758,7 @@ export const s_PostCustomersCustomerBalanceTransactionsRequestBody = z.object({
   description: z.string().max(350).optional(),
   expand: z.array(z.string().max(5000)).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
 })
 
@@ -17770,7 +17767,7 @@ export const s_PostCustomersCustomerBalanceTransactionsTransactionRequestBody =
     description: z.string().max(350).optional(),
     expand: z.array(z.string().max(5000)).optional(),
     metadata: z
-      .union([z.record(z.string(), z.string()), z.enum([""])])
+      .union([z.record(z.string(), z.string()), z.literal("")])
       .optional(),
   })
 
@@ -17784,7 +17781,7 @@ export const s_PostCustomersCustomerBankAccountsRequestBody = z.object({
         account_number: z.string().max(5000),
         country: z.string().max(5000),
         currency: z.string().optional(),
-        object: z.enum(["bank_account"]).optional(),
+        object: z.literal("bank_account").optional(),
         routing_number: z.string().max(5000).optional(),
       }),
       z.string().max(5000),
@@ -17805,7 +17802,7 @@ export const s_PostCustomersCustomerBankAccountsRequestBody = z.object({
         metadata: z.record(z.string(), z.string()).optional(),
         name: z.string().max(5000).optional(),
         number: z.string().max(5000),
-        object: z.enum(["card"]).optional(),
+        object: z.literal("card").optional(),
       }),
       z.string().max(5000),
     ])
@@ -17839,7 +17836,7 @@ export const s_PostCustomersCustomerBankAccountsIdRequestBody = z.object({
   exp_year: z.string().max(5000).optional(),
   expand: z.array(z.string().max(5000)).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   name: z.string().max(5000).optional(),
   owner: z
@@ -17876,7 +17873,7 @@ export const s_PostCustomersCustomerCardsRequestBody = z.object({
         account_number: z.string().max(5000),
         country: z.string().max(5000),
         currency: z.string().optional(),
-        object: z.enum(["bank_account"]).optional(),
+        object: z.literal("bank_account").optional(),
         routing_number: z.string().max(5000).optional(),
       }),
       z.string().max(5000),
@@ -17897,7 +17894,7 @@ export const s_PostCustomersCustomerCardsRequestBody = z.object({
         metadata: z.record(z.string(), z.string()).optional(),
         name: z.string().max(5000).optional(),
         number: z.string().max(5000),
-        object: z.enum(["card"]).optional(),
+        object: z.literal("card").optional(),
       }),
       z.string().max(5000),
     ])
@@ -17924,7 +17921,7 @@ export const s_PostCustomersCustomerCardsIdRequestBody = z.object({
   exp_year: z.string().max(5000).optional(),
   expand: z.array(z.string().max(5000)).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   name: z.string().max(5000).optional(),
   owner: z
@@ -17974,7 +17971,7 @@ export const s_customer_cash_balance_transaction: z.ZodType<t_customer_cash_bala
     id: z.string().max(5000),
     livemode: PermissiveBoolean,
     net_amount: z.coerce.number(),
-    object: z.enum(["customer_cash_balance_transaction"]),
+    object: z.literal("customer_cash_balance_transaction"),
     refunded_from_payment: z.lazy(() =>
       s_customer_balance_resource_cash_balance_transaction_resource_refunded_from_payment_transaction.optional(),
     ),
@@ -18008,7 +18005,7 @@ export const s_deleted_discount: z.ZodType<t_deleted_discount> = z.object({
   id: z.string().max(5000),
   invoice: z.string().max(5000).nullable().optional(),
   invoice_item: z.string().max(5000).nullable().optional(),
-  object: z.enum(["discount"]),
+  object: z.literal("discount"),
   promotion_code: z
     .union([z.string().max(5000), z.lazy(() => s_promotion_code)])
     .nullable()
@@ -18029,7 +18026,7 @@ export const s_discount: z.ZodType<t_discount> = z.object({
   id: z.string().max(5000),
   invoice: z.string().max(5000).nullable().optional(),
   invoice_item: z.string().max(5000).nullable().optional(),
-  object: z.enum(["discount"]),
+  object: z.literal("discount"),
   promotion_code: z
     .union([z.string().max(5000), z.lazy(() => s_promotion_code)])
     .nullable()
@@ -18055,7 +18052,7 @@ export const s_PostCustomersCustomerFundingInstructionsRequestBody = z.object({
   }),
   currency: z.string(),
   expand: z.array(z.string().max(5000)).optional(),
-  funding_type: z.enum(["bank_transfer"]),
+  funding_type: z.literal("bank_transfer"),
 })
 
 export const s_payment_method: z.ZodType<t_payment_method> = z.object({
@@ -18101,7 +18098,7 @@ export const s_payment_method: z.ZodType<t_payment_method> = z.object({
   multibanco: s_payment_method_multibanco.optional(),
   naver_pay: s_payment_method_naver_pay.optional(),
   nz_bank_account: s_payment_method_nz_bank_account.optional(),
-  object: z.enum(["payment_method"]),
+  object: z.literal("payment_method"),
   oxxo: s_payment_method_oxxo.optional(),
   p24: s_payment_method_p24.optional(),
   pay_by_bank: s_payment_method_pay_by_bank.optional(),
@@ -18185,7 +18182,7 @@ export const s_PostCustomersCustomerSourcesRequestBody = z.object({
         account_number: z.string().max(5000),
         country: z.string().max(5000),
         currency: z.string().optional(),
-        object: z.enum(["bank_account"]).optional(),
+        object: z.literal("bank_account").optional(),
         routing_number: z.string().max(5000).optional(),
       }),
       z.string().max(5000),
@@ -18206,7 +18203,7 @@ export const s_PostCustomersCustomerSourcesRequestBody = z.object({
         metadata: z.record(z.string(), z.string()).optional(),
         name: z.string().max(5000).optional(),
         number: z.string().max(5000),
-        object: z.enum(["card"]).optional(),
+        object: z.literal("card").optional(),
       }),
       z.string().max(5000),
     ])
@@ -18233,7 +18230,7 @@ export const s_PostCustomersCustomerSourcesIdRequestBody = z.object({
   exp_year: z.string().max(5000).optional(),
   expand: z.array(z.string().max(5000)).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   name: z.string().max(5000).optional(),
   owner: z
@@ -18309,7 +18306,7 @@ export const s_subscription: z.ZodType<t_subscription> = z.object({
   items: z.object({
     data: z.array(z.lazy(() => s_subscription_item)),
     has_more: PermissiveBoolean,
-    object: z.enum(["list"]),
+    object: z.literal("list"),
     url: z.string().max(5000),
   }),
   latest_invoice: z
@@ -18319,7 +18316,7 @@ export const s_subscription: z.ZodType<t_subscription> = z.object({
   livemode: PermissiveBoolean,
   metadata: z.record(z.string(), z.string().max(500)),
   next_pending_invoice_item_invoice: z.coerce.number().nullable().optional(),
-  object: z.enum(["subscription"]),
+  object: z.literal("subscription"),
   on_behalf_of: z
     .union([z.string().max(5000), z.lazy(() => s_account)])
     .nullable()
@@ -18398,13 +18395,13 @@ export const s_PostCustomersCustomerSubscriptionsRequestBody = z.object({
           .optional(),
         quantity: z.coerce.number().optional(),
         tax_rates: z
-          .union([z.array(z.string().max(5000)), z.enum([""])])
+          .union([z.array(z.string().max(5000)), z.literal("")])
           .optional(),
       }),
     )
     .optional(),
   application_fee_percent: z
-    .union([z.coerce.number(), z.enum([""])])
+    .union([z.coerce.number(), z.literal("")])
     .optional(),
   automatic_tax: z
     .object({
@@ -18425,7 +18422,7 @@ export const s_PostCustomersCustomerSubscriptionsRequestBody = z.object({
         amount_gte: z.coerce.number().optional(),
         reset_billing_cycle_anchor: PermissiveBoolean.optional(),
       }),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   cancel_at: z
@@ -18440,7 +18437,7 @@ export const s_PostCustomersCustomerSubscriptionsRequestBody = z.object({
   default_payment_method: z.string().max(5000).optional(),
   default_source: z.string().max(5000).optional(),
   default_tax_rates: z
-    .union([z.array(z.string().max(5000)), z.enum([""])])
+    .union([z.array(z.string().max(5000)), z.literal("")])
     .optional(),
   discounts: z
     .union([
@@ -18451,14 +18448,14 @@ export const s_PostCustomersCustomerSubscriptionsRequestBody = z.object({
           promotion_code: z.string().max(5000).optional(),
         }),
       ),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   expand: z.array(z.string().max(5000)).optional(),
   invoice_settings: z
     .object({
       account_tax_ids: z
-        .union([z.array(z.string().max(5000)), z.enum([""])])
+        .union([z.array(z.string().max(5000)), z.literal("")])
         .optional(),
       issuer: z
         .object({
@@ -18472,7 +18469,7 @@ export const s_PostCustomersCustomerSubscriptionsRequestBody = z.object({
     .array(
       z.object({
         billing_thresholds: z
-          .union([z.object({usage_gte: z.coerce.number()}), z.enum([""])])
+          .union([z.object({usage_gte: z.coerce.number()}), z.literal("")])
           .optional(),
         discounts: z
           .union([
@@ -18483,7 +18480,7 @@ export const s_PostCustomersCustomerSubscriptionsRequestBody = z.object({
                 promotion_code: z.string().max(5000).optional(),
               }),
             ),
-            z.enum([""]),
+            z.literal(""),
           ])
           .optional(),
         metadata: z.record(z.string(), z.string()).optional(),
@@ -18505,13 +18502,13 @@ export const s_PostCustomersCustomerSubscriptionsRequestBody = z.object({
           .optional(),
         quantity: z.coerce.number().optional(),
         tax_rates: z
-          .union([z.array(z.string().max(5000)), z.enum([""])])
+          .union([z.array(z.string().max(5000)), z.literal("")])
           .optional(),
       }),
     )
     .optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   off_session: PermissiveBoolean.optional(),
   payment_behavior: z
@@ -18540,7 +18537,7 @@ export const s_PostCustomersCustomerSubscriptionsRequestBody = z.object({
                   .enum(["automatic", "instant", "microdeposits"])
                   .optional(),
               }),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
           bancontact: z
@@ -18548,7 +18545,7 @@ export const s_PostCustomersCustomerSubscriptionsRequestBody = z.object({
               z.object({
                 preferred_language: z.enum(["de", "en", "fr", "nl"]).optional(),
               }),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
           card: z
@@ -18582,7 +18579,7 @@ export const s_PostCustomersCustomerSubscriptionsRequestBody = z.object({
                   .enum(["any", "automatic", "challenge"])
                   .optional(),
               }),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
           customer_balance: z
@@ -18598,14 +18595,14 @@ export const s_PostCustomersCustomerSubscriptionsRequestBody = z.object({
                   .optional(),
                 funding_type: z.string().optional(),
               }),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
           konbini: z
-            .union([z.record(z.string(), z.unknown()), z.enum([""])])
+            .union([z.record(z.string(), z.unknown()), z.literal("")])
             .optional(),
           sepa_debit: z
-            .union([z.record(z.string(), z.unknown()), z.enum([""])])
+            .union([z.record(z.string(), z.unknown()), z.literal("")])
             .optional(),
           us_bank_account: z
             .union([
@@ -18638,7 +18635,7 @@ export const s_PostCustomersCustomerSubscriptionsRequestBody = z.object({
                   .enum(["automatic", "instant", "microdeposits"])
                   .optional(),
               }),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
         })
@@ -18688,7 +18685,7 @@ export const s_PostCustomersCustomerSubscriptionsRequestBody = z.object({
               "wechat_pay",
             ]),
           ),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       save_default_payment_method: z
@@ -18702,7 +18699,7 @@ export const s_PostCustomersCustomerSubscriptionsRequestBody = z.object({
         interval: z.enum(["day", "month", "week", "year"]),
         interval_count: z.coerce.number().optional(),
       }),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   proration_behavior: z
@@ -18714,7 +18711,7 @@ export const s_PostCustomersCustomerSubscriptionsRequestBody = z.object({
       destination: z.string(),
     })
     .optional(),
-  trial_end: z.union([z.enum(["now"]), z.coerce.number()]).optional(),
+  trial_end: z.union([z.literal("now"), z.coerce.number()]).optional(),
   trial_from_plan: PermissiveBoolean.optional(),
   trial_period_days: z.coerce.number().optional(),
   trial_settings: z
@@ -18761,13 +18758,13 @@ export const s_PostCustomersCustomerSubscriptionsSubscriptionExposedIdRequestBod
             .optional(),
           quantity: z.coerce.number().optional(),
           tax_rates: z
-            .union([z.array(z.string().max(5000)), z.enum([""])])
+            .union([z.array(z.string().max(5000)), z.literal("")])
             .optional(),
         }),
       )
       .optional(),
     application_fee_percent: z
-      .union([z.coerce.number(), z.enum([""])])
+      .union([z.coerce.number(), z.literal("")])
       .optional(),
     automatic_tax: z
       .object({
@@ -18787,20 +18784,20 @@ export const s_PostCustomersCustomerSubscriptionsSubscriptionExposedIdRequestBod
           amount_gte: z.coerce.number().optional(),
           reset_billing_cycle_anchor: PermissiveBoolean.optional(),
         }),
-        z.enum([""]),
+        z.literal(""),
       ])
       .optional(),
     cancel_at: z
       .union([
         z.coerce.number(),
-        z.enum([""]),
+        z.literal(""),
         z.enum(["max_period_end", "min_period_end"]),
       ])
       .optional(),
     cancel_at_period_end: PermissiveBoolean.optional(),
     cancellation_details: z
       .object({
-        comment: z.union([z.string().max(5000), z.enum([""])]).optional(),
+        comment: z.union([z.string().max(5000), z.literal("")]).optional(),
         feedback: z
           .enum([
             "",
@@ -18821,9 +18818,9 @@ export const s_PostCustomersCustomerSubscriptionsSubscriptionExposedIdRequestBod
       .optional(),
     days_until_due: z.coerce.number().optional(),
     default_payment_method: z.string().max(5000).optional(),
-    default_source: z.union([z.string().max(5000), z.enum([""])]).optional(),
+    default_source: z.union([z.string().max(5000), z.literal("")]).optional(),
     default_tax_rates: z
-      .union([z.array(z.string().max(5000)), z.enum([""])])
+      .union([z.array(z.string().max(5000)), z.literal("")])
       .optional(),
     discounts: z
       .union([
@@ -18834,14 +18831,14 @@ export const s_PostCustomersCustomerSubscriptionsSubscriptionExposedIdRequestBod
             promotion_code: z.string().max(5000).optional(),
           }),
         ),
-        z.enum([""]),
+        z.literal(""),
       ])
       .optional(),
     expand: z.array(z.string().max(5000)).optional(),
     invoice_settings: z
       .object({
         account_tax_ids: z
-          .union([z.array(z.string().max(5000)), z.enum([""])])
+          .union([z.array(z.string().max(5000)), z.literal("")])
           .optional(),
         issuer: z
           .object({
@@ -18855,7 +18852,7 @@ export const s_PostCustomersCustomerSubscriptionsSubscriptionExposedIdRequestBod
       .array(
         z.object({
           billing_thresholds: z
-            .union([z.object({usage_gte: z.coerce.number()}), z.enum([""])])
+            .union([z.object({usage_gte: z.coerce.number()}), z.literal("")])
             .optional(),
           clear_usage: PermissiveBoolean.optional(),
           deleted: PermissiveBoolean.optional(),
@@ -18868,12 +18865,12 @@ export const s_PostCustomersCustomerSubscriptionsSubscriptionExposedIdRequestBod
                   promotion_code: z.string().max(5000).optional(),
                 }),
               ),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
           id: z.string().max(5000).optional(),
           metadata: z
-            .union([z.record(z.string(), z.string()), z.enum([""])])
+            .union([z.record(z.string(), z.string()), z.literal("")])
             .optional(),
           price: z.string().max(5000).optional(),
           price_data: z
@@ -18893,13 +18890,13 @@ export const s_PostCustomersCustomerSubscriptionsSubscriptionExposedIdRequestBod
             .optional(),
           quantity: z.coerce.number().optional(),
           tax_rates: z
-            .union([z.array(z.string().max(5000)), z.enum([""])])
+            .union([z.array(z.string().max(5000)), z.literal("")])
             .optional(),
         }),
       )
       .optional(),
     metadata: z
-      .union([z.record(z.string(), z.string()), z.enum([""])])
+      .union([z.record(z.string(), z.string()), z.literal("")])
       .optional(),
     off_session: PermissiveBoolean.optional(),
     pause_collection: z
@@ -18908,7 +18905,7 @@ export const s_PostCustomersCustomerSubscriptionsSubscriptionExposedIdRequestBod
           behavior: z.enum(["keep_as_draft", "mark_uncollectible", "void"]),
           resumes_at: z.coerce.number().optional(),
         }),
-        z.enum([""]),
+        z.literal(""),
       ])
       .optional(),
     payment_behavior: z
@@ -18937,7 +18934,7 @@ export const s_PostCustomersCustomerSubscriptionsSubscriptionExposedIdRequestBod
                     .enum(["automatic", "instant", "microdeposits"])
                     .optional(),
                 }),
-                z.enum([""]),
+                z.literal(""),
               ])
               .optional(),
             bancontact: z
@@ -18947,7 +18944,7 @@ export const s_PostCustomersCustomerSubscriptionsSubscriptionExposedIdRequestBod
                     .enum(["de", "en", "fr", "nl"])
                     .optional(),
                 }),
-                z.enum([""]),
+                z.literal(""),
               ])
               .optional(),
             card: z
@@ -18981,7 +18978,7 @@ export const s_PostCustomersCustomerSubscriptionsSubscriptionExposedIdRequestBod
                     .enum(["any", "automatic", "challenge"])
                     .optional(),
                 }),
-                z.enum([""]),
+                z.literal(""),
               ])
               .optional(),
             customer_balance: z
@@ -18997,14 +18994,14 @@ export const s_PostCustomersCustomerSubscriptionsSubscriptionExposedIdRequestBod
                     .optional(),
                   funding_type: z.string().optional(),
                 }),
-                z.enum([""]),
+                z.literal(""),
               ])
               .optional(),
             konbini: z
-              .union([z.record(z.string(), z.unknown()), z.enum([""])])
+              .union([z.record(z.string(), z.unknown()), z.literal("")])
               .optional(),
             sepa_debit: z
-              .union([z.record(z.string(), z.unknown()), z.enum([""])])
+              .union([z.record(z.string(), z.unknown()), z.literal("")])
               .optional(),
             us_bank_account: z
               .union([
@@ -19039,7 +19036,7 @@ export const s_PostCustomersCustomerSubscriptionsSubscriptionExposedIdRequestBod
                     .enum(["automatic", "instant", "microdeposits"])
                     .optional(),
                 }),
-                z.enum([""]),
+                z.literal(""),
               ])
               .optional(),
           })
@@ -19089,7 +19086,7 @@ export const s_PostCustomersCustomerSubscriptionsSubscriptionExposedIdRequestBod
                 "wechat_pay",
               ]),
             ),
-            z.enum([""]),
+            z.literal(""),
           ])
           .optional(),
         save_default_payment_method: z
@@ -19103,7 +19100,7 @@ export const s_PostCustomersCustomerSubscriptionsSubscriptionExposedIdRequestBod
           interval: z.enum(["day", "month", "week", "year"]),
           interval_count: z.coerce.number().optional(),
         }),
-        z.enum([""]),
+        z.literal(""),
       ])
       .optional(),
     proration_behavior: z
@@ -19116,10 +19113,10 @@ export const s_PostCustomersCustomerSubscriptionsSubscriptionExposedIdRequestBod
           amount_percent: z.coerce.number().optional(),
           destination: z.string(),
         }),
-        z.enum([""]),
+        z.literal(""),
       ])
       .optional(),
-    trial_end: z.union([z.enum(["now"]), z.coerce.number()]).optional(),
+    trial_end: z.union([z.literal("now"), z.coerce.number()]).optional(),
     trial_from_plan: PermissiveBoolean.optional(),
     trial_settings: z
       .object({
@@ -19139,7 +19136,7 @@ export const s_tax_id: z.ZodType<t_tax_id> = z.object({
     .optional(),
   id: z.string().max(5000),
   livemode: PermissiveBoolean,
-  object: z.enum(["tax_id"]),
+  object: z.literal("tax_id"),
   owner: z
     .lazy(() => s_tax_i_ds_owner)
     .nullable()
@@ -19402,45 +19399,45 @@ export const s_PostDisputesDisputeRequestBody = z.object({
                 disputed_transaction: z
                   .object({
                     customer_account_id: z
-                      .union([z.string().max(5000), z.enum([""])])
+                      .union([z.string().max(5000), z.literal("")])
                       .optional(),
                     customer_device_fingerprint: z
-                      .union([z.string().max(5000), z.enum([""])])
+                      .union([z.string().max(5000), z.literal("")])
                       .optional(),
                     customer_device_id: z
-                      .union([z.string().max(5000), z.enum([""])])
+                      .union([z.string().max(5000), z.literal("")])
                       .optional(),
                     customer_email_address: z
-                      .union([z.string().max(5000), z.enum([""])])
+                      .union([z.string().max(5000), z.literal("")])
                       .optional(),
                     customer_purchase_ip: z
-                      .union([z.string().max(5000), z.enum([""])])
+                      .union([z.string().max(5000), z.literal("")])
                       .optional(),
                     merchandise_or_services: z
                       .enum(["merchandise", "services"])
                       .optional(),
                     product_description: z
-                      .union([z.string().max(5000), z.enum([""])])
+                      .union([z.string().max(5000), z.literal("")])
                       .optional(),
                     shipping_address: z
                       .object({
                         city: z
-                          .union([z.string().max(5000), z.enum([""])])
+                          .union([z.string().max(5000), z.literal("")])
                           .optional(),
                         country: z
-                          .union([z.string().max(5000), z.enum([""])])
+                          .union([z.string().max(5000), z.literal("")])
                           .optional(),
                         line1: z
-                          .union([z.string().max(5000), z.enum([""])])
+                          .union([z.string().max(5000), z.literal("")])
                           .optional(),
                         line2: z
-                          .union([z.string().max(5000), z.enum([""])])
+                          .union([z.string().max(5000), z.literal("")])
                           .optional(),
                         postal_code: z
-                          .union([z.string().max(5000), z.enum([""])])
+                          .union([z.string().max(5000), z.literal("")])
                           .optional(),
                         state: z
-                          .union([z.string().max(5000), z.enum([""])])
+                          .union([z.string().max(5000), z.literal("")])
                           .optional(),
                       })
                       .optional(),
@@ -19451,42 +19448,42 @@ export const s_PostDisputesDisputeRequestBody = z.object({
                     z.object({
                       charge: z.string().max(5000),
                       customer_account_id: z
-                        .union([z.string().max(5000), z.enum([""])])
+                        .union([z.string().max(5000), z.literal("")])
                         .optional(),
                       customer_device_fingerprint: z
-                        .union([z.string().max(5000), z.enum([""])])
+                        .union([z.string().max(5000), z.literal("")])
                         .optional(),
                       customer_device_id: z
-                        .union([z.string().max(5000), z.enum([""])])
+                        .union([z.string().max(5000), z.literal("")])
                         .optional(),
                       customer_email_address: z
-                        .union([z.string().max(5000), z.enum([""])])
+                        .union([z.string().max(5000), z.literal("")])
                         .optional(),
                       customer_purchase_ip: z
-                        .union([z.string().max(5000), z.enum([""])])
+                        .union([z.string().max(5000), z.literal("")])
                         .optional(),
                       product_description: z
-                        .union([z.string().max(5000), z.enum([""])])
+                        .union([z.string().max(5000), z.literal("")])
                         .optional(),
                       shipping_address: z
                         .object({
                           city: z
-                            .union([z.string().max(5000), z.enum([""])])
+                            .union([z.string().max(5000), z.literal("")])
                             .optional(),
                           country: z
-                            .union([z.string().max(5000), z.enum([""])])
+                            .union([z.string().max(5000), z.literal("")])
                             .optional(),
                           line1: z
-                            .union([z.string().max(5000), z.enum([""])])
+                            .union([z.string().max(5000), z.literal("")])
                             .optional(),
                           line2: z
-                            .union([z.string().max(5000), z.enum([""])])
+                            .union([z.string().max(5000), z.literal("")])
                             .optional(),
                           postal_code: z
-                            .union([z.string().max(5000), z.enum([""])])
+                            .union([z.string().max(5000), z.literal("")])
                             .optional(),
                           state: z
-                            .union([z.string().max(5000), z.enum([""])])
+                            .union([z.string().max(5000), z.literal("")])
                             .optional(),
                         })
                         .optional(),
@@ -19499,7 +19496,7 @@ export const s_PostDisputesDisputeRequestBody = z.object({
               .object({fee_acknowledged: PermissiveBoolean.optional()})
               .optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       product_description: z.string().max(20000).optional(),
@@ -19520,7 +19517,7 @@ export const s_PostDisputesDisputeRequestBody = z.object({
     .optional(),
   expand: z.array(z.string().max(5000)).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   submit: PermissiveBoolean.optional(),
 })
@@ -19540,7 +19537,7 @@ export const s_PostEntitlementsFeaturesIdRequestBody = z.object({
   active: PermissiveBoolean.optional(),
   expand: z.array(z.string().max(5000)).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   name: z.string().max(80).optional(),
 })
@@ -19579,7 +19576,7 @@ export const s_PostExternalAccountsIdRequestBody = z.object({
   exp_year: z.string().max(5000).optional(),
   expand: z.array(z.string().max(5000)).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   name: z.string().max(5000).optional(),
 })
@@ -19592,7 +19589,7 @@ export const s_file_link: z.ZodType<t_file_link> = z.object({
   id: z.string().max(5000),
   livemode: PermissiveBoolean,
   metadata: z.record(z.string(), z.string().max(500)),
-  object: z.enum(["file_link"]),
+  object: z.literal("file_link"),
   url: z.string().max(5000).nullable().optional(),
 })
 
@@ -19601,17 +19598,17 @@ export const s_PostFileLinksRequestBody = z.object({
   expires_at: z.coerce.number().optional(),
   file: z.string().max(5000),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
 })
 
 export const s_PostFileLinksLinkRequestBody = z.object({
   expand: z.array(z.string().max(5000)).optional(),
   expires_at: z
-    .union([z.enum(["now"]), z.coerce.number(), z.enum([""])])
+    .union([z.literal("now"), z.coerce.number(), z.literal("")])
     .optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
 })
 
@@ -19624,12 +19621,12 @@ export const s_file: z.ZodType<t_file> = z.object({
     .object({
       data: z.array(z.lazy(() => s_file_link)),
       has_more: PermissiveBoolean,
-      object: z.enum(["list"]),
+      object: z.literal("list"),
       url: z.string().max(5000).regex(new RegExp("^/v1/file_links")),
     })
     .nullable()
     .optional(),
-  object: z.enum(["file"]),
+  object: z.literal("file"),
   purpose: z.enum([
     "account_requirement",
     "additional_verification",
@@ -19672,7 +19669,7 @@ export const s_financial_connections_account: z.ZodType<t_financial_connections_
     institution_name: z.string().max(5000),
     last4: z.string().max(5000).nullable().optional(),
     livemode: PermissiveBoolean,
-    object: z.enum(["financial_connections.account"]),
+    object: z.literal("financial_connections.account"),
     ownership: z
       .union([z.string().max(5000), s_financial_connections_account_ownership])
       .nullable()
@@ -19695,10 +19692,7 @@ export const s_financial_connections_account: z.ZodType<t_financial_connections_
       "other",
       "savings",
     ]),
-    subscriptions: z
-      .array(z.enum(["transactions"]))
-      .nullable()
-      .optional(),
+    subscriptions: z.array(z.literal("transactions")).nullable().optional(),
     supported_payment_method_types: z.array(
       z.enum(["link", "us_bank_account"]),
     ),
@@ -19719,13 +19713,13 @@ export const s_PostFinancialConnectionsAccountsAccountRefreshRequestBody =
 export const s_PostFinancialConnectionsAccountsAccountSubscribeRequestBody =
   z.object({
     expand: z.array(z.string().max(5000)).optional(),
-    features: z.array(z.enum(["transactions"])),
+    features: z.array(z.literal("transactions")),
   })
 
 export const s_PostFinancialConnectionsAccountsAccountUnsubscribeRequestBody =
   z.object({
     expand: z.array(z.string().max(5000)).optional(),
-    features: z.array(z.enum(["transactions"])),
+    features: z.array(z.literal("transactions")),
   })
 
 export const s_PostFinancialConnectionsSessionsRequestBody = z.object({
@@ -19769,7 +19763,7 @@ export const s_financial_connections_session: z.ZodType<t_financial_connections_
     accounts: z.object({
       data: z.array(z.lazy(() => s_financial_connections_account)),
       has_more: PermissiveBoolean,
-      object: z.enum(["list"]),
+      object: z.literal("list"),
       url: z
         .string()
         .max(5000)
@@ -19780,7 +19774,7 @@ export const s_financial_connections_session: z.ZodType<t_financial_connections_
       s_bank_connections_resource_link_account_session_filters.optional(),
     id: z.string().max(5000),
     livemode: PermissiveBoolean,
-    object: z.enum(["financial_connections.session"]),
+    object: z.literal("financial_connections.session"),
     permissions: z.array(
       z.enum(["balances", "ownership", "payment_method", "transactions"]),
     ),
@@ -19833,7 +19827,7 @@ export const s_PostIdentityVerificationSessionsRequestBody = z.object({
             require_live_capture: PermissiveBoolean.optional(),
             require_matching_selfie: PermissiveBoolean.optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
     })
@@ -19865,7 +19859,7 @@ export const s_PostIdentityVerificationSessionsSessionRequestBody = z.object({
             require_live_capture: PermissiveBoolean.optional(),
             require_matching_selfie: PermissiveBoolean.optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
     })
@@ -19895,7 +19889,7 @@ export const s_invoice_payment: z.ZodType<t_invoice_payment> = z.object({
   ]),
   is_default: PermissiveBoolean,
   livemode: PermissiveBoolean,
-  object: z.enum(["invoice_payment"]),
+  object: z.literal("invoice_payment"),
   payment: z.lazy(() => s_invoices_payments_invoice_payment_associated_payment),
   status: z.string().max(5000),
   status_transitions: s_invoices_payments_invoice_payment_status_transitions,
@@ -19929,7 +19923,7 @@ export const s_invoiceitem: z.ZodType<t_invoiceitem> = z.object({
     .optional(),
   livemode: PermissiveBoolean,
   metadata: z.record(z.string(), z.string().max(500)).nullable().optional(),
-  object: z.enum(["invoiceitem"]),
+  object: z.literal("invoiceitem"),
   parent: s_billing_bill_resource_invoice_item_parents_invoice_item_parent
     .nullable()
     .optional(),
@@ -19961,13 +19955,13 @@ export const s_PostInvoiceitemsRequestBody = z.object({
           promotion_code: z.string().max(5000).optional(),
         }),
       ),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   expand: z.array(z.string().max(5000)).optional(),
   invoice: z.string().max(5000).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   period: z
     .object({end: z.coerce.number(), start: z.coerce.number()})
@@ -19987,7 +19981,7 @@ export const s_PostInvoiceitemsRequestBody = z.object({
   quantity: z.coerce.number().optional(),
   subscription: z.string().max(5000).optional(),
   tax_behavior: z.enum(["exclusive", "inclusive", "unspecified"]).optional(),
-  tax_code: z.union([z.string(), z.enum([""])]).optional(),
+  tax_code: z.union([z.string(), z.literal("")]).optional(),
   tax_rates: z.array(z.string().max(5000)).optional(),
   unit_amount_decimal: z.string().optional(),
 })
@@ -20005,12 +19999,12 @@ export const s_PostInvoiceitemsInvoiceitemRequestBody = z.object({
           promotion_code: z.string().max(5000).optional(),
         }),
       ),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   expand: z.array(z.string().max(5000)).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   period: z
     .object({end: z.coerce.number(), start: z.coerce.number()})
@@ -20029,8 +20023,8 @@ export const s_PostInvoiceitemsInvoiceitemRequestBody = z.object({
   pricing: z.object({price: z.string().max(5000).optional()}).optional(),
   quantity: z.coerce.number().optional(),
   tax_behavior: z.enum(["exclusive", "inclusive", "unspecified"]).optional(),
-  tax_code: z.union([z.string(), z.enum([""])]).optional(),
-  tax_rates: z.union([z.array(z.string().max(5000)), z.enum([""])]).optional(),
+  tax_code: z.union([z.string(), z.literal("")]).optional(),
+  tax_rates: z.union([z.array(z.string().max(5000)), z.literal("")]).optional(),
   unit_amount_decimal: z.string().optional(),
 })
 
@@ -20141,14 +20135,14 @@ export const s_invoice: z.ZodType<t_invoice> = z.object({
   lines: z.object({
     data: z.array(z.lazy(() => s_line_item)),
     has_more: PermissiveBoolean,
-    object: z.enum(["list"]),
+    object: z.literal("list"),
     url: z.string().max(5000),
   }),
   livemode: PermissiveBoolean,
   metadata: z.record(z.string(), z.string().max(500)).nullable().optional(),
   next_payment_attempt: z.coerce.number().nullable().optional(),
   number: z.string().max(5000).nullable().optional(),
-  object: z.enum(["invoice"]),
+  object: z.literal("invoice"),
   on_behalf_of: z
     .union([z.string().max(5000), z.lazy(() => s_account)])
     .nullable()
@@ -20162,7 +20156,7 @@ export const s_invoice: z.ZodType<t_invoice> = z.object({
     .object({
       data: z.array(z.lazy(() => s_invoice_payment)),
       has_more: PermissiveBoolean,
-      object: z.enum(["list"]),
+      object: z.literal("list"),
       url: z.string().max(5000),
     })
     .optional(),
@@ -20207,7 +20201,7 @@ export const s_invoice: z.ZodType<t_invoice> = z.object({
 
 export const s_PostInvoicesRequestBody = z.object({
   account_tax_ids: z
-    .union([z.array(z.string().max(5000)), z.enum([""])])
+    .union([z.array(z.string().max(5000)), z.literal("")])
     .optional(),
   application_fee_amount: z.coerce.number().optional(),
   auto_advance: PermissiveBoolean.optional(),
@@ -20230,7 +20224,7 @@ export const s_PostInvoicesRequestBody = z.object({
   custom_fields: z
     .union([
       z.array(z.object({name: z.string().max(40), value: z.string().max(140)})),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   customer: z.string().max(5000).optional(),
@@ -20248,7 +20242,7 @@ export const s_PostInvoicesRequestBody = z.object({
           promotion_code: z.string().max(5000).optional(),
         }),
       ),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   due_date: z.coerce.number().optional(),
@@ -20256,19 +20250,21 @@ export const s_PostInvoicesRequestBody = z.object({
   expand: z.array(z.string().max(5000)).optional(),
   footer: z.string().max(5000).optional(),
   from_invoice: z
-    .object({action: z.enum(["revision"]), invoice: z.string().max(5000)})
+    .object({action: z.literal("revision"), invoice: z.string().max(5000)})
     .optional(),
   issuer: z
     .object({account: z.string().optional(), type: z.enum(["account", "self"])})
     .optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   number: z.string().max(26).optional(),
   on_behalf_of: z.string().optional(),
   payment_settings: z
     .object({
-      default_mandate: z.union([z.string().max(5000), z.enum([""])]).optional(),
+      default_mandate: z
+        .union([z.string().max(5000), z.literal("")])
+        .optional(),
       payment_method_options: z
         .object({
           acss_debit: z
@@ -20285,7 +20281,7 @@ export const s_PostInvoicesRequestBody = z.object({
                   .enum(["automatic", "instant", "microdeposits"])
                   .optional(),
               }),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
           bancontact: z
@@ -20293,7 +20289,7 @@ export const s_PostInvoicesRequestBody = z.object({
               z.object({
                 preferred_language: z.enum(["de", "en", "fr", "nl"]).optional(),
               }),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
           card: z
@@ -20306,10 +20302,10 @@ export const s_PostInvoicesRequestBody = z.object({
                       .union([
                         z.object({
                           count: z.coerce.number().optional(),
-                          interval: z.enum(["month"]).optional(),
+                          interval: z.literal("month").optional(),
                           type: z.enum(["bonus", "fixed_count", "revolving"]),
                         }),
-                        z.enum([""]),
+                        z.literal(""),
                       ])
                       .optional(),
                   })
@@ -20318,7 +20314,7 @@ export const s_PostInvoicesRequestBody = z.object({
                   .enum(["any", "automatic", "challenge"])
                   .optional(),
               }),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
           customer_balance: z
@@ -20334,14 +20330,14 @@ export const s_PostInvoicesRequestBody = z.object({
                   .optional(),
                 funding_type: z.string().optional(),
               }),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
           konbini: z
-            .union([z.record(z.string(), z.unknown()), z.enum([""])])
+            .union([z.record(z.string(), z.unknown()), z.literal("")])
             .optional(),
           sepa_debit: z
-            .union([z.record(z.string(), z.unknown()), z.enum([""])])
+            .union([z.record(z.string(), z.unknown()), z.literal("")])
             .optional(),
           us_bank_account: z
             .union([
@@ -20374,7 +20370,7 @@ export const s_PostInvoicesRequestBody = z.object({
                   .enum(["automatic", "instant", "microdeposits"])
                   .optional(),
               }),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
         })
@@ -20424,7 +20420,7 @@ export const s_PostInvoicesRequestBody = z.object({
               "wechat_pay",
             ]),
           ),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
     })
@@ -20439,7 +20435,7 @@ export const s_PostInvoicesRequestBody = z.object({
         .object({page_size: z.enum(["a4", "auto", "letter"]).optional()})
         .optional(),
       template: z.string().max(5000).optional(),
-      template_version: z.union([z.coerce.number(), z.enum([""])]).optional(),
+      template_version: z.union([z.coerce.number(), z.literal("")]).optional(),
     })
     .optional(),
   shipping_cost: z
@@ -20498,7 +20494,7 @@ export const s_PostInvoicesRequestBody = z.object({
             .enum(["exclusive", "inclusive", "unspecified"])
             .optional(),
           tax_code: z.string().optional(),
-          type: z.enum(["fixed_amount"]).optional(),
+          type: z.literal("fixed_amount").optional(),
         })
         .optional(),
     })
@@ -20514,7 +20510,7 @@ export const s_PostInvoicesRequestBody = z.object({
         state: z.string().max(5000).optional(),
       }),
       name: z.string().max(5000),
-      phone: z.union([z.string().max(5000), z.enum([""])]).optional(),
+      phone: z.union([z.string().max(5000), z.literal("")]).optional(),
     })
     .optional(),
   statement_descriptor: z.string().max(22).optional(),
@@ -20550,7 +20546,7 @@ export const s_PostInvoicesCreatePreviewRequestBody = z.object({
             postal_code: z.string().max(5000).optional(),
             state: z.string().max(5000).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       shipping: z
@@ -20567,11 +20563,11 @@ export const s_PostInvoicesCreatePreviewRequestBody = z.object({
             name: z.string().max(5000),
             phone: z.string().max(5000).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       tax: z
-        .object({ip_address: z.union([z.string(), z.enum([""])]).optional()})
+        .object({ip_address: z.union([z.string(), z.literal("")]).optional()})
         .optional(),
       tax_exempt: z.enum(["", "exempt", "none", "reverse"]).optional(),
       tax_ids: z
@@ -20704,7 +20700,7 @@ export const s_PostInvoicesCreatePreviewRequestBody = z.object({
           promotion_code: z.string().max(5000).optional(),
         }),
       ),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   expand: z.array(z.string().max(5000)).optional(),
@@ -20724,12 +20720,12 @@ export const s_PostInvoicesCreatePreviewRequestBody = z.object({
                 promotion_code: z.string().max(5000).optional(),
               }),
             ),
-            z.enum([""]),
+            z.literal(""),
           ])
           .optional(),
         invoiceitem: z.string().max(5000).optional(),
         metadata: z
-          .union([z.record(z.string(), z.string()), z.enum([""])])
+          .union([z.record(z.string(), z.string()), z.literal("")])
           .optional(),
         period: z
           .object({end: z.coerce.number(), start: z.coerce.number()})
@@ -20750,9 +20746,9 @@ export const s_PostInvoicesCreatePreviewRequestBody = z.object({
         tax_behavior: z
           .enum(["exclusive", "inclusive", "unspecified"])
           .optional(),
-        tax_code: z.union([z.string(), z.enum([""])]).optional(),
+        tax_code: z.union([z.string(), z.literal("")]).optional(),
         tax_rates: z
-          .union([z.array(z.string().max(5000)), z.enum([""])])
+          .union([z.array(z.string().max(5000)), z.literal("")])
           .optional(),
         unit_amount: z.coerce.number().optional(),
         unit_amount_decimal: z.string().optional(),
@@ -20762,7 +20758,7 @@ export const s_PostInvoicesCreatePreviewRequestBody = z.object({
   issuer: z
     .object({account: z.string().optional(), type: z.enum(["account", "self"])})
     .optional(),
-  on_behalf_of: z.union([z.string(), z.enum([""])]).optional(),
+  on_behalf_of: z.union([z.string(), z.literal("")]).optional(),
   preview_mode: z.enum(["next", "recurring"]).optional(),
   schedule: z.string().max(5000).optional(),
   schedule_details: z
@@ -20800,7 +20796,7 @@ export const s_PostInvoicesCreatePreviewRequestBody = z.object({
                     .optional(),
                   quantity: z.coerce.number().optional(),
                   tax_rates: z
-                    .union([z.array(z.string().max(5000)), z.enum([""])])
+                    .union([z.array(z.string().max(5000)), z.literal("")])
                     .optional(),
                 }),
               )
@@ -20826,7 +20822,7 @@ export const s_PostInvoicesCreatePreviewRequestBody = z.object({
                   amount_gte: z.coerce.number().optional(),
                   reset_billing_cycle_anchor: PermissiveBoolean.optional(),
                 }),
-                z.enum([""]),
+                z.literal(""),
               ])
               .optional(),
             collection_method: z
@@ -20834,10 +20830,10 @@ export const s_PostInvoicesCreatePreviewRequestBody = z.object({
               .optional(),
             default_payment_method: z.string().max(5000).optional(),
             default_tax_rates: z
-              .union([z.array(z.string().max(5000)), z.enum([""])])
+              .union([z.array(z.string().max(5000)), z.literal("")])
               .optional(),
             description: z
-              .union([z.string().max(500), z.enum([""])])
+              .union([z.string().max(500), z.literal("")])
               .optional(),
             discounts: z
               .union([
@@ -20848,7 +20844,7 @@ export const s_PostInvoicesCreatePreviewRequestBody = z.object({
                     promotion_code: z.string().max(5000).optional(),
                   }),
                 ),
-                z.enum([""]),
+                z.literal(""),
               ])
               .optional(),
             duration: z
@@ -20857,11 +20853,11 @@ export const s_PostInvoicesCreatePreviewRequestBody = z.object({
                 interval_count: z.coerce.number().optional(),
               })
               .optional(),
-            end_date: z.union([z.coerce.number(), z.enum(["now"])]).optional(),
+            end_date: z.union([z.coerce.number(), z.literal("now")]).optional(),
             invoice_settings: z
               .object({
                 account_tax_ids: z
-                  .union([z.array(z.string().max(5000)), z.enum([""])])
+                  .union([z.array(z.string().max(5000)), z.literal("")])
                   .optional(),
                 days_until_due: z.coerce.number().optional(),
                 issuer: z
@@ -20877,7 +20873,7 @@ export const s_PostInvoicesCreatePreviewRequestBody = z.object({
                 billing_thresholds: z
                   .union([
                     z.object({usage_gte: z.coerce.number()}),
-                    z.enum([""]),
+                    z.literal(""),
                   ])
                   .optional(),
                 discounts: z
@@ -20889,7 +20885,7 @@ export const s_PostInvoicesCreatePreviewRequestBody = z.object({
                         promotion_code: z.string().max(5000).optional(),
                       }),
                     ),
-                    z.enum([""]),
+                    z.literal(""),
                   ])
                   .optional(),
                 metadata: z.record(z.string(), z.string()).optional(),
@@ -20911,7 +20907,7 @@ export const s_PostInvoicesCreatePreviewRequestBody = z.object({
                   .optional(),
                 quantity: z.coerce.number().optional(),
                 tax_rates: z
-                  .union([z.array(z.string().max(5000)), z.enum([""])])
+                  .union([z.array(z.string().max(5000)), z.literal("")])
                   .optional(),
               }),
             ),
@@ -20922,7 +20918,7 @@ export const s_PostInvoicesCreatePreviewRequestBody = z.object({
               .enum(["always_invoice", "create_prorations", "none"])
               .optional(),
             start_date: z
-              .union([z.coerce.number(), z.enum(["now"])])
+              .union([z.coerce.number(), z.literal("now")])
               .optional(),
             transfer_data: z
               .object({
@@ -20931,7 +20927,9 @@ export const s_PostInvoicesCreatePreviewRequestBody = z.object({
               })
               .optional(),
             trial: PermissiveBoolean.optional(),
-            trial_end: z.union([z.coerce.number(), z.enum(["now"])]).optional(),
+            trial_end: z
+              .union([z.coerce.number(), z.literal("now")])
+              .optional(),
           }),
         )
         .optional(),
@@ -20952,20 +20950,20 @@ export const s_PostInvoicesCreatePreviewRequestBody = z.object({
       cancel_at: z
         .union([
           z.coerce.number(),
-          z.enum([""]),
+          z.literal(""),
           z.enum(["max_period_end", "min_period_end"]),
         ])
         .optional(),
       cancel_at_period_end: PermissiveBoolean.optional(),
       cancel_now: PermissiveBoolean.optional(),
       default_tax_rates: z
-        .union([z.array(z.string().max(5000)), z.enum([""])])
+        .union([z.array(z.string().max(5000)), z.literal("")])
         .optional(),
       items: z
         .array(
           z.object({
             billing_thresholds: z
-              .union([z.object({usage_gte: z.coerce.number()}), z.enum([""])])
+              .union([z.object({usage_gte: z.coerce.number()}), z.literal("")])
               .optional(),
             clear_usage: PermissiveBoolean.optional(),
             deleted: PermissiveBoolean.optional(),
@@ -20978,12 +20976,12 @@ export const s_PostInvoicesCreatePreviewRequestBody = z.object({
                     promotion_code: z.string().max(5000).optional(),
                   }),
                 ),
-                z.enum([""]),
+                z.literal(""),
               ])
               .optional(),
             id: z.string().max(5000).optional(),
             metadata: z
-              .union([z.record(z.string(), z.string()), z.enum([""])])
+              .union([z.record(z.string(), z.string()), z.literal("")])
               .optional(),
             price: z.string().max(5000).optional(),
             price_data: z
@@ -21003,7 +21001,7 @@ export const s_PostInvoicesCreatePreviewRequestBody = z.object({
               .optional(),
             quantity: z.coerce.number().optional(),
             tax_rates: z
-              .union([z.array(z.string().max(5000)), z.enum([""])])
+              .union([z.array(z.string().max(5000)), z.literal("")])
               .optional(),
           }),
         )
@@ -21012,16 +21010,16 @@ export const s_PostInvoicesCreatePreviewRequestBody = z.object({
         .enum(["always_invoice", "create_prorations", "none"])
         .optional(),
       proration_date: z.coerce.number().optional(),
-      resume_at: z.enum(["now"]).optional(),
+      resume_at: z.literal("now").optional(),
       start_date: z.coerce.number().optional(),
-      trial_end: z.union([z.enum(["now"]), z.coerce.number()]).optional(),
+      trial_end: z.union([z.literal("now"), z.coerce.number()]).optional(),
     })
     .optional(),
 })
 
 export const s_PostInvoicesInvoiceRequestBody = z.object({
   account_tax_ids: z
-    .union([z.array(z.string().max(5000)), z.enum([""])])
+    .union([z.array(z.string().max(5000)), z.literal("")])
     .optional(),
   application_fee_amount: z.coerce.number().optional(),
   auto_advance: PermissiveBoolean.optional(),
@@ -21043,14 +21041,14 @@ export const s_PostInvoicesInvoiceRequestBody = z.object({
   custom_fields: z
     .union([
       z.array(z.object({name: z.string().max(40), value: z.string().max(140)})),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   days_until_due: z.coerce.number().optional(),
   default_payment_method: z.string().max(5000).optional(),
-  default_source: z.union([z.string().max(5000), z.enum([""])]).optional(),
+  default_source: z.union([z.string().max(5000), z.literal("")]).optional(),
   default_tax_rates: z
-    .union([z.array(z.string().max(5000)), z.enum([""])])
+    .union([z.array(z.string().max(5000)), z.literal("")])
     .optional(),
   description: z.string().max(1500).optional(),
   discounts: z
@@ -21062,24 +21060,26 @@ export const s_PostInvoicesInvoiceRequestBody = z.object({
           promotion_code: z.string().max(5000).optional(),
         }),
       ),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   due_date: z.coerce.number().optional(),
-  effective_at: z.union([z.coerce.number(), z.enum([""])]).optional(),
+  effective_at: z.union([z.coerce.number(), z.literal("")]).optional(),
   expand: z.array(z.string().max(5000)).optional(),
   footer: z.string().max(5000).optional(),
   issuer: z
     .object({account: z.string().optional(), type: z.enum(["account", "self"])})
     .optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
-  number: z.union([z.string().max(26), z.enum([""])]).optional(),
-  on_behalf_of: z.union([z.string(), z.enum([""])]).optional(),
+  number: z.union([z.string().max(26), z.literal("")]).optional(),
+  on_behalf_of: z.union([z.string(), z.literal("")]).optional(),
   payment_settings: z
     .object({
-      default_mandate: z.union([z.string().max(5000), z.enum([""])]).optional(),
+      default_mandate: z
+        .union([z.string().max(5000), z.literal("")])
+        .optional(),
       payment_method_options: z
         .object({
           acss_debit: z
@@ -21096,7 +21096,7 @@ export const s_PostInvoicesInvoiceRequestBody = z.object({
                   .enum(["automatic", "instant", "microdeposits"])
                   .optional(),
               }),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
           bancontact: z
@@ -21104,7 +21104,7 @@ export const s_PostInvoicesInvoiceRequestBody = z.object({
               z.object({
                 preferred_language: z.enum(["de", "en", "fr", "nl"]).optional(),
               }),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
           card: z
@@ -21117,10 +21117,10 @@ export const s_PostInvoicesInvoiceRequestBody = z.object({
                       .union([
                         z.object({
                           count: z.coerce.number().optional(),
-                          interval: z.enum(["month"]).optional(),
+                          interval: z.literal("month").optional(),
                           type: z.enum(["bonus", "fixed_count", "revolving"]),
                         }),
-                        z.enum([""]),
+                        z.literal(""),
                       ])
                       .optional(),
                   })
@@ -21129,7 +21129,7 @@ export const s_PostInvoicesInvoiceRequestBody = z.object({
                   .enum(["any", "automatic", "challenge"])
                   .optional(),
               }),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
           customer_balance: z
@@ -21145,14 +21145,14 @@ export const s_PostInvoicesInvoiceRequestBody = z.object({
                   .optional(),
                 funding_type: z.string().optional(),
               }),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
           konbini: z
-            .union([z.record(z.string(), z.unknown()), z.enum([""])])
+            .union([z.record(z.string(), z.unknown()), z.literal("")])
             .optional(),
           sepa_debit: z
-            .union([z.record(z.string(), z.unknown()), z.enum([""])])
+            .union([z.record(z.string(), z.unknown()), z.literal("")])
             .optional(),
           us_bank_account: z
             .union([
@@ -21185,7 +21185,7 @@ export const s_PostInvoicesInvoiceRequestBody = z.object({
                   .enum(["automatic", "instant", "microdeposits"])
                   .optional(),
               }),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
         })
@@ -21235,7 +21235,7 @@ export const s_PostInvoicesInvoiceRequestBody = z.object({
               "wechat_pay",
             ]),
           ),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
     })
@@ -21249,7 +21249,7 @@ export const s_PostInvoicesInvoiceRequestBody = z.object({
         .object({page_size: z.enum(["a4", "auto", "letter"]).optional()})
         .optional(),
       template: z.string().max(5000).optional(),
-      template_version: z.union([z.coerce.number(), z.enum([""])]).optional(),
+      template_version: z.union([z.coerce.number(), z.literal("")]).optional(),
     })
     .optional(),
   shipping_cost: z
@@ -21309,11 +21309,11 @@ export const s_PostInvoicesInvoiceRequestBody = z.object({
               .enum(["exclusive", "inclusive", "unspecified"])
               .optional(),
             tax_code: z.string().optional(),
-            type: z.enum(["fixed_amount"]).optional(),
+            type: z.literal("fixed_amount").optional(),
           })
           .optional(),
       }),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   shipping_details: z
@@ -21328,16 +21328,16 @@ export const s_PostInvoicesInvoiceRequestBody = z.object({
           state: z.string().max(5000).optional(),
         }),
         name: z.string().max(5000),
-        phone: z.union([z.string().max(5000), z.enum([""])]).optional(),
+        phone: z.union([z.string().max(5000), z.literal("")]).optional(),
       }),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   statement_descriptor: z.string().max(22).optional(),
   transfer_data: z
     .union([
       z.object({amount: z.coerce.number().optional(), destination: z.string()}),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
 })
@@ -21345,7 +21345,7 @@ export const s_PostInvoicesInvoiceRequestBody = z.object({
 export const s_PostInvoicesInvoiceAddLinesRequestBody = z.object({
   expand: z.array(z.string().max(5000)).optional(),
   invoice_metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   lines: z.array(
     z.object({
@@ -21361,12 +21361,12 @@ export const s_PostInvoicesInvoiceAddLinesRequestBody = z.object({
               promotion_code: z.string().max(5000).optional(),
             }),
           ),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       invoice_item: z.string().max(5000).optional(),
       metadata: z
-        .union([z.record(z.string(), z.string()), z.enum([""])])
+        .union([z.record(z.string(), z.string()), z.literal("")])
         .optional(),
       period: z
         .object({end: z.coerce.number(), start: z.coerce.number()})
@@ -21457,11 +21457,11 @@ export const s_PostInvoicesInvoiceAddLinesRequestBody = z.object({
               taxable_amount: z.coerce.number(),
             }),
           ),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       tax_rates: z
-        .union([z.array(z.string().max(5000)), z.enum([""])])
+        .union([z.array(z.string().max(5000)), z.literal("")])
         .optional(),
     }),
   ),
@@ -21491,7 +21491,7 @@ export const s_line_item: z.ZodType<t_line_item> = z.object({
   invoice: z.string().max(5000).nullable().optional(),
   livemode: PermissiveBoolean,
   metadata: z.record(z.string(), z.string().max(500)),
-  object: z.enum(["line_item"]),
+  object: z.literal("line_item"),
   parent:
     s_billing_bill_resource_invoicing_lines_parents_invoice_line_item_parent
       .nullable()
@@ -21528,12 +21528,12 @@ export const s_PostInvoicesInvoiceLinesLineItemIdRequestBody = z.object({
           promotion_code: z.string().max(5000).optional(),
         }),
       ),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   expand: z.array(z.string().max(5000)).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   period: z
     .object({end: z.coerce.number(), start: z.coerce.number()})
@@ -21624,10 +21624,10 @@ export const s_PostInvoicesInvoiceLinesLineItemIdRequestBody = z.object({
           taxable_amount: z.coerce.number(),
         }),
       ),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
-  tax_rates: z.union([z.array(z.string().max(5000)), z.enum([""])]).optional(),
+  tax_rates: z.union([z.array(z.string().max(5000)), z.literal("")]).optional(),
 })
 
 export const s_PostInvoicesInvoiceMarkUncollectibleRequestBody = z.object({
@@ -21637,7 +21637,7 @@ export const s_PostInvoicesInvoiceMarkUncollectibleRequestBody = z.object({
 export const s_PostInvoicesInvoicePayRequestBody = z.object({
   expand: z.array(z.string().max(5000)).optional(),
   forgive: PermissiveBoolean.optional(),
-  mandate: z.union([z.string().max(5000), z.enum([""])]).optional(),
+  mandate: z.union([z.string().max(5000), z.literal("")]).optional(),
   off_session: PermissiveBoolean.optional(),
   paid_out_of_band: PermissiveBoolean.optional(),
   payment_method: z.string().max(5000).optional(),
@@ -21647,7 +21647,7 @@ export const s_PostInvoicesInvoicePayRequestBody = z.object({
 export const s_PostInvoicesInvoiceRemoveLinesRequestBody = z.object({
   expand: z.array(z.string().max(5000)).optional(),
   invoice_metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   lines: z.array(
     z.object({
@@ -21664,7 +21664,7 @@ export const s_PostInvoicesInvoiceSendRequestBody = z.object({
 export const s_PostInvoicesInvoiceUpdateLinesRequestBody = z.object({
   expand: z.array(z.string().max(5000)).optional(),
   invoice_metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   lines: z.array(
     z.object({
@@ -21680,12 +21680,12 @@ export const s_PostInvoicesInvoiceUpdateLinesRequestBody = z.object({
               promotion_code: z.string().max(5000).optional(),
             }),
           ),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       id: z.string().max(5000),
       metadata: z
-        .union([z.record(z.string(), z.string()), z.enum([""])])
+        .union([z.record(z.string(), z.string()), z.literal("")])
         .optional(),
       period: z
         .object({end: z.coerce.number(), start: z.coerce.number()})
@@ -21776,11 +21776,11 @@ export const s_PostInvoicesInvoiceUpdateLinesRequestBody = z.object({
               taxable_amount: z.coerce.number(),
             }),
           ),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       tax_rates: z
-        .union([z.array(z.string().max(5000)), z.enum([""])])
+        .union([z.array(z.string().max(5000)), z.literal("")])
         .optional(),
     }),
   ),
@@ -21825,7 +21825,7 @@ export const s_issuing_authorization: z.ZodType<t_issuing_authorization> =
     merchant_data: s_issuing_authorization_merchant_data,
     metadata: z.record(z.string(), z.string().max(500)),
     network_data: s_issuing_authorization_network_data.nullable().optional(),
-    object: z.enum(["issuing.authorization"]),
+    object: z.literal("issuing.authorization"),
     pending_request: s_issuing_authorization_pending_request
       .nullable()
       .optional(),
@@ -21845,7 +21845,7 @@ export const s_issuing_authorization: z.ZodType<t_issuing_authorization> =
 export const s_PostIssuingAuthorizationsAuthorizationRequestBody = z.object({
   expand: z.array(z.string().max(5000)).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
 })
 
@@ -21854,7 +21854,7 @@ export const s_PostIssuingAuthorizationsAuthorizationApproveRequestBody =
     amount: z.coerce.number().optional(),
     expand: z.array(z.string().max(5000)).optional(),
     metadata: z
-      .union([z.record(z.string(), z.string()), z.enum([""])])
+      .union([z.record(z.string(), z.string()), z.literal("")])
       .optional(),
   })
 
@@ -21862,7 +21862,7 @@ export const s_PostIssuingAuthorizationsAuthorizationDeclineRequestBody =
   z.object({
     expand: z.array(z.string().max(5000)).optional(),
     metadata: z
-      .union([z.record(z.string(), z.string()), z.enum([""])])
+      .union([z.record(z.string(), z.string()), z.literal("")])
       .optional(),
   })
 
@@ -21879,7 +21879,7 @@ export const s_issuing_cardholder: z.ZodType<t_issuing_cardholder> = z.object({
   livemode: PermissiveBoolean,
   metadata: z.record(z.string(), z.string().max(500)),
   name: z.string().max(5000),
-  object: z.enum(["issuing.cardholder"]),
+  object: z.literal("issuing.cardholder"),
   phone_number: z.string().max(5000).nullable().optional(),
   preferred_locales: z
     .array(z.enum(["de", "en", "es", "fr", "it"]))
@@ -21916,7 +21916,7 @@ export const s_PostIssuingCardholdersRequestBody = z.object({
               date: z.coerce.number().optional(),
               ip: z.string().optional(),
               user_agent: z
-                .union([z.string().max(5000), z.enum([""])])
+                .union([z.string().max(5000), z.literal("")])
                 .optional(),
             })
             .optional(),
@@ -22901,7 +22901,7 @@ export const s_PostIssuingCardholdersCardholderRequestBody = z.object({
               date: z.coerce.number().optional(),
               ip: z.string().optional(),
               user_agent: z
-                .union([z.string().max(5000), z.enum([""])])
+                .union([z.string().max(5000), z.literal("")])
                 .optional(),
             })
             .optional(),
@@ -23877,7 +23877,7 @@ export const s_issuing_card: z.ZodType<t_issuing_card> = z.object({
   livemode: PermissiveBoolean,
   metadata: z.record(z.string(), z.string().max(500)),
   number: z.string().max(5000).optional(),
-  object: z.enum(["issuing.card"]),
+  object: z.literal("issuing.card"),
   personalization_design: z
     .union([
       z.string().max(5000),
@@ -23916,7 +23916,7 @@ export const s_PostIssuingCardsRequestBody = z.object({
   replacement_reason: z
     .enum(["damaged", "expired", "lost", "stolen"])
     .optional(),
-  second_line: z.union([z.string().max(5000), z.enum([""])]).optional(),
+  second_line: z.union([z.string().max(5000), z.literal("")]).optional(),
   shipping: z
     .object({
       address: z.object({
@@ -24878,7 +24878,7 @@ export const s_PostIssuingCardsCardRequestBody = z.object({
   cancellation_reason: z.enum(["lost", "stolen"]).optional(),
   expand: z.array(z.string().max(5000)).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   personalization_design: z.string().max(5000).optional(),
   pin: z.object({encrypted_number: z.string().max(5000).optional()}).optional(),
@@ -25874,7 +25874,7 @@ export const s_issuing_dispute: z.ZodType<t_issuing_dispute> = z.object({
     ])
     .optional(),
   metadata: z.record(z.string(), z.string().max(500)),
-  object: z.enum(["issuing.dispute"]),
+  object: z.literal("issuing.dispute"),
   status: z.enum(["expired", "lost", "submitted", "unsubmitted", "won"]),
   transaction: z.union([
     z.string().max(5000),
@@ -25891,128 +25891,128 @@ export const s_PostIssuingDisputesRequestBody = z.object({
         .union([
           z.object({
             additional_documentation: z
-              .union([z.string(), z.enum([""])])
+              .union([z.string(), z.literal("")])
               .optional(),
-            canceled_at: z.union([z.coerce.number(), z.enum([""])]).optional(),
+            canceled_at: z.union([z.coerce.number(), z.literal("")]).optional(),
             cancellation_policy_provided: z
-              .union([PermissiveBoolean, z.enum([""])])
+              .union([PermissiveBoolean, z.literal("")])
               .optional(),
             cancellation_reason: z
-              .union([z.string().max(2500), z.enum([""])])
+              .union([z.string().max(2500), z.literal("")])
               .optional(),
-            expected_at: z.union([z.coerce.number(), z.enum([""])]).optional(),
+            expected_at: z.union([z.coerce.number(), z.literal("")]).optional(),
             explanation: z
-              .union([z.string().max(2500), z.enum([""])])
+              .union([z.string().max(2500), z.literal("")])
               .optional(),
             product_description: z
-              .union([z.string().max(2500), z.enum([""])])
+              .union([z.string().max(2500), z.literal("")])
               .optional(),
             product_type: z.enum(["", "merchandise", "service"]).optional(),
             return_status: z
               .enum(["", "merchant_rejected", "successful"])
               .optional(),
-            returned_at: z.union([z.coerce.number(), z.enum([""])]).optional(),
+            returned_at: z.union([z.coerce.number(), z.literal("")]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       duplicate: z
         .union([
           z.object({
             additional_documentation: z
-              .union([z.string(), z.enum([""])])
+              .union([z.string(), z.literal("")])
               .optional(),
-            card_statement: z.union([z.string(), z.enum([""])]).optional(),
-            cash_receipt: z.union([z.string(), z.enum([""])]).optional(),
-            check_image: z.union([z.string(), z.enum([""])]).optional(),
+            card_statement: z.union([z.string(), z.literal("")]).optional(),
+            cash_receipt: z.union([z.string(), z.literal("")]).optional(),
+            check_image: z.union([z.string(), z.literal("")]).optional(),
             explanation: z
-              .union([z.string().max(2500), z.enum([""])])
+              .union([z.string().max(2500), z.literal("")])
               .optional(),
             original_transaction: z.string().max(5000).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       fraudulent: z
         .union([
           z.object({
             additional_documentation: z
-              .union([z.string(), z.enum([""])])
+              .union([z.string(), z.literal("")])
               .optional(),
             explanation: z
-              .union([z.string().max(2500), z.enum([""])])
+              .union([z.string().max(2500), z.literal("")])
               .optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       merchandise_not_as_described: z
         .union([
           z.object({
             additional_documentation: z
-              .union([z.string(), z.enum([""])])
+              .union([z.string(), z.literal("")])
               .optional(),
             explanation: z
-              .union([z.string().max(2500), z.enum([""])])
+              .union([z.string().max(2500), z.literal("")])
               .optional(),
-            received_at: z.union([z.coerce.number(), z.enum([""])]).optional(),
+            received_at: z.union([z.coerce.number(), z.literal("")]).optional(),
             return_description: z
-              .union([z.string().max(2500), z.enum([""])])
+              .union([z.string().max(2500), z.literal("")])
               .optional(),
             return_status: z
               .enum(["", "merchant_rejected", "successful"])
               .optional(),
-            returned_at: z.union([z.coerce.number(), z.enum([""])]).optional(),
+            returned_at: z.union([z.coerce.number(), z.literal("")]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       no_valid_authorization: z
         .union([
           z.object({
             additional_documentation: z
-              .union([z.string(), z.enum([""])])
+              .union([z.string(), z.literal("")])
               .optional(),
             explanation: z
-              .union([z.string().max(2500), z.enum([""])])
+              .union([z.string().max(2500), z.literal("")])
               .optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       not_received: z
         .union([
           z.object({
             additional_documentation: z
-              .union([z.string(), z.enum([""])])
+              .union([z.string(), z.literal("")])
               .optional(),
-            expected_at: z.union([z.coerce.number(), z.enum([""])]).optional(),
+            expected_at: z.union([z.coerce.number(), z.literal("")]).optional(),
             explanation: z
-              .union([z.string().max(2500), z.enum([""])])
+              .union([z.string().max(2500), z.literal("")])
               .optional(),
             product_description: z
-              .union([z.string().max(2500), z.enum([""])])
+              .union([z.string().max(2500), z.literal("")])
               .optional(),
             product_type: z.enum(["", "merchandise", "service"]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       other: z
         .union([
           z.object({
             additional_documentation: z
-              .union([z.string(), z.enum([""])])
+              .union([z.string(), z.literal("")])
               .optional(),
             explanation: z
-              .union([z.string().max(2500), z.enum([""])])
+              .union([z.string().max(2500), z.literal("")])
               .optional(),
             product_description: z
-              .union([z.string().max(2500), z.enum([""])])
+              .union([z.string().max(2500), z.literal("")])
               .optional(),
             product_type: z.enum(["", "merchandise", "service"]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       reason: z
@@ -26031,18 +26031,18 @@ export const s_PostIssuingDisputesRequestBody = z.object({
         .union([
           z.object({
             additional_documentation: z
-              .union([z.string(), z.enum([""])])
+              .union([z.string(), z.literal("")])
               .optional(),
-            canceled_at: z.union([z.coerce.number(), z.enum([""])]).optional(),
+            canceled_at: z.union([z.coerce.number(), z.literal("")]).optional(),
             cancellation_reason: z
-              .union([z.string().max(2500), z.enum([""])])
+              .union([z.string().max(2500), z.literal("")])
               .optional(),
             explanation: z
-              .union([z.string().max(2500), z.enum([""])])
+              .union([z.string().max(2500), z.literal("")])
               .optional(),
-            received_at: z.union([z.coerce.number(), z.enum([""])]).optional(),
+            received_at: z.union([z.coerce.number(), z.literal("")]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
     })
@@ -26061,128 +26061,128 @@ export const s_PostIssuingDisputesDisputeRequestBody = z.object({
         .union([
           z.object({
             additional_documentation: z
-              .union([z.string(), z.enum([""])])
+              .union([z.string(), z.literal("")])
               .optional(),
-            canceled_at: z.union([z.coerce.number(), z.enum([""])]).optional(),
+            canceled_at: z.union([z.coerce.number(), z.literal("")]).optional(),
             cancellation_policy_provided: z
-              .union([PermissiveBoolean, z.enum([""])])
+              .union([PermissiveBoolean, z.literal("")])
               .optional(),
             cancellation_reason: z
-              .union([z.string().max(2500), z.enum([""])])
+              .union([z.string().max(2500), z.literal("")])
               .optional(),
-            expected_at: z.union([z.coerce.number(), z.enum([""])]).optional(),
+            expected_at: z.union([z.coerce.number(), z.literal("")]).optional(),
             explanation: z
-              .union([z.string().max(2500), z.enum([""])])
+              .union([z.string().max(2500), z.literal("")])
               .optional(),
             product_description: z
-              .union([z.string().max(2500), z.enum([""])])
+              .union([z.string().max(2500), z.literal("")])
               .optional(),
             product_type: z.enum(["", "merchandise", "service"]).optional(),
             return_status: z
               .enum(["", "merchant_rejected", "successful"])
               .optional(),
-            returned_at: z.union([z.coerce.number(), z.enum([""])]).optional(),
+            returned_at: z.union([z.coerce.number(), z.literal("")]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       duplicate: z
         .union([
           z.object({
             additional_documentation: z
-              .union([z.string(), z.enum([""])])
+              .union([z.string(), z.literal("")])
               .optional(),
-            card_statement: z.union([z.string(), z.enum([""])]).optional(),
-            cash_receipt: z.union([z.string(), z.enum([""])]).optional(),
-            check_image: z.union([z.string(), z.enum([""])]).optional(),
+            card_statement: z.union([z.string(), z.literal("")]).optional(),
+            cash_receipt: z.union([z.string(), z.literal("")]).optional(),
+            check_image: z.union([z.string(), z.literal("")]).optional(),
             explanation: z
-              .union([z.string().max(2500), z.enum([""])])
+              .union([z.string().max(2500), z.literal("")])
               .optional(),
             original_transaction: z.string().max(5000).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       fraudulent: z
         .union([
           z.object({
             additional_documentation: z
-              .union([z.string(), z.enum([""])])
+              .union([z.string(), z.literal("")])
               .optional(),
             explanation: z
-              .union([z.string().max(2500), z.enum([""])])
+              .union([z.string().max(2500), z.literal("")])
               .optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       merchandise_not_as_described: z
         .union([
           z.object({
             additional_documentation: z
-              .union([z.string(), z.enum([""])])
+              .union([z.string(), z.literal("")])
               .optional(),
             explanation: z
-              .union([z.string().max(2500), z.enum([""])])
+              .union([z.string().max(2500), z.literal("")])
               .optional(),
-            received_at: z.union([z.coerce.number(), z.enum([""])]).optional(),
+            received_at: z.union([z.coerce.number(), z.literal("")]).optional(),
             return_description: z
-              .union([z.string().max(2500), z.enum([""])])
+              .union([z.string().max(2500), z.literal("")])
               .optional(),
             return_status: z
               .enum(["", "merchant_rejected", "successful"])
               .optional(),
-            returned_at: z.union([z.coerce.number(), z.enum([""])]).optional(),
+            returned_at: z.union([z.coerce.number(), z.literal("")]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       no_valid_authorization: z
         .union([
           z.object({
             additional_documentation: z
-              .union([z.string(), z.enum([""])])
+              .union([z.string(), z.literal("")])
               .optional(),
             explanation: z
-              .union([z.string().max(2500), z.enum([""])])
+              .union([z.string().max(2500), z.literal("")])
               .optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       not_received: z
         .union([
           z.object({
             additional_documentation: z
-              .union([z.string(), z.enum([""])])
+              .union([z.string(), z.literal("")])
               .optional(),
-            expected_at: z.union([z.coerce.number(), z.enum([""])]).optional(),
+            expected_at: z.union([z.coerce.number(), z.literal("")]).optional(),
             explanation: z
-              .union([z.string().max(2500), z.enum([""])])
+              .union([z.string().max(2500), z.literal("")])
               .optional(),
             product_description: z
-              .union([z.string().max(2500), z.enum([""])])
+              .union([z.string().max(2500), z.literal("")])
               .optional(),
             product_type: z.enum(["", "merchandise", "service"]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       other: z
         .union([
           z.object({
             additional_documentation: z
-              .union([z.string(), z.enum([""])])
+              .union([z.string(), z.literal("")])
               .optional(),
             explanation: z
-              .union([z.string().max(2500), z.enum([""])])
+              .union([z.string().max(2500), z.literal("")])
               .optional(),
             product_description: z
-              .union([z.string().max(2500), z.enum([""])])
+              .union([z.string().max(2500), z.literal("")])
               .optional(),
             product_type: z.enum(["", "merchandise", "service"]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       reason: z
@@ -26201,32 +26201,32 @@ export const s_PostIssuingDisputesDisputeRequestBody = z.object({
         .union([
           z.object({
             additional_documentation: z
-              .union([z.string(), z.enum([""])])
+              .union([z.string(), z.literal("")])
               .optional(),
-            canceled_at: z.union([z.coerce.number(), z.enum([""])]).optional(),
+            canceled_at: z.union([z.coerce.number(), z.literal("")]).optional(),
             cancellation_reason: z
-              .union([z.string().max(2500), z.enum([""])])
+              .union([z.string().max(2500), z.literal("")])
               .optional(),
             explanation: z
-              .union([z.string().max(2500), z.enum([""])])
+              .union([z.string().max(2500), z.literal("")])
               .optional(),
-            received_at: z.union([z.coerce.number(), z.enum([""])]).optional(),
+            received_at: z.union([z.coerce.number(), z.literal("")]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
     })
     .optional(),
   expand: z.array(z.string().max(5000)).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
 })
 
 export const s_PostIssuingDisputesDisputeSubmitRequestBody = z.object({
   expand: z.array(z.string().max(5000)).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
 })
 
@@ -26245,7 +26245,7 @@ export const s_issuing_personalization_design: z.ZodType<t_issuing_personalizati
     lookup_key: z.string().max(5000).nullable().optional(),
     metadata: z.record(z.string(), z.string().max(500)),
     name: z.string().max(5000).nullable().optional(),
-    object: z.enum(["issuing.personalization_design"]),
+    object: z.literal("issuing.personalization_design"),
     physical_bundle: z.union([z.string().max(5000), s_issuing_physical_bundle]),
     preferences: s_issuing_personalization_design_preferences,
     rejection_reasons: s_issuing_personalization_design_rejection_reasons,
@@ -26256,10 +26256,10 @@ export const s_PostIssuingPersonalizationDesignsRequestBody = z.object({
   card_logo: z.string().optional(),
   carrier_text: z
     .object({
-      footer_body: z.union([z.string().max(200), z.enum([""])]).optional(),
-      footer_title: z.union([z.string().max(30), z.enum([""])]).optional(),
-      header_body: z.union([z.string().max(200), z.enum([""])]).optional(),
-      header_title: z.union([z.string().max(30), z.enum([""])]).optional(),
+      footer_body: z.union([z.string().max(200), z.literal("")]).optional(),
+      footer_title: z.union([z.string().max(30), z.literal("")]).optional(),
+      header_body: z.union([z.string().max(200), z.literal("")]).optional(),
+      header_title: z.union([z.string().max(30), z.literal("")]).optional(),
     })
     .optional(),
   expand: z.array(z.string().max(5000)).optional(),
@@ -26273,22 +26273,22 @@ export const s_PostIssuingPersonalizationDesignsRequestBody = z.object({
 
 export const s_PostIssuingPersonalizationDesignsPersonalizationDesignRequestBody =
   z.object({
-    card_logo: z.union([z.string(), z.enum([""])]).optional(),
+    card_logo: z.union([z.string(), z.literal("")]).optional(),
     carrier_text: z
       .union([
         z.object({
-          footer_body: z.union([z.string().max(200), z.enum([""])]).optional(),
-          footer_title: z.union([z.string().max(30), z.enum([""])]).optional(),
-          header_body: z.union([z.string().max(200), z.enum([""])]).optional(),
-          header_title: z.union([z.string().max(30), z.enum([""])]).optional(),
+          footer_body: z.union([z.string().max(200), z.literal("")]).optional(),
+          footer_title: z.union([z.string().max(30), z.literal("")]).optional(),
+          header_body: z.union([z.string().max(200), z.literal("")]).optional(),
+          header_title: z.union([z.string().max(30), z.literal("")]).optional(),
         }),
-        z.enum([""]),
+        z.literal(""),
       ])
       .optional(),
     expand: z.array(z.string().max(5000)).optional(),
-    lookup_key: z.union([z.string().max(200), z.enum([""])]).optional(),
+    lookup_key: z.union([z.string().max(200), z.literal("")]).optional(),
     metadata: z.record(z.string(), z.string()).optional(),
-    name: z.union([z.string().max(200), z.enum([""])]).optional(),
+    name: z.union([z.string().max(200), z.literal("")]).optional(),
     physical_bundle: z.string().max(5000).optional(),
     preferences: z.object({is_default: PermissiveBoolean}).optional(),
     transfer_lookup_key: PermissiveBoolean.optional(),
@@ -26309,7 +26309,7 @@ export const s_issuing_token: z.ZodType<t_issuing_token> = z.object({
   network: z.enum(["mastercard", "visa"]),
   network_data: s_issuing_network_token_network_data.optional(),
   network_updated_at: z.coerce.number(),
-  object: z.enum(["issuing.token"]),
+  object: z.literal("issuing.token"),
   status: z.enum(["active", "deleted", "requested", "suspended"]),
   wallet_provider: z
     .enum(["apple_pay", "google_pay", "samsung_pay"])
@@ -26351,7 +26351,7 @@ export const s_issuing_transaction: z.ZodType<t_issuing_transaction> = z.object(
     merchant_data: s_issuing_authorization_merchant_data,
     metadata: z.record(z.string(), z.string().max(500)),
     network_data: s_issuing_transaction_network_data.nullable().optional(),
-    object: z.enum(["issuing.transaction"]),
+    object: z.literal("issuing.transaction"),
     purchase_details: s_issuing_transaction_purchase_details
       .nullable()
       .optional(),
@@ -26371,7 +26371,7 @@ export const s_issuing_transaction: z.ZodType<t_issuing_transaction> = z.object(
 export const s_PostIssuingTransactionsTransactionRequestBody = z.object({
   expand: z.array(z.string().max(5000)).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
 })
 
@@ -26421,7 +26421,7 @@ export const s_mandate: z.ZodType<t_mandate> = z.object({
   id: z.string().max(5000),
   livemode: PermissiveBoolean,
   multi_use: s_mandate_multi_use.optional(),
-  object: z.enum(["mandate"]),
+  object: z.literal("mandate"),
   on_behalf_of: z.string().max(5000).optional(),
   payment_method: z.union([
     z.string().max(5000),
@@ -26488,7 +26488,7 @@ export const s_payment_intent: z.ZodType<t_payment_intent> = z.object({
   livemode: PermissiveBoolean,
   metadata: z.record(z.string(), z.string().max(500)).optional(),
   next_action: s_payment_intent_next_action.nullable().optional(),
-  object: z.enum(["payment_intent"]),
+  object: z.literal("payment_intent"),
   on_behalf_of: z
     .union([z.string().max(5000), z.lazy(() => s_account)])
     .nullable()
@@ -26567,7 +26567,7 @@ export const s_PostPaymentIntentsRequestBody = z.object({
           type: z.enum(["offline", "online"]),
         }),
       }),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   metadata: z.record(z.string(), z.string()).optional(),
@@ -26618,12 +26618,12 @@ export const s_PostPaymentIntentsRequestBody = z.object({
                 postal_code: z.string().max(5000).optional(),
                 state: z.string().max(5000).optional(),
               }),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
-          email: z.union([z.string(), z.enum([""])]).optional(),
-          name: z.union([z.string().max(5000), z.enum([""])]).optional(),
-          phone: z.union([z.string().max(5000), z.enum([""])]).optional(),
+          email: z.union([z.string(), z.literal("")]).optional(),
+          name: z.union([z.string().max(5000), z.literal("")]).optional(),
+          phone: z.union([z.string().max(5000), z.literal("")]).optional(),
           tax_id: z.string().max(5000).optional(),
         })
         .optional(),
@@ -26878,7 +26878,7 @@ export const s_PostPaymentIntentsRequestBody = z.object({
             mandate_options: z
               .object({
                 custom_mandate_url: z
-                  .union([z.string(), z.enum([""])])
+                  .union([z.string(), z.literal("")])
                   .optional(),
                 interval_description: z.string().max(500).optional(),
                 payment_schedule: z
@@ -26895,7 +26895,7 @@ export const s_PostPaymentIntentsRequestBody = z.object({
               .enum(["automatic", "instant", "microdeposits"])
               .optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       affirm: z
@@ -26903,9 +26903,9 @@ export const s_PostPaymentIntentsRequestBody = z.object({
           z.object({
             capture_method: z.enum(["", "manual"]).optional(),
             preferred_locale: z.string().max(30).optional(),
-            setup_future_usage: z.enum(["none"]).optional(),
+            setup_future_usage: z.literal("none").optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       afterpay_clearpay: z
@@ -26913,9 +26913,9 @@ export const s_PostPaymentIntentsRequestBody = z.object({
           z.object({
             capture_method: z.enum(["", "manual"]).optional(),
             reference: z.string().max(128).optional(),
-            setup_future_usage: z.enum(["none"]).optional(),
+            setup_future_usage: z.literal("none").optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       alipay: z
@@ -26923,13 +26923,13 @@ export const s_PostPaymentIntentsRequestBody = z.object({
           z.object({
             setup_future_usage: z.enum(["", "none", "off_session"]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       alma: z
         .union([
           z.object({capture_method: z.enum(["", "manual"]).optional()}),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       amazon_pay: z
@@ -26938,7 +26938,7 @@ export const s_PostPaymentIntentsRequestBody = z.object({
             capture_method: z.enum(["", "manual"]).optional(),
             setup_future_usage: z.enum(["", "none", "off_session"]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       au_becs_debit: z
@@ -26949,7 +26949,7 @@ export const s_PostPaymentIntentsRequestBody = z.object({
               .optional(),
             target_date: z.string().max(5000).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       bacs_debit: z
@@ -26958,7 +26958,7 @@ export const s_PostPaymentIntentsRequestBody = z.object({
             mandate_options: z
               .object({
                 reference_prefix: z
-                  .union([z.string().max(12), z.enum([""])])
+                  .union([z.string().max(12), z.literal("")])
                   .optional(),
               })
               .optional(),
@@ -26967,7 +26967,7 @@ export const s_PostPaymentIntentsRequestBody = z.object({
               .optional(),
             target_date: z.string().max(5000).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       bancontact: z
@@ -26976,13 +26976,13 @@ export const s_PostPaymentIntentsRequestBody = z.object({
             preferred_language: z.enum(["de", "en", "fr", "nl"]).optional(),
             setup_future_usage: z.enum(["", "none", "off_session"]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       billie: z
         .union([
           z.object({capture_method: z.enum(["", "manual"]).optional()}),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       blik: z
@@ -26991,7 +26991,7 @@ export const s_PostPaymentIntentsRequestBody = z.object({
             code: z.string().max(5000).optional(),
             setup_future_usage: z.enum(["", "none"]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       boleto: z
@@ -27002,7 +27002,7 @@ export const s_PostPaymentIntentsRequestBody = z.object({
               .enum(["", "none", "off_session", "on_session"])
               .optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       card: z
@@ -27017,10 +27017,10 @@ export const s_PostPaymentIntentsRequestBody = z.object({
                   .union([
                     z.object({
                       count: z.coerce.number().optional(),
-                      interval: z.enum(["month"]).optional(),
+                      interval: z.literal("month").optional(),
                       type: z.enum(["bonus", "fixed_count", "revolving"]),
                     }),
-                    z.enum([""]),
+                    z.literal(""),
                   ])
                   .optional(),
               })
@@ -27035,7 +27035,7 @@ export const s_PostPaymentIntentsRequestBody = z.object({
                 interval_count: z.coerce.number().optional(),
                 reference: z.string().max(80),
                 start_date: z.coerce.number(),
-                supported_types: z.array(z.enum(["india"])).optional(),
+                supported_types: z.array(z.literal("india")).optional(),
               })
               .optional(),
             network: z
@@ -27071,10 +27071,10 @@ export const s_PostPaymentIntentsRequestBody = z.object({
               .enum(["", "none", "off_session", "on_session"])
               .optional(),
             statement_descriptor_suffix_kana: z
-              .union([z.string().max(22), z.enum([""])])
+              .union([z.string().max(22), z.literal("")])
               .optional(),
             statement_descriptor_suffix_kanji: z
-              .union([z.string().max(17), z.enum([""])])
+              .union([z.string().max(17), z.literal("")])
               .optional(),
             three_d_secure: z
               .object({
@@ -27103,7 +27103,7 @@ export const s_PostPaymentIntentsRequestBody = z.object({
               })
               .optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       card_present: z
@@ -27120,7 +27120,7 @@ export const s_PostPaymentIntentsRequestBody = z.object({
               })
               .optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       cashapp: z
@@ -27131,13 +27131,13 @@ export const s_PostPaymentIntentsRequestBody = z.object({
               .enum(["", "none", "off_session", "on_session"])
               .optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       crypto: z
         .union([
-          z.object({setup_future_usage: z.enum(["none"]).optional()}),
-          z.enum([""]),
+          z.object({setup_future_usage: z.literal("none").optional()}),
+          z.literal(""),
         ])
         .optional(),
       customer_balance: z
@@ -27170,34 +27170,34 @@ export const s_PostPaymentIntentsRequestBody = z.object({
                 ]),
               })
               .optional(),
-            funding_type: z.enum(["bank_transfer"]).optional(),
-            setup_future_usage: z.enum(["none"]).optional(),
+            funding_type: z.literal("bank_transfer").optional(),
+            setup_future_usage: z.literal("none").optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       eps: z
         .union([
-          z.object({setup_future_usage: z.enum(["none"]).optional()}),
-          z.enum([""]),
+          z.object({setup_future_usage: z.literal("none").optional()}),
+          z.literal(""),
         ])
         .optional(),
       fpx: z
         .union([
-          z.object({setup_future_usage: z.enum(["none"]).optional()}),
-          z.enum([""]),
+          z.object({setup_future_usage: z.literal("none").optional()}),
+          z.literal(""),
         ])
         .optional(),
       giropay: z
         .union([
-          z.object({setup_future_usage: z.enum(["none"]).optional()}),
-          z.enum([""]),
+          z.object({setup_future_usage: z.literal("none").optional()}),
+          z.literal(""),
         ])
         .optional(),
       grabpay: z
         .union([
-          z.object({setup_future_usage: z.enum(["none"]).optional()}),
-          z.enum([""]),
+          z.object({setup_future_usage: z.literal("none").optional()}),
+          z.literal(""),
         ])
         .optional(),
       ideal: z
@@ -27205,11 +27205,11 @@ export const s_PostPaymentIntentsRequestBody = z.object({
           z.object({
             setup_future_usage: z.enum(["", "none", "off_session"]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       interac_present: z
-        .union([z.record(z.string(), z.unknown()), z.enum([""])])
+        .union([z.record(z.string(), z.unknown()), z.literal("")])
         .optional(),
       kakao_pay: z
         .union([
@@ -27217,7 +27217,7 @@ export const s_PostPaymentIntentsRequestBody = z.object({
             capture_method: z.enum(["", "manual"]).optional(),
             setup_future_usage: z.enum(["", "none", "off_session"]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       klarna: z
@@ -27304,29 +27304,29 @@ export const s_PostPaymentIntentsRequestBody = z.object({
                     reference: z.string().max(255),
                   }),
                 ),
-                z.enum([""]),
+                z.literal(""),
               ])
               .optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       konbini: z
         .union([
           z.object({
             confirmation_number: z
-              .union([z.string().max(11), z.enum([""])])
+              .union([z.string().max(11), z.literal("")])
               .optional(),
             expires_after_days: z
-              .union([z.coerce.number(), z.enum([""])])
+              .union([z.coerce.number(), z.literal("")])
               .optional(),
-            expires_at: z.union([z.coerce.number(), z.enum([""])]).optional(),
+            expires_at: z.union([z.coerce.number(), z.literal("")]).optional(),
             product_description: z
-              .union([z.string().max(22), z.enum([""])])
+              .union([z.string().max(22), z.literal("")])
               .optional(),
-            setup_future_usage: z.enum(["none"]).optional(),
+            setup_future_usage: z.literal("none").optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       kr_card: z
@@ -27335,7 +27335,7 @@ export const s_PostPaymentIntentsRequestBody = z.object({
             capture_method: z.enum(["", "manual"]).optional(),
             setup_future_usage: z.enum(["", "none", "off_session"]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       link: z
@@ -27344,22 +27344,22 @@ export const s_PostPaymentIntentsRequestBody = z.object({
             capture_method: z.enum(["", "manual"]).optional(),
             setup_future_usage: z.enum(["", "none", "off_session"]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       mobilepay: z
         .union([
           z.object({
             capture_method: z.enum(["", "manual"]).optional(),
-            setup_future_usage: z.enum(["none"]).optional(),
+            setup_future_usage: z.literal("none").optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       multibanco: z
         .union([
-          z.object({setup_future_usage: z.enum(["none"]).optional()}),
-          z.enum([""]),
+          z.object({setup_future_usage: z.literal("none").optional()}),
+          z.literal(""),
         ])
         .optional(),
       naver_pay: z
@@ -27368,7 +27368,7 @@ export const s_PostPaymentIntentsRequestBody = z.object({
             capture_method: z.enum(["", "manual"]).optional(),
             setup_future_usage: z.enum(["", "none", "off_session"]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       nz_bank_account: z
@@ -27379,40 +27379,40 @@ export const s_PostPaymentIntentsRequestBody = z.object({
               .optional(),
             target_date: z.string().max(5000).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       oxxo: z
         .union([
           z.object({
             expires_after_days: z.coerce.number().optional(),
-            setup_future_usage: z.enum(["none"]).optional(),
+            setup_future_usage: z.literal("none").optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       p24: z
         .union([
           z.object({
-            setup_future_usage: z.enum(["none"]).optional(),
+            setup_future_usage: z.literal("none").optional(),
             tos_shown_and_accepted: PermissiveBoolean.optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       pay_by_bank: z
-        .union([z.record(z.string(), z.unknown()), z.enum([""])])
+        .union([z.record(z.string(), z.unknown()), z.literal("")])
         .optional(),
       payco: z
         .union([
           z.object({capture_method: z.enum(["", "manual"]).optional()}),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       paynow: z
         .union([
-          z.object({setup_future_usage: z.enum(["none"]).optional()}),
-          z.enum([""]),
+          z.object({setup_future_usage: z.literal("none").optional()}),
+          z.literal(""),
         ])
         .optional(),
       paypal: z
@@ -27448,7 +27448,7 @@ export const s_PostPaymentIntentsRequestBody = z.object({
             risk_correlation_id: z.string().max(32).optional(),
             setup_future_usage: z.enum(["", "none", "off_session"]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       pix: z
@@ -27456,15 +27456,15 @@ export const s_PostPaymentIntentsRequestBody = z.object({
           z.object({
             expires_after_seconds: z.coerce.number().optional(),
             expires_at: z.coerce.number().optional(),
-            setup_future_usage: z.enum(["none"]).optional(),
+            setup_future_usage: z.literal("none").optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       promptpay: z
         .union([
-          z.object({setup_future_usage: z.enum(["none"]).optional()}),
-          z.enum([""]),
+          z.object({setup_future_usage: z.literal("none").optional()}),
+          z.literal(""),
         ])
         .optional(),
       revolut_pay: z
@@ -27473,19 +27473,19 @@ export const s_PostPaymentIntentsRequestBody = z.object({
             capture_method: z.enum(["", "manual"]).optional(),
             setup_future_usage: z.enum(["", "none", "off_session"]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       samsung_pay: z
         .union([
           z.object({capture_method: z.enum(["", "manual"]).optional()}),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       satispay: z
         .union([
           z.object({capture_method: z.enum(["", "manual"]).optional()}),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       sepa_debit: z
@@ -27494,7 +27494,7 @@ export const s_PostPaymentIntentsRequestBody = z.object({
             mandate_options: z
               .object({
                 reference_prefix: z
-                  .union([z.string().max(12), z.enum([""])])
+                  .union([z.string().max(12), z.literal("")])
                   .optional(),
               })
               .optional(),
@@ -27503,7 +27503,7 @@ export const s_PostPaymentIntentsRequestBody = z.object({
               .optional(),
             target_date: z.string().max(5000).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       sofort: z
@@ -27514,22 +27514,24 @@ export const s_PostPaymentIntentsRequestBody = z.object({
               .optional(),
             setup_future_usage: z.enum(["", "none", "off_session"]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       swish: z
         .union([
           z.object({
-            reference: z.union([z.string().max(5000), z.enum([""])]).optional(),
-            setup_future_usage: z.enum(["none"]).optional(),
+            reference: z
+              .union([z.string().max(5000), z.literal("")])
+              .optional(),
+            setup_future_usage: z.literal("none").optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       twint: z
         .union([
-          z.object({setup_future_usage: z.enum(["none"]).optional()}),
-          z.enum([""]),
+          z.object({setup_future_usage: z.literal("none").optional()}),
+          z.literal(""),
         ])
         .optional(),
       us_bank_account: z
@@ -27581,7 +27583,7 @@ export const s_PostPaymentIntentsRequestBody = z.object({
               .enum(["automatic", "instant", "microdeposits"])
               .optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       wechat_pay: z
@@ -27589,15 +27591,15 @@ export const s_PostPaymentIntentsRequestBody = z.object({
           z.object({
             app_id: z.string().max(5000).optional(),
             client: z.enum(["android", "ios", "web"]).optional(),
-            setup_future_usage: z.enum(["none"]).optional(),
+            setup_future_usage: z.literal("none").optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       zip: z
         .union([
-          z.object({setup_future_usage: z.enum(["none"]).optional()}),
-          z.enum([""]),
+          z.object({setup_future_usage: z.literal("none").optional()}),
+          z.literal(""),
         ])
         .optional(),
     })
@@ -27636,14 +27638,16 @@ export const s_PostPaymentIntentsRequestBody = z.object({
 
 export const s_PostPaymentIntentsIntentRequestBody = z.object({
   amount: z.coerce.number().optional(),
-  application_fee_amount: z.union([z.coerce.number(), z.enum([""])]).optional(),
+  application_fee_amount: z
+    .union([z.coerce.number(), z.literal("")])
+    .optional(),
   capture_method: z.enum(["automatic", "automatic_async", "manual"]).optional(),
   currency: z.string().optional(),
   customer: z.string().max(5000).optional(),
   description: z.string().max(1000).optional(),
   expand: z.array(z.string().max(5000)).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   payment_method: z.string().max(5000).optional(),
   payment_method_configuration: z.string().max(100).optional(),
@@ -27688,12 +27692,12 @@ export const s_PostPaymentIntentsIntentRequestBody = z.object({
                 postal_code: z.string().max(5000).optional(),
                 state: z.string().max(5000).optional(),
               }),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
-          email: z.union([z.string(), z.enum([""])]).optional(),
-          name: z.union([z.string().max(5000), z.enum([""])]).optional(),
-          phone: z.union([z.string().max(5000), z.enum([""])]).optional(),
+          email: z.union([z.string(), z.literal("")]).optional(),
+          name: z.union([z.string().max(5000), z.literal("")]).optional(),
+          phone: z.union([z.string().max(5000), z.literal("")]).optional(),
           tax_id: z.string().max(5000).optional(),
         })
         .optional(),
@@ -27948,7 +27952,7 @@ export const s_PostPaymentIntentsIntentRequestBody = z.object({
             mandate_options: z
               .object({
                 custom_mandate_url: z
-                  .union([z.string(), z.enum([""])])
+                  .union([z.string(), z.literal("")])
                   .optional(),
                 interval_description: z.string().max(500).optional(),
                 payment_schedule: z
@@ -27965,7 +27969,7 @@ export const s_PostPaymentIntentsIntentRequestBody = z.object({
               .enum(["automatic", "instant", "microdeposits"])
               .optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       affirm: z
@@ -27973,9 +27977,9 @@ export const s_PostPaymentIntentsIntentRequestBody = z.object({
           z.object({
             capture_method: z.enum(["", "manual"]).optional(),
             preferred_locale: z.string().max(30).optional(),
-            setup_future_usage: z.enum(["none"]).optional(),
+            setup_future_usage: z.literal("none").optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       afterpay_clearpay: z
@@ -27983,9 +27987,9 @@ export const s_PostPaymentIntentsIntentRequestBody = z.object({
           z.object({
             capture_method: z.enum(["", "manual"]).optional(),
             reference: z.string().max(128).optional(),
-            setup_future_usage: z.enum(["none"]).optional(),
+            setup_future_usage: z.literal("none").optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       alipay: z
@@ -27993,13 +27997,13 @@ export const s_PostPaymentIntentsIntentRequestBody = z.object({
           z.object({
             setup_future_usage: z.enum(["", "none", "off_session"]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       alma: z
         .union([
           z.object({capture_method: z.enum(["", "manual"]).optional()}),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       amazon_pay: z
@@ -28008,7 +28012,7 @@ export const s_PostPaymentIntentsIntentRequestBody = z.object({
             capture_method: z.enum(["", "manual"]).optional(),
             setup_future_usage: z.enum(["", "none", "off_session"]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       au_becs_debit: z
@@ -28019,7 +28023,7 @@ export const s_PostPaymentIntentsIntentRequestBody = z.object({
               .optional(),
             target_date: z.string().max(5000).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       bacs_debit: z
@@ -28028,7 +28032,7 @@ export const s_PostPaymentIntentsIntentRequestBody = z.object({
             mandate_options: z
               .object({
                 reference_prefix: z
-                  .union([z.string().max(12), z.enum([""])])
+                  .union([z.string().max(12), z.literal("")])
                   .optional(),
               })
               .optional(),
@@ -28037,7 +28041,7 @@ export const s_PostPaymentIntentsIntentRequestBody = z.object({
               .optional(),
             target_date: z.string().max(5000).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       bancontact: z
@@ -28046,13 +28050,13 @@ export const s_PostPaymentIntentsIntentRequestBody = z.object({
             preferred_language: z.enum(["de", "en", "fr", "nl"]).optional(),
             setup_future_usage: z.enum(["", "none", "off_session"]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       billie: z
         .union([
           z.object({capture_method: z.enum(["", "manual"]).optional()}),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       blik: z
@@ -28061,7 +28065,7 @@ export const s_PostPaymentIntentsIntentRequestBody = z.object({
             code: z.string().max(5000).optional(),
             setup_future_usage: z.enum(["", "none"]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       boleto: z
@@ -28072,7 +28076,7 @@ export const s_PostPaymentIntentsIntentRequestBody = z.object({
               .enum(["", "none", "off_session", "on_session"])
               .optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       card: z
@@ -28087,10 +28091,10 @@ export const s_PostPaymentIntentsIntentRequestBody = z.object({
                   .union([
                     z.object({
                       count: z.coerce.number().optional(),
-                      interval: z.enum(["month"]).optional(),
+                      interval: z.literal("month").optional(),
                       type: z.enum(["bonus", "fixed_count", "revolving"]),
                     }),
-                    z.enum([""]),
+                    z.literal(""),
                   ])
                   .optional(),
               })
@@ -28105,7 +28109,7 @@ export const s_PostPaymentIntentsIntentRequestBody = z.object({
                 interval_count: z.coerce.number().optional(),
                 reference: z.string().max(80),
                 start_date: z.coerce.number(),
-                supported_types: z.array(z.enum(["india"])).optional(),
+                supported_types: z.array(z.literal("india")).optional(),
               })
               .optional(),
             network: z
@@ -28141,10 +28145,10 @@ export const s_PostPaymentIntentsIntentRequestBody = z.object({
               .enum(["", "none", "off_session", "on_session"])
               .optional(),
             statement_descriptor_suffix_kana: z
-              .union([z.string().max(22), z.enum([""])])
+              .union([z.string().max(22), z.literal("")])
               .optional(),
             statement_descriptor_suffix_kanji: z
-              .union([z.string().max(17), z.enum([""])])
+              .union([z.string().max(17), z.literal("")])
               .optional(),
             three_d_secure: z
               .object({
@@ -28173,7 +28177,7 @@ export const s_PostPaymentIntentsIntentRequestBody = z.object({
               })
               .optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       card_present: z
@@ -28190,7 +28194,7 @@ export const s_PostPaymentIntentsIntentRequestBody = z.object({
               })
               .optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       cashapp: z
@@ -28201,13 +28205,13 @@ export const s_PostPaymentIntentsIntentRequestBody = z.object({
               .enum(["", "none", "off_session", "on_session"])
               .optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       crypto: z
         .union([
-          z.object({setup_future_usage: z.enum(["none"]).optional()}),
-          z.enum([""]),
+          z.object({setup_future_usage: z.literal("none").optional()}),
+          z.literal(""),
         ])
         .optional(),
       customer_balance: z
@@ -28240,34 +28244,34 @@ export const s_PostPaymentIntentsIntentRequestBody = z.object({
                 ]),
               })
               .optional(),
-            funding_type: z.enum(["bank_transfer"]).optional(),
-            setup_future_usage: z.enum(["none"]).optional(),
+            funding_type: z.literal("bank_transfer").optional(),
+            setup_future_usage: z.literal("none").optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       eps: z
         .union([
-          z.object({setup_future_usage: z.enum(["none"]).optional()}),
-          z.enum([""]),
+          z.object({setup_future_usage: z.literal("none").optional()}),
+          z.literal(""),
         ])
         .optional(),
       fpx: z
         .union([
-          z.object({setup_future_usage: z.enum(["none"]).optional()}),
-          z.enum([""]),
+          z.object({setup_future_usage: z.literal("none").optional()}),
+          z.literal(""),
         ])
         .optional(),
       giropay: z
         .union([
-          z.object({setup_future_usage: z.enum(["none"]).optional()}),
-          z.enum([""]),
+          z.object({setup_future_usage: z.literal("none").optional()}),
+          z.literal(""),
         ])
         .optional(),
       grabpay: z
         .union([
-          z.object({setup_future_usage: z.enum(["none"]).optional()}),
-          z.enum([""]),
+          z.object({setup_future_usage: z.literal("none").optional()}),
+          z.literal(""),
         ])
         .optional(),
       ideal: z
@@ -28275,11 +28279,11 @@ export const s_PostPaymentIntentsIntentRequestBody = z.object({
           z.object({
             setup_future_usage: z.enum(["", "none", "off_session"]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       interac_present: z
-        .union([z.record(z.string(), z.unknown()), z.enum([""])])
+        .union([z.record(z.string(), z.unknown()), z.literal("")])
         .optional(),
       kakao_pay: z
         .union([
@@ -28287,7 +28291,7 @@ export const s_PostPaymentIntentsIntentRequestBody = z.object({
             capture_method: z.enum(["", "manual"]).optional(),
             setup_future_usage: z.enum(["", "none", "off_session"]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       klarna: z
@@ -28374,29 +28378,29 @@ export const s_PostPaymentIntentsIntentRequestBody = z.object({
                     reference: z.string().max(255),
                   }),
                 ),
-                z.enum([""]),
+                z.literal(""),
               ])
               .optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       konbini: z
         .union([
           z.object({
             confirmation_number: z
-              .union([z.string().max(11), z.enum([""])])
+              .union([z.string().max(11), z.literal("")])
               .optional(),
             expires_after_days: z
-              .union([z.coerce.number(), z.enum([""])])
+              .union([z.coerce.number(), z.literal("")])
               .optional(),
-            expires_at: z.union([z.coerce.number(), z.enum([""])]).optional(),
+            expires_at: z.union([z.coerce.number(), z.literal("")]).optional(),
             product_description: z
-              .union([z.string().max(22), z.enum([""])])
+              .union([z.string().max(22), z.literal("")])
               .optional(),
-            setup_future_usage: z.enum(["none"]).optional(),
+            setup_future_usage: z.literal("none").optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       kr_card: z
@@ -28405,7 +28409,7 @@ export const s_PostPaymentIntentsIntentRequestBody = z.object({
             capture_method: z.enum(["", "manual"]).optional(),
             setup_future_usage: z.enum(["", "none", "off_session"]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       link: z
@@ -28414,22 +28418,22 @@ export const s_PostPaymentIntentsIntentRequestBody = z.object({
             capture_method: z.enum(["", "manual"]).optional(),
             setup_future_usage: z.enum(["", "none", "off_session"]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       mobilepay: z
         .union([
           z.object({
             capture_method: z.enum(["", "manual"]).optional(),
-            setup_future_usage: z.enum(["none"]).optional(),
+            setup_future_usage: z.literal("none").optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       multibanco: z
         .union([
-          z.object({setup_future_usage: z.enum(["none"]).optional()}),
-          z.enum([""]),
+          z.object({setup_future_usage: z.literal("none").optional()}),
+          z.literal(""),
         ])
         .optional(),
       naver_pay: z
@@ -28438,7 +28442,7 @@ export const s_PostPaymentIntentsIntentRequestBody = z.object({
             capture_method: z.enum(["", "manual"]).optional(),
             setup_future_usage: z.enum(["", "none", "off_session"]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       nz_bank_account: z
@@ -28449,40 +28453,40 @@ export const s_PostPaymentIntentsIntentRequestBody = z.object({
               .optional(),
             target_date: z.string().max(5000).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       oxxo: z
         .union([
           z.object({
             expires_after_days: z.coerce.number().optional(),
-            setup_future_usage: z.enum(["none"]).optional(),
+            setup_future_usage: z.literal("none").optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       p24: z
         .union([
           z.object({
-            setup_future_usage: z.enum(["none"]).optional(),
+            setup_future_usage: z.literal("none").optional(),
             tos_shown_and_accepted: PermissiveBoolean.optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       pay_by_bank: z
-        .union([z.record(z.string(), z.unknown()), z.enum([""])])
+        .union([z.record(z.string(), z.unknown()), z.literal("")])
         .optional(),
       payco: z
         .union([
           z.object({capture_method: z.enum(["", "manual"]).optional()}),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       paynow: z
         .union([
-          z.object({setup_future_usage: z.enum(["none"]).optional()}),
-          z.enum([""]),
+          z.object({setup_future_usage: z.literal("none").optional()}),
+          z.literal(""),
         ])
         .optional(),
       paypal: z
@@ -28518,7 +28522,7 @@ export const s_PostPaymentIntentsIntentRequestBody = z.object({
             risk_correlation_id: z.string().max(32).optional(),
             setup_future_usage: z.enum(["", "none", "off_session"]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       pix: z
@@ -28526,15 +28530,15 @@ export const s_PostPaymentIntentsIntentRequestBody = z.object({
           z.object({
             expires_after_seconds: z.coerce.number().optional(),
             expires_at: z.coerce.number().optional(),
-            setup_future_usage: z.enum(["none"]).optional(),
+            setup_future_usage: z.literal("none").optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       promptpay: z
         .union([
-          z.object({setup_future_usage: z.enum(["none"]).optional()}),
-          z.enum([""]),
+          z.object({setup_future_usage: z.literal("none").optional()}),
+          z.literal(""),
         ])
         .optional(),
       revolut_pay: z
@@ -28543,19 +28547,19 @@ export const s_PostPaymentIntentsIntentRequestBody = z.object({
             capture_method: z.enum(["", "manual"]).optional(),
             setup_future_usage: z.enum(["", "none", "off_session"]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       samsung_pay: z
         .union([
           z.object({capture_method: z.enum(["", "manual"]).optional()}),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       satispay: z
         .union([
           z.object({capture_method: z.enum(["", "manual"]).optional()}),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       sepa_debit: z
@@ -28564,7 +28568,7 @@ export const s_PostPaymentIntentsIntentRequestBody = z.object({
             mandate_options: z
               .object({
                 reference_prefix: z
-                  .union([z.string().max(12), z.enum([""])])
+                  .union([z.string().max(12), z.literal("")])
                   .optional(),
               })
               .optional(),
@@ -28573,7 +28577,7 @@ export const s_PostPaymentIntentsIntentRequestBody = z.object({
               .optional(),
             target_date: z.string().max(5000).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       sofort: z
@@ -28584,22 +28588,24 @@ export const s_PostPaymentIntentsIntentRequestBody = z.object({
               .optional(),
             setup_future_usage: z.enum(["", "none", "off_session"]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       swish: z
         .union([
           z.object({
-            reference: z.union([z.string().max(5000), z.enum([""])]).optional(),
-            setup_future_usage: z.enum(["none"]).optional(),
+            reference: z
+              .union([z.string().max(5000), z.literal("")])
+              .optional(),
+            setup_future_usage: z.literal("none").optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       twint: z
         .union([
-          z.object({setup_future_usage: z.enum(["none"]).optional()}),
-          z.enum([""]),
+          z.object({setup_future_usage: z.literal("none").optional()}),
+          z.literal(""),
         ])
         .optional(),
       us_bank_account: z
@@ -28651,7 +28657,7 @@ export const s_PostPaymentIntentsIntentRequestBody = z.object({
               .enum(["automatic", "instant", "microdeposits"])
               .optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       wechat_pay: z
@@ -28659,21 +28665,21 @@ export const s_PostPaymentIntentsIntentRequestBody = z.object({
           z.object({
             app_id: z.string().max(5000).optional(),
             client: z.enum(["android", "ios", "web"]).optional(),
-            setup_future_usage: z.enum(["none"]).optional(),
+            setup_future_usage: z.literal("none").optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       zip: z
         .union([
-          z.object({setup_future_usage: z.enum(["none"]).optional()}),
-          z.enum([""]),
+          z.object({setup_future_usage: z.literal("none").optional()}),
+          z.literal(""),
         ])
         .optional(),
     })
     .optional(),
   payment_method_types: z.array(z.string().max(5000)).optional(),
-  receipt_email: z.union([z.string(), z.enum([""])]).optional(),
+  receipt_email: z.union([z.string(), z.literal("")]).optional(),
   setup_future_usage: z.enum(["", "off_session", "on_session"]).optional(),
   shipping: z
     .union([
@@ -28691,7 +28697,7 @@ export const s_PostPaymentIntentsIntentRequestBody = z.object({
         phone: z.string().max(5000).optional(),
         tracking_number: z.string().max(5000).optional(),
       }),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   statement_descriptor: z.string().max(22).optional(),
@@ -28720,7 +28726,7 @@ export const s_PostPaymentIntentsIntentCaptureRequestBody = z.object({
   expand: z.array(z.string().max(5000)).optional(),
   final_capture: PermissiveBoolean.optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   statement_descriptor: z.string().max(22).optional(),
   statement_descriptor_suffix: z.string().max(22).optional(),
@@ -28746,14 +28752,14 @@ export const s_PostPaymentIntentsIntentConfirmRequestBody = z.object({
           type: z.enum(["offline", "online"]),
         }),
       }),
-      z.enum([""]),
+      z.literal(""),
       z.object({
         customer_acceptance: z.object({
           online: z.object({
             ip_address: z.string().optional(),
             user_agent: z.string().max(5000).optional(),
           }),
-          type: z.enum(["online"]),
+          type: z.literal("online"),
         }),
       }),
     ])
@@ -28803,12 +28809,12 @@ export const s_PostPaymentIntentsIntentConfirmRequestBody = z.object({
                 postal_code: z.string().max(5000).optional(),
                 state: z.string().max(5000).optional(),
               }),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
-          email: z.union([z.string(), z.enum([""])]).optional(),
-          name: z.union([z.string().max(5000), z.enum([""])]).optional(),
-          phone: z.union([z.string().max(5000), z.enum([""])]).optional(),
+          email: z.union([z.string(), z.literal("")]).optional(),
+          name: z.union([z.string().max(5000), z.literal("")]).optional(),
+          phone: z.union([z.string().max(5000), z.literal("")]).optional(),
           tax_id: z.string().max(5000).optional(),
         })
         .optional(),
@@ -29063,7 +29069,7 @@ export const s_PostPaymentIntentsIntentConfirmRequestBody = z.object({
             mandate_options: z
               .object({
                 custom_mandate_url: z
-                  .union([z.string(), z.enum([""])])
+                  .union([z.string(), z.literal("")])
                   .optional(),
                 interval_description: z.string().max(500).optional(),
                 payment_schedule: z
@@ -29080,7 +29086,7 @@ export const s_PostPaymentIntentsIntentConfirmRequestBody = z.object({
               .enum(["automatic", "instant", "microdeposits"])
               .optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       affirm: z
@@ -29088,9 +29094,9 @@ export const s_PostPaymentIntentsIntentConfirmRequestBody = z.object({
           z.object({
             capture_method: z.enum(["", "manual"]).optional(),
             preferred_locale: z.string().max(30).optional(),
-            setup_future_usage: z.enum(["none"]).optional(),
+            setup_future_usage: z.literal("none").optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       afterpay_clearpay: z
@@ -29098,9 +29104,9 @@ export const s_PostPaymentIntentsIntentConfirmRequestBody = z.object({
           z.object({
             capture_method: z.enum(["", "manual"]).optional(),
             reference: z.string().max(128).optional(),
-            setup_future_usage: z.enum(["none"]).optional(),
+            setup_future_usage: z.literal("none").optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       alipay: z
@@ -29108,13 +29114,13 @@ export const s_PostPaymentIntentsIntentConfirmRequestBody = z.object({
           z.object({
             setup_future_usage: z.enum(["", "none", "off_session"]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       alma: z
         .union([
           z.object({capture_method: z.enum(["", "manual"]).optional()}),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       amazon_pay: z
@@ -29123,7 +29129,7 @@ export const s_PostPaymentIntentsIntentConfirmRequestBody = z.object({
             capture_method: z.enum(["", "manual"]).optional(),
             setup_future_usage: z.enum(["", "none", "off_session"]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       au_becs_debit: z
@@ -29134,7 +29140,7 @@ export const s_PostPaymentIntentsIntentConfirmRequestBody = z.object({
               .optional(),
             target_date: z.string().max(5000).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       bacs_debit: z
@@ -29143,7 +29149,7 @@ export const s_PostPaymentIntentsIntentConfirmRequestBody = z.object({
             mandate_options: z
               .object({
                 reference_prefix: z
-                  .union([z.string().max(12), z.enum([""])])
+                  .union([z.string().max(12), z.literal("")])
                   .optional(),
               })
               .optional(),
@@ -29152,7 +29158,7 @@ export const s_PostPaymentIntentsIntentConfirmRequestBody = z.object({
               .optional(),
             target_date: z.string().max(5000).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       bancontact: z
@@ -29161,13 +29167,13 @@ export const s_PostPaymentIntentsIntentConfirmRequestBody = z.object({
             preferred_language: z.enum(["de", "en", "fr", "nl"]).optional(),
             setup_future_usage: z.enum(["", "none", "off_session"]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       billie: z
         .union([
           z.object({capture_method: z.enum(["", "manual"]).optional()}),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       blik: z
@@ -29176,7 +29182,7 @@ export const s_PostPaymentIntentsIntentConfirmRequestBody = z.object({
             code: z.string().max(5000).optional(),
             setup_future_usage: z.enum(["", "none"]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       boleto: z
@@ -29187,7 +29193,7 @@ export const s_PostPaymentIntentsIntentConfirmRequestBody = z.object({
               .enum(["", "none", "off_session", "on_session"])
               .optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       card: z
@@ -29202,10 +29208,10 @@ export const s_PostPaymentIntentsIntentConfirmRequestBody = z.object({
                   .union([
                     z.object({
                       count: z.coerce.number().optional(),
-                      interval: z.enum(["month"]).optional(),
+                      interval: z.literal("month").optional(),
                       type: z.enum(["bonus", "fixed_count", "revolving"]),
                     }),
-                    z.enum([""]),
+                    z.literal(""),
                   ])
                   .optional(),
               })
@@ -29220,7 +29226,7 @@ export const s_PostPaymentIntentsIntentConfirmRequestBody = z.object({
                 interval_count: z.coerce.number().optional(),
                 reference: z.string().max(80),
                 start_date: z.coerce.number(),
-                supported_types: z.array(z.enum(["india"])).optional(),
+                supported_types: z.array(z.literal("india")).optional(),
               })
               .optional(),
             network: z
@@ -29256,10 +29262,10 @@ export const s_PostPaymentIntentsIntentConfirmRequestBody = z.object({
               .enum(["", "none", "off_session", "on_session"])
               .optional(),
             statement_descriptor_suffix_kana: z
-              .union([z.string().max(22), z.enum([""])])
+              .union([z.string().max(22), z.literal("")])
               .optional(),
             statement_descriptor_suffix_kanji: z
-              .union([z.string().max(17), z.enum([""])])
+              .union([z.string().max(17), z.literal("")])
               .optional(),
             three_d_secure: z
               .object({
@@ -29288,7 +29294,7 @@ export const s_PostPaymentIntentsIntentConfirmRequestBody = z.object({
               })
               .optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       card_present: z
@@ -29305,7 +29311,7 @@ export const s_PostPaymentIntentsIntentConfirmRequestBody = z.object({
               })
               .optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       cashapp: z
@@ -29316,13 +29322,13 @@ export const s_PostPaymentIntentsIntentConfirmRequestBody = z.object({
               .enum(["", "none", "off_session", "on_session"])
               .optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       crypto: z
         .union([
-          z.object({setup_future_usage: z.enum(["none"]).optional()}),
-          z.enum([""]),
+          z.object({setup_future_usage: z.literal("none").optional()}),
+          z.literal(""),
         ])
         .optional(),
       customer_balance: z
@@ -29355,34 +29361,34 @@ export const s_PostPaymentIntentsIntentConfirmRequestBody = z.object({
                 ]),
               })
               .optional(),
-            funding_type: z.enum(["bank_transfer"]).optional(),
-            setup_future_usage: z.enum(["none"]).optional(),
+            funding_type: z.literal("bank_transfer").optional(),
+            setup_future_usage: z.literal("none").optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       eps: z
         .union([
-          z.object({setup_future_usage: z.enum(["none"]).optional()}),
-          z.enum([""]),
+          z.object({setup_future_usage: z.literal("none").optional()}),
+          z.literal(""),
         ])
         .optional(),
       fpx: z
         .union([
-          z.object({setup_future_usage: z.enum(["none"]).optional()}),
-          z.enum([""]),
+          z.object({setup_future_usage: z.literal("none").optional()}),
+          z.literal(""),
         ])
         .optional(),
       giropay: z
         .union([
-          z.object({setup_future_usage: z.enum(["none"]).optional()}),
-          z.enum([""]),
+          z.object({setup_future_usage: z.literal("none").optional()}),
+          z.literal(""),
         ])
         .optional(),
       grabpay: z
         .union([
-          z.object({setup_future_usage: z.enum(["none"]).optional()}),
-          z.enum([""]),
+          z.object({setup_future_usage: z.literal("none").optional()}),
+          z.literal(""),
         ])
         .optional(),
       ideal: z
@@ -29390,11 +29396,11 @@ export const s_PostPaymentIntentsIntentConfirmRequestBody = z.object({
           z.object({
             setup_future_usage: z.enum(["", "none", "off_session"]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       interac_present: z
-        .union([z.record(z.string(), z.unknown()), z.enum([""])])
+        .union([z.record(z.string(), z.unknown()), z.literal("")])
         .optional(),
       kakao_pay: z
         .union([
@@ -29402,7 +29408,7 @@ export const s_PostPaymentIntentsIntentConfirmRequestBody = z.object({
             capture_method: z.enum(["", "manual"]).optional(),
             setup_future_usage: z.enum(["", "none", "off_session"]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       klarna: z
@@ -29489,29 +29495,29 @@ export const s_PostPaymentIntentsIntentConfirmRequestBody = z.object({
                     reference: z.string().max(255),
                   }),
                 ),
-                z.enum([""]),
+                z.literal(""),
               ])
               .optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       konbini: z
         .union([
           z.object({
             confirmation_number: z
-              .union([z.string().max(11), z.enum([""])])
+              .union([z.string().max(11), z.literal("")])
               .optional(),
             expires_after_days: z
-              .union([z.coerce.number(), z.enum([""])])
+              .union([z.coerce.number(), z.literal("")])
               .optional(),
-            expires_at: z.union([z.coerce.number(), z.enum([""])]).optional(),
+            expires_at: z.union([z.coerce.number(), z.literal("")]).optional(),
             product_description: z
-              .union([z.string().max(22), z.enum([""])])
+              .union([z.string().max(22), z.literal("")])
               .optional(),
-            setup_future_usage: z.enum(["none"]).optional(),
+            setup_future_usage: z.literal("none").optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       kr_card: z
@@ -29520,7 +29526,7 @@ export const s_PostPaymentIntentsIntentConfirmRequestBody = z.object({
             capture_method: z.enum(["", "manual"]).optional(),
             setup_future_usage: z.enum(["", "none", "off_session"]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       link: z
@@ -29529,22 +29535,22 @@ export const s_PostPaymentIntentsIntentConfirmRequestBody = z.object({
             capture_method: z.enum(["", "manual"]).optional(),
             setup_future_usage: z.enum(["", "none", "off_session"]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       mobilepay: z
         .union([
           z.object({
             capture_method: z.enum(["", "manual"]).optional(),
-            setup_future_usage: z.enum(["none"]).optional(),
+            setup_future_usage: z.literal("none").optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       multibanco: z
         .union([
-          z.object({setup_future_usage: z.enum(["none"]).optional()}),
-          z.enum([""]),
+          z.object({setup_future_usage: z.literal("none").optional()}),
+          z.literal(""),
         ])
         .optional(),
       naver_pay: z
@@ -29553,7 +29559,7 @@ export const s_PostPaymentIntentsIntentConfirmRequestBody = z.object({
             capture_method: z.enum(["", "manual"]).optional(),
             setup_future_usage: z.enum(["", "none", "off_session"]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       nz_bank_account: z
@@ -29564,40 +29570,40 @@ export const s_PostPaymentIntentsIntentConfirmRequestBody = z.object({
               .optional(),
             target_date: z.string().max(5000).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       oxxo: z
         .union([
           z.object({
             expires_after_days: z.coerce.number().optional(),
-            setup_future_usage: z.enum(["none"]).optional(),
+            setup_future_usage: z.literal("none").optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       p24: z
         .union([
           z.object({
-            setup_future_usage: z.enum(["none"]).optional(),
+            setup_future_usage: z.literal("none").optional(),
             tos_shown_and_accepted: PermissiveBoolean.optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       pay_by_bank: z
-        .union([z.record(z.string(), z.unknown()), z.enum([""])])
+        .union([z.record(z.string(), z.unknown()), z.literal("")])
         .optional(),
       payco: z
         .union([
           z.object({capture_method: z.enum(["", "manual"]).optional()}),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       paynow: z
         .union([
-          z.object({setup_future_usage: z.enum(["none"]).optional()}),
-          z.enum([""]),
+          z.object({setup_future_usage: z.literal("none").optional()}),
+          z.literal(""),
         ])
         .optional(),
       paypal: z
@@ -29633,7 +29639,7 @@ export const s_PostPaymentIntentsIntentConfirmRequestBody = z.object({
             risk_correlation_id: z.string().max(32).optional(),
             setup_future_usage: z.enum(["", "none", "off_session"]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       pix: z
@@ -29641,15 +29647,15 @@ export const s_PostPaymentIntentsIntentConfirmRequestBody = z.object({
           z.object({
             expires_after_seconds: z.coerce.number().optional(),
             expires_at: z.coerce.number().optional(),
-            setup_future_usage: z.enum(["none"]).optional(),
+            setup_future_usage: z.literal("none").optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       promptpay: z
         .union([
-          z.object({setup_future_usage: z.enum(["none"]).optional()}),
-          z.enum([""]),
+          z.object({setup_future_usage: z.literal("none").optional()}),
+          z.literal(""),
         ])
         .optional(),
       revolut_pay: z
@@ -29658,19 +29664,19 @@ export const s_PostPaymentIntentsIntentConfirmRequestBody = z.object({
             capture_method: z.enum(["", "manual"]).optional(),
             setup_future_usage: z.enum(["", "none", "off_session"]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       samsung_pay: z
         .union([
           z.object({capture_method: z.enum(["", "manual"]).optional()}),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       satispay: z
         .union([
           z.object({capture_method: z.enum(["", "manual"]).optional()}),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       sepa_debit: z
@@ -29679,7 +29685,7 @@ export const s_PostPaymentIntentsIntentConfirmRequestBody = z.object({
             mandate_options: z
               .object({
                 reference_prefix: z
-                  .union([z.string().max(12), z.enum([""])])
+                  .union([z.string().max(12), z.literal("")])
                   .optional(),
               })
               .optional(),
@@ -29688,7 +29694,7 @@ export const s_PostPaymentIntentsIntentConfirmRequestBody = z.object({
               .optional(),
             target_date: z.string().max(5000).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       sofort: z
@@ -29699,22 +29705,24 @@ export const s_PostPaymentIntentsIntentConfirmRequestBody = z.object({
               .optional(),
             setup_future_usage: z.enum(["", "none", "off_session"]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       swish: z
         .union([
           z.object({
-            reference: z.union([z.string().max(5000), z.enum([""])]).optional(),
-            setup_future_usage: z.enum(["none"]).optional(),
+            reference: z
+              .union([z.string().max(5000), z.literal("")])
+              .optional(),
+            setup_future_usage: z.literal("none").optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       twint: z
         .union([
-          z.object({setup_future_usage: z.enum(["none"]).optional()}),
-          z.enum([""]),
+          z.object({setup_future_usage: z.literal("none").optional()}),
+          z.literal(""),
         ])
         .optional(),
       us_bank_account: z
@@ -29766,7 +29774,7 @@ export const s_PostPaymentIntentsIntentConfirmRequestBody = z.object({
               .enum(["automatic", "instant", "microdeposits"])
               .optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       wechat_pay: z
@@ -29774,15 +29782,15 @@ export const s_PostPaymentIntentsIntentConfirmRequestBody = z.object({
           z.object({
             app_id: z.string().max(5000).optional(),
             client: z.enum(["android", "ios", "web"]).optional(),
-            setup_future_usage: z.enum(["none"]).optional(),
+            setup_future_usage: z.literal("none").optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       zip: z
         .union([
-          z.object({setup_future_usage: z.enum(["none"]).optional()}),
-          z.enum([""]),
+          z.object({setup_future_usage: z.literal("none").optional()}),
+          z.literal(""),
         ])
         .optional(),
     })
@@ -29791,7 +29799,7 @@ export const s_PostPaymentIntentsIntentConfirmRequestBody = z.object({
   radar_options: z
     .object({session: z.string().max(5000).optional()})
     .optional(),
-  receipt_email: z.union([z.string(), z.enum([""])]).optional(),
+  receipt_email: z.union([z.string(), z.literal("")]).optional(),
   return_url: z.string().optional(),
   setup_future_usage: z.enum(["", "off_session", "on_session"]).optional(),
   shipping: z
@@ -29810,7 +29818,7 @@ export const s_PostPaymentIntentsIntentConfirmRequestBody = z.object({
         phone: z.string().max(5000).optional(),
         tracking_number: z.string().max(5000).optional(),
       }),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   use_stripe_sdk: PermissiveBoolean.optional(),
@@ -29864,13 +29872,13 @@ export const s_payment_link: z.ZodType<t_payment_link> = z.object({
     .object({
       data: z.array(z.lazy(() => s_item)),
       has_more: PermissiveBoolean,
-      object: z.enum(["list"]),
+      object: z.literal("list"),
       url: z.string().max(5000),
     })
     .optional(),
   livemode: PermissiveBoolean,
   metadata: z.record(z.string(), z.string().max(500)),
-  object: z.enum(["payment_link"]),
+  object: z.literal("payment_link"),
   on_behalf_of: z
     .union([z.string().max(5000), z.lazy(() => s_account)])
     .nullable()
@@ -29995,7 +30003,10 @@ export const s_PostPaymentLinksRequestBody = z.object({
           })
           .optional(),
         key: z.string().max(200),
-        label: z.object({custom: z.string().max(50), type: z.enum(["custom"])}),
+        label: z.object({
+          custom: z.string().max(50),
+          type: z.literal("custom"),
+        }),
         numeric: z
           .object({
             default_value: z.string().max(255).optional(),
@@ -30018,16 +30029,16 @@ export const s_PostPaymentLinksRequestBody = z.object({
   custom_text: z
     .object({
       after_submit: z
-        .union([z.object({message: z.string().max(1200)}), z.enum([""])])
+        .union([z.object({message: z.string().max(1200)}), z.literal("")])
         .optional(),
       shipping_address: z
-        .union([z.object({message: z.string().max(1200)}), z.enum([""])])
+        .union([z.object({message: z.string().max(1200)}), z.literal("")])
         .optional(),
       submit: z
-        .union([z.object({message: z.string().max(1200)}), z.enum([""])])
+        .union([z.object({message: z.string().max(1200)}), z.literal("")])
         .optional(),
       terms_of_service_acceptance: z
-        .union([z.object({message: z.string().max(1200)}), z.enum([""])])
+        .union([z.object({message: z.string().max(1200)}), z.literal("")])
         .optional(),
     })
     .optional(),
@@ -30040,7 +30051,7 @@ export const s_PostPaymentLinksRequestBody = z.object({
       invoice_data: z
         .object({
           account_tax_ids: z
-            .union([z.array(z.string().max(5000)), z.enum([""])])
+            .union([z.array(z.string().max(5000)), z.literal("")])
             .optional(),
           custom_fields: z
             .union([
@@ -30050,7 +30061,7 @@ export const s_PostPaymentLinksRequestBody = z.object({
                   value: z.string().max(140),
                 }),
               ),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
           description: z.string().max(1500).optional(),
@@ -30062,7 +30073,7 @@ export const s_PostPaymentLinksRequestBody = z.object({
             })
             .optional(),
           metadata: z
-            .union([z.record(z.string(), z.string()), z.enum([""])])
+            .union([z.record(z.string(), z.string()), z.literal("")])
             .optional(),
           rendering_options: z
             .union([
@@ -30072,7 +30083,7 @@ export const s_PostPaymentLinksRequestBody = z.object({
                   .optional(),
                 template: z.string().max(5000).optional(),
               }),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
         })
@@ -30529,7 +30540,7 @@ export const s_PostPaymentLinksPaymentLinkRequestBody = z.object({
           key: z.string().max(200),
           label: z.object({
             custom: z.string().max(50),
-            type: z.enum(["custom"]),
+            type: z.literal("custom"),
           }),
           numeric: z
             .object({
@@ -30549,35 +30560,35 @@ export const s_PostPaymentLinksPaymentLinkRequestBody = z.object({
           type: z.enum(["dropdown", "numeric", "text"]),
         }),
       ),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   custom_text: z
     .object({
       after_submit: z
-        .union([z.object({message: z.string().max(1200)}), z.enum([""])])
+        .union([z.object({message: z.string().max(1200)}), z.literal("")])
         .optional(),
       shipping_address: z
-        .union([z.object({message: z.string().max(1200)}), z.enum([""])])
+        .union([z.object({message: z.string().max(1200)}), z.literal("")])
         .optional(),
       submit: z
-        .union([z.object({message: z.string().max(1200)}), z.enum([""])])
+        .union([z.object({message: z.string().max(1200)}), z.literal("")])
         .optional(),
       terms_of_service_acceptance: z
-        .union([z.object({message: z.string().max(1200)}), z.enum([""])])
+        .union([z.object({message: z.string().max(1200)}), z.literal("")])
         .optional(),
     })
     .optional(),
   customer_creation: z.enum(["always", "if_required"]).optional(),
   expand: z.array(z.string().max(5000)).optional(),
-  inactive_message: z.union([z.string().max(500), z.enum([""])]).optional(),
+  inactive_message: z.union([z.string().max(500), z.literal("")]).optional(),
   invoice_creation: z
     .object({
       enabled: PermissiveBoolean,
       invoice_data: z
         .object({
           account_tax_ids: z
-            .union([z.array(z.string().max(5000)), z.enum([""])])
+            .union([z.array(z.string().max(5000)), z.literal("")])
             .optional(),
           custom_fields: z
             .union([
@@ -30587,7 +30598,7 @@ export const s_PostPaymentLinksPaymentLinkRequestBody = z.object({
                   value: z.string().max(140),
                 }),
               ),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
           description: z.string().max(1500).optional(),
@@ -30599,7 +30610,7 @@ export const s_PostPaymentLinksPaymentLinkRequestBody = z.object({
             })
             .optional(),
           metadata: z
-            .union([z.record(z.string(), z.string()), z.enum([""])])
+            .union([z.record(z.string(), z.string()), z.literal("")])
             .optional(),
           rendering_options: z
             .union([
@@ -30609,7 +30620,7 @@ export const s_PostPaymentLinksPaymentLinkRequestBody = z.object({
                   .optional(),
                 template: z.string().max(5000).optional(),
               }),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
         })
@@ -30634,17 +30645,17 @@ export const s_PostPaymentLinksPaymentLinkRequestBody = z.object({
   metadata: z.record(z.string(), z.string()).optional(),
   payment_intent_data: z
     .object({
-      description: z.union([z.string().max(1000), z.enum([""])]).optional(),
+      description: z.union([z.string().max(1000), z.literal("")]).optional(),
       metadata: z
-        .union([z.record(z.string(), z.string()), z.enum([""])])
+        .union([z.record(z.string(), z.string()), z.literal("")])
         .optional(),
       statement_descriptor: z
-        .union([z.string().max(22), z.enum([""])])
+        .union([z.string().max(22), z.literal("")])
         .optional(),
       statement_descriptor_suffix: z
-        .union([z.string().max(22), z.enum([""])])
+        .union([z.string().max(22), z.literal("")])
         .optional(),
-      transfer_group: z.union([z.string().max(5000), z.enum([""])]).optional(),
+      transfer_group: z.union([z.string().max(5000), z.literal("")]).optional(),
     })
     .optional(),
   payment_method_collection: z.enum(["always", "if_required"]).optional(),
@@ -30691,14 +30702,14 @@ export const s_PostPaymentLinksPaymentLinkRequestBody = z.object({
           "zip",
         ]),
       ),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   phone_number_collection: z.object({enabled: PermissiveBoolean}).optional(),
   restrictions: z
     .union([
       z.object({completed_sessions: z.object({limit: z.coerce.number()})}),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   shipping_address_collection: z
@@ -30947,7 +30958,7 @@ export const s_PostPaymentLinksPaymentLinkRequestBody = z.object({
           ]),
         ),
       }),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   submit_type: z
@@ -30966,9 +30977,9 @@ export const s_PostPaymentLinksPaymentLinkRequestBody = z.object({
         })
         .optional(),
       metadata: z
-        .union([z.record(z.string(), z.string()), z.enum([""])])
+        .union([z.record(z.string(), z.string()), z.literal("")])
         .optional(),
-      trial_period_days: z.union([z.coerce.number(), z.enum([""])]).optional(),
+      trial_period_days: z.union([z.coerce.number(), z.literal("")]).optional(),
       trial_settings: z
         .union([
           z.object({
@@ -30980,7 +30991,7 @@ export const s_PostPaymentLinksPaymentLinkRequestBody = z.object({
               ]),
             }),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
     })
@@ -31789,12 +31800,12 @@ export const s_PostPaymentMethodsRequestBody = z.object({
             postal_code: z.string().max(5000).optional(),
             state: z.string().max(5000).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
-      email: z.union([z.string(), z.enum([""])]).optional(),
-      name: z.union([z.string().max(5000), z.enum([""])]).optional(),
-      phone: z.union([z.string().max(5000), z.enum([""])]).optional(),
+      email: z.union([z.string(), z.literal("")]).optional(),
+      name: z.union([z.string().max(5000), z.literal("")]).optional(),
+      phone: z.union([z.string().max(5000), z.literal("")]).optional(),
       tax_id: z.string().max(5000).optional(),
     })
     .optional(),
@@ -32079,12 +32090,12 @@ export const s_PostPaymentMethodsPaymentMethodRequestBody = z.object({
             postal_code: z.string().max(5000).optional(),
             state: z.string().max(5000).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
-      email: z.union([z.string(), z.enum([""])]).optional(),
-      name: z.union([z.string().max(5000), z.enum([""])]).optional(),
-      phone: z.union([z.string().max(5000), z.enum([""])]).optional(),
+      email: z.union([z.string(), z.literal("")]).optional(),
+      name: z.union([z.string().max(5000), z.literal("")]).optional(),
+      phone: z.union([z.string().max(5000), z.literal("")]).optional(),
       tax_id: z.string().max(5000).optional(),
     })
     .optional(),
@@ -32104,7 +32115,7 @@ export const s_PostPaymentMethodsPaymentMethodRequestBody = z.object({
   expand: z.array(z.string().max(5000)).optional(),
   link: z.record(z.string(), z.unknown()).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   pay_by_bank: z.record(z.string(), z.unknown()).optional(),
   us_bank_account: z
@@ -32160,7 +32171,7 @@ export const s_payout: z.ZodType<t_payout> = z.object({
   livemode: PermissiveBoolean,
   metadata: z.record(z.string(), z.string().max(500)).nullable().optional(),
   method: z.string().max(5000),
-  object: z.enum(["payout"]),
+  object: z.literal("payout"),
   original_payout: z
     .union([z.string().max(5000), z.lazy(() => s_payout)])
     .nullable()
@@ -32192,7 +32203,7 @@ export const s_PostPayoutsRequestBody = z.object({
 export const s_PostPayoutsPayoutRequestBody = z.object({
   expand: z.array(z.string().max(5000)).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
 })
 
@@ -32219,7 +32230,7 @@ export const s_plan: z.ZodType<t_plan> = z.object({
   metadata: z.record(z.string(), z.string().max(500)).nullable().optional(),
   meter: z.string().max(5000).nullable().optional(),
   nickname: z.string().max(5000).nullable().optional(),
-  object: z.enum(["plan"]),
+  object: z.literal("plan"),
   product: z
     .union([z.string().max(5000), z.lazy(() => s_product), s_deleted_product])
     .nullable()
@@ -32242,7 +32253,7 @@ export const s_PostPlansRequestBody = z.object({
   interval: z.enum(["day", "month", "week", "year"]),
   interval_count: z.coerce.number().optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   meter: z.string().max(5000).optional(),
   nickname: z.string().max(5000).optional(),
@@ -32267,7 +32278,7 @@ export const s_PostPlansRequestBody = z.object({
         flat_amount_decimal: z.string().optional(),
         unit_amount: z.coerce.number().optional(),
         unit_amount_decimal: z.string().optional(),
-        up_to: z.union([z.enum(["inf"]), z.coerce.number()]),
+        up_to: z.union([z.literal("inf"), z.coerce.number()]),
       }),
     )
     .optional(),
@@ -32283,7 +32294,7 @@ export const s_PostPlansPlanRequestBody = z.object({
   active: PermissiveBoolean.optional(),
   expand: z.array(z.string().max(5000)).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   nickname: z.string().max(5000).optional(),
   product: z.string().max(5000).optional(),
@@ -32302,7 +32313,7 @@ export const s_price: z.ZodType<t_price> = z.object({
   lookup_key: z.string().max(5000).nullable().optional(),
   metadata: z.record(z.string(), z.string().max(500)),
   nickname: z.string().max(5000).nullable().optional(),
-  object: z.enum(["price"]),
+  object: z.literal("price"),
   product: z.union([
     z.string().max(5000),
     z.lazy(() => s_product),
@@ -32347,7 +32358,7 @@ export const s_PostPricesRequestBody = z.object({
               flat_amount_decimal: z.string().optional(),
               unit_amount: z.coerce.number().optional(),
               unit_amount_decimal: z.string().optional(),
-              up_to: z.union([z.enum(["inf"]), z.coerce.number()]),
+              up_to: z.union([z.literal("inf"), z.coerce.number()]),
             }),
           )
           .optional(),
@@ -32396,7 +32407,7 @@ export const s_PostPricesRequestBody = z.object({
         flat_amount_decimal: z.string().optional(),
         unit_amount: z.coerce.number().optional(),
         unit_amount_decimal: z.string().optional(),
-        up_to: z.union([z.enum(["inf"]), z.coerce.number()]),
+        up_to: z.union([z.literal("inf"), z.coerce.number()]),
       }),
     )
     .optional(),
@@ -32434,7 +32445,7 @@ export const s_PostPricesPriceRequestBody = z.object({
                 flat_amount_decimal: z.string().optional(),
                 unit_amount: z.coerce.number().optional(),
                 unit_amount_decimal: z.string().optional(),
-                up_to: z.union([z.enum(["inf"]), z.coerce.number()]),
+                up_to: z.union([z.literal("inf"), z.coerce.number()]),
               }),
             )
             .optional(),
@@ -32442,13 +32453,13 @@ export const s_PostPricesPriceRequestBody = z.object({
           unit_amount_decimal: z.string().optional(),
         }),
       ),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   expand: z.array(z.string().max(5000)).optional(),
   lookup_key: z.string().max(200).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   nickname: z.string().max(5000).optional(),
   tax_behavior: z.enum(["exclusive", "inclusive", "unspecified"]).optional(),
@@ -32469,7 +32480,7 @@ export const s_product: z.ZodType<t_product> = z.object({
   marketing_features: z.array(s_product_marketing_feature),
   metadata: z.record(z.string(), z.string().max(500)),
   name: z.string().max(5000),
-  object: z.enum(["product"]),
+  object: z.literal("product"),
   package_dimensions: s_package_dimensions.nullable().optional(),
   shippable: PermissiveBoolean.nullable().optional(),
   statement_descriptor: z.string().max(5000).nullable().optional(),
@@ -32509,7 +32520,7 @@ export const s_PostProductsRequestBody = z.object({
                   flat_amount_decimal: z.string().optional(),
                   unit_amount: z.coerce.number().optional(),
                   unit_amount_decimal: z.string().optional(),
-                  up_to: z.union([z.enum(["inf"]), z.coerce.number()]),
+                  up_to: z.union([z.literal("inf"), z.coerce.number()]),
                 }),
               )
               .optional(),
@@ -32567,14 +32578,14 @@ export const s_PostProductsRequestBody = z.object({
 export const s_PostProductsIdRequestBody = z.object({
   active: PermissiveBoolean.optional(),
   default_price: z.string().max(5000).optional(),
-  description: z.union([z.string().max(40000), z.enum([""])]).optional(),
+  description: z.union([z.string().max(40000), z.literal("")]).optional(),
   expand: z.array(z.string().max(5000)).optional(),
-  images: z.union([z.array(z.string()), z.enum([""])]).optional(),
+  images: z.union([z.array(z.string()), z.literal("")]).optional(),
   marketing_features: z
-    .union([z.array(z.object({name: z.string().max(5000)})), z.enum([""])])
+    .union([z.array(z.object({name: z.string().max(5000)})), z.literal("")])
     .optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   name: z.string().max(5000).optional(),
   package_dimensions: z
@@ -32585,14 +32596,14 @@ export const s_PostProductsIdRequestBody = z.object({
         weight: z.coerce.number(),
         width: z.coerce.number(),
       }),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   shippable: PermissiveBoolean.optional(),
   statement_descriptor: z.string().max(22).optional(),
-  tax_code: z.union([z.string(), z.enum([""])]).optional(),
-  unit_label: z.union([z.string().max(12), z.enum([""])]).optional(),
-  url: z.union([z.string(), z.enum([""])]).optional(),
+  tax_code: z.union([z.string(), z.literal("")]).optional(),
+  unit_label: z.union([z.string().max(12), z.literal("")]).optional(),
+  url: z.union([z.string(), z.literal("")]).optional(),
 })
 
 export const s_PostProductsProductFeaturesRequestBody = z.object({
@@ -32614,7 +32625,7 @@ export const s_promotion_code: z.ZodType<t_promotion_code> = z.object({
   livemode: PermissiveBoolean,
   max_redemptions: z.coerce.number().nullable().optional(),
   metadata: z.record(z.string(), z.string().max(500)).nullable().optional(),
-  object: z.enum(["promotion_code"]),
+  object: z.literal("promotion_code"),
   restrictions: s_promotion_codes_resource_restrictions,
   times_redeemed: z.coerce.number(),
 })
@@ -32647,7 +32658,7 @@ export const s_PostPromotionCodesPromotionCodeRequestBody = z.object({
   active: PermissiveBoolean.optional(),
   expand: z.array(z.string().max(5000)).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   restrictions: z
     .object({
@@ -32701,14 +32712,14 @@ export const s_quote: z.ZodType<t_quote> = z.object({
     .object({
       data: z.array(z.lazy(() => s_item)),
       has_more: PermissiveBoolean,
-      object: z.enum(["list"]),
+      object: z.literal("list"),
       url: z.string().max(5000),
     })
     .optional(),
   livemode: PermissiveBoolean,
   metadata: z.record(z.string(), z.string().max(500)),
   number: z.string().max(5000).nullable().optional(),
-  object: z.enum(["quote"]),
+  object: z.literal("quote"),
   on_behalf_of: z
     .union([z.string().max(5000), z.lazy(() => s_account)])
     .nullable()
@@ -32736,9 +32747,11 @@ export const s_quote: z.ZodType<t_quote> = z.object({
 })
 
 export const s_PostQuotesRequestBody = z.object({
-  application_fee_amount: z.union([z.coerce.number(), z.enum([""])]).optional(),
+  application_fee_amount: z
+    .union([z.coerce.number(), z.literal("")])
+    .optional(),
   application_fee_percent: z
-    .union([z.coerce.number(), z.enum([""])])
+    .union([z.coerce.number(), z.literal("")])
     .optional(),
   automatic_tax: z
     .object({
@@ -32756,9 +32769,9 @@ export const s_PostQuotesRequestBody = z.object({
     .optional(),
   customer: z.string().max(5000).optional(),
   default_tax_rates: z
-    .union([z.array(z.string().max(5000)), z.enum([""])])
+    .union([z.array(z.string().max(5000)), z.literal("")])
     .optional(),
-  description: z.union([z.string().max(500), z.enum([""])]).optional(),
+  description: z.union([z.string().max(500), z.literal("")]).optional(),
   discounts: z
     .union([
       z.array(
@@ -32768,19 +32781,19 @@ export const s_PostQuotesRequestBody = z.object({
           promotion_code: z.string().max(5000).optional(),
         }),
       ),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   expand: z.array(z.string().max(5000)).optional(),
   expires_at: z.coerce.number().optional(),
-  footer: z.union([z.string().max(500), z.enum([""])]).optional(),
+  footer: z.union([z.string().max(500), z.literal("")]).optional(),
   from_quote: z
     .object({
       is_revision: PermissiveBoolean.optional(),
       quote: z.string().max(5000),
     })
     .optional(),
-  header: z.union([z.string().max(50), z.enum([""])]).optional(),
+  header: z.union([z.string().max(50), z.literal("")]).optional(),
   invoice_settings: z
     .object({
       days_until_due: z.coerce.number().optional(),
@@ -32804,7 +32817,7 @@ export const s_PostQuotesRequestBody = z.object({
                 promotion_code: z.string().max(5000).optional(),
               }),
             ),
-            z.enum([""]),
+            z.literal(""),
           ])
           .optional(),
         price: z.string().max(5000).optional(),
@@ -32827,13 +32840,13 @@ export const s_PostQuotesRequestBody = z.object({
           .optional(),
         quantity: z.coerce.number().optional(),
         tax_rates: z
-          .union([z.array(z.string().max(5000)), z.enum([""])])
+          .union([z.array(z.string().max(5000)), z.literal("")])
           .optional(),
       }),
     )
     .optional(),
   metadata: z.record(z.string(), z.string()).optional(),
-  on_behalf_of: z.union([z.string(), z.enum([""])]).optional(),
+  on_behalf_of: z.union([z.string(), z.literal("")]).optional(),
   subscription_data: z
     .object({
       billing_mode: z
@@ -32842,13 +32855,13 @@ export const s_PostQuotesRequestBody = z.object({
       description: z.string().max(500).optional(),
       effective_date: z
         .union([
-          z.enum(["current_period_end"]),
+          z.literal("current_period_end"),
           z.coerce.number(),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       metadata: z.record(z.string(), z.string()).optional(),
-      trial_period_days: z.union([z.coerce.number(), z.enum([""])]).optional(),
+      trial_period_days: z.union([z.coerce.number(), z.literal("")]).optional(),
     })
     .optional(),
   test_clock: z.string().max(5000).optional(),
@@ -32859,15 +32872,17 @@ export const s_PostQuotesRequestBody = z.object({
         amount_percent: z.coerce.number().optional(),
         destination: z.string(),
       }),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
 })
 
 export const s_PostQuotesQuoteRequestBody = z.object({
-  application_fee_amount: z.union([z.coerce.number(), z.enum([""])]).optional(),
+  application_fee_amount: z
+    .union([z.coerce.number(), z.literal("")])
+    .optional(),
   application_fee_percent: z
-    .union([z.coerce.number(), z.enum([""])])
+    .union([z.coerce.number(), z.literal("")])
     .optional(),
   automatic_tax: z
     .object({
@@ -32885,9 +32900,9 @@ export const s_PostQuotesQuoteRequestBody = z.object({
     .optional(),
   customer: z.string().max(5000).optional(),
   default_tax_rates: z
-    .union([z.array(z.string().max(5000)), z.enum([""])])
+    .union([z.array(z.string().max(5000)), z.literal("")])
     .optional(),
-  description: z.union([z.string().max(500), z.enum([""])]).optional(),
+  description: z.union([z.string().max(500), z.literal("")]).optional(),
   discounts: z
     .union([
       z.array(
@@ -32897,13 +32912,13 @@ export const s_PostQuotesQuoteRequestBody = z.object({
           promotion_code: z.string().max(5000).optional(),
         }),
       ),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   expand: z.array(z.string().max(5000)).optional(),
   expires_at: z.coerce.number().optional(),
-  footer: z.union([z.string().max(500), z.enum([""])]).optional(),
-  header: z.union([z.string().max(50), z.enum([""])]).optional(),
+  footer: z.union([z.string().max(500), z.literal("")]).optional(),
+  header: z.union([z.string().max(50), z.literal("")]).optional(),
   invoice_settings: z
     .object({
       days_until_due: z.coerce.number().optional(),
@@ -32927,7 +32942,7 @@ export const s_PostQuotesQuoteRequestBody = z.object({
                 promotion_code: z.string().max(5000).optional(),
               }),
             ),
-            z.enum([""]),
+            z.literal(""),
           ])
           .optional(),
         id: z.string().max(5000).optional(),
@@ -32951,25 +32966,25 @@ export const s_PostQuotesQuoteRequestBody = z.object({
           .optional(),
         quantity: z.coerce.number().optional(),
         tax_rates: z
-          .union([z.array(z.string().max(5000)), z.enum([""])])
+          .union([z.array(z.string().max(5000)), z.literal("")])
           .optional(),
       }),
     )
     .optional(),
   metadata: z.record(z.string(), z.string()).optional(),
-  on_behalf_of: z.union([z.string(), z.enum([""])]).optional(),
+  on_behalf_of: z.union([z.string(), z.literal("")]).optional(),
   subscription_data: z
     .object({
-      description: z.union([z.string().max(500), z.enum([""])]).optional(),
+      description: z.union([z.string().max(500), z.literal("")]).optional(),
       effective_date: z
         .union([
-          z.enum(["current_period_end"]),
+          z.literal("current_period_end"),
           z.coerce.number(),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       metadata: z.record(z.string(), z.string()).optional(),
-      trial_period_days: z.union([z.coerce.number(), z.enum([""])]).optional(),
+      trial_period_days: z.union([z.coerce.number(), z.literal("")]).optional(),
     })
     .optional(),
   transfer_data: z
@@ -32979,7 +32994,7 @@ export const s_PostQuotesQuoteRequestBody = z.object({
         amount_percent: z.coerce.number().optional(),
         destination: z.string(),
       }),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
 })
@@ -33005,7 +33020,7 @@ export const s_radar_early_fraud_warning: z.ZodType<t_radar_early_fraud_warning>
     fraud_type: z.string().max(5000),
     id: z.string().max(5000),
     livemode: PermissiveBoolean,
-    object: z.enum(["radar.early_fraud_warning"]),
+    object: z.literal("radar.early_fraud_warning"),
     payment_intent: z
       .union([z.string().max(5000), z.lazy(() => s_payment_intent)])
       .optional(),
@@ -33053,9 +33068,9 @@ export const s_PostRefundsRequestBody = z.object({
   expand: z.array(z.string().max(5000)).optional(),
   instructions_email: z.string().optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
-  origin: z.enum(["customer_balance"]).optional(),
+  origin: z.literal("customer_balance").optional(),
   payment_intent: z.string().max(5000).optional(),
   reason: z
     .enum(["duplicate", "fraudulent", "requested_by_customer"])
@@ -33067,7 +33082,7 @@ export const s_PostRefundsRequestBody = z.object({
 export const s_PostRefundsRefundRequestBody = z.object({
   expand: z.array(z.string().max(5000)).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
 })
 
@@ -33081,7 +33096,7 @@ export const s_reporting_report_run: z.ZodType<t_reporting_report_run> =
     error: z.string().max(5000).nullable().optional(),
     id: z.string().max(5000),
     livemode: PermissiveBoolean,
-    object: z.enum(["reporting.report_run"]),
+    object: z.literal("reporting.report_run"),
     parameters: s_financial_reporting_finance_report_run_run_parameters,
     report_type: z.string().max(5000),
     result: z
@@ -33773,7 +33788,7 @@ export const s_review: z.ZodType<t_review> = z.object({
   ip_address: z.string().max(5000).nullable().optional(),
   ip_address_location: s_radar_review_resource_location.nullable().optional(),
   livemode: PermissiveBoolean,
-  object: z.enum(["review"]),
+  object: z.literal("review"),
   open: PermissiveBoolean,
   opened_reason: z.enum(["manual", "rule"]),
   payment_intent: z
@@ -33804,7 +33819,7 @@ export const s_setup_attempt: z.ZodType<t_setup_attempt> = z.object({
     .optional(),
   id: z.string().max(5000),
   livemode: PermissiveBoolean,
-  object: z.enum(["setup_attempt"]),
+  object: z.literal("setup_attempt"),
   on_behalf_of: z
     .union([z.string().max(5000), z.lazy(() => s_account)])
     .nullable()
@@ -33864,7 +33879,7 @@ export const s_setup_intent: z.ZodType<t_setup_intent> = z.object({
     .optional(),
   metadata: z.record(z.string(), z.string().max(500)).nullable().optional(),
   next_action: s_setup_intent_next_action.nullable().optional(),
-  object: z.enum(["setup_intent"]),
+  object: z.literal("setup_intent"),
   on_behalf_of: z
     .union([z.string().max(5000), z.lazy(() => s_account)])
     .nullable()
@@ -33922,7 +33937,7 @@ export const s_PostSetupIntentsRequestBody = z.object({
           type: z.enum(["offline", "online"]),
         }),
       }),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   metadata: z.record(z.string(), z.string()).optional(),
@@ -33970,12 +33985,12 @@ export const s_PostSetupIntentsRequestBody = z.object({
                 postal_code: z.string().max(5000).optional(),
                 state: z.string().max(5000).optional(),
               }),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
-          email: z.union([z.string(), z.enum([""])]).optional(),
-          name: z.union([z.string().max(5000), z.enum([""])]).optional(),
-          phone: z.union([z.string().max(5000), z.enum([""])]).optional(),
+          email: z.union([z.string(), z.literal("")]).optional(),
+          name: z.union([z.string().max(5000), z.literal("")]).optional(),
+          phone: z.union([z.string().max(5000), z.literal("")]).optional(),
           tax_id: z.string().max(5000).optional(),
         })
         .optional(),
@@ -34230,7 +34245,7 @@ export const s_PostSetupIntentsRequestBody = z.object({
           mandate_options: z
             .object({
               custom_mandate_url: z
-                .union([z.string(), z.enum([""])])
+                .union([z.string(), z.literal("")])
                 .optional(),
               default_for: z
                 .array(z.enum(["invoice", "subscription"]))
@@ -34253,7 +34268,7 @@ export const s_PostSetupIntentsRequestBody = z.object({
           mandate_options: z
             .object({
               reference_prefix: z
-                .union([z.string().max(12), z.enum([""])])
+                .union([z.string().max(12), z.literal("")])
                 .optional(),
             })
             .optional(),
@@ -34272,7 +34287,7 @@ export const s_PostSetupIntentsRequestBody = z.object({
               interval_count: z.coerce.number().optional(),
               reference: z.string().max(80),
               start_date: z.coerce.number(),
-              supported_types: z.array(z.enum(["india"])).optional(),
+              supported_types: z.array(z.literal("india")).optional(),
             })
             .optional(),
           network: z
@@ -34401,7 +34416,7 @@ export const s_PostSetupIntentsRequestBody = z.object({
                   reference: z.string().max(255),
                 }),
               ),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
         })
@@ -34415,7 +34430,7 @@ export const s_PostSetupIntentsRequestBody = z.object({
           mandate_options: z
             .object({
               reference_prefix: z
-                .union([z.string().max(12), z.enum([""])])
+                .union([z.string().max(12), z.literal("")])
                 .optional(),
             })
             .optional(),
@@ -34481,7 +34496,7 @@ export const s_PostSetupIntentsIntentRequestBody = z.object({
   expand: z.array(z.string().max(5000)).optional(),
   flow_directions: z.array(z.enum(["inbound", "outbound"])).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   payment_method: z.string().max(5000).optional(),
   payment_method_configuration: z.string().max(100).optional(),
@@ -34526,12 +34541,12 @@ export const s_PostSetupIntentsIntentRequestBody = z.object({
                 postal_code: z.string().max(5000).optional(),
                 state: z.string().max(5000).optional(),
               }),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
-          email: z.union([z.string(), z.enum([""])]).optional(),
-          name: z.union([z.string().max(5000), z.enum([""])]).optional(),
-          phone: z.union([z.string().max(5000), z.enum([""])]).optional(),
+          email: z.union([z.string(), z.literal("")]).optional(),
+          name: z.union([z.string().max(5000), z.literal("")]).optional(),
+          phone: z.union([z.string().max(5000), z.literal("")]).optional(),
           tax_id: z.string().max(5000).optional(),
         })
         .optional(),
@@ -34786,7 +34801,7 @@ export const s_PostSetupIntentsIntentRequestBody = z.object({
           mandate_options: z
             .object({
               custom_mandate_url: z
-                .union([z.string(), z.enum([""])])
+                .union([z.string(), z.literal("")])
                 .optional(),
               default_for: z
                 .array(z.enum(["invoice", "subscription"]))
@@ -34809,7 +34824,7 @@ export const s_PostSetupIntentsIntentRequestBody = z.object({
           mandate_options: z
             .object({
               reference_prefix: z
-                .union([z.string().max(12), z.enum([""])])
+                .union([z.string().max(12), z.literal("")])
                 .optional(),
             })
             .optional(),
@@ -34828,7 +34843,7 @@ export const s_PostSetupIntentsIntentRequestBody = z.object({
               interval_count: z.coerce.number().optional(),
               reference: z.string().max(80),
               start_date: z.coerce.number(),
-              supported_types: z.array(z.enum(["india"])).optional(),
+              supported_types: z.array(z.literal("india")).optional(),
             })
             .optional(),
           network: z
@@ -34957,7 +34972,7 @@ export const s_PostSetupIntentsIntentRequestBody = z.object({
                   reference: z.string().max(255),
                 }),
               ),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
         })
@@ -34971,7 +34986,7 @@ export const s_PostSetupIntentsIntentRequestBody = z.object({
           mandate_options: z
             .object({
               reference_prefix: z
-                .union([z.string().max(12), z.enum([""])])
+                .union([z.string().max(12), z.literal("")])
                 .optional(),
             })
             .optional(),
@@ -35047,14 +35062,14 @@ export const s_PostSetupIntentsIntentConfirmRequestBody = z.object({
           type: z.enum(["offline", "online"]),
         }),
       }),
-      z.enum([""]),
+      z.literal(""),
       z.object({
         customer_acceptance: z.object({
           online: z.object({
             ip_address: z.string().optional(),
             user_agent: z.string().max(5000).optional(),
           }),
-          type: z.enum(["online"]),
+          type: z.literal("online"),
         }),
       }),
     ])
@@ -35101,12 +35116,12 @@ export const s_PostSetupIntentsIntentConfirmRequestBody = z.object({
                 postal_code: z.string().max(5000).optional(),
                 state: z.string().max(5000).optional(),
               }),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
-          email: z.union([z.string(), z.enum([""])]).optional(),
-          name: z.union([z.string().max(5000), z.enum([""])]).optional(),
-          phone: z.union([z.string().max(5000), z.enum([""])]).optional(),
+          email: z.union([z.string(), z.literal("")]).optional(),
+          name: z.union([z.string().max(5000), z.literal("")]).optional(),
+          phone: z.union([z.string().max(5000), z.literal("")]).optional(),
           tax_id: z.string().max(5000).optional(),
         })
         .optional(),
@@ -35361,7 +35376,7 @@ export const s_PostSetupIntentsIntentConfirmRequestBody = z.object({
           mandate_options: z
             .object({
               custom_mandate_url: z
-                .union([z.string(), z.enum([""])])
+                .union([z.string(), z.literal("")])
                 .optional(),
               default_for: z
                 .array(z.enum(["invoice", "subscription"]))
@@ -35384,7 +35399,7 @@ export const s_PostSetupIntentsIntentConfirmRequestBody = z.object({
           mandate_options: z
             .object({
               reference_prefix: z
-                .union([z.string().max(12), z.enum([""])])
+                .union([z.string().max(12), z.literal("")])
                 .optional(),
             })
             .optional(),
@@ -35403,7 +35418,7 @@ export const s_PostSetupIntentsIntentConfirmRequestBody = z.object({
               interval_count: z.coerce.number().optional(),
               reference: z.string().max(80),
               start_date: z.coerce.number(),
-              supported_types: z.array(z.enum(["india"])).optional(),
+              supported_types: z.array(z.literal("india")).optional(),
             })
             .optional(),
           network: z
@@ -35532,7 +35547,7 @@ export const s_PostSetupIntentsIntentConfirmRequestBody = z.object({
                   reference: z.string().max(255),
                 }),
               ),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
         })
@@ -35546,7 +35561,7 @@ export const s_PostSetupIntentsIntentConfirmRequestBody = z.object({
           mandate_options: z
             .object({
               reference_prefix: z
-                .union([z.string().max(12), z.enum([""])])
+                .union([z.string().max(12), z.literal("")])
                 .optional(),
             })
             .optional(),
@@ -35646,7 +35661,7 @@ export const s_PostShippingRatesRequestBody = z.object({
   metadata: z.record(z.string(), z.string()).optional(),
   tax_behavior: z.enum(["exclusive", "inclusive", "unspecified"]).optional(),
   tax_code: z.string().optional(),
-  type: z.enum(["fixed_amount"]).optional(),
+  type: z.literal("fixed_amount").optional(),
 })
 
 export const s_PostShippingRatesShippingRateTokenRequestBody = z.object({
@@ -35668,7 +35683,7 @@ export const s_PostShippingRatesShippingRateTokenRequestBody = z.object({
     })
     .optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   tax_behavior: z.enum(["exclusive", "inclusive", "unspecified"]).optional(),
 })
@@ -35690,7 +35705,7 @@ export const s_scheduled_query_run: z.ZodType<t_scheduled_query_run> = z.object(
       .optional(),
     id: z.string().max(5000),
     livemode: PermissiveBoolean,
-    object: z.enum(["scheduled_query_run"]),
+    object: z.literal("scheduled_query_run"),
     result_available_until: z.coerce.number(),
     sql: z.string().max(100000),
     status: z.string().max(5000),
@@ -35725,7 +35740,7 @@ export const s_PostSourcesRequestBody = z.object({
           user_agent: z.string().max(5000).optional(),
         })
         .optional(),
-      amount: z.union([z.coerce.number(), z.enum([""])]).optional(),
+      amount: z.union([z.coerce.number(), z.literal("")]).optional(),
       currency: z.string().optional(),
       interval: z.enum(["one_time", "scheduled", "variable"]).optional(),
       notification_method: z
@@ -35818,7 +35833,7 @@ export const s_PostSourcesSourceRequestBody = z.object({
           user_agent: z.string().max(5000).optional(),
         })
         .optional(),
-      amount: z.union([z.coerce.number(), z.enum([""])]).optional(),
+      amount: z.union([z.coerce.number(), z.literal("")]).optional(),
       currency: z.string().optional(),
       interval: z.enum(["one_time", "scheduled", "variable"]).optional(),
       notification_method: z
@@ -35827,7 +35842,7 @@ export const s_PostSourcesSourceRequestBody = z.object({
     })
     .optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   owner: z
     .object({
@@ -35895,7 +35910,7 @@ export const s_subscription_item: z.ZodType<t_subscription_item> = z.object({
   discounts: z.array(z.union([z.string().max(5000), z.lazy(() => s_discount)])),
   id: z.string().max(5000),
   metadata: z.record(z.string(), z.string().max(500)),
-  object: z.enum(["subscription_item"]),
+  object: z.literal("subscription_item"),
   price: z.lazy(() => s_price),
   quantity: z.coerce.number().optional(),
   subscription: z.string().max(5000),
@@ -35904,7 +35919,7 @@ export const s_subscription_item: z.ZodType<t_subscription_item> = z.object({
 
 export const s_PostSubscriptionItemsRequestBody = z.object({
   billing_thresholds: z
-    .union([z.object({usage_gte: z.coerce.number()}), z.enum([""])])
+    .union([z.object({usage_gte: z.coerce.number()}), z.literal("")])
     .optional(),
   discounts: z
     .union([
@@ -35915,7 +35930,7 @@ export const s_PostSubscriptionItemsRequestBody = z.object({
           promotion_code: z.string().max(5000).optional(),
         }),
       ),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   expand: z.array(z.string().max(5000)).optional(),
@@ -35950,7 +35965,7 @@ export const s_PostSubscriptionItemsRequestBody = z.object({
   proration_date: z.coerce.number().optional(),
   quantity: z.coerce.number().optional(),
   subscription: z.string().max(5000),
-  tax_rates: z.union([z.array(z.string().max(5000)), z.enum([""])]).optional(),
+  tax_rates: z.union([z.array(z.string().max(5000)), z.literal("")]).optional(),
 })
 
 export const s_DeleteSubscriptionItemsItemRequestBody = z.object({
@@ -35963,7 +35978,7 @@ export const s_DeleteSubscriptionItemsItemRequestBody = z.object({
 
 export const s_PostSubscriptionItemsItemRequestBody = z.object({
   billing_thresholds: z
-    .union([z.object({usage_gte: z.coerce.number()}), z.enum([""])])
+    .union([z.object({usage_gte: z.coerce.number()}), z.literal("")])
     .optional(),
   discounts: z
     .union([
@@ -35974,12 +35989,12 @@ export const s_PostSubscriptionItemsItemRequestBody = z.object({
           promotion_code: z.string().max(5000).optional(),
         }),
       ),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   expand: z.array(z.string().max(5000)).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   off_session: PermissiveBoolean.optional(),
   payment_behavior: z
@@ -36011,7 +36026,7 @@ export const s_PostSubscriptionItemsItemRequestBody = z.object({
     .optional(),
   proration_date: z.coerce.number().optional(),
   quantity: z.coerce.number().optional(),
-  tax_rates: z.union([z.array(z.string().max(5000)), z.enum([""])]).optional(),
+  tax_rates: z.union([z.array(z.string().max(5000)), z.literal("")]).optional(),
 })
 
 export const s_subscription_schedule: z.ZodType<t_subscription_schedule> =
@@ -36037,7 +36052,7 @@ export const s_subscription_schedule: z.ZodType<t_subscription_schedule> =
     id: z.string().max(5000),
     livemode: PermissiveBoolean,
     metadata: z.record(z.string(), z.string().max(500)).nullable().optional(),
-    object: z.enum(["subscription_schedule"]),
+    object: z.literal("subscription_schedule"),
     phases: z.array(z.lazy(() => s_subscription_schedule_phase_configuration)),
     released_at: z.coerce.number().nullable().optional(),
     released_subscription: z.string().max(5000).nullable().optional(),
@@ -36082,18 +36097,18 @@ export const s_PostSubscriptionSchedulesRequestBody = z.object({
             amount_gte: z.coerce.number().optional(),
             reset_billing_cycle_anchor: PermissiveBoolean.optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       collection_method: z
         .enum(["charge_automatically", "send_invoice"])
         .optional(),
       default_payment_method: z.string().max(5000).optional(),
-      description: z.union([z.string().max(500), z.enum([""])]).optional(),
+      description: z.union([z.string().max(500), z.literal("")]).optional(),
       invoice_settings: z
         .object({
           account_tax_ids: z
-            .union([z.array(z.string().max(5000)), z.enum([""])])
+            .union([z.array(z.string().max(5000)), z.literal("")])
             .optional(),
           days_until_due: z.coerce.number().optional(),
           issuer: z
@@ -36104,14 +36119,14 @@ export const s_PostSubscriptionSchedulesRequestBody = z.object({
             .optional(),
         })
         .optional(),
-      on_behalf_of: z.union([z.string(), z.enum([""])]).optional(),
+      on_behalf_of: z.union([z.string(), z.literal("")]).optional(),
       transfer_data: z
         .union([
           z.object({
             amount_percent: z.coerce.number().optional(),
             destination: z.string(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
     })
@@ -36120,7 +36135,7 @@ export const s_PostSubscriptionSchedulesRequestBody = z.object({
   expand: z.array(z.string().max(5000)).optional(),
   from_subscription: z.string().max(5000).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   phases: z
     .array(
@@ -36151,7 +36166,7 @@ export const s_PostSubscriptionSchedulesRequestBody = z.object({
                 .optional(),
               quantity: z.coerce.number().optional(),
               tax_rates: z
-                .union([z.array(z.string().max(5000)), z.enum([""])])
+                .union([z.array(z.string().max(5000)), z.literal("")])
                 .optional(),
             }),
           )
@@ -36175,7 +36190,7 @@ export const s_PostSubscriptionSchedulesRequestBody = z.object({
               amount_gte: z.coerce.number().optional(),
               reset_billing_cycle_anchor: PermissiveBoolean.optional(),
             }),
-            z.enum([""]),
+            z.literal(""),
           ])
           .optional(),
         collection_method: z
@@ -36184,9 +36199,9 @@ export const s_PostSubscriptionSchedulesRequestBody = z.object({
         currency: z.string().optional(),
         default_payment_method: z.string().max(5000).optional(),
         default_tax_rates: z
-          .union([z.array(z.string().max(5000)), z.enum([""])])
+          .union([z.array(z.string().max(5000)), z.literal("")])
           .optional(),
-        description: z.union([z.string().max(500), z.enum([""])]).optional(),
+        description: z.union([z.string().max(500), z.literal("")]).optional(),
         discounts: z
           .union([
             z.array(
@@ -36196,7 +36211,7 @@ export const s_PostSubscriptionSchedulesRequestBody = z.object({
                 promotion_code: z.string().max(5000).optional(),
               }),
             ),
-            z.enum([""]),
+            z.literal(""),
           ])
           .optional(),
         duration: z
@@ -36209,7 +36224,7 @@ export const s_PostSubscriptionSchedulesRequestBody = z.object({
         invoice_settings: z
           .object({
             account_tax_ids: z
-              .union([z.array(z.string().max(5000)), z.enum([""])])
+              .union([z.array(z.string().max(5000)), z.literal("")])
               .optional(),
             days_until_due: z.coerce.number().optional(),
             issuer: z
@@ -36223,7 +36238,7 @@ export const s_PostSubscriptionSchedulesRequestBody = z.object({
         items: z.array(
           z.object({
             billing_thresholds: z
-              .union([z.object({usage_gte: z.coerce.number()}), z.enum([""])])
+              .union([z.object({usage_gte: z.coerce.number()}), z.literal("")])
               .optional(),
             discounts: z
               .union([
@@ -36234,7 +36249,7 @@ export const s_PostSubscriptionSchedulesRequestBody = z.object({
                     promotion_code: z.string().max(5000).optional(),
                   }),
                 ),
-                z.enum([""]),
+                z.literal(""),
               ])
               .optional(),
             metadata: z.record(z.string(), z.string()).optional(),
@@ -36256,7 +36271,7 @@ export const s_PostSubscriptionSchedulesRequestBody = z.object({
               .optional(),
             quantity: z.coerce.number().optional(),
             tax_rates: z
-              .union([z.array(z.string().max(5000)), z.enum([""])])
+              .union([z.array(z.string().max(5000)), z.literal("")])
               .optional(),
           }),
         ),
@@ -36277,7 +36292,7 @@ export const s_PostSubscriptionSchedulesRequestBody = z.object({
       }),
     )
     .optional(),
-  start_date: z.union([z.coerce.number(), z.enum(["now"])]).optional(),
+  start_date: z.union([z.coerce.number(), z.literal("now")]).optional(),
 })
 
 export const s_PostSubscriptionSchedulesScheduleRequestBody = z.object({
@@ -36302,18 +36317,18 @@ export const s_PostSubscriptionSchedulesScheduleRequestBody = z.object({
             amount_gte: z.coerce.number().optional(),
             reset_billing_cycle_anchor: PermissiveBoolean.optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       collection_method: z
         .enum(["charge_automatically", "send_invoice"])
         .optional(),
       default_payment_method: z.string().max(5000).optional(),
-      description: z.union([z.string().max(500), z.enum([""])]).optional(),
+      description: z.union([z.string().max(500), z.literal("")]).optional(),
       invoice_settings: z
         .object({
           account_tax_ids: z
-            .union([z.array(z.string().max(5000)), z.enum([""])])
+            .union([z.array(z.string().max(5000)), z.literal("")])
             .optional(),
           days_until_due: z.coerce.number().optional(),
           issuer: z
@@ -36324,14 +36339,14 @@ export const s_PostSubscriptionSchedulesScheduleRequestBody = z.object({
             .optional(),
         })
         .optional(),
-      on_behalf_of: z.union([z.string(), z.enum([""])]).optional(),
+      on_behalf_of: z.union([z.string(), z.literal("")]).optional(),
       transfer_data: z
         .union([
           z.object({
             amount_percent: z.coerce.number().optional(),
             destination: z.string(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
     })
@@ -36339,7 +36354,7 @@ export const s_PostSubscriptionSchedulesScheduleRequestBody = z.object({
   end_behavior: z.enum(["cancel", "none", "release", "renew"]).optional(),
   expand: z.array(z.string().max(5000)).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   phases: z
     .array(
@@ -36370,7 +36385,7 @@ export const s_PostSubscriptionSchedulesScheduleRequestBody = z.object({
                 .optional(),
               quantity: z.coerce.number().optional(),
               tax_rates: z
-                .union([z.array(z.string().max(5000)), z.enum([""])])
+                .union([z.array(z.string().max(5000)), z.literal("")])
                 .optional(),
             }),
           )
@@ -36394,7 +36409,7 @@ export const s_PostSubscriptionSchedulesScheduleRequestBody = z.object({
               amount_gte: z.coerce.number().optional(),
               reset_billing_cycle_anchor: PermissiveBoolean.optional(),
             }),
-            z.enum([""]),
+            z.literal(""),
           ])
           .optional(),
         collection_method: z
@@ -36402,9 +36417,9 @@ export const s_PostSubscriptionSchedulesScheduleRequestBody = z.object({
           .optional(),
         default_payment_method: z.string().max(5000).optional(),
         default_tax_rates: z
-          .union([z.array(z.string().max(5000)), z.enum([""])])
+          .union([z.array(z.string().max(5000)), z.literal("")])
           .optional(),
-        description: z.union([z.string().max(500), z.enum([""])]).optional(),
+        description: z.union([z.string().max(500), z.literal("")]).optional(),
         discounts: z
           .union([
             z.array(
@@ -36414,7 +36429,7 @@ export const s_PostSubscriptionSchedulesScheduleRequestBody = z.object({
                 promotion_code: z.string().max(5000).optional(),
               }),
             ),
-            z.enum([""]),
+            z.literal(""),
           ])
           .optional(),
         duration: z
@@ -36423,11 +36438,11 @@ export const s_PostSubscriptionSchedulesScheduleRequestBody = z.object({
             interval_count: z.coerce.number().optional(),
           })
           .optional(),
-        end_date: z.union([z.coerce.number(), z.enum(["now"])]).optional(),
+        end_date: z.union([z.coerce.number(), z.literal("now")]).optional(),
         invoice_settings: z
           .object({
             account_tax_ids: z
-              .union([z.array(z.string().max(5000)), z.enum([""])])
+              .union([z.array(z.string().max(5000)), z.literal("")])
               .optional(),
             days_until_due: z.coerce.number().optional(),
             issuer: z
@@ -36441,7 +36456,7 @@ export const s_PostSubscriptionSchedulesScheduleRequestBody = z.object({
         items: z.array(
           z.object({
             billing_thresholds: z
-              .union([z.object({usage_gte: z.coerce.number()}), z.enum([""])])
+              .union([z.object({usage_gte: z.coerce.number()}), z.literal("")])
               .optional(),
             discounts: z
               .union([
@@ -36452,7 +36467,7 @@ export const s_PostSubscriptionSchedulesScheduleRequestBody = z.object({
                     promotion_code: z.string().max(5000).optional(),
                   }),
                 ),
-                z.enum([""]),
+                z.literal(""),
               ])
               .optional(),
             metadata: z.record(z.string(), z.string()).optional(),
@@ -36474,7 +36489,7 @@ export const s_PostSubscriptionSchedulesScheduleRequestBody = z.object({
               .optional(),
             quantity: z.coerce.number().optional(),
             tax_rates: z
-              .union([z.array(z.string().max(5000)), z.enum([""])])
+              .union([z.array(z.string().max(5000)), z.literal("")])
               .optional(),
           }),
         ),
@@ -36484,7 +36499,7 @@ export const s_PostSubscriptionSchedulesScheduleRequestBody = z.object({
         proration_behavior: z
           .enum(["always_invoice", "create_prorations", "none"])
           .optional(),
-        start_date: z.union([z.coerce.number(), z.enum(["now"])]).optional(),
+        start_date: z.union([z.coerce.number(), z.literal("now")]).optional(),
         transfer_data: z
           .object({
             amount_percent: z.coerce.number().optional(),
@@ -36492,7 +36507,7 @@ export const s_PostSubscriptionSchedulesScheduleRequestBody = z.object({
           })
           .optional(),
         trial: PermissiveBoolean.optional(),
-        trial_end: z.union([z.coerce.number(), z.enum(["now"])]).optional(),
+        trial_end: z.union([z.coerce.number(), z.literal("now")]).optional(),
       }),
     )
     .optional(),
@@ -36539,13 +36554,13 @@ export const s_PostSubscriptionsRequestBody = z.object({
           .optional(),
         quantity: z.coerce.number().optional(),
         tax_rates: z
-          .union([z.array(z.string().max(5000)), z.enum([""])])
+          .union([z.array(z.string().max(5000)), z.literal("")])
           .optional(),
       }),
     )
     .optional(),
   application_fee_percent: z
-    .union([z.coerce.number(), z.enum([""])])
+    .union([z.coerce.number(), z.literal("")])
     .optional(),
   automatic_tax: z
     .object({
@@ -36576,7 +36591,7 @@ export const s_PostSubscriptionsRequestBody = z.object({
         amount_gte: z.coerce.number().optional(),
         reset_billing_cycle_anchor: PermissiveBoolean.optional(),
       }),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   cancel_at: z
@@ -36592,7 +36607,7 @@ export const s_PostSubscriptionsRequestBody = z.object({
   default_payment_method: z.string().max(5000).optional(),
   default_source: z.string().max(5000).optional(),
   default_tax_rates: z
-    .union([z.array(z.string().max(5000)), z.enum([""])])
+    .union([z.array(z.string().max(5000)), z.literal("")])
     .optional(),
   description: z.string().max(500).optional(),
   discounts: z
@@ -36604,14 +36619,14 @@ export const s_PostSubscriptionsRequestBody = z.object({
           promotion_code: z.string().max(5000).optional(),
         }),
       ),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   expand: z.array(z.string().max(5000)).optional(),
   invoice_settings: z
     .object({
       account_tax_ids: z
-        .union([z.array(z.string().max(5000)), z.enum([""])])
+        .union([z.array(z.string().max(5000)), z.literal("")])
         .optional(),
       issuer: z
         .object({
@@ -36625,7 +36640,7 @@ export const s_PostSubscriptionsRequestBody = z.object({
     .array(
       z.object({
         billing_thresholds: z
-          .union([z.object({usage_gte: z.coerce.number()}), z.enum([""])])
+          .union([z.object({usage_gte: z.coerce.number()}), z.literal("")])
           .optional(),
         discounts: z
           .union([
@@ -36636,7 +36651,7 @@ export const s_PostSubscriptionsRequestBody = z.object({
                 promotion_code: z.string().max(5000).optional(),
               }),
             ),
-            z.enum([""]),
+            z.literal(""),
           ])
           .optional(),
         metadata: z.record(z.string(), z.string()).optional(),
@@ -36658,16 +36673,16 @@ export const s_PostSubscriptionsRequestBody = z.object({
           .optional(),
         quantity: z.coerce.number().optional(),
         tax_rates: z
-          .union([z.array(z.string().max(5000)), z.enum([""])])
+          .union([z.array(z.string().max(5000)), z.literal("")])
           .optional(),
       }),
     )
     .optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   off_session: PermissiveBoolean.optional(),
-  on_behalf_of: z.union([z.string(), z.enum([""])]).optional(),
+  on_behalf_of: z.union([z.string(), z.literal("")]).optional(),
   payment_behavior: z
     .enum([
       "allow_incomplete",
@@ -36694,7 +36709,7 @@ export const s_PostSubscriptionsRequestBody = z.object({
                   .enum(["automatic", "instant", "microdeposits"])
                   .optional(),
               }),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
           bancontact: z
@@ -36702,7 +36717,7 @@ export const s_PostSubscriptionsRequestBody = z.object({
               z.object({
                 preferred_language: z.enum(["de", "en", "fr", "nl"]).optional(),
               }),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
           card: z
@@ -36736,7 +36751,7 @@ export const s_PostSubscriptionsRequestBody = z.object({
                   .enum(["any", "automatic", "challenge"])
                   .optional(),
               }),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
           customer_balance: z
@@ -36752,14 +36767,14 @@ export const s_PostSubscriptionsRequestBody = z.object({
                   .optional(),
                 funding_type: z.string().optional(),
               }),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
           konbini: z
-            .union([z.record(z.string(), z.unknown()), z.enum([""])])
+            .union([z.record(z.string(), z.unknown()), z.literal("")])
             .optional(),
           sepa_debit: z
-            .union([z.record(z.string(), z.unknown()), z.enum([""])])
+            .union([z.record(z.string(), z.unknown()), z.literal("")])
             .optional(),
           us_bank_account: z
             .union([
@@ -36792,7 +36807,7 @@ export const s_PostSubscriptionsRequestBody = z.object({
                   .enum(["automatic", "instant", "microdeposits"])
                   .optional(),
               }),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
         })
@@ -36842,7 +36857,7 @@ export const s_PostSubscriptionsRequestBody = z.object({
               "wechat_pay",
             ]),
           ),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       save_default_payment_method: z
@@ -36856,7 +36871,7 @@ export const s_PostSubscriptionsRequestBody = z.object({
         interval: z.enum(["day", "month", "week", "year"]),
         interval_count: z.coerce.number().optional(),
       }),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   proration_behavior: z
@@ -36868,7 +36883,7 @@ export const s_PostSubscriptionsRequestBody = z.object({
       destination: z.string(),
     })
     .optional(),
-  trial_end: z.union([z.enum(["now"]), z.coerce.number()]).optional(),
+  trial_end: z.union([z.literal("now"), z.coerce.number()]).optional(),
   trial_from_plan: PermissiveBoolean.optional(),
   trial_period_days: z.coerce.number().optional(),
   trial_settings: z
@@ -36883,7 +36898,7 @@ export const s_PostSubscriptionsRequestBody = z.object({
 export const s_DeleteSubscriptionsSubscriptionExposedIdRequestBody = z.object({
   cancellation_details: z
     .object({
-      comment: z.union([z.string().max(5000), z.enum([""])]).optional(),
+      comment: z.union([z.string().max(5000), z.literal("")]).optional(),
       feedback: z
         .enum([
           "",
@@ -36931,13 +36946,13 @@ export const s_PostSubscriptionsSubscriptionExposedIdRequestBody = z.object({
           .optional(),
         quantity: z.coerce.number().optional(),
         tax_rates: z
-          .union([z.array(z.string().max(5000)), z.enum([""])])
+          .union([z.array(z.string().max(5000)), z.literal("")])
           .optional(),
       }),
     )
     .optional(),
   application_fee_percent: z
-    .union([z.coerce.number(), z.enum([""])])
+    .union([z.coerce.number(), z.literal("")])
     .optional(),
   automatic_tax: z
     .object({
@@ -36957,20 +36972,20 @@ export const s_PostSubscriptionsSubscriptionExposedIdRequestBody = z.object({
         amount_gte: z.coerce.number().optional(),
         reset_billing_cycle_anchor: PermissiveBoolean.optional(),
       }),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   cancel_at: z
     .union([
       z.coerce.number(),
-      z.enum([""]),
+      z.literal(""),
       z.enum(["max_period_end", "min_period_end"]),
     ])
     .optional(),
   cancel_at_period_end: PermissiveBoolean.optional(),
   cancellation_details: z
     .object({
-      comment: z.union([z.string().max(5000), z.enum([""])]).optional(),
+      comment: z.union([z.string().max(5000), z.literal("")]).optional(),
       feedback: z
         .enum([
           "",
@@ -36991,11 +37006,11 @@ export const s_PostSubscriptionsSubscriptionExposedIdRequestBody = z.object({
     .optional(),
   days_until_due: z.coerce.number().optional(),
   default_payment_method: z.string().max(5000).optional(),
-  default_source: z.union([z.string().max(5000), z.enum([""])]).optional(),
+  default_source: z.union([z.string().max(5000), z.literal("")]).optional(),
   default_tax_rates: z
-    .union([z.array(z.string().max(5000)), z.enum([""])])
+    .union([z.array(z.string().max(5000)), z.literal("")])
     .optional(),
-  description: z.union([z.string().max(500), z.enum([""])]).optional(),
+  description: z.union([z.string().max(500), z.literal("")]).optional(),
   discounts: z
     .union([
       z.array(
@@ -37005,14 +37020,14 @@ export const s_PostSubscriptionsSubscriptionExposedIdRequestBody = z.object({
           promotion_code: z.string().max(5000).optional(),
         }),
       ),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   expand: z.array(z.string().max(5000)).optional(),
   invoice_settings: z
     .object({
       account_tax_ids: z
-        .union([z.array(z.string().max(5000)), z.enum([""])])
+        .union([z.array(z.string().max(5000)), z.literal("")])
         .optional(),
       issuer: z
         .object({
@@ -37026,7 +37041,7 @@ export const s_PostSubscriptionsSubscriptionExposedIdRequestBody = z.object({
     .array(
       z.object({
         billing_thresholds: z
-          .union([z.object({usage_gte: z.coerce.number()}), z.enum([""])])
+          .union([z.object({usage_gte: z.coerce.number()}), z.literal("")])
           .optional(),
         clear_usage: PermissiveBoolean.optional(),
         deleted: PermissiveBoolean.optional(),
@@ -37039,12 +37054,12 @@ export const s_PostSubscriptionsSubscriptionExposedIdRequestBody = z.object({
                 promotion_code: z.string().max(5000).optional(),
               }),
             ),
-            z.enum([""]),
+            z.literal(""),
           ])
           .optional(),
         id: z.string().max(5000).optional(),
         metadata: z
-          .union([z.record(z.string(), z.string()), z.enum([""])])
+          .union([z.record(z.string(), z.string()), z.literal("")])
           .optional(),
         price: z.string().max(5000).optional(),
         price_data: z
@@ -37064,23 +37079,23 @@ export const s_PostSubscriptionsSubscriptionExposedIdRequestBody = z.object({
           .optional(),
         quantity: z.coerce.number().optional(),
         tax_rates: z
-          .union([z.array(z.string().max(5000)), z.enum([""])])
+          .union([z.array(z.string().max(5000)), z.literal("")])
           .optional(),
       }),
     )
     .optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   off_session: PermissiveBoolean.optional(),
-  on_behalf_of: z.union([z.string(), z.enum([""])]).optional(),
+  on_behalf_of: z.union([z.string(), z.literal("")]).optional(),
   pause_collection: z
     .union([
       z.object({
         behavior: z.enum(["keep_as_draft", "mark_uncollectible", "void"]),
         resumes_at: z.coerce.number().optional(),
       }),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   payment_behavior: z
@@ -37109,7 +37124,7 @@ export const s_PostSubscriptionsSubscriptionExposedIdRequestBody = z.object({
                   .enum(["automatic", "instant", "microdeposits"])
                   .optional(),
               }),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
           bancontact: z
@@ -37117,7 +37132,7 @@ export const s_PostSubscriptionsSubscriptionExposedIdRequestBody = z.object({
               z.object({
                 preferred_language: z.enum(["de", "en", "fr", "nl"]).optional(),
               }),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
           card: z
@@ -37151,7 +37166,7 @@ export const s_PostSubscriptionsSubscriptionExposedIdRequestBody = z.object({
                   .enum(["any", "automatic", "challenge"])
                   .optional(),
               }),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
           customer_balance: z
@@ -37167,14 +37182,14 @@ export const s_PostSubscriptionsSubscriptionExposedIdRequestBody = z.object({
                   .optional(),
                 funding_type: z.string().optional(),
               }),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
           konbini: z
-            .union([z.record(z.string(), z.unknown()), z.enum([""])])
+            .union([z.record(z.string(), z.unknown()), z.literal("")])
             .optional(),
           sepa_debit: z
-            .union([z.record(z.string(), z.unknown()), z.enum([""])])
+            .union([z.record(z.string(), z.unknown()), z.literal("")])
             .optional(),
           us_bank_account: z
             .union([
@@ -37207,7 +37222,7 @@ export const s_PostSubscriptionsSubscriptionExposedIdRequestBody = z.object({
                   .enum(["automatic", "instant", "microdeposits"])
                   .optional(),
               }),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
         })
@@ -37257,7 +37272,7 @@ export const s_PostSubscriptionsSubscriptionExposedIdRequestBody = z.object({
               "wechat_pay",
             ]),
           ),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       save_default_payment_method: z
@@ -37271,7 +37286,7 @@ export const s_PostSubscriptionsSubscriptionExposedIdRequestBody = z.object({
         interval: z.enum(["day", "month", "week", "year"]),
         interval_count: z.coerce.number().optional(),
       }),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   proration_behavior: z
@@ -37284,10 +37299,10 @@ export const s_PostSubscriptionsSubscriptionExposedIdRequestBody = z.object({
         amount_percent: z.coerce.number().optional(),
         destination: z.string(),
       }),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
-  trial_end: z.union([z.enum(["now"]), z.coerce.number()]).optional(),
+  trial_end: z.union([z.literal("now"), z.coerce.number()]).optional(),
   trial_from_plan: PermissiveBoolean.optional(),
   trial_settings: z
     .object({
@@ -37299,7 +37314,7 @@ export const s_PostSubscriptionsSubscriptionExposedIdRequestBody = z.object({
 })
 
 export const s_PostSubscriptionsSubscriptionMigrateRequestBody = z.object({
-  billing_mode: z.object({type: z.enum(["flexible"])}),
+  billing_mode: z.object({type: z.literal("flexible")}),
   expand: z.array(z.string().max(5000)).optional(),
 })
 
@@ -37319,12 +37334,14 @@ export const s_PostTaxCalculationsRequestBody = z.object({
     .object({
       address: z
         .object({
-          city: z.union([z.string().max(5000), z.enum([""])]).optional(),
+          city: z.union([z.string().max(5000), z.literal("")]).optional(),
           country: z.string().max(5000),
-          line1: z.union([z.string().max(5000), z.enum([""])]).optional(),
-          line2: z.union([z.string().max(5000), z.enum([""])]).optional(),
-          postal_code: z.union([z.string().max(5000), z.enum([""])]).optional(),
-          state: z.union([z.string().max(5000), z.enum([""])]).optional(),
+          line1: z.union([z.string().max(5000), z.literal("")]).optional(),
+          line2: z.union([z.string().max(5000), z.literal("")]).optional(),
+          postal_code: z
+            .union([z.string().max(5000), z.literal("")])
+            .optional(),
+          state: z.union([z.string().max(5000), z.literal("")]).optional(),
         })
         .optional(),
       address_source: z.enum(["billing", "shipping"]).optional(),
@@ -37468,12 +37485,12 @@ export const s_PostTaxCalculationsRequestBody = z.object({
   ship_from_details: z
     .object({
       address: z.object({
-        city: z.union([z.string().max(5000), z.enum([""])]).optional(),
+        city: z.union([z.string().max(5000), z.literal("")]).optional(),
         country: z.string().max(5000),
-        line1: z.union([z.string().max(5000), z.enum([""])]).optional(),
-        line2: z.union([z.string().max(5000), z.enum([""])]).optional(),
-        postal_code: z.union([z.string().max(5000), z.enum([""])]).optional(),
-        state: z.union([z.string().max(5000), z.enum([""])]).optional(),
+        line1: z.union([z.string().max(5000), z.literal("")]).optional(),
+        line2: z.union([z.string().max(5000), z.literal("")]).optional(),
+        postal_code: z.union([z.string().max(5000), z.literal("")]).optional(),
+        state: z.union([z.string().max(5000), z.literal("")]).optional(),
       }),
     })
     .optional(),
@@ -37489,7 +37506,7 @@ export const s_PostTaxCalculationsRequestBody = z.object({
 })
 
 export const s_PostTaxRegistrationsRequestBody = z.object({
-  active_from: z.union([z.enum(["now"]), z.coerce.number()]),
+  active_from: z.union([z.literal("now"), z.coerce.number()]),
   country: z.string().max(5000),
   country_options: z.object({
     ae: z
@@ -37501,7 +37518,7 @@ export const s_PostTaxRegistrationsRequestBody = z.object({
               .optional(),
           })
           .optional(),
-        type: z.enum(["standard"]),
+        type: z.literal("standard"),
       })
       .optional(),
     al: z
@@ -37513,10 +37530,10 @@ export const s_PostTaxRegistrationsRequestBody = z.object({
               .optional(),
           })
           .optional(),
-        type: z.enum(["standard"]),
+        type: z.literal("standard"),
       })
       .optional(),
-    am: z.object({type: z.enum(["simplified"])}).optional(),
+    am: z.object({type: z.literal("simplified")}).optional(),
     ao: z
       .object({
         standard: z
@@ -37526,7 +37543,7 @@ export const s_PostTaxRegistrationsRequestBody = z.object({
               .optional(),
           })
           .optional(),
-        type: z.enum(["standard"]),
+        type: z.literal("standard"),
       })
       .optional(),
     at: z
@@ -37552,7 +37569,7 @@ export const s_PostTaxRegistrationsRequestBody = z.object({
               .optional(),
           })
           .optional(),
-        type: z.enum(["standard"]),
+        type: z.literal("standard"),
       })
       .optional(),
     aw: z
@@ -37564,10 +37581,10 @@ export const s_PostTaxRegistrationsRequestBody = z.object({
               .optional(),
           })
           .optional(),
-        type: z.enum(["standard"]),
+        type: z.literal("standard"),
       })
       .optional(),
-    az: z.object({type: z.enum(["simplified"])}).optional(),
+    az: z.object({type: z.literal("simplified")}).optional(),
     ba: z
       .object({
         standard: z
@@ -37577,7 +37594,7 @@ export const s_PostTaxRegistrationsRequestBody = z.object({
               .optional(),
           })
           .optional(),
-        type: z.enum(["standard"]),
+        type: z.literal("standard"),
       })
       .optional(),
     bb: z
@@ -37589,7 +37606,7 @@ export const s_PostTaxRegistrationsRequestBody = z.object({
               .optional(),
           })
           .optional(),
-        type: z.enum(["standard"]),
+        type: z.literal("standard"),
       })
       .optional(),
     bd: z
@@ -37601,7 +37618,7 @@ export const s_PostTaxRegistrationsRequestBody = z.object({
               .optional(),
           })
           .optional(),
-        type: z.enum(["standard"]),
+        type: z.literal("standard"),
       })
       .optional(),
     be: z
@@ -37627,7 +37644,7 @@ export const s_PostTaxRegistrationsRequestBody = z.object({
               .optional(),
           })
           .optional(),
-        type: z.enum(["standard"]),
+        type: z.literal("standard"),
       })
       .optional(),
     bg: z
@@ -37653,10 +37670,10 @@ export const s_PostTaxRegistrationsRequestBody = z.object({
               .optional(),
           })
           .optional(),
-        type: z.enum(["standard"]),
+        type: z.literal("standard"),
       })
       .optional(),
-    bj: z.object({type: z.enum(["simplified"])}).optional(),
+    bj: z.object({type: z.literal("simplified")}).optional(),
     bs: z
       .object({
         standard: z
@@ -37666,10 +37683,10 @@ export const s_PostTaxRegistrationsRequestBody = z.object({
               .optional(),
           })
           .optional(),
-        type: z.enum(["standard"]),
+        type: z.literal("standard"),
       })
       .optional(),
-    by: z.object({type: z.enum(["simplified"])}).optional(),
+    by: z.object({type: z.literal("simplified")}).optional(),
     ca: z
       .object({
         province_standard: z
@@ -37687,7 +37704,7 @@ export const s_PostTaxRegistrationsRequestBody = z.object({
               .optional(),
           })
           .optional(),
-        type: z.enum(["standard"]),
+        type: z.literal("standard"),
       })
       .optional(),
     ch: z
@@ -37699,14 +37716,14 @@ export const s_PostTaxRegistrationsRequestBody = z.object({
               .optional(),
           })
           .optional(),
-        type: z.enum(["standard"]),
+        type: z.literal("standard"),
       })
       .optional(),
-    cl: z.object({type: z.enum(["simplified"])}).optional(),
-    cm: z.object({type: z.enum(["simplified"])}).optional(),
-    co: z.object({type: z.enum(["simplified"])}).optional(),
-    cr: z.object({type: z.enum(["simplified"])}).optional(),
-    cv: z.object({type: z.enum(["simplified"])}).optional(),
+    cl: z.object({type: z.literal("simplified")}).optional(),
+    cm: z.object({type: z.literal("simplified")}).optional(),
+    co: z.object({type: z.literal("simplified")}).optional(),
+    cr: z.object({type: z.literal("simplified")}).optional(),
+    cv: z.object({type: z.literal("simplified")}).optional(),
     cy: z
       .object({
         standard: z
@@ -37763,7 +37780,7 @@ export const s_PostTaxRegistrationsRequestBody = z.object({
         type: z.enum(["ioss", "oss_non_union", "oss_union", "standard"]),
       })
       .optional(),
-    ec: z.object({type: z.enum(["simplified"])}).optional(),
+    ec: z.object({type: z.literal("simplified")}).optional(),
     ee: z
       .object({
         standard: z
@@ -37778,7 +37795,7 @@ export const s_PostTaxRegistrationsRequestBody = z.object({
         type: z.enum(["ioss", "oss_non_union", "oss_union", "standard"]),
       })
       .optional(),
-    eg: z.object({type: z.enum(["simplified"])}).optional(),
+    eg: z.object({type: z.literal("simplified")}).optional(),
     es: z
       .object({
         standard: z
@@ -37802,7 +37819,7 @@ export const s_PostTaxRegistrationsRequestBody = z.object({
               .optional(),
           })
           .optional(),
-        type: z.enum(["standard"]),
+        type: z.literal("standard"),
       })
       .optional(),
     fi: z
@@ -37842,10 +37859,10 @@ export const s_PostTaxRegistrationsRequestBody = z.object({
               .optional(),
           })
           .optional(),
-        type: z.enum(["standard"]),
+        type: z.literal("standard"),
       })
       .optional(),
-    ge: z.object({type: z.enum(["simplified"])}).optional(),
+    ge: z.object({type: z.literal("simplified")}).optional(),
     gn: z
       .object({
         standard: z
@@ -37855,7 +37872,7 @@ export const s_PostTaxRegistrationsRequestBody = z.object({
               .optional(),
           })
           .optional(),
-        type: z.enum(["standard"]),
+        type: z.literal("standard"),
       })
       .optional(),
     gr: z
@@ -37900,7 +37917,7 @@ export const s_PostTaxRegistrationsRequestBody = z.object({
         type: z.enum(["ioss", "oss_non_union", "oss_union", "standard"]),
       })
       .optional(),
-    id: z.object({type: z.enum(["simplified"])}).optional(),
+    id: z.object({type: z.literal("simplified")}).optional(),
     ie: z
       .object({
         standard: z
@@ -37915,7 +37932,7 @@ export const s_PostTaxRegistrationsRequestBody = z.object({
         type: z.enum(["ioss", "oss_non_union", "oss_union", "standard"]),
       })
       .optional(),
-    in: z.object({type: z.enum(["simplified"])}).optional(),
+    in: z.object({type: z.literal("simplified")}).optional(),
     is: z
       .object({
         standard: z
@@ -37925,7 +37942,7 @@ export const s_PostTaxRegistrationsRequestBody = z.object({
               .optional(),
           })
           .optional(),
-        type: z.enum(["standard"]),
+        type: z.literal("standard"),
       })
       .optional(),
     it: z
@@ -37951,15 +37968,15 @@ export const s_PostTaxRegistrationsRequestBody = z.object({
               .optional(),
           })
           .optional(),
-        type: z.enum(["standard"]),
+        type: z.literal("standard"),
       })
       .optional(),
-    ke: z.object({type: z.enum(["simplified"])}).optional(),
-    kg: z.object({type: z.enum(["simplified"])}).optional(),
-    kh: z.object({type: z.enum(["simplified"])}).optional(),
-    kr: z.object({type: z.enum(["simplified"])}).optional(),
-    kz: z.object({type: z.enum(["simplified"])}).optional(),
-    la: z.object({type: z.enum(["simplified"])}).optional(),
+    ke: z.object({type: z.literal("simplified")}).optional(),
+    kg: z.object({type: z.literal("simplified")}).optional(),
+    kh: z.object({type: z.literal("simplified")}).optional(),
+    kr: z.object({type: z.literal("simplified")}).optional(),
+    kz: z.object({type: z.literal("simplified")}).optional(),
+    la: z.object({type: z.literal("simplified")}).optional(),
     lt: z
       .object({
         standard: z
@@ -38002,8 +38019,8 @@ export const s_PostTaxRegistrationsRequestBody = z.object({
         type: z.enum(["ioss", "oss_non_union", "oss_union", "standard"]),
       })
       .optional(),
-    ma: z.object({type: z.enum(["simplified"])}).optional(),
-    md: z.object({type: z.enum(["simplified"])}).optional(),
+    ma: z.object({type: z.literal("simplified")}).optional(),
+    md: z.object({type: z.literal("simplified")}).optional(),
     me: z
       .object({
         standard: z
@@ -38013,7 +38030,7 @@ export const s_PostTaxRegistrationsRequestBody = z.object({
               .optional(),
           })
           .optional(),
-        type: z.enum(["standard"]),
+        type: z.literal("standard"),
       })
       .optional(),
     mk: z
@@ -38025,7 +38042,7 @@ export const s_PostTaxRegistrationsRequestBody = z.object({
               .optional(),
           })
           .optional(),
-        type: z.enum(["standard"]),
+        type: z.literal("standard"),
       })
       .optional(),
     mr: z
@@ -38037,7 +38054,7 @@ export const s_PostTaxRegistrationsRequestBody = z.object({
               .optional(),
           })
           .optional(),
-        type: z.enum(["standard"]),
+        type: z.literal("standard"),
       })
       .optional(),
     mt: z
@@ -38054,9 +38071,9 @@ export const s_PostTaxRegistrationsRequestBody = z.object({
         type: z.enum(["ioss", "oss_non_union", "oss_union", "standard"]),
       })
       .optional(),
-    mx: z.object({type: z.enum(["simplified"])}).optional(),
-    my: z.object({type: z.enum(["simplified"])}).optional(),
-    ng: z.object({type: z.enum(["simplified"])}).optional(),
+    mx: z.object({type: z.literal("simplified")}).optional(),
+    my: z.object({type: z.literal("simplified")}).optional(),
+    ng: z.object({type: z.literal("simplified")}).optional(),
     nl: z
       .object({
         standard: z
@@ -38080,10 +38097,10 @@ export const s_PostTaxRegistrationsRequestBody = z.object({
               .optional(),
           })
           .optional(),
-        type: z.enum(["standard"]),
+        type: z.literal("standard"),
       })
       .optional(),
-    np: z.object({type: z.enum(["simplified"])}).optional(),
+    np: z.object({type: z.literal("simplified")}).optional(),
     nz: z
       .object({
         standard: z
@@ -38093,7 +38110,7 @@ export const s_PostTaxRegistrationsRequestBody = z.object({
               .optional(),
           })
           .optional(),
-        type: z.enum(["standard"]),
+        type: z.literal("standard"),
       })
       .optional(),
     om: z
@@ -38105,11 +38122,11 @@ export const s_PostTaxRegistrationsRequestBody = z.object({
               .optional(),
           })
           .optional(),
-        type: z.enum(["standard"]),
+        type: z.literal("standard"),
       })
       .optional(),
-    pe: z.object({type: z.enum(["simplified"])}).optional(),
-    ph: z.object({type: z.enum(["simplified"])}).optional(),
+    pe: z.object({type: z.literal("simplified")}).optional(),
+    ph: z.object({type: z.literal("simplified")}).optional(),
     pl: z
       .object({
         standard: z
@@ -38161,11 +38178,11 @@ export const s_PostTaxRegistrationsRequestBody = z.object({
               .optional(),
           })
           .optional(),
-        type: z.enum(["standard"]),
+        type: z.literal("standard"),
       })
       .optional(),
-    ru: z.object({type: z.enum(["simplified"])}).optional(),
-    sa: z.object({type: z.enum(["simplified"])}).optional(),
+    ru: z.object({type: z.literal("simplified")}).optional(),
+    sa: z.object({type: z.literal("simplified")}).optional(),
     se: z
       .object({
         standard: z
@@ -38189,7 +38206,7 @@ export const s_PostTaxRegistrationsRequestBody = z.object({
               .optional(),
           })
           .optional(),
-        type: z.enum(["standard"]),
+        type: z.literal("standard"),
       })
       .optional(),
     si: z
@@ -38220,7 +38237,7 @@ export const s_PostTaxRegistrationsRequestBody = z.object({
         type: z.enum(["ioss", "oss_non_union", "oss_union", "standard"]),
       })
       .optional(),
-    sn: z.object({type: z.enum(["simplified"])}).optional(),
+    sn: z.object({type: z.literal("simplified")}).optional(),
     sr: z
       .object({
         standard: z
@@ -38230,15 +38247,15 @@ export const s_PostTaxRegistrationsRequestBody = z.object({
               .optional(),
           })
           .optional(),
-        type: z.enum(["standard"]),
+        type: z.literal("standard"),
       })
       .optional(),
-    th: z.object({type: z.enum(["simplified"])}).optional(),
-    tj: z.object({type: z.enum(["simplified"])}).optional(),
-    tr: z.object({type: z.enum(["simplified"])}).optional(),
-    tz: z.object({type: z.enum(["simplified"])}).optional(),
-    ua: z.object({type: z.enum(["simplified"])}).optional(),
-    ug: z.object({type: z.enum(["simplified"])}).optional(),
+    th: z.object({type: z.literal("simplified")}).optional(),
+    tj: z.object({type: z.literal("simplified")}).optional(),
+    tr: z.object({type: z.literal("simplified")}).optional(),
+    tz: z.object({type: z.literal("simplified")}).optional(),
+    ua: z.object({type: z.literal("simplified")}).optional(),
+    ug: z.object({type: z.literal("simplified")}).optional(),
     us: z
       .object({
         local_amusement_tax: z
@@ -38280,11 +38297,11 @@ export const s_PostTaxRegistrationsRequestBody = z.object({
               .optional(),
           })
           .optional(),
-        type: z.enum(["standard"]),
+        type: z.literal("standard"),
       })
       .optional(),
-    uz: z.object({type: z.enum(["simplified"])}).optional(),
-    vn: z.object({type: z.enum(["simplified"])}).optional(),
+    uz: z.object({type: z.literal("simplified")}).optional(),
+    vn: z.object({type: z.literal("simplified")}).optional(),
     za: z
       .object({
         standard: z
@@ -38294,10 +38311,10 @@ export const s_PostTaxRegistrationsRequestBody = z.object({
               .optional(),
           })
           .optional(),
-        type: z.enum(["standard"]),
+        type: z.literal("standard"),
       })
       .optional(),
-    zm: z.object({type: z.enum(["simplified"])}).optional(),
+    zm: z.object({type: z.literal("simplified")}).optional(),
     zw: z
       .object({
         standard: z
@@ -38307,7 +38324,7 @@ export const s_PostTaxRegistrationsRequestBody = z.object({
               .optional(),
           })
           .optional(),
-        type: z.enum(["standard"]),
+        type: z.literal("standard"),
       })
       .optional(),
   }),
@@ -38316,10 +38333,10 @@ export const s_PostTaxRegistrationsRequestBody = z.object({
 })
 
 export const s_PostTaxRegistrationsIdRequestBody = z.object({
-  active_from: z.union([z.enum(["now"]), z.coerce.number()]).optional(),
+  active_from: z.union([z.literal("now"), z.coerce.number()]).optional(),
   expand: z.array(z.string().max(5000)).optional(),
   expires_at: z
-    .union([z.enum(["now"]), z.coerce.number(), z.enum([""])])
+    .union([z.literal("now"), z.coerce.number(), z.literal("")])
     .optional(),
 })
 
@@ -38542,7 +38559,7 @@ export const s_PostTaxRatesTaxRateRequestBody = z.object({
   expand: z.array(z.string().max(5000)).optional(),
   jurisdiction: z.string().max(50).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   state: z.string().max(5000).optional(),
   tax_type: z
@@ -38574,7 +38591,7 @@ export const s_terminal_configuration: z.ZodType<t_terminal_configuration> =
     is_account_default: PermissiveBoolean.nullable().optional(),
     livemode: PermissiveBoolean,
     name: z.string().max(5000).nullable().optional(),
-    object: z.enum(["terminal.configuration"]),
+    object: z.literal("terminal.configuration"),
     offline:
       s_terminal_configuration_configuration_resource_offline_config.optional(),
     reboot_window:
@@ -38591,18 +38608,18 @@ export const s_terminal_configuration: z.ZodType<t_terminal_configuration> =
 
 export const s_PostTerminalConfigurationsRequestBody = z.object({
   bbpos_wisepos_e: z
-    .object({splashscreen: z.union([z.string(), z.enum([""])]).optional()})
+    .object({splashscreen: z.union([z.string(), z.literal("")]).optional()})
     .optional(),
   expand: z.array(z.string().max(5000)).optional(),
   name: z.string().max(100).optional(),
   offline: z
-    .union([z.object({enabled: PermissiveBoolean}), z.enum([""])])
+    .union([z.object({enabled: PermissiveBoolean}), z.literal("")])
     .optional(),
   reboot_window: z
     .object({end_hour: z.coerce.number(), start_hour: z.coerce.number()})
     .optional(),
   stripe_s700: z
-    .object({splashscreen: z.union([z.string(), z.enum([""])]).optional()})
+    .object({splashscreen: z.union([z.string(), z.literal("")]).optional()})
     .optional(),
   tipping: z
     .union([
@@ -38748,11 +38765,11 @@ export const s_PostTerminalConfigurationsRequestBody = z.object({
           })
           .optional(),
       }),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   verifone_p400: z
-    .object({splashscreen: z.union([z.string(), z.enum([""])]).optional()})
+    .object({splashscreen: z.union([z.string(), z.literal("")]).optional()})
     .optional(),
   wifi: z
     .union([
@@ -38783,7 +38800,7 @@ export const s_PostTerminalConfigurationsRequestBody = z.object({
           "personal_psk",
         ]),
       }),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
 })
@@ -38791,25 +38808,25 @@ export const s_PostTerminalConfigurationsRequestBody = z.object({
 export const s_PostTerminalConfigurationsConfigurationRequestBody = z.object({
   bbpos_wisepos_e: z
     .union([
-      z.object({splashscreen: z.union([z.string(), z.enum([""])]).optional()}),
-      z.enum([""]),
+      z.object({splashscreen: z.union([z.string(), z.literal("")]).optional()}),
+      z.literal(""),
     ])
     .optional(),
   expand: z.array(z.string().max(5000)).optional(),
   name: z.string().max(100).optional(),
   offline: z
-    .union([z.object({enabled: PermissiveBoolean}), z.enum([""])])
+    .union([z.object({enabled: PermissiveBoolean}), z.literal("")])
     .optional(),
   reboot_window: z
     .union([
       z.object({end_hour: z.coerce.number(), start_hour: z.coerce.number()}),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   stripe_s700: z
     .union([
-      z.object({splashscreen: z.union([z.string(), z.enum([""])]).optional()}),
-      z.enum([""]),
+      z.object({splashscreen: z.union([z.string(), z.literal("")]).optional()}),
+      z.literal(""),
     ])
     .optional(),
   tipping: z
@@ -38956,13 +38973,13 @@ export const s_PostTerminalConfigurationsConfigurationRequestBody = z.object({
           })
           .optional(),
       }),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   verifone_p400: z
     .union([
-      z.object({splashscreen: z.union([z.string(), z.enum([""])]).optional()}),
-      z.enum([""]),
+      z.object({splashscreen: z.union([z.string(), z.literal("")]).optional()}),
+      z.literal(""),
     ])
     .optional(),
   wifi: z
@@ -38994,7 +39011,7 @@ export const s_PostTerminalConfigurationsConfigurationRequestBody = z.object({
           "personal_psk",
         ]),
       }),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
 })
@@ -39017,7 +39034,7 @@ export const s_PostTerminalLocationsRequestBody = z.object({
   display_name: z.string().max(1000),
   expand: z.array(z.string().max(5000)).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
 })
 
@@ -39033,12 +39050,12 @@ export const s_PostTerminalLocationsLocationRequestBody = z.object({
     })
     .optional(),
   configuration_overrides: z
-    .union([z.string().max(1000), z.enum([""])])
+    .union([z.string().max(1000), z.literal("")])
     .optional(),
-  display_name: z.union([z.string().max(1000), z.enum([""])]).optional(),
+  display_name: z.union([z.string().max(1000), z.literal("")]).optional(),
   expand: z.array(z.string().max(5000)).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
 })
 
@@ -39068,7 +39085,7 @@ export const s_terminal_reader: z.ZodType<t_terminal_reader> = z.object({
     .nullable()
     .optional(),
   metadata: z.record(z.string(), z.string().max(500)),
-  object: z.enum(["terminal.reader"]),
+  object: z.literal("terminal.reader"),
   serial_number: z.string().max(5000),
   status: z.enum(["offline", "online"]).nullable().optional(),
 })
@@ -39078,16 +39095,16 @@ export const s_PostTerminalReadersRequestBody = z.object({
   label: z.string().max(5000).optional(),
   location: z.string().max(5000).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   registration_code: z.string().max(5000),
 })
 
 export const s_PostTerminalReadersReaderRequestBody = z.object({
   expand: z.array(z.string().max(5000)).optional(),
-  label: z.union([z.string().max(5000), z.enum([""])]).optional(),
+  label: z.union([z.string().max(5000), z.literal("")]).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
 })
 
@@ -39222,7 +39239,7 @@ export const s_PostTerminalReadersReaderSetReaderDisplayRequestBody = z.object({
     })
     .optional(),
   expand: z.array(z.string().max(5000)).optional(),
-  type: z.enum(["cart"]),
+  type: z.literal("cart"),
 })
 
 export const s_PostTestHelpersConfirmationTokensRequestBody = z.object({
@@ -39269,12 +39286,12 @@ export const s_PostTestHelpersConfirmationTokensRequestBody = z.object({
                 postal_code: z.string().max(5000).optional(),
                 state: z.string().max(5000).optional(),
               }),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
-          email: z.union([z.string(), z.enum([""])]).optional(),
-          name: z.union([z.string().max(5000), z.enum([""])]).optional(),
-          phone: z.union([z.string().max(5000), z.enum([""])]).optional(),
+          email: z.union([z.string(), z.literal("")]).optional(),
+          name: z.union([z.string().max(5000), z.literal("")]).optional(),
+          phone: z.union([z.string().max(5000), z.literal("")]).optional(),
           tax_id: z.string().max(5000).optional(),
         })
         .optional(),
@@ -39529,7 +39546,7 @@ export const s_PostTestHelpersConfirmationTokensRequestBody = z.object({
             .object({
               plan: z.object({
                 count: z.coerce.number().optional(),
-                interval: z.enum(["month"]).optional(),
+                interval: z.literal("month").optional(),
                 type: z.enum(["bonus", "fixed_count", "revolving"]),
               }),
             })
@@ -39551,7 +39568,7 @@ export const s_PostTestHelpersConfirmationTokensRequestBody = z.object({
         state: z.string().max(5000).optional(),
       }),
       name: z.string().max(5000),
-      phone: z.union([z.string().max(5000), z.enum([""])]).optional(),
+      phone: z.union([z.string().max(5000), z.literal("")]).optional(),
     })
     .optional(),
 })
@@ -41215,7 +41232,7 @@ export const s_treasury_inbound_transfer: z.ZodType<t_treasury_inbound_transfer>
       s_treasury_inbound_transfers_resource_inbound_transfer_resource_linked_flows,
     livemode: PermissiveBoolean,
     metadata: z.record(z.string(), z.string().max(500)),
-    object: z.enum(["treasury.inbound_transfer"]),
+    object: z.literal("treasury.inbound_transfer"),
     origin_payment_method: z.string().max(5000).nullable().optional(),
     origin_payment_method_details: z
       .lazy(() => s_inbound_transfers)
@@ -41276,7 +41293,7 @@ export const s_treasury_outbound_payment: z.ZodType<t_treasury_outbound_payment>
     id: z.string().max(5000),
     livemode: PermissiveBoolean,
     metadata: z.record(z.string(), z.string().max(500)),
-    object: z.enum(["treasury.outbound_payment"]),
+    object: z.literal("treasury.outbound_payment"),
     returned_details: z
       .lazy(() => s_treasury_outbound_payments_resource_returned_status)
       .nullable()
@@ -41357,7 +41374,7 @@ export const s_treasury_outbound_transfer: z.ZodType<t_treasury_outbound_transfe
     id: z.string().max(5000),
     livemode: PermissiveBoolean,
     metadata: z.record(z.string(), z.string().max(500)),
-    object: z.enum(["treasury.outbound_transfer"]),
+    object: z.literal("treasury.outbound_transfer"),
     returned_details: z
       .lazy(() => s_treasury_outbound_transfers_resource_returned_details)
       .nullable()
@@ -41413,7 +41430,7 @@ export const s_PostTestHelpersTreasuryReceivedCreditsRequestBody = z.object({
   financial_account: z.string(),
   initiating_payment_method_details: z
     .object({
-      type: z.enum(["us_bank_account"]),
+      type: z.literal("us_bank_account"),
       us_bank_account: z
         .object({
           account_holder_name: z.string().max(5000).optional(),
@@ -41451,7 +41468,7 @@ export const s_treasury_received_credit: z.ZodType<t_treasury_received_credit> =
     ),
     livemode: PermissiveBoolean,
     network: z.enum(["ach", "card", "stripe", "us_domestic_wire"]),
-    object: z.enum(["treasury.received_credit"]),
+    object: z.literal("treasury.received_credit"),
     reversal_details: s_treasury_received_credits_resource_reversal_details
       .nullable()
       .optional(),
@@ -41470,7 +41487,7 @@ export const s_PostTestHelpersTreasuryReceivedDebitsRequestBody = z.object({
   financial_account: z.string(),
   initiating_payment_method_details: z
     .object({
-      type: z.enum(["us_bank_account"]),
+      type: z.literal("us_bank_account"),
       us_bank_account: z
         .object({
           account_holder_name: z.string().max(5000).optional(),
@@ -41480,7 +41497,7 @@ export const s_PostTestHelpersTreasuryReceivedDebitsRequestBody = z.object({
         .optional(),
     })
     .optional(),
-  network: z.enum(["ach"]),
+  network: z.literal("ach"),
 })
 
 export const s_treasury_received_debit: z.ZodType<t_treasury_received_debit> =
@@ -41507,7 +41524,7 @@ export const s_treasury_received_debit: z.ZodType<t_treasury_received_debit> =
     linked_flows: s_treasury_received_debits_resource_linked_flows,
     livemode: PermissiveBoolean,
     network: z.enum(["ach", "card", "stripe"]),
-    object: z.enum(["treasury.received_debit"]),
+    object: z.literal("treasury.received_debit"),
     reversal_details: s_treasury_received_debits_resource_reversal_details
       .nullable()
       .optional(),
@@ -41596,7 +41613,7 @@ export const s_PostTokensRequestBody = z.object({
                 month: z.coerce.number(),
                 year: z.coerce.number(),
               }),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
           registration_number: z.string().max(5000).optional(),
@@ -41684,7 +41701,7 @@ export const s_PostTokensRequestBody = z.object({
                 month: z.coerce.number(),
                 year: z.coerce.number(),
               }),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
           email: z.string().optional(),
@@ -41692,7 +41709,7 @@ export const s_PostTokensRequestBody = z.object({
           first_name_kana: z.string().max(5000).optional(),
           first_name_kanji: z.string().max(5000).optional(),
           full_name_aliases: z
-            .union([z.array(z.string().max(300)), z.enum([""])])
+            .union([z.array(z.string().max(300)), z.literal("")])
             .optional(),
           gender: z.string().optional(),
           id_number: z.string().max(5000).optional(),
@@ -41702,7 +41719,7 @@ export const s_PostTokensRequestBody = z.object({
           last_name_kanji: z.string().max(5000).optional(),
           maiden_name: z.string().max(5000).optional(),
           metadata: z
-            .union([z.record(z.string(), z.string()), z.enum([""])])
+            .union([z.record(z.string(), z.string()), z.literal("")])
             .optional(),
           phone: z.string().optional(),
           political_exposure: z.enum(["existing", "none"]).optional(),
@@ -41722,7 +41739,7 @@ export const s_PostTokensRequestBody = z.object({
               executive: PermissiveBoolean.optional(),
               owner: PermissiveBoolean.optional(),
               percent_ownership: z
-                .union([z.coerce.number(), z.enum([""])])
+                .union([z.coerce.number(), z.literal("")])
                 .optional(),
               title: z.string().max(5000).optional(),
             })
@@ -41799,7 +41816,7 @@ export const s_PostTokensRequestBody = z.object({
               date: z.coerce.number().optional(),
               ip: z.string().optional(),
               user_agent: z
-                .union([z.string().max(5000), z.enum([""])])
+                .union([z.string().max(5000), z.literal("")])
                 .optional(),
             })
             .optional(),
@@ -41844,7 +41861,7 @@ export const s_PostTokensRequestBody = z.object({
             month: z.coerce.number(),
             year: z.coerce.number(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       documents: z
@@ -41852,21 +41869,21 @@ export const s_PostTokensRequestBody = z.object({
           company_authorization: z
             .object({
               files: z
-                .array(z.union([z.string().max(500), z.enum([""])]))
+                .array(z.union([z.string().max(500), z.literal("")]))
                 .optional(),
             })
             .optional(),
           passport: z
             .object({
               files: z
-                .array(z.union([z.string().max(500), z.enum([""])]))
+                .array(z.union([z.string().max(500), z.literal("")]))
                 .optional(),
             })
             .optional(),
           visa: z
             .object({
               files: z
-                .array(z.union([z.string().max(500), z.enum([""])]))
+                .array(z.union([z.string().max(500), z.literal("")]))
                 .optional(),
             })
             .optional(),
@@ -41877,7 +41894,7 @@ export const s_PostTokensRequestBody = z.object({
       first_name_kana: z.string().max(5000).optional(),
       first_name_kanji: z.string().max(5000).optional(),
       full_name_aliases: z
-        .union([z.array(z.string().max(5000)), z.enum([""])])
+        .union([z.array(z.string().max(5000)), z.literal("")])
         .optional(),
       gender: z.string().optional(),
       id_number: z.string().max(5000).optional(),
@@ -41887,7 +41904,7 @@ export const s_PostTokensRequestBody = z.object({
       last_name_kanji: z.string().max(5000).optional(),
       maiden_name: z.string().max(5000).optional(),
       metadata: z
-        .union([z.record(z.string(), z.string()), z.enum([""])])
+        .union([z.record(z.string(), z.string()), z.literal("")])
         .optional(),
       nationality: z.string().max(5000).optional(),
       phone: z.string().optional(),
@@ -41910,7 +41927,7 @@ export const s_PostTokensRequestBody = z.object({
           legal_guardian: PermissiveBoolean.optional(),
           owner: PermissiveBoolean.optional(),
           percent_ownership: z
-            .union([z.coerce.number(), z.enum([""])])
+            .union([z.coerce.number(), z.literal("")])
             .optional(),
           representative: PermissiveBoolean.optional(),
           title: z.string().max(5000).optional(),
@@ -42003,7 +42020,7 @@ export const s_token: z.ZodType<t_token> = z.object({
   created: z.coerce.number(),
   id: z.string().max(5000),
   livemode: PermissiveBoolean,
-  object: z.enum(["token"]),
+  object: z.literal("token"),
   type: z.string().max(5000),
   used: PermissiveBoolean,
 })
@@ -42023,7 +42040,7 @@ export const s_topup: z.ZodType<t_topup> = z.object({
   id: z.string().max(5000),
   livemode: PermissiveBoolean,
   metadata: z.record(z.string(), z.string().max(500)),
-  object: z.enum(["topup"]),
+  object: z.literal("topup"),
   source: s_source.nullable().optional(),
   statement_descriptor: z.string().max(5000).nullable().optional(),
   status: z.enum(["canceled", "failed", "pending", "reversed", "succeeded"]),
@@ -42036,7 +42053,7 @@ export const s_PostTopupsRequestBody = z.object({
   description: z.string().max(5000).optional(),
   expand: z.array(z.string().max(5000)).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   source: z.string().max(5000).optional(),
   statement_descriptor: z.string().max(15).optional(),
@@ -42047,7 +42064,7 @@ export const s_PostTopupsTopupRequestBody = z.object({
   description: z.string().max(5000).optional(),
   expand: z.array(z.string().max(5000)).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
 })
 
@@ -42075,11 +42092,11 @@ export const s_transfer: z.ZodType<t_transfer> = z.object({
   id: z.string().max(5000),
   livemode: PermissiveBoolean,
   metadata: z.record(z.string(), z.string().max(500)),
-  object: z.enum(["transfer"]),
+  object: z.literal("transfer"),
   reversals: z.object({
     data: z.array(z.lazy(() => s_transfer_reversal)),
     has_more: PermissiveBoolean,
-    object: z.enum(["list"]),
+    object: z.literal("list"),
     url: z.string().max(5000),
   }),
   reversed: PermissiveBoolean,
@@ -42117,7 +42134,7 @@ export const s_transfer_reversal: z.ZodType<t_transfer_reversal> = z.object({
     .optional(),
   id: z.string().max(5000),
   metadata: z.record(z.string(), z.string().max(500)).nullable().optional(),
-  object: z.enum(["transfer_reversal"]),
+  object: z.literal("transfer_reversal"),
   source_refund: z
     .union([z.string().max(5000), z.lazy(() => s_refund)])
     .nullable()
@@ -42130,7 +42147,7 @@ export const s_PostTransfersIdReversalsRequestBody = z.object({
   description: z.string().max(5000).optional(),
   expand: z.array(z.string().max(5000)).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   refund_application_fee: PermissiveBoolean.optional(),
 })
@@ -42139,14 +42156,14 @@ export const s_PostTransfersTransferRequestBody = z.object({
   description: z.string().max(5000).optional(),
   expand: z.array(z.string().max(5000)).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
 })
 
 export const s_PostTransfersTransferReversalsIdRequestBody = z.object({
   expand: z.array(z.string().max(5000)).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
 })
 
@@ -42161,7 +42178,7 @@ export const s_treasury_credit_reversal: z.ZodType<t_treasury_credit_reversal> =
     livemode: PermissiveBoolean,
     metadata: z.record(z.string(), z.string().max(500)),
     network: z.enum(["ach", "stripe"]),
-    object: z.enum(["treasury.credit_reversal"]),
+    object: z.literal("treasury.credit_reversal"),
     received_credit: z.string().max(5000),
     status: z.enum(["canceled", "posted", "processing"]),
     status_transitions: s_treasury_received_credits_resource_status_transitions,
@@ -42192,7 +42209,7 @@ export const s_treasury_debit_reversal: z.ZodType<t_treasury_debit_reversal> =
     livemode: PermissiveBoolean,
     metadata: z.record(z.string(), z.string().max(500)),
     network: z.enum(["ach", "card"]),
-    object: z.enum(["treasury.debit_reversal"]),
+    object: z.literal("treasury.debit_reversal"),
     received_debit: z.string().max(5000),
     status: z.enum(["failed", "processing", "succeeded"]),
     status_transitions: s_treasury_received_debits_resource_status_transitions,
@@ -42236,7 +42253,7 @@ export const s_PostTreasuryFinancialAccountsRequestBody = z.object({
     })
     .optional(),
   metadata: z.record(z.string(), z.string()).optional(),
-  nickname: z.union([z.string().max(5000), z.enum([""])]).optional(),
+  nickname: z.union([z.string().max(5000), z.literal("")]).optional(),
   platform_restrictions: z
     .object({
       inbound_flows: z.enum(["restricted", "unrestricted"]).optional(),
@@ -42286,7 +42303,7 @@ export const s_PostTreasuryFinancialAccountsFinancialAccountRequestBody =
       })
       .optional(),
     metadata: z.record(z.string(), z.string()).optional(),
-    nickname: z.union([z.string().max(5000), z.enum([""])]).optional(),
+    nickname: z.union([z.string().max(5000), z.literal("")]).optional(),
     platform_restrictions: z
       .object({
         inbound_flows: z.enum(["restricted", "unrestricted"]).optional(),
@@ -42367,12 +42384,12 @@ export const s_PostTreasuryOutboundPaymentsRequestBody = z.object({
                 postal_code: z.string().max(5000).optional(),
                 state: z.string().max(5000).optional(),
               }),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
-          email: z.union([z.string(), z.enum([""])]).optional(),
-          name: z.union([z.string().max(5000), z.enum([""])]).optional(),
-          phone: z.union([z.string().max(5000), z.enum([""])]).optional(),
+          email: z.union([z.string(), z.literal("")]).optional(),
+          name: z.union([z.string().max(5000), z.literal("")]).optional(),
+          phone: z.union([z.string().max(5000), z.literal("")]).optional(),
         })
         .optional(),
       financial_account: z.string().optional(),
@@ -42394,7 +42411,7 @@ export const s_PostTreasuryOutboundPaymentsRequestBody = z.object({
       us_bank_account: z
         .union([
           z.object({network: z.enum(["ach", "us_domestic_wire"]).optional()}),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
     })
@@ -42420,7 +42437,7 @@ export const s_PostTreasuryOutboundTransfersRequestBody = z.object({
   destination_payment_method_data: z
     .object({
       financial_account: z.string().optional(),
-      type: z.enum(["financial_account"]),
+      type: z.literal("financial_account"),
     })
     .optional(),
   destination_payment_method_options: z
@@ -42428,7 +42445,7 @@ export const s_PostTreasuryOutboundTransfersRequestBody = z.object({
       us_bank_account: z
         .union([
           z.object({network: z.enum(["ach", "us_domestic_wire"]).optional()}),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
     })
@@ -42467,7 +42484,7 @@ export const s_treasury_transaction_entry: z.ZodType<t_treasury_transaction_entr
     ]),
     id: z.string().max(5000),
     livemode: PermissiveBoolean,
-    object: z.enum(["treasury.transaction_entry"]),
+    object: z.literal("treasury.transaction_entry"),
     transaction: z.union([
       z.string().max(5000),
       z.lazy(() => s_treasury_transaction),
@@ -42507,7 +42524,7 @@ export const s_treasury_transaction: z.ZodType<t_treasury_transaction> =
       .object({
         data: z.array(z.lazy(() => s_treasury_transaction_entry)),
         has_more: PermissiveBoolean,
-        object: z.enum(["list"]),
+        object: z.literal("list"),
         url: z
           .string()
           .max(5000)
@@ -42534,7 +42551,7 @@ export const s_treasury_transaction: z.ZodType<t_treasury_transaction> =
     ]),
     id: z.string().max(5000),
     livemode: PermissiveBoolean,
-    object: z.enum(["treasury.transaction"]),
+    object: z.literal("treasury.transaction"),
     status: z.enum(["open", "posted", "void"]),
     status_transitions:
       s_treasury_transactions_resource_abstract_transaction_resource_status_transitions,
@@ -42660,7 +42677,7 @@ export const s_PostWebhookEndpointsRequestBody = z.object({
     ])
     .optional(),
   connect: PermissiveBoolean.optional(),
-  description: z.union([z.string().max(5000), z.enum([""])]).optional(),
+  description: z.union([z.string().max(5000), z.literal("")]).optional(),
   enabled_events: z.array(
     z.enum([
       "*",
@@ -42910,13 +42927,13 @@ export const s_PostWebhookEndpointsRequestBody = z.object({
   ),
   expand: z.array(z.string().max(5000)).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   url: z.string(),
 })
 
 export const s_PostWebhookEndpointsWebhookEndpointRequestBody = z.object({
-  description: z.union([z.string().max(5000), z.enum([""])]).optional(),
+  description: z.union([z.string().max(5000), z.literal("")]).optional(),
   disabled: PermissiveBoolean.optional(),
   enabled_events: z
     .array(
@@ -43169,7 +43186,7 @@ export const s_PostWebhookEndpointsWebhookEndpointRequestBody = z.object({
     .optional(),
   expand: z.array(z.string().max(5000)).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   url: z.string().optional(),
 })
@@ -43295,7 +43312,7 @@ export const s_connect_collection_transfer: z.ZodType<t_connect_collection_trans
     destination: z.union([z.string().max(5000), z.lazy(() => s_account)]),
     id: z.string().max(5000),
     livemode: PermissiveBoolean,
-    object: z.enum(["connect_collection_transfer"]),
+    object: z.literal("connect_collection_transfer"),
   })
 
 export const s_thresholds_resource_usage_threshold_config: z.ZodType<t_thresholds_resource_usage_threshold_config> =
@@ -43306,7 +43323,7 @@ export const s_thresholds_resource_usage_threshold_config: z.ZodType<t_threshold
       .optional(),
     gte: z.coerce.number(),
     meter: z.union([z.string().max(5000), s_billing_meter]),
-    recurrence: z.enum(["one_time"]),
+    recurrence: z.literal("one_time"),
   })
 
 export const s_billing_credit_grants_resource_balance_credit: z.ZodType<t_billing_credit_grants_resource_balance_credit> =
@@ -43746,7 +43763,10 @@ export const s_payment_method_sepa_debit: z.ZodType<t_payment_method_sepa_debit>
 
 export const s_subscription_automatic_tax: z.ZodType<t_subscription_automatic_tax> =
   z.object({
-    disabled_reason: z.enum(["requires_location_inputs"]).nullable().optional(),
+    disabled_reason: z
+      .literal("requires_location_inputs")
+      .nullable()
+      .optional(),
     enabled: PermissiveBoolean,
     liability: z
       .lazy(() => s_connect_account_reference)
@@ -44177,7 +44197,7 @@ export const s_terminal_reader_reader_resource_reader_action: z.ZodType<t_termin
 
 export const s_inbound_transfers: z.ZodType<t_inbound_transfers> = z.object({
   billing_details: s_treasury_shared_resource_billing_details,
-  type: z.enum(["us_bank_account"]),
+  type: z.literal("us_bank_account"),
   us_bank_account: z.lazy(() =>
     s_inbound_transfers_payment_method_details_us_bank_account.optional(),
   ),
@@ -44332,7 +44352,7 @@ export const s_thresholds_resource_usage_alert_filter: z.ZodType<t_thresholds_re
       .union([z.string().max(5000), z.lazy(() => s_customer)])
       .nullable()
       .optional(),
-    type: z.enum(["customer"]),
+    type: z.literal("customer"),
   })
 
 export const s_billing_credit_grants_resource_balance_credits_application_invoice_voided: z.ZodType<t_billing_credit_grants_resource_balance_credits_application_invoice_voided> =
@@ -44695,7 +44715,7 @@ export const s_quotes_resource_upfront: z.ZodType<t_quotes_resource_upfront> =
       .object({
         data: z.array(z.lazy(() => s_item)),
         has_more: PermissiveBoolean,
-        object: z.enum(["list"]),
+        object: z.literal("list"),
         url: z.string().max(5000),
       })
       .optional(),
@@ -44816,7 +44836,10 @@ export const s_setup_attempt_payment_method_details_sofort: z.ZodType<t_setup_at
 
 export const s_subscription_schedules_resource_default_settings_automatic_tax: z.ZodType<t_subscription_schedules_resource_default_settings_automatic_tax> =
   z.object({
-    disabled_reason: z.enum(["requires_location_inputs"]).nullable().optional(),
+    disabled_reason: z
+      .literal("requires_location_inputs")
+      .nullable()
+      .optional(),
     enabled: PermissiveBoolean,
     liability: z
       .lazy(() => s_connect_account_reference)
@@ -44854,7 +44877,10 @@ export const s_subscription_schedule_add_invoice_item: z.ZodType<t_subscription_
 
 export const s_schedules_phase_automatic_tax: z.ZodType<t_schedules_phase_automatic_tax> =
   z.object({
-    disabled_reason: z.enum(["requires_location_inputs"]).nullable().optional(),
+    disabled_reason: z
+      .literal("requires_location_inputs")
+      .nullable()
+      .optional(),
     enabled: PermissiveBoolean,
     liability: z
       .lazy(() => s_connect_account_reference)
@@ -44980,7 +45006,7 @@ export const s_inbound_transfers_payment_method_details_us_bank_account: z.ZodTy
     mandate: z
       .union([z.string().max(5000), z.lazy(() => s_mandate)])
       .optional(),
-    network: z.enum(["ach"]),
+    network: z.literal("ach"),
     routing_number: z.string().max(5000).nullable().optional(),
   })
 

--- a/integration-tests/typescript-fetch/src/generated/api.github.com.yaml/client.ts
+++ b/integration-tests/typescript-fetch/src/generated/api.github.com.yaml/client.ts
@@ -1463,7 +1463,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       ecosystem?: string
       package?: string
       epssPercentage?: string
-      has?: string | ("patch" | UnknownEnumStringValue)[]
+      has?: string | "patch"[]
       scope?: "development" | "runtime" | UnknownEnumStringValue
       sort?: "created" | "updated" | "epss_percentage" | UnknownEnumStringValue
       direction?: "asc" | "desc" | UnknownEnumStringValue
@@ -5225,7 +5225,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       ecosystem?: string
       package?: string
       epssPercentage?: string
-      has?: string | ("patch" | UnknownEnumStringValue)[]
+      has?: string | "patch"[]
       scope?: "development" | "runtime" | UnknownEnumStringValue
       sort?: "created" | "updated" | "epss_percentage" | UnknownEnumStringValue
       direction?: "asc" | "desc" | UnknownEnumStringValue
@@ -6504,7 +6504,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       org: string
       perPage?: number
       page?: number
-      exclude?: ("repositories" | UnknownEnumStringValue)[]
+      exclude?: "repositories"[]
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -6550,7 +6550,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     p: {
       org: string
       migrationId: number
-      exclude?: ("repositories" | UnknownEnumStringValue)[]
+      exclude?: "repositories"[]
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -7142,7 +7142,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       org: string
       perPage?: number
       page?: number
-      sort?: "created_at" | UnknownEnumStringValue
+      sort?: "created_at"
       direction?: "asc" | "desc" | UnknownEnumStringValue
       owner?: string[]
       repository?: string
@@ -7272,7 +7272,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       org: string
       perPage?: number
       page?: number
-      sort?: "created_at" | UnknownEnumStringValue
+      sort?: "created_at"
       direction?: "asc" | "desc" | UnknownEnumStringValue
       owner?: string[]
       repository?: string
@@ -12864,7 +12864,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       ref?: t_code_scanning_ref
       sarifId?: t_code_scanning_analysis_sarif_id
       direction?: "asc" | "desc" | UnknownEnumStringValue
-      sort?: "created" | UnknownEnumStringValue
+      sort?: "created"
     },
     timeout?: number,
     opts: RequestInit = {},
@@ -14324,7 +14324,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       package?: string
       manifest?: string
       epssPercentage?: string
-      has?: string | ("patch" | UnknownEnumStringValue)[]
+      has?: string | "patch"[]
       scope?: "development" | "runtime" | UnknownEnumStringValue
       sort?: "created" | "updated" | "epss_percentage" | UnknownEnumStringValue
       direction?: "asc" | "desc" | UnknownEnumStringValue
@@ -20268,7 +20268,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   async searchCode(
     p: {
       q: string
-      sort?: "indexed" | UnknownEnumStringValue
+      sort?: "indexed"
       order?: "desc" | "asc" | UnknownEnumStringValue
       perPage?: number
       page?: number

--- a/integration-tests/typescript-fetch/src/generated/api.github.com.yaml/models.ts
+++ b/integration-tests/typescript-fetch/src/generated/api.github.com.yaml/models.ts
@@ -324,7 +324,7 @@ export type t_app_permissions = {
   metadata?: "read" | "write" | UnknownEnumStringValue
   organization_administration?: "read" | "write" | UnknownEnumStringValue
   organization_announcement_banners?: "read" | "write" | UnknownEnumStringValue
-  organization_copilot_seat_management?: "write" | UnknownEnumStringValue
+  organization_copilot_seat_management?: "write"
   organization_custom_org_roles?: "read" | "write" | UnknownEnumStringValue
   organization_custom_properties?:
     | "read"
@@ -332,7 +332,7 @@ export type t_app_permissions = {
     | "admin"
     | UnknownEnumStringValue
   organization_custom_roles?: "read" | "write" | UnknownEnumStringValue
-  organization_events?: "read" | UnknownEnumStringValue
+  organization_events?: "read"
   organization_hooks?: "read" | "write" | UnknownEnumStringValue
   organization_packages?: "read" | "write" | UnknownEnumStringValue
   organization_personal_access_token_requests?:
@@ -343,14 +343,14 @@ export type t_app_permissions = {
     | "read"
     | "write"
     | UnknownEnumStringValue
-  organization_plan?: "read" | UnknownEnumStringValue
+  organization_plan?: "read"
   organization_projects?: "read" | "write" | "admin" | UnknownEnumStringValue
   organization_secrets?: "read" | "write" | UnknownEnumStringValue
   organization_self_hosted_runners?: "read" | "write" | UnknownEnumStringValue
   organization_user_blocking?: "read" | "write" | UnknownEnumStringValue
   packages?: "read" | "write" | UnknownEnumStringValue
   pages?: "read" | "write" | UnknownEnumStringValue
-  profile?: "write" | UnknownEnumStringValue
+  profile?: "write"
   pull_requests?: "read" | "write" | UnknownEnumStringValue
   repository_custom_properties?: "read" | "write" | UnknownEnumStringValue
   repository_hooks?: "read" | "write" | UnknownEnumStringValue
@@ -363,7 +363,7 @@ export type t_app_permissions = {
   statuses?: "read" | "write" | UnknownEnumStringValue
   team_discussions?: "read" | "write" | UnknownEnumStringValue
   vulnerability_alerts?: "read" | "write" | UnknownEnumStringValue
-  workflows?: "write" | UnknownEnumStringValue
+  workflows?: "write"
 }
 
 export type t_artifact = {
@@ -1167,7 +1167,7 @@ export type t_code_scanning_default_setup = {
   query_suite?: "default" | "extended" | UnknownEnumStringValue
   runner_label?: string | null
   runner_type?: "standard" | "labeled" | UnknownEnumStringValue | null
-  schedule?: "weekly" | UnknownEnumStringValue | null
+  schedule?: "weekly" | null
   state?: "configured" | "not-configured" | UnknownEnumStringValue
   threat_model?: "remote" | "remote_and_local" | UnknownEnumStringValue
   updated_at?: string | null
@@ -1893,7 +1893,7 @@ export type t_content_file = {
   size: number
   submodule_git_url?: string
   target?: string
-  type: "file" | UnknownEnumStringValue
+  type: "file"
   url: string
 }
 
@@ -1911,7 +1911,7 @@ export type t_content_submodule = {
   sha: string
   size: number
   submodule_git_url: string
-  type: "submodule" | UnknownEnumStringValue
+  type: "submodule"
   url: string
 }
 
@@ -1929,7 +1929,7 @@ export type t_content_symlink = {
   sha: string
   size: number
   target: string
-  type: "symlink" | UnknownEnumStringValue
+  type: "symlink"
   url: string
 }
 
@@ -6301,14 +6301,14 @@ export type t_repository_rule_branch_name_pattern = {
       | UnknownEnumStringValue
     pattern: string
   }
-  type: "branch_name_pattern" | UnknownEnumStringValue
+  type: "branch_name_pattern"
 }
 
 export type t_repository_rule_code_scanning = {
   parameters?: {
     code_scanning_tools: t_repository_rule_params_code_scanning_tool[]
   }
-  type: "code_scanning" | UnknownEnumStringValue
+  type: "code_scanning"
 }
 
 export type t_repository_rule_commit_author_email_pattern = {
@@ -6323,7 +6323,7 @@ export type t_repository_rule_commit_author_email_pattern = {
       | UnknownEnumStringValue
     pattern: string
   }
-  type: "commit_author_email_pattern" | UnknownEnumStringValue
+  type: "commit_author_email_pattern"
 }
 
 export type t_repository_rule_commit_message_pattern = {
@@ -6338,7 +6338,7 @@ export type t_repository_rule_commit_message_pattern = {
       | UnknownEnumStringValue
     pattern: string
   }
-  type: "commit_message_pattern" | UnknownEnumStringValue
+  type: "commit_message_pattern"
 }
 
 export type t_repository_rule_committer_email_pattern = {
@@ -6353,15 +6353,15 @@ export type t_repository_rule_committer_email_pattern = {
       | UnknownEnumStringValue
     pattern: string
   }
-  type: "committer_email_pattern" | UnknownEnumStringValue
+  type: "committer_email_pattern"
 }
 
 export type t_repository_rule_creation = {
-  type: "creation" | UnknownEnumStringValue
+  type: "creation"
 }
 
 export type t_repository_rule_deletion = {
-  type: "deletion" | UnknownEnumStringValue
+  type: "deletion"
 }
 
 export type t_repository_rule_detailed =
@@ -6399,28 +6399,28 @@ export type t_repository_rule_file_extension_restriction = {
   parameters?: {
     restricted_file_extensions: string[]
   }
-  type: "file_extension_restriction" | UnknownEnumStringValue
+  type: "file_extension_restriction"
 }
 
 export type t_repository_rule_file_path_restriction = {
   parameters?: {
     restricted_file_paths: string[]
   }
-  type: "file_path_restriction" | UnknownEnumStringValue
+  type: "file_path_restriction"
 }
 
 export type t_repository_rule_max_file_path_length = {
   parameters?: {
     max_file_path_length: number
   }
-  type: "max_file_path_length" | UnknownEnumStringValue
+  type: "max_file_path_length"
 }
 
 export type t_repository_rule_max_file_size = {
   parameters?: {
     max_file_size: number
   }
-  type: "max_file_size" | UnknownEnumStringValue
+  type: "max_file_size"
 }
 
 export type t_repository_rule_merge_queue = {
@@ -6433,11 +6433,11 @@ export type t_repository_rule_merge_queue = {
     min_entries_to_merge: number
     min_entries_to_merge_wait_minutes: number
   }
-  type: "merge_queue" | UnknownEnumStringValue
+  type: "merge_queue"
 }
 
 export type t_repository_rule_non_fast_forward = {
-  type: "non_fast_forward" | UnknownEnumStringValue
+  type: "non_fast_forward"
 }
 
 export type t_repository_rule_params_code_scanning_tool = {
@@ -6484,22 +6484,22 @@ export type t_repository_rule_pull_request = {
     required_approving_review_count: number
     required_review_thread_resolution: boolean
   }
-  type: "pull_request" | UnknownEnumStringValue
+  type: "pull_request"
 }
 
 export type t_repository_rule_required_deployments = {
   parameters?: {
     required_deployment_environments: string[]
   }
-  type: "required_deployments" | UnknownEnumStringValue
+  type: "required_deployments"
 }
 
 export type t_repository_rule_required_linear_history = {
-  type: "required_linear_history" | UnknownEnumStringValue
+  type: "required_linear_history"
 }
 
 export type t_repository_rule_required_signatures = {
-  type: "required_signatures" | UnknownEnumStringValue
+  type: "required_signatures"
 }
 
 export type t_repository_rule_required_status_checks = {
@@ -6508,7 +6508,7 @@ export type t_repository_rule_required_status_checks = {
     required_status_checks: t_repository_rule_params_status_check_configuration[]
     strict_required_status_checks_policy: boolean
   }
-  type: "required_status_checks" | UnknownEnumStringValue
+  type: "required_status_checks"
 }
 
 export type t_repository_rule_ruleset_info = {
@@ -6529,14 +6529,14 @@ export type t_repository_rule_tag_name_pattern = {
       | UnknownEnumStringValue
     pattern: string
   }
-  type: "tag_name_pattern" | UnknownEnumStringValue
+  type: "tag_name_pattern"
 }
 
 export type t_repository_rule_update = {
   parameters?: {
     update_allows_fetch_and_merge: boolean
   }
-  type: "update" | UnknownEnumStringValue
+  type: "update"
 }
 
 export type t_repository_rule_violation_error = {
@@ -6558,7 +6558,7 @@ export type t_repository_rule_workflows = {
     do_not_enforce_on_create?: boolean
     workflows: t_repository_rule_params_workflow_file_reference[]
   }
-  type: "workflows" | UnknownEnumStringValue
+  type: "workflows"
 }
 
 export type t_repository_ruleset = {
@@ -8547,7 +8547,7 @@ export type t_ChecksCreateRequestBody = {
         | "stale"
         | "timed_out"
         | UnknownEnumStringValue
-      status: "completed" | UnknownEnumStringValue
+      status: "completed"
       [key: string]: unknown | undefined
     }
   | {
@@ -8633,7 +8633,7 @@ export type t_ChecksUpdateRequestBody = {
         | "stale"
         | "timed_out"
         | UnknownEnumStringValue
-      status?: "completed" | UnknownEnumStringValue
+      status?: "completed"
       [key: string]: unknown | undefined
     }
   | {
@@ -9501,7 +9501,7 @@ export type t_MigrationsSetLfsPreferenceRequestBody = {
 }
 
 export type t_MigrationsStartForAuthenticatedUserRequestBody = {
-  exclude?: ("repositories" | UnknownEnumStringValue)[]
+  exclude?: "repositories"[]
   exclude_attachments?: boolean
   exclude_git_data?: boolean
   exclude_metadata?: boolean
@@ -9513,7 +9513,7 @@ export type t_MigrationsStartForAuthenticatedUserRequestBody = {
 }
 
 export type t_MigrationsStartForOrgRequestBody = {
-  exclude?: ("repositories" | UnknownEnumStringValue)[]
+  exclude?: "repositories"[]
   exclude_attachments?: boolean
   exclude_git_data?: boolean
   exclude_metadata?: boolean
@@ -9653,15 +9653,15 @@ export type t_OrgsUpdateRequestBody = {
 }
 
 export type t_OrgsUpdateMembershipForAuthenticatedUserRequestBody = {
-  state: "active" | UnknownEnumStringValue
+  state: "active"
 }
 
 export type t_OrgsUpdatePatAccessRequestBody = {
-  action: "revoke" | UnknownEnumStringValue
+  action: "revoke"
 }
 
 export type t_OrgsUpdatePatAccessesRequestBody = {
-  action: "revoke" | UnknownEnumStringValue
+  action: "revoke"
   pat_ids: number[]
 }
 
@@ -9843,7 +9843,7 @@ export type t_PullsCreateReviewCommentRequestBody = {
 }
 
 export type t_PullsDismissReviewRequestBody = {
-  event?: "DISMISS" | UnknownEnumStringValue
+  event?: "DISMISS"
   message: string
 }
 

--- a/integration-tests/typescript-fetch/src/generated/azure-core-data-plane-service.tsp/models.ts
+++ b/integration-tests/typescript-fetch/src/generated/azure-core-data-plane-service.tsp/models.ts
@@ -66,7 +66,7 @@ export type t_Widget = {
 }
 
 export type t_WidgetAnalytics = {
-  id: "current" | UnknownEnumStringValue
+  id: "current"
   repairCount: number
   useCount: number
 }

--- a/integration-tests/typescript-fetch/src/generated/azure-resource-manager.tsp/models.ts
+++ b/integration-tests/typescript-fetch/src/generated/azure-resource-manager.tsp/models.ts
@@ -12,10 +12,7 @@ export type t_Azure_Core_azureLocation = string
 
 export type t_Azure_Core_uuid = string
 
-export type t_Azure_ResourceManager_CommonTypes_ActionType =
-  | "Internal"
-  | UnknownEnumStringValue
-  | string
+export type t_Azure_ResourceManager_CommonTypes_ActionType = "Internal" | string
 
 export type t_Azure_ResourceManager_CommonTypes_ErrorAdditionalInfo = {
   info?: unknown

--- a/integration-tests/typescript-fetch/src/generated/okta.idp.yaml/client.ts
+++ b/integration-tests/typescript-fetch/src/generated/okta.idp.yaml/client.ts
@@ -362,13 +362,13 @@ export class MyAccountManagement extends AbstractFetchClient {
           _links: {
             poll: {
               hints: {
-                allow: ("GET" | UnknownEnumStringValue)[]
+                allow: "GET"[]
               }
               href: string
             }
             verify: {
               hints: {
-                allow: ("POST" | UnknownEnumStringValue)[]
+                allow: "POST"[]
               }
               href: string
             }
@@ -634,7 +634,7 @@ export class MyAccountManagement extends AbstractFetchClient {
           _links?: {
             verify?: {
               hints: {
-                allow: ("GET" | UnknownEnumStringValue)[]
+                allow: "GET"[]
               }
               href: string
             }

--- a/integration-tests/typescript-fetch/src/generated/okta.idp.yaml/models.ts
+++ b/integration-tests/typescript-fetch/src/generated/okta.idp.yaml/models.ts
@@ -14,7 +14,7 @@ export type t_AppAuthenticatorEnrollment = {
     createdDate?: string
     id?: string
     lastUpdated?: string
-    status?: "ACTIVE" | UnknownEnumStringValue
+    status?: "ACTIVE"
   }
   id?: string
   lastUpdated?: string
@@ -34,7 +34,7 @@ export type t_AppAuthenticatorEnrollment = {
       links?: {
         pending?: {
           hints?: {
-            allow?: ("GET" | UnknownEnumStringValue)[]
+            allow?: "GET"[]
           }
           href?: string
         }
@@ -192,9 +192,9 @@ export type t_HttpMethod =
   | UnknownEnumStringValue
 
 export type t_KeyEC = {
-  crv: "P-256" | UnknownEnumStringValue
+  crv: "P-256"
   kid: string
-  kty: "EC" | UnknownEnumStringValue
+  kty: "EC"
   "okta:kpr": "HARDWARE" | "SOFTWARE" | UnknownEnumStringValue
   x: string
   y: string
@@ -205,7 +205,7 @@ export type t_KeyObject = t_KeyEC | t_KeyRSA
 export type t_KeyRSA = {
   e: string
   kid: string
-  kty: "RSA" | UnknownEnumStringValue
+  kty: "RSA"
   n: string
   "okta:kpr": "HARDWARE" | "SOFTWARE" | UnknownEnumStringValue
 }
@@ -220,7 +220,7 @@ export type t_Organization = {
   _links?: {
     self?: {
       hints?: {
-        allow?: ("GET" | UnknownEnumStringValue)[]
+        allow?: "GET"[]
       }
       href?: string
     }
@@ -290,12 +290,12 @@ export type t_Profile = {
 
 export type t_PushNotificationChallenge = {
   challenge?: string
-  payloadVersion?: "IDXv1" | UnknownEnumStringValue
+  payloadVersion?: "IDXv1"
 }
 
 export type t_PushNotificationVerification = {
   challengeResponse?: string
-  method?: "push" | UnknownEnumStringValue
+  method?: "push"
 }
 
 export type t_Schema = {

--- a/integration-tests/typescript-fetch/src/generated/okta.oauth.yaml/models.ts
+++ b/integration-tests/typescript-fetch/src/generated/okta.oauth.yaml/models.ts
@@ -135,7 +135,7 @@ export type t_Client = {
   tos_uri?: string | null
 }
 
-export type t_CodeChallengeMethod = "S256" | UnknownEnumStringValue
+export type t_CodeChallengeMethod = "S256"
 
 export type t_DeviceAuthorizeRequest = {
   client_id?: string
@@ -376,7 +376,7 @@ export type t_SigningAlgorithm =
 
 export type t_SubjectType = "pairwise" | "public" | UnknownEnumStringValue
 
-export type t_TokenDeliveryMode = "poll" | UnknownEnumStringValue
+export type t_TokenDeliveryMode = "poll"
 
 export type t_TokenRequest = {
   grant_type?: t_GrantType
@@ -425,6 +425,6 @@ export type t_UserInfo = {
 }
 
 export type t_sub_id = {
-  format?: "opaque" | UnknownEnumStringValue
+  format?: "opaque"
   id?: string
 }

--- a/integration-tests/typescript-fetch/src/generated/stripe.yaml/client.ts
+++ b/integration-tests/typescript-fetch/src/generated/stripe.yaml/client.ts
@@ -620,7 +620,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_account[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -892,7 +892,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_capability[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -988,7 +988,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: (t_bank_account | t_card)[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -1184,7 +1184,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_person[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -1365,7 +1365,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_person[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -1561,7 +1561,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_apple_pay_domain[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -1677,7 +1677,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_application_fee[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -1838,7 +1838,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_fee_refund[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -1913,7 +1913,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_apps_secret[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -2070,7 +2070,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_balance_transaction[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -2157,7 +2157,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_balance_transaction[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -2219,7 +2219,7 @@ export class StripeApi extends AbstractFetchClient {
 
   async getBillingAlerts(
     p: {
-      alertType?: "usage_threshold" | UnknownEnumStringValue
+      alertType?: "usage_threshold"
       endingBefore?: string
       expand?: string[]
       limit?: number
@@ -2234,7 +2234,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_billing_alert[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -2411,7 +2411,7 @@ export class StripeApi extends AbstractFetchClient {
       expand?: string[]
       filter: {
         applicability_scope?: {
-          price_type?: "metered" | UnknownEnumStringValue
+          price_type?: "metered"
           prices?: {
             id: string
           }[]
@@ -2462,7 +2462,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_billing_credit_balance_transaction[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -2533,7 +2533,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_billing_credit_grant[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -2774,7 +2774,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_billing_meter[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -2935,7 +2935,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_billing_meter_event_summary[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -3013,7 +3013,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_billing_portal_configuration[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -3187,7 +3187,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_charge[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -3271,7 +3271,7 @@ export class StripeApi extends AbstractFetchClient {
           data: t_charge[]
           has_more: boolean
           next_page?: string | null
-          object: "search_result" | UnknownEnumStringValue
+          object: "search_result"
           total_count?: number
           url: string
         }
@@ -3512,7 +3512,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_refund[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -3656,7 +3656,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_checkout_session[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -3858,7 +3858,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_item[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -3900,7 +3900,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_climate_order[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -4056,7 +4056,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_climate_product[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -4122,7 +4122,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_climate_supplier[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -4214,7 +4214,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_country_spec[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -4288,7 +4288,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_coupon[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -4444,7 +4444,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_credit_note[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -4523,8 +4523,7 @@ export class StripeApi extends AbstractFetchClient {
               taxable_amount: number
             }[]
           | ""
-          | UnknownEnumStringValue
-        tax_rates?: string[] | "" | UnknownEnumStringValue
+        tax_rates?: string[] | ""
         type: "custom_line_item" | "invoice_line_item" | UnknownEnumStringValue
         unit_amount?: number
         unit_amount_decimal?: string
@@ -4618,8 +4617,7 @@ export class StripeApi extends AbstractFetchClient {
               taxable_amount: number
             }[]
           | ""
-          | UnknownEnumStringValue
-        tax_rates?: string[] | "" | UnknownEnumStringValue
+        tax_rates?: string[] | ""
         type: "custom_line_item" | "invoice_line_item" | UnknownEnumStringValue
         unit_amount?: number
         unit_amount_decimal?: string
@@ -4651,7 +4649,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_credit_note_line_item[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -4722,7 +4720,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_credit_note_line_item[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -4880,7 +4878,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_customer[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -4965,7 +4963,7 @@ export class StripeApi extends AbstractFetchClient {
           data: t_customer[]
           has_more: boolean
           next_page?: string | null
-          object: "search_result" | UnknownEnumStringValue
+          object: "search_result"
           total_count?: number
           url: string
         }
@@ -5087,7 +5085,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_customer_balance_transaction[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -5223,7 +5221,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_bank_account[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -5431,7 +5429,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_card[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -5659,7 +5657,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_customer_cash_balance_transaction[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -5851,7 +5849,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_payment_method[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -5924,7 +5922,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: (t_bank_account | t_card | t_source)[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -6132,7 +6130,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_subscription[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -6378,7 +6376,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_tax_id[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -6494,7 +6492,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_dispute[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -6626,7 +6624,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_entitlements_active_entitlement[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -6697,7 +6695,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_entitlements_feature[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -6894,7 +6892,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_event[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -6970,7 +6968,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_exchange_rate[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -7079,7 +7077,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_file_link[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -7231,7 +7229,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_file[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -7331,7 +7329,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_financial_connections_account[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -7441,7 +7439,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_financial_connections_account_owner[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -7640,7 +7638,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_financial_connections_transaction[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -7726,7 +7724,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_forwarding_request[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -7835,7 +7833,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_identity_verification_report[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -7927,7 +7925,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_identity_verification_session[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -8135,7 +8133,7 @@ export class StripeApi extends AbstractFetchClient {
       limit?: number
       payment?: {
         payment_intent?: string
-        type: "payment_intent" | UnknownEnumStringValue
+        type: "payment_intent"
       }
       startingAfter?: string
       status?: "canceled" | "open" | "paid" | UnknownEnumStringValue
@@ -8148,7 +8146,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_invoice_payment[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -8222,7 +8220,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_invoice_rendering_template[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -8370,7 +8368,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_invoiceitem[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -8551,7 +8549,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_invoice[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -8684,7 +8682,7 @@ export class StripeApi extends AbstractFetchClient {
           data: t_invoice[]
           has_more: boolean
           next_page?: string | null
-          object: "search_result" | UnknownEnumStringValue
+          object: "search_result"
           total_count?: number
           url: string
         }
@@ -8893,7 +8891,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_line_item[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -9156,7 +9154,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_issuing_authorization[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -9342,7 +9340,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_issuing_cardholder[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -9499,7 +9497,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_issuing_card[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -9657,7 +9655,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_issuing_dispute[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -9839,7 +9837,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_issuing_personalization_design[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -9989,7 +9987,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_issuing_physical_bundle[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -10130,7 +10128,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_issuing_token[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -10239,7 +10237,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_issuing_transaction[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -10405,7 +10403,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_financial_connections_account[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -10512,7 +10510,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_financial_connections_account_owner[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -10613,7 +10611,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_payment_intent[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -10695,7 +10693,7 @@ export class StripeApi extends AbstractFetchClient {
           data: t_payment_intent[]
           has_more: boolean
           next_page?: string | null
-          object: "search_result" | UnknownEnumStringValue
+          object: "search_result"
           total_count?: number
           url: string
         }
@@ -11001,7 +10999,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_payment_link[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -11157,7 +11155,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_item[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -11186,7 +11184,7 @@ export class StripeApi extends AbstractFetchClient {
 
   async getPaymentMethodConfigurations(
     p: {
-      application?: string | "" | UnknownEnumStringValue
+      application?: string | ""
       endingBefore?: string
       expand?: string[]
       limit?: number
@@ -11200,7 +11198,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_payment_method_configuration[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -11443,7 +11441,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_payment_method_domain[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -11652,7 +11650,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_payment_method[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -11915,7 +11913,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_payout[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -12113,7 +12111,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_plan[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -12273,7 +12271,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_price[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -12363,7 +12361,7 @@ export class StripeApi extends AbstractFetchClient {
           data: t_price[]
           has_more: boolean
           next_page?: string | null
-          object: "search_result" | UnknownEnumStringValue
+          object: "search_result"
           total_count?: number
           url: string
         }
@@ -12471,7 +12469,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_product[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -12553,7 +12551,7 @@ export class StripeApi extends AbstractFetchClient {
           data: t_product[]
           has_more: boolean
           next_page?: string | null
-          object: "search_result" | UnknownEnumStringValue
+          object: "search_result"
           total_count?: number
           url: string
         }
@@ -12671,7 +12669,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_product_feature[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -12793,7 +12791,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_promotion_code[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -12935,7 +12933,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_quote[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -13147,7 +13145,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_item[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -13219,7 +13217,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_item[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -13296,7 +13294,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_radar_early_fraud_warning[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -13381,7 +13379,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_radar_value_list_item[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -13504,7 +13502,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_radar_value_list[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -13660,7 +13658,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_refund[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -13827,7 +13825,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_reporting_report_run[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -13920,7 +13918,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_reporting_report_type[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -13989,7 +13987,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_review[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -14096,7 +14094,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_setup_attempt[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -14154,7 +14152,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_setup_intent[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -14411,7 +14409,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_shipping_rate[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -14575,7 +14573,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_scheduled_query_run[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -14763,7 +14761,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_source_transaction[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -14857,7 +14855,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_subscription_item[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -15053,7 +15051,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_subscription_schedule[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -15320,7 +15318,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_subscription[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -15429,7 +15427,7 @@ export class StripeApi extends AbstractFetchClient {
           data: t_subscription[]
           has_more: boolean
           next_page?: string | null
-          object: "search_result" | UnknownEnumStringValue
+          object: "search_result"
           total_count?: number
           url: string
         }
@@ -15709,7 +15707,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_tax_calculation_line_item[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -15757,7 +15755,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_tax_registration[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -16017,7 +16015,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_tax_transaction_line_item[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -16059,7 +16057,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_tax_code[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -16133,7 +16131,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_tax_id[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -16250,7 +16248,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_tax_rate[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -16375,7 +16373,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_terminal_configuration[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -16569,7 +16567,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_terminal_location[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -16728,7 +16726,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_terminal_reader[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -17917,7 +17915,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_test_helpers_test_clock[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -18545,7 +18543,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_topup[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -18712,7 +18710,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_transfer[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -18784,7 +18782,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_transfer_reversal[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -18974,7 +18972,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_treasury_credit_reversal[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -19075,7 +19073,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_treasury_debit_reversal[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -19180,7 +19178,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_treasury_financial_account[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -19433,7 +19431,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_treasury_inbound_transfer[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -19579,7 +19577,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_treasury_outbound_payment[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -19724,7 +19722,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_treasury_outbound_transfer[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -19867,7 +19865,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_treasury_received_credit[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -19943,7 +19941,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_treasury_received_debit[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -20030,7 +20028,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_treasury_transaction_entry[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -20131,7 +20129,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_treasury_transaction[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >
@@ -20210,7 +20208,7 @@ export class StripeApi extends AbstractFetchClient {
         {
           data: t_webhook_endpoint[]
           has_more: boolean
-          object: "list" | UnknownEnumStringValue
+          object: "list"
           url: string
         }
       >

--- a/integration-tests/typescript-fetch/src/generated/stripe.yaml/models.ts
+++ b/integration-tests/typescript-fetch/src/generated/stripe.yaml/models.ts
@@ -27,7 +27,7 @@ export type t_account = {
   external_accounts?: {
     data: (t_bank_account | t_card)[]
     has_more: boolean
-    object: "list" | UnknownEnumStringValue
+    object: "list"
     url: string
   }
   future_requirements?: t_account_future_requirements
@@ -35,7 +35,7 @@ export type t_account = {
   id: string
   individual?: t_person
   metadata?: Record<string, string>
-  object: "account" | UnknownEnumStringValue
+  object: "account"
   payouts_enabled?: boolean
   requirements?: t_account_requirements
   settings?: t_account_settings | null
@@ -367,7 +367,7 @@ export type t_account_invoices_settings = {
 export type t_account_link = {
   created: number
   expires_at: number
-  object: "account_link" | UnknownEnumStringValue
+  object: "account_link"
   url: string
 }
 
@@ -532,7 +532,7 @@ export type t_account_session = {
   components: t_connect_embedded_account_session_create_components
   expires_at: number
   livemode: boolean
-  object: "account_session" | UnknownEnumStringValue
+  object: "account_session"
 }
 
 export type t_account_settings = {
@@ -602,7 +602,7 @@ export type t_address = {
 
 export type t_amazon_pay_underlying_payment_method_funding_details = {
   card?: t_payment_method_details_passthrough_card
-  type?: "card" | UnknownEnumStringValue | null
+  type?: "card" | null
 }
 
 export type t_api_errors = {
@@ -634,13 +634,13 @@ export type t_apple_pay_domain = {
   domain_name: string
   id: string
   livemode: boolean
-  object: "apple_pay_domain" | UnknownEnumStringValue
+  object: "apple_pay_domain"
 }
 
 export type t_application = {
   id: string
   name?: string | null
-  object: "application" | UnknownEnumStringValue
+  object: "application"
 }
 
 export type t_application_fee = {
@@ -655,13 +655,13 @@ export type t_application_fee = {
   fee_source?: t_platform_earning_fee_source | null
   id: string
   livemode: boolean
-  object: "application_fee" | UnknownEnumStringValue
+  object: "application_fee"
   originating_transaction?: string | t_charge | null
   refunded: boolean
   refunds: {
     data: t_fee_refund[]
     has_more: boolean
-    object: "list" | UnknownEnumStringValue
+    object: "list"
     url: string
   }
 }
@@ -673,7 +673,7 @@ export type t_apps_secret = {
   id: string
   livemode: boolean
   name: string
-  object: "apps.secret" | UnknownEnumStringValue
+  object: "apps.secret"
   payload?: string | null
   scope: t_secret_service_resource_scope
 }
@@ -701,7 +701,7 @@ export type t_balance = {
   instant_available?: t_balance_amount_net[]
   issuing?: t_balance_detail
   livemode: boolean
-  object: "balance" | UnknownEnumStringValue
+  object: "balance"
   pending: t_balance_amount[]
   refund_and_dispute_prefunding?: t_balance_detail_ungated
 }
@@ -756,7 +756,7 @@ export type t_balance_transaction = {
   fee_details: t_fee[]
   id: string
   net: number
-  object: "balance_transaction" | UnknownEnumStringValue
+  object: "balance_transaction"
   reporting_category: string
   source?:
     | string
@@ -844,7 +844,7 @@ export type t_bank_account = {
   id: string
   last4: string
   metadata?: Record<string, string> | null
-  object: "bank_account" | UnknownEnumStringValue
+  object: "bank_account"
   requirements?: t_external_account_requirements | null
   routing_number?: string | null
   status: string
@@ -912,10 +912,10 @@ export type t_bank_connections_resource_transaction_resource_status_transitions 
   }
 
 export type t_billing_alert = {
-  alert_type: "usage_threshold" | UnknownEnumStringValue
+  alert_type: "usage_threshold"
   id: string
   livemode: boolean
-  object: "billing.alert" | UnknownEnumStringValue
+  object: "billing.alert"
   status?: "active" | "archived" | "inactive" | UnknownEnumStringValue | null
   title: string
   usage_threshold?: t_thresholds_resource_usage_threshold_config | null
@@ -925,7 +925,7 @@ export type t_billing_credit_balance_summary = {
   balances: t_credit_balance[]
   customer: string | t_customer | t_deleted_customer
   livemode: boolean
-  object: "billing.credit_balance_summary" | UnknownEnumStringValue
+  object: "billing.credit_balance_summary"
 }
 
 export type t_billing_credit_balance_transaction = {
@@ -936,7 +936,7 @@ export type t_billing_credit_balance_transaction = {
   effective_at: number
   id: string
   livemode: boolean
-  object: "billing.credit_balance_transaction" | UnknownEnumStringValue
+  object: "billing.credit_balance_transaction"
   test_clock?: string | t_test_helpers_test_clock | null
   type?: "credit" | "debit" | UnknownEnumStringValue | null
 }
@@ -953,7 +953,7 @@ export type t_billing_credit_grant = {
   livemode: boolean
   metadata: Record<string, string>
   name?: string | null
-  object: "billing.credit_grant" | UnknownEnumStringValue
+  object: "billing.credit_grant"
   priority?: number | null
   test_clock?: string | t_test_helpers_test_clock | null
   updated: number
@@ -969,7 +969,7 @@ export type t_billing_meter = {
   event_time_window?: "day" | "hour" | UnknownEnumStringValue | null
   id: string
   livemode: boolean
-  object: "billing.meter" | UnknownEnumStringValue
+  object: "billing.meter"
   status: "active" | "inactive" | UnknownEnumStringValue
   status_transitions: t_billing_meter_resource_billing_meter_status_transitions
   updated: number
@@ -981,7 +981,7 @@ export type t_billing_meter_event = {
   event_name: string
   identifier: string
   livemode: boolean
-  object: "billing.meter_event" | UnknownEnumStringValue
+  object: "billing.meter_event"
   payload: Record<string, string>
   timestamp: number
 }
@@ -990,9 +990,9 @@ export type t_billing_meter_event_adjustment = {
   cancel?: t_billing_meter_resource_billing_meter_event_adjustment_cancel | null
   event_name: string
   livemode: boolean
-  object: "billing.meter_event_adjustment" | UnknownEnumStringValue
+  object: "billing.meter_event_adjustment"
   status: "complete" | "pending" | UnknownEnumStringValue
-  type: "cancel" | UnknownEnumStringValue
+  type: "cancel"
 }
 
 export type t_billing_meter_event_summary = {
@@ -1001,13 +1001,13 @@ export type t_billing_meter_event_summary = {
   id: string
   livemode: boolean
   meter: string
-  object: "billing.meter_event_summary" | UnknownEnumStringValue
+  object: "billing.meter_event_summary"
   start_time: number
 }
 
 export type t_billing_bill_resource_invoice_item_parents_invoice_item_parent = {
   subscription_details?: t_billing_bill_resource_invoice_item_parents_invoice_item_subscription_parent | null
-  type: "subscription_details" | UnknownEnumStringValue
+  type: "subscription_details"
 }
 
 export type t_billing_bill_resource_invoice_item_parents_invoice_item_subscription_parent =
@@ -1071,7 +1071,7 @@ export type t_billing_bill_resource_invoicing_parents_invoice_subscription_paren
 
 export type t_billing_bill_resource_invoicing_pricing_pricing = {
   price_details?: t_billing_bill_resource_invoicing_pricing_pricing_price_details
-  type: "price_details" | UnknownEnumStringValue
+  type: "price_details"
   unit_amount_decimal?: string | null
 }
 
@@ -1103,7 +1103,7 @@ export type t_billing_bill_resource_invoicing_taxes_tax = {
     | "zero_rated"
     | UnknownEnumStringValue
   taxable_amount?: number | null
-  type: "tax_rate_details" | UnknownEnumStringValue
+  type: "tax_rate_details"
 }
 
 export type t_billing_bill_resource_invoicing_taxes_tax_rate_details = {
@@ -1121,7 +1121,7 @@ export type t_billing_clocks_resource_status_details_status_details = {
 
 export type t_billing_credit_grants_resource_amount = {
   monetary?: t_billing_credit_grants_resource_monetary_amount | null
-  type: "monetary" | UnknownEnumStringValue
+  type: "monetary"
 }
 
 export type t_billing_credit_grants_resource_applicability_config = {
@@ -1168,7 +1168,7 @@ export type t_billing_credit_grants_resource_monetary_amount = {
 }
 
 export type t_billing_credit_grants_resource_scope = {
-  price_type?: "metered" | UnknownEnumStringValue
+  price_type?: "metered"
   prices?: t_billing_credit_grants_resource_applicable_price[]
 }
 
@@ -1198,7 +1198,7 @@ export type t_billing_meter_resource_billing_meter_value = {
 
 export type t_billing_meter_resource_customer_mapping_settings = {
   event_payload_key: string
-  type: "by_id" | UnknownEnumStringValue
+  type: "by_id"
 }
 
 export type t_billing_portal_configuration = {
@@ -1213,7 +1213,7 @@ export type t_billing_portal_configuration = {
   livemode: boolean
   login_page: t_portal_login_page
   metadata?: Record<string, string> | null
-  object: "billing_portal.configuration" | UnknownEnumStringValue
+  object: "billing_portal.configuration"
   updated: number
 }
 
@@ -1274,7 +1274,7 @@ export type t_billing_portal_session = {
     | "zh-TW"
     | UnknownEnumStringValue
     | null
-  object: "billing_portal.session" | UnknownEnumStringValue
+  object: "billing_portal.session"
   on_behalf_of?: string | null
   return_url?: string | null
   url: string
@@ -1305,7 +1305,7 @@ export type t_capability = {
   account: string | t_account
   future_requirements?: t_account_capability_future_requirements
   id: string
-  object: "capability" | UnknownEnumStringValue
+  object: "capability"
   requested: boolean
   requested_at?: number | null
   requirements?: t_account_capability_requirements
@@ -1353,7 +1353,7 @@ export type t_card = {
   metadata?: Record<string, string> | null
   name?: string | null
   networks?: t_token_card_networks
-  object: "card" | UnknownEnumStringValue
+  object: "card"
   regulated_status?: "regulated" | "unregulated" | UnknownEnumStringValue | null
   status?: string | null
   tokenization_method?: string | null
@@ -1376,7 +1376,7 @@ export type t_cash_balance = {
   available?: Record<string, number> | null
   customer: string
   livemode: boolean
-  object: "cash_balance" | UnknownEnumStringValue
+  object: "cash_balance"
   settings: t_customer_balance_customer_balance_settings
 }
 
@@ -1403,7 +1403,7 @@ export type t_charge = {
   id: string
   livemode: boolean
   metadata: Record<string, string>
-  object: "charge" | UnknownEnumStringValue
+  object: "charge"
   on_behalf_of?: string | t_account | null
   outcome?: t_charge_outcome | null
   paid: boolean
@@ -1419,7 +1419,7 @@ export type t_charge = {
   refunds?: {
     data: t_refund[]
     has_more: boolean
-    object: "list" | UnknownEnumStringValue
+    object: "list"
     url: string
   } | null
   review?: string | t_review | null
@@ -1496,7 +1496,7 @@ export type t_checkout_session = {
   line_items?: {
     data: t_item[]
     has_more: boolean
-    object: "list" | UnknownEnumStringValue
+    object: "list"
     url: string
   }
   livemode: boolean
@@ -1546,7 +1546,7 @@ export type t_checkout_session = {
     | null
   metadata?: Record<string, string> | null
   mode: "payment" | "setup" | "subscription" | UnknownEnumStringValue
-  object: "checkout.session" | UnknownEnumStringValue
+  object: "checkout.session"
   optional_items?: t_payment_pages_checkout_session_optional_item[] | null
   origin_context?: "mobile_app" | "web" | UnknownEnumStringValue | null
   payment_intent?: string | t_payment_intent | null
@@ -1627,15 +1627,15 @@ export type t_checkout_acss_debit_payment_method_options = {
 }
 
 export type t_checkout_affirm_payment_method_options = {
-  setup_future_usage?: "none" | UnknownEnumStringValue
+  setup_future_usage?: "none"
 }
 
 export type t_checkout_afterpay_clearpay_payment_method_options = {
-  setup_future_usage?: "none" | UnknownEnumStringValue
+  setup_future_usage?: "none"
 }
 
 export type t_checkout_alipay_payment_method_options = {
-  setup_future_usage?: "none" | UnknownEnumStringValue
+  setup_future_usage?: "none"
 }
 
 export type t_checkout_amazon_pay_payment_method_options = {
@@ -1643,7 +1643,7 @@ export type t_checkout_amazon_pay_payment_method_options = {
 }
 
 export type t_checkout_au_becs_debit_payment_method_options = {
-  setup_future_usage?: "none" | UnknownEnumStringValue
+  setup_future_usage?: "none"
   target_date?: string
 }
 
@@ -1658,7 +1658,7 @@ export type t_checkout_bacs_debit_payment_method_options = {
 }
 
 export type t_checkout_bancontact_payment_method_options = {
-  setup_future_usage?: "none" | UnknownEnumStringValue
+  setup_future_usage?: "none"
 }
 
 export type t_checkout_boleto_payment_method_options = {
@@ -1702,7 +1702,7 @@ export type t_checkout_card_payment_method_options = {
 }
 
 export type t_checkout_cashapp_payment_method_options = {
-  setup_future_usage?: "none" | UnknownEnumStringValue
+  setup_future_usage?: "none"
 }
 
 export type t_checkout_customer_balance_bank_transfer_payment_method_options = {
@@ -1729,32 +1729,32 @@ export type t_checkout_customer_balance_bank_transfer_payment_method_options = {
 
 export type t_checkout_customer_balance_payment_method_options = {
   bank_transfer?: t_checkout_customer_balance_bank_transfer_payment_method_options
-  funding_type?: "bank_transfer" | UnknownEnumStringValue | null
-  setup_future_usage?: "none" | UnknownEnumStringValue
+  funding_type?: "bank_transfer" | null
+  setup_future_usage?: "none"
 }
 
 export type t_checkout_eps_payment_method_options = {
-  setup_future_usage?: "none" | UnknownEnumStringValue
+  setup_future_usage?: "none"
 }
 
 export type t_checkout_fpx_payment_method_options = {
-  setup_future_usage?: "none" | UnknownEnumStringValue
+  setup_future_usage?: "none"
 }
 
 export type t_checkout_giropay_payment_method_options = {
-  setup_future_usage?: "none" | UnknownEnumStringValue
+  setup_future_usage?: "none"
 }
 
 export type t_checkout_grab_pay_payment_method_options = {
-  setup_future_usage?: "none" | UnknownEnumStringValue
+  setup_future_usage?: "none"
 }
 
 export type t_checkout_ideal_payment_method_options = {
-  setup_future_usage?: "none" | UnknownEnumStringValue
+  setup_future_usage?: "none"
 }
 
 export type t_checkout_kakao_pay_payment_method_options = {
-  capture_method?: "manual" | UnknownEnumStringValue
+  capture_method?: "manual"
   setup_future_usage?: "none" | "off_session" | UnknownEnumStringValue
 }
 
@@ -1768,11 +1768,11 @@ export type t_checkout_klarna_payment_method_options = {
 
 export type t_checkout_konbini_payment_method_options = {
   expires_after_days?: number | null
-  setup_future_usage?: "none" | UnknownEnumStringValue
+  setup_future_usage?: "none"
 }
 
 export type t_checkout_kr_card_payment_method_options = {
-  capture_method?: "manual" | UnknownEnumStringValue
+  capture_method?: "manual"
   setup_future_usage?: "none" | "off_session" | UnknownEnumStringValue
 }
 
@@ -1785,29 +1785,29 @@ export type t_checkout_link_wallet_options = {
 }
 
 export type t_checkout_mobilepay_payment_method_options = {
-  setup_future_usage?: "none" | UnknownEnumStringValue
+  setup_future_usage?: "none"
 }
 
 export type t_checkout_multibanco_payment_method_options = {
-  setup_future_usage?: "none" | UnknownEnumStringValue
+  setup_future_usage?: "none"
 }
 
 export type t_checkout_naver_pay_payment_method_options = {
-  capture_method?: "manual" | UnknownEnumStringValue
+  capture_method?: "manual"
   setup_future_usage?: "none" | "off_session" | UnknownEnumStringValue
 }
 
 export type t_checkout_oxxo_payment_method_options = {
   expires_after_days: number
-  setup_future_usage?: "none" | UnknownEnumStringValue
+  setup_future_usage?: "none"
 }
 
 export type t_checkout_p24_payment_method_options = {
-  setup_future_usage?: "none" | UnknownEnumStringValue
+  setup_future_usage?: "none"
 }
 
 export type t_checkout_payco_payment_method_options = {
-  capture_method?: "manual" | UnknownEnumStringValue
+  capture_method?: "manual"
 }
 
 export type t_checkout_payment_method_options_mandate_options_bacs_debit = {
@@ -1819,11 +1819,11 @@ export type t_checkout_payment_method_options_mandate_options_sepa_debit = {
 }
 
 export type t_checkout_paynow_payment_method_options = {
-  setup_future_usage?: "none" | UnknownEnumStringValue
+  setup_future_usage?: "none"
 }
 
 export type t_checkout_paypal_payment_method_options = {
-  capture_method?: "manual" | UnknownEnumStringValue
+  capture_method?: "manual"
   preferred_locale?: string | null
   reference?: string | null
   setup_future_usage?: "none" | "off_session" | UnknownEnumStringValue
@@ -1831,7 +1831,7 @@ export type t_checkout_paypal_payment_method_options = {
 
 export type t_checkout_pix_payment_method_options = {
   expires_after_seconds?: number | null
-  setup_future_usage?: "none" | UnknownEnumStringValue
+  setup_future_usage?: "none"
 }
 
 export type t_checkout_revolut_pay_payment_method_options = {
@@ -1839,7 +1839,7 @@ export type t_checkout_revolut_pay_payment_method_options = {
 }
 
 export type t_checkout_samsung_pay_payment_method_options = {
-  capture_method?: "manual" | UnknownEnumStringValue
+  capture_method?: "manual"
 }
 
 export type t_checkout_sepa_debit_payment_method_options = {
@@ -1897,7 +1897,7 @@ export type t_checkout_session_wallet_options = {
 }
 
 export type t_checkout_sofort_payment_method_options = {
-  setup_future_usage?: "none" | UnknownEnumStringValue
+  setup_future_usage?: "none"
 }
 
 export type t_checkout_swish_payment_method_options = {
@@ -1939,7 +1939,7 @@ export type t_climate_order = {
   livemode: boolean
   metadata: Record<string, string>
   metric_tons: string
-  object: "climate.order" | UnknownEnumStringValue
+  object: "climate.order"
   product: string | t_climate_product
   product_substituted_at?: number | null
   status:
@@ -1962,7 +1962,7 @@ export type t_climate_product = {
   livemode: boolean
   metric_tons_available: string
   name: string
-  object: "climate.product" | UnknownEnumStringValue
+  object: "climate.product"
   suppliers: t_climate_supplier[]
 }
 
@@ -1972,7 +1972,7 @@ export type t_climate_supplier = {
   livemode: boolean
   locations: t_climate_removals_location[]
   name: string
-  object: "climate.supplier" | UnknownEnumStringValue
+  object: "climate.supplier"
   removal_pathway:
     | "biomass_carbon_removal_and_storage"
     | "direct_air_capture"
@@ -2012,7 +2012,7 @@ export type t_confirmation_token = {
   id: string
   livemode: boolean
   mandate_data?: t_confirmation_tokens_resource_mandate_data | null
-  object: "confirmation_token" | UnknownEnumStringValue
+  object: "confirmation_token"
   payment_intent?: string | null
   payment_method_options?: t_confirmation_tokens_resource_payment_method_options | null
   payment_method_preview?: t_confirmation_tokens_resource_payment_method_preview | null
@@ -2187,7 +2187,7 @@ export type t_connect_collection_transfer = {
   destination: string | t_account
   id: string
   livemode: boolean
-  object: "connect_collection_transfer" | UnknownEnumStringValue
+  object: "connect_collection_transfer"
 }
 
 export type t_connect_embedded_account_config_claim = {
@@ -2336,7 +2336,7 @@ export type t_connect_embedded_payouts_features = {
 export type t_country_spec = {
   default_currency: string
   id: string
-  object: "country_spec" | UnknownEnumStringValue
+  object: "country_spec"
   supported_bank_account_currencies: Record<string, string[]>
   supported_payment_currencies: string[]
   supported_payment_methods: string[]
@@ -2367,7 +2367,7 @@ export type t_coupon = {
   max_redemptions?: number | null
   metadata?: Record<string, string> | null
   name?: string | null
-  object: "coupon" | UnknownEnumStringValue
+  object: "coupon"
   percent_off?: number | null
   redeem_by?: number | null
   times_redeemed: number
@@ -2402,14 +2402,14 @@ export type t_credit_note = {
   lines: {
     data: t_credit_note_line_item[]
     has_more: boolean
-    object: "list" | UnknownEnumStringValue
+    object: "list"
     url: string
   }
   livemode: boolean
   memo?: string | null
   metadata?: Record<string, string> | null
   number: string
-  object: "credit_note" | UnknownEnumStringValue
+  object: "credit_note"
   out_of_band_amount?: number | null
   pdf: string
   post_payment_amount: number
@@ -2442,7 +2442,7 @@ export type t_credit_note_line_item = {
   id: string
   invoice_line_item?: string
   livemode: boolean
-  object: "credit_note_line_item" | UnknownEnumStringValue
+  object: "credit_note_line_item"
   pretax_credit_amounts: t_credit_notes_pretax_credit_amount[]
   quantity?: number | null
   tax_rates: t_tax_rate[]
@@ -2502,20 +2502,20 @@ export type t_customer = {
   metadata?: Record<string, string>
   name?: string | null
   next_invoice_sequence?: number
-  object: "customer" | UnknownEnumStringValue
+  object: "customer"
   phone?: string | null
   preferred_locales?: string[] | null
   shipping?: t_shipping | null
   sources?: {
     data: (t_bank_account | t_card | t_source)[]
     has_more: boolean
-    object: "list" | UnknownEnumStringValue
+    object: "list"
     url: string
   }
   subscriptions?: {
     data: t_subscription[]
     has_more: boolean
-    object: "list" | UnknownEnumStringValue
+    object: "list"
     url: string
   }
   tax?: t_customer_tax
@@ -2523,7 +2523,7 @@ export type t_customer = {
   tax_ids?: {
     data: t_tax_id[]
     has_more: boolean
-    object: "list" | UnknownEnumStringValue
+    object: "list"
     url: string
   }
   test_clock?: string | t_test_helpers_test_clock | null
@@ -2628,7 +2628,7 @@ export type t_customer_balance_transaction = {
   invoice?: string | t_invoice | null
   livemode: boolean
   metadata?: Record<string, string> | null
-  object: "customer_balance_transaction" | UnknownEnumStringValue
+  object: "customer_balance_transaction"
   type:
     | "adjustment"
     | "applied_to_invoice"
@@ -2656,7 +2656,7 @@ export type t_customer_cash_balance_transaction = {
   id: string
   livemode: boolean
   net_amount: number
-  object: "customer_cash_balance_transaction" | UnknownEnumStringValue
+  object: "customer_cash_balance_transaction"
   refunded_from_payment?: t_customer_balance_resource_cash_balance_transaction_resource_refunded_from_payment_transaction
   transferred_to_balance?: t_customer_balance_resource_cash_balance_transaction_resource_transferred_to_balance
   type:
@@ -2680,7 +2680,7 @@ export type t_customer_session = {
   customer: string | t_customer
   expires_at: number
   livemode: boolean
-  object: "customer_session" | UnknownEnumStringValue
+  object: "customer_session"
 }
 
 export type t_customer_session_resource_components = {
@@ -2746,46 +2746,46 @@ export type t_customer_tax_location = {
 export type t_deleted_account = {
   deleted: true
   id: string
-  object: "account" | UnknownEnumStringValue
+  object: "account"
 }
 
 export type t_deleted_apple_pay_domain = {
   deleted: true
   id: string
-  object: "apple_pay_domain" | UnknownEnumStringValue
+  object: "apple_pay_domain"
 }
 
 export type t_deleted_application = {
   deleted: true
   id: string
   name?: string | null
-  object: "application" | UnknownEnumStringValue
+  object: "application"
 }
 
 export type t_deleted_bank_account = {
   currency?: string | null
   deleted: true
   id: string
-  object: "bank_account" | UnknownEnumStringValue
+  object: "bank_account"
 }
 
 export type t_deleted_card = {
   currency?: string | null
   deleted: true
   id: string
-  object: "card" | UnknownEnumStringValue
+  object: "card"
 }
 
 export type t_deleted_coupon = {
   deleted: true
   id: string
-  object: "coupon" | UnknownEnumStringValue
+  object: "coupon"
 }
 
 export type t_deleted_customer = {
   deleted: true
   id: string
-  object: "customer" | UnknownEnumStringValue
+  object: "customer"
 }
 
 export type t_deleted_discount = {
@@ -2796,7 +2796,7 @@ export type t_deleted_discount = {
   id: string
   invoice?: string | null
   invoice_item?: string | null
-  object: "discount" | UnknownEnumStringValue
+  object: "discount"
   promotion_code?: string | t_promotion_code | null
   start: number
   subscription?: string | null
@@ -2808,13 +2808,13 @@ export type t_deleted_external_account = t_deleted_bank_account | t_deleted_card
 export type t_deleted_invoice = {
   deleted: true
   id: string
-  object: "invoice" | UnknownEnumStringValue
+  object: "invoice"
 }
 
 export type t_deleted_invoiceitem = {
   deleted: true
   id: string
-  object: "invoiceitem" | UnknownEnumStringValue
+  object: "invoiceitem"
 }
 
 export type t_deleted_payment_source = t_deleted_bank_account | t_deleted_card
@@ -2822,85 +2822,85 @@ export type t_deleted_payment_source = t_deleted_bank_account | t_deleted_card
 export type t_deleted_person = {
   deleted: true
   id: string
-  object: "person" | UnknownEnumStringValue
+  object: "person"
 }
 
 export type t_deleted_plan = {
   deleted: true
   id: string
-  object: "plan" | UnknownEnumStringValue
+  object: "plan"
 }
 
 export type t_deleted_price = {
   deleted: true
   id: string
-  object: "price" | UnknownEnumStringValue
+  object: "price"
 }
 
 export type t_deleted_product = {
   deleted: true
   id: string
-  object: "product" | UnknownEnumStringValue
+  object: "product"
 }
 
 export type t_deleted_product_feature = {
   deleted: true
   id: string
-  object: "product_feature" | UnknownEnumStringValue
+  object: "product_feature"
 }
 
 export type t_deleted_radar_value_list = {
   deleted: true
   id: string
-  object: "radar.value_list" | UnknownEnumStringValue
+  object: "radar.value_list"
 }
 
 export type t_deleted_radar_value_list_item = {
   deleted: true
   id: string
-  object: "radar.value_list_item" | UnknownEnumStringValue
+  object: "radar.value_list_item"
 }
 
 export type t_deleted_subscription_item = {
   deleted: true
   id: string
-  object: "subscription_item" | UnknownEnumStringValue
+  object: "subscription_item"
 }
 
 export type t_deleted_tax_id = {
   deleted: true
   id: string
-  object: "tax_id" | UnknownEnumStringValue
+  object: "tax_id"
 }
 
 export type t_deleted_terminal_configuration = {
   deleted: true
   id: string
-  object: "terminal.configuration" | UnknownEnumStringValue
+  object: "terminal.configuration"
 }
 
 export type t_deleted_terminal_location = {
   deleted: true
   id: string
-  object: "terminal.location" | UnknownEnumStringValue
+  object: "terminal.location"
 }
 
 export type t_deleted_terminal_reader = {
   deleted: true
   id: string
-  object: "terminal.reader" | UnknownEnumStringValue
+  object: "terminal.reader"
 }
 
 export type t_deleted_test_helpers_test_clock = {
   deleted: true
   id: string
-  object: "test_helpers.test_clock" | UnknownEnumStringValue
+  object: "test_helpers.test_clock"
 }
 
 export type t_deleted_webhook_endpoint = {
   deleted: true
   id: string
-  object: "webhook_endpoint" | UnknownEnumStringValue
+  object: "webhook_endpoint"
 }
 
 export type t_destination_details_unimplemented = Record<string, unknown>
@@ -2913,7 +2913,7 @@ export type t_discount = {
   id: string
   invoice?: string | null
   invoice_item?: string | null
-  object: "discount" | UnknownEnumStringValue
+  object: "discount"
   promotion_code?: string | t_promotion_code | null
   start: number
   subscription?: string | null
@@ -2948,7 +2948,7 @@ export type t_dispute = {
   is_charge_refundable: boolean
   livemode: boolean
   metadata: Record<string, string>
-  object: "dispute" | UnknownEnumStringValue
+  object: "dispute"
   payment_intent?: string | t_payment_intent | null
   payment_method_details?: t_dispute_payment_method_details
   reason: string
@@ -3116,7 +3116,7 @@ export type t_entitlements_active_entitlement = {
   id: string
   livemode: boolean
   lookup_key: string
-  object: "entitlements.active_entitlement" | UnknownEnumStringValue
+  object: "entitlements.active_entitlement"
 }
 
 export type t_entitlements_feature = {
@@ -3126,7 +3126,7 @@ export type t_entitlements_feature = {
   lookup_key: string
   metadata: Record<string, string>
   name: string
-  object: "entitlements.feature" | UnknownEnumStringValue
+  object: "entitlements.feature"
 }
 
 export type t_ephemeral_key = {
@@ -3134,7 +3134,7 @@ export type t_ephemeral_key = {
   expires: number
   id: string
   livemode: boolean
-  object: "ephemeral_key" | UnknownEnumStringValue
+  object: "ephemeral_key"
   secret?: string
 }
 
@@ -3150,7 +3150,7 @@ export type t_event = {
   data: t_notification_event_data
   id: string
   livemode: boolean
-  object: "event" | UnknownEnumStringValue
+  object: "event"
   pending_webhooks: number
   request?: t_notification_event_request | null
   type: string
@@ -3158,7 +3158,7 @@ export type t_event = {
 
 export type t_exchange_rate = {
   id: string
-  object: "exchange_rate" | UnknownEnumStringValue
+  object: "exchange_rate"
   rates: Record<string, number>
 }
 
@@ -3187,7 +3187,7 @@ export type t_fee_refund = {
   fee: string | t_application_fee
   id: string
   metadata?: Record<string, string> | null
-  object: "fee_refund" | UnknownEnumStringValue
+  object: "fee_refund"
 }
 
 export type t_file = {
@@ -3198,10 +3198,10 @@ export type t_file = {
   links?: {
     data: t_file_link[]
     has_more: boolean
-    object: "list" | UnknownEnumStringValue
+    object: "list"
     url: string
   } | null
-  object: "file" | UnknownEnumStringValue
+  object: "file"
   purpose:
     | "account_requirement"
     | "additional_verification"
@@ -3235,7 +3235,7 @@ export type t_file_link = {
   id: string
   livemode: boolean
   metadata: Record<string, string>
-  object: "file_link" | UnknownEnumStringValue
+  object: "file_link"
   url?: string | null
 }
 
@@ -3250,7 +3250,7 @@ export type t_financial_connections_account = {
   institution_name: string
   last4?: string | null
   livemode: boolean
-  object: "financial_connections.account" | UnknownEnumStringValue
+  object: "financial_connections.account"
   ownership?: string | t_financial_connections_account_ownership | null
   ownership_refresh?: t_bank_connections_resource_ownership_refresh | null
   permissions?:
@@ -3271,7 +3271,7 @@ export type t_financial_connections_account = {
     | "other"
     | "savings"
     | UnknownEnumStringValue
-  subscriptions?: ("transactions" | UnknownEnumStringValue)[] | null
+  subscriptions?: "transactions"[] | null
   supported_payment_method_types: (
     | "link"
     | "us_bank_account"
@@ -3284,7 +3284,7 @@ export type t_financial_connections_account_owner = {
   email?: string | null
   id: string
   name: string
-  object: "financial_connections.account_owner" | UnknownEnumStringValue
+  object: "financial_connections.account_owner"
   ownership: string
   phone?: string | null
   raw_address?: string | null
@@ -3294,11 +3294,11 @@ export type t_financial_connections_account_owner = {
 export type t_financial_connections_account_ownership = {
   created: number
   id: string
-  object: "financial_connections.account_ownership" | UnknownEnumStringValue
+  object: "financial_connections.account_ownership"
   owners: {
     data: t_financial_connections_account_owner[]
     has_more: boolean
-    object: "list" | UnknownEnumStringValue
+    object: "list"
     url: string
   }
 }
@@ -3308,14 +3308,14 @@ export type t_financial_connections_session = {
   accounts: {
     data: t_financial_connections_account[]
     has_more: boolean
-    object: "list" | UnknownEnumStringValue
+    object: "list"
     url: string
   }
   client_secret: string
   filters?: t_bank_connections_resource_link_account_session_filters
   id: string
   livemode: boolean
-  object: "financial_connections.session" | UnknownEnumStringValue
+  object: "financial_connections.session"
   permissions: (
     | "balances"
     | "ownership"
@@ -3336,7 +3336,7 @@ export type t_financial_connections_transaction = {
   description: string
   id: string
   livemode: boolean
-  object: "financial_connections.transaction" | UnknownEnumStringValue
+  object: "financial_connections.transaction"
   status: "pending" | "posted" | "void" | UnknownEnumStringValue
   status_transitions: t_bank_connections_resource_transaction_resource_status_transitions
   transacted_at: number
@@ -3363,7 +3363,7 @@ export type t_forwarded_request_context = {
 export type t_forwarded_request_details = {
   body: string
   headers: t_forwarded_request_header[]
-  http_method: "POST" | UnknownEnumStringValue
+  http_method: "POST"
 }
 
 export type t_forwarded_request_header = {
@@ -3382,7 +3382,7 @@ export type t_forwarding_request = {
   id: string
   livemode: boolean
   metadata?: Record<string, string> | null
-  object: "forwarding.request" | UnknownEnumStringValue
+  object: "forwarding.request"
   payment_method: string
   replacements: (
     | "card_cvc"
@@ -3401,9 +3401,9 @@ export type t_forwarding_request = {
 export type t_funding_instructions = {
   bank_transfer: t_funding_instructions_bank_transfer
   currency: string
-  funding_type: "bank_transfer" | UnknownEnumStringValue
+  funding_type: "bank_transfer"
   livemode: boolean
-  object: "funding_instructions" | UnknownEnumStringValue
+  object: "funding_instructions"
 }
 
 export type t_funding_instructions_bank_transfer = {
@@ -3763,7 +3763,7 @@ export type t_identity_verification_report = {
   id: string
   id_number?: t_gelato_id_number_report
   livemode: boolean
-  object: "identity.verification_report" | UnknownEnumStringValue
+  object: "identity.verification_report"
   options?: t_gelato_verification_report_options
   phone?: t_gelato_phone_report
   selfie?: t_gelato_selfie_report
@@ -3781,7 +3781,7 @@ export type t_identity_verification_session = {
   last_verification_report?: string | t_identity_verification_report | null
   livemode: boolean
   metadata: Record<string, string>
-  object: "identity.verification_session" | UnknownEnumStringValue
+  object: "identity.verification_session"
   options?: t_gelato_verification_session_options | null
   provided_details?: t_gelato_provided_details | null
   redaction?: t_verification_session_redaction | null
@@ -3801,7 +3801,7 @@ export type t_identity_verification_session = {
 
 export type t_inbound_transfers = {
   billing_details: t_treasury_shared_resource_billing_details
-  type: "us_bank_account" | UnknownEnumStringValue
+  type: "us_bank_account"
   us_bank_account?: t_inbound_transfers_payment_method_details_us_bank_account
 }
 
@@ -3812,7 +3812,7 @@ export type t_inbound_transfers_payment_method_details_us_bank_account = {
   fingerprint?: string | null
   last4?: string | null
   mandate?: string | t_mandate
-  network: "ach" | UnknownEnumStringValue
+  network: "ach"
   routing_number?: string | null
 }
 
@@ -3891,21 +3891,21 @@ export type t_invoice = {
   lines: {
     data: t_line_item[]
     has_more: boolean
-    object: "list" | UnknownEnumStringValue
+    object: "list"
     url: string
   }
   livemode: boolean
   metadata?: Record<string, string> | null
   next_payment_attempt?: number | null
   number?: string | null
-  object: "invoice" | UnknownEnumStringValue
+  object: "invoice"
   on_behalf_of?: string | t_account | null
   parent?: t_billing_bill_resource_invoicing_parents_invoice_parent | null
   payment_settings: t_invoices_payment_settings
   payments?: {
     data: t_invoice_payment[]
     has_more: boolean
-    object: "list" | UnknownEnumStringValue
+    object: "list"
     url: string
   }
   period_end: number
@@ -3970,7 +3970,7 @@ export type t_invoice_payment = {
   invoice: string | t_invoice | t_deleted_invoice
   is_default: boolean
   livemode: boolean
-  object: "invoice_payment" | UnknownEnumStringValue
+  object: "invoice_payment"
   payment: t_invoices_payments_invoice_payment_associated_payment
   status: string
   status_transitions: t_invoices_payments_invoice_payment_status_transitions
@@ -4005,7 +4005,7 @@ export type t_invoice_payment_method_options_card = {
 
 export type t_invoice_payment_method_options_customer_balance = {
   bank_transfer?: t_invoice_payment_method_options_customer_balance_bank_transfer
-  funding_type?: "bank_transfer" | UnknownEnumStringValue | null
+  funding_type?: "bank_transfer" | null
 }
 
 export type t_invoice_payment_method_options_customer_balance_bank_transfer = {
@@ -4064,7 +4064,7 @@ export type t_invoice_rendering_template = {
   livemode: boolean
   metadata?: Record<string, string> | null
   nickname?: string | null
-  object: "invoice_rendering_template" | UnknownEnumStringValue
+  object: "invoice_rendering_template"
   status: "active" | "archived" | UnknownEnumStringValue
   version: number
 }
@@ -4125,7 +4125,7 @@ export type t_invoiceitem = {
   invoice?: string | t_invoice | null
   livemode: boolean
   metadata?: Record<string, string> | null
-  object: "invoiceitem" | UnknownEnumStringValue
+  object: "invoiceitem"
   parent?: t_billing_bill_resource_invoice_item_parents_invoice_item_parent | null
   period: t_invoice_line_item_period
   pricing?: t_billing_bill_resource_invoicing_pricing_pricing | null
@@ -4390,7 +4390,7 @@ export type t_issuing_authorization = {
   merchant_data: t_issuing_authorization_merchant_data
   metadata: Record<string, string>
   network_data?: t_issuing_authorization_network_data | null
-  object: "issuing.authorization" | UnknownEnumStringValue
+  object: "issuing.authorization"
   pending_request?: t_issuing_authorization_pending_request | null
   request_history: t_issuing_authorization_request[]
   status: "closed" | "expired" | "pending" | "reversed" | UnknownEnumStringValue
@@ -4422,7 +4422,7 @@ export type t_issuing_card = {
   livemode: boolean
   metadata: Record<string, string>
   number?: string
-  object: "issuing.card" | UnknownEnumStringValue
+  object: "issuing.card"
   personalization_design?: string | t_issuing_personalization_design | null
   replaced_by?: string | t_issuing_card | null
   replacement_for?: string | t_issuing_card | null
@@ -4450,7 +4450,7 @@ export type t_issuing_cardholder = {
   livemode: boolean
   metadata: Record<string, string>
   name: string
-  object: "issuing.cardholder" | UnknownEnumStringValue
+  object: "issuing.cardholder"
   phone_number?: string | null
   preferred_locales?:
     | ("de" | "en" | "es" | "fr" | "it" | UnknownEnumStringValue)[]
@@ -4492,7 +4492,7 @@ export type t_issuing_dispute = {
     | "transaction_unattended"
     | UnknownEnumStringValue
   metadata: Record<string, string>
-  object: "issuing.dispute" | UnknownEnumStringValue
+  object: "issuing.dispute"
   status:
     | "expired"
     | "lost"
@@ -4513,7 +4513,7 @@ export type t_issuing_personalization_design = {
   lookup_key?: string | null
   metadata: Record<string, string>
   name?: string | null
-  object: "issuing.personalization_design" | UnknownEnumStringValue
+  object: "issuing.personalization_design"
   physical_bundle: string | t_issuing_physical_bundle
   preferences: t_issuing_personalization_design_preferences
   rejection_reasons: t_issuing_personalization_design_rejection_reasons
@@ -4525,7 +4525,7 @@ export type t_issuing_physical_bundle = {
   id: string
   livemode: boolean
   name: string
-  object: "issuing.physical_bundle" | UnknownEnumStringValue
+  object: "issuing.physical_bundle"
   status: "active" | "inactive" | "review" | UnknownEnumStringValue
   type: "custom" | "standard" | UnknownEnumStringValue
 }
@@ -4543,7 +4543,7 @@ export type t_issuing_settlement = {
   network: "maestro" | "visa" | UnknownEnumStringValue
   network_fees_amount: number
   network_settlement_identifier: string
-  object: "issuing.settlement" | UnknownEnumStringValue
+  object: "issuing.settlement"
   settlement_service: string
   status: "complete" | "pending" | UnknownEnumStringValue
   transaction_amount: number
@@ -4560,7 +4560,7 @@ export type t_issuing_token = {
   network: "mastercard" | "visa" | UnknownEnumStringValue
   network_data?: t_issuing_network_token_network_data
   network_updated_at: number
-  object: "issuing.token" | UnknownEnumStringValue
+  object: "issuing.token"
   status:
     | "active"
     | "deleted"
@@ -4591,7 +4591,7 @@ export type t_issuing_transaction = {
   merchant_data: t_issuing_authorization_merchant_data
   metadata: Record<string, string>
   network_data?: t_issuing_transaction_network_data | null
-  object: "issuing.transaction" | UnknownEnumStringValue
+  object: "issuing.transaction"
   purchase_details?: t_issuing_transaction_purchase_details | null
   token?: string | t_issuing_token | null
   treasury?: t_issuing_transaction_treasury | null
@@ -4664,7 +4664,7 @@ export type t_issuing_authorization_fleet_tax_data = {
 }
 
 export type t_issuing_authorization_fraud_challenge = {
-  channel: "sms" | UnknownEnumStringValue
+  channel: "sms"
   status:
     | "expired"
     | "pending"
@@ -7119,7 +7119,7 @@ export type t_item = {
   description?: string | null
   discounts?: t_line_items_discount_amount[]
   id: string
-  object: "item" | UnknownEnumStringValue
+  object: "item"
   price?: t_price | null
   quantity?: number | null
   taxes?: t_line_items_tax_amount[]
@@ -7255,7 +7255,7 @@ export type t_line_item = {
   invoice?: string | null
   livemode: boolean
   metadata: Record<string, string>
-  object: "line_item" | UnknownEnumStringValue
+  object: "line_item"
   parent?: t_billing_bill_resource_invoicing_lines_parents_invoice_line_item_parent | null
   period: t_invoice_line_item_period
   pretax_credit_amounts?: t_invoices_resource_pretax_credit_amount[] | null
@@ -7311,7 +7311,7 @@ export type t_linked_account_options_common = {
 
 export type t_login_link = {
   created: number
-  object: "login_link" | UnknownEnumStringValue
+  object: "login_link"
   url: string
 }
 
@@ -7320,7 +7320,7 @@ export type t_mandate = {
   id: string
   livemode: boolean
   multi_use?: t_mandate_multi_use
-  object: "mandate" | UnknownEnumStringValue
+  object: "mandate"
   on_behalf_of?: string
   payment_method: string | t_payment_method
   payment_method_details: t_mandate_payment_method_details
@@ -7419,7 +7419,7 @@ export type t_mandate_single_use = {
 }
 
 export type t_mandate_us_bank_account = {
-  collection_method?: "paper" | UnknownEnumStringValue
+  collection_method?: "paper"
 }
 
 export type t_networks = {
@@ -7453,7 +7453,7 @@ export type t_outbound_payments_payment_method_details = {
 
 export type t_outbound_payments_payment_method_details_financial_account = {
   id: string
-  network: "stripe" | UnknownEnumStringValue
+  network: "stripe"
 }
 
 export type t_outbound_payments_payment_method_details_us_bank_account = {
@@ -7476,7 +7476,7 @@ export type t_outbound_transfers_payment_method_details = {
 
 export type t_outbound_transfers_payment_method_details_financial_account = {
   id: string
-  network: "stripe" | UnknownEnumStringValue
+  network: "stripe"
 }
 
 export type t_outbound_transfers_payment_method_details_us_bank_account = {
@@ -7578,7 +7578,7 @@ export type t_payment_flows_private_payment_methods_financial_connections_common
 
 export type t_payment_flows_private_payment_methods_kakao_pay_payment_method_options =
   {
-    capture_method?: "manual" | UnknownEnumStringValue
+    capture_method?: "manual"
     setup_future_usage?: "none" | "off_session" | UnknownEnumStringValue
   }
 
@@ -7590,18 +7590,18 @@ export type t_payment_flows_private_payment_methods_klarna_dob = {
 
 export type t_payment_flows_private_payment_methods_naver_pay_payment_method_options =
   {
-    capture_method?: "manual" | UnknownEnumStringValue
+    capture_method?: "manual"
     setup_future_usage?: "none" | "off_session" | UnknownEnumStringValue
   }
 
 export type t_payment_flows_private_payment_methods_payco_payment_method_options =
   {
-    capture_method?: "manual" | UnknownEnumStringValue
+    capture_method?: "manual"
   }
 
 export type t_payment_flows_private_payment_methods_samsung_pay_payment_method_options =
   {
-    capture_method?: "manual" | UnknownEnumStringValue
+    capture_method?: "manual"
   }
 
 export type t_payment_intent = {
@@ -7643,7 +7643,7 @@ export type t_payment_intent = {
   livemode: boolean
   metadata?: Record<string, string>
   next_action?: t_payment_intent_next_action | null
-  object: "payment_intent" | UnknownEnumStringValue
+  object: "payment_intent"
   on_behalf_of?: string | t_account | null
   payment_method?: string | t_payment_method | null
   payment_method_configuration_details?: t_payment_method_config_biz_payment_method_configuration_details | null
@@ -8052,11 +8052,11 @@ export type t_payment_intent_payment_method_options_bacs_debit = {
 }
 
 export type t_payment_intent_payment_method_options_blik = {
-  setup_future_usage?: "none" | UnknownEnumStringValue
+  setup_future_usage?: "none"
 }
 
 export type t_payment_intent_payment_method_options_card = {
-  capture_method?: "manual" | UnknownEnumStringValue
+  capture_method?: "manual"
   installments?: t_payment_method_options_card_installments | null
   mandate_options?: t_payment_method_options_card_mandate_options | null
   network?:
@@ -8102,11 +8102,11 @@ export type t_payment_intent_payment_method_options_card = {
 }
 
 export type t_payment_intent_payment_method_options_eps = {
-  setup_future_usage?: "none" | UnknownEnumStringValue
+  setup_future_usage?: "none"
 }
 
 export type t_payment_intent_payment_method_options_link = {
-  capture_method?: "manual" | UnknownEnumStringValue
+  capture_method?: "manual"
   setup_future_usage?: "none" | "off_session" | UnknownEnumStringValue
 }
 
@@ -8134,8 +8134,8 @@ export type t_payment_intent_payment_method_options_mandate_options_sepa_debit =
   }
 
 export type t_payment_intent_payment_method_options_mobilepay = {
-  capture_method?: "manual" | UnknownEnumStringValue
-  setup_future_usage?: "none" | UnknownEnumStringValue
+  capture_method?: "manual"
+  setup_future_usage?: "none"
 }
 
 export type t_payment_intent_payment_method_options_nz_bank_account = {
@@ -8159,7 +8159,7 @@ export type t_payment_intent_payment_method_options_sepa_debit = {
 
 export type t_payment_intent_payment_method_options_swish = {
   reference?: string | null
-  setup_future_usage?: "none" | UnknownEnumStringValue
+  setup_future_usage?: "none"
 }
 
 export type t_payment_intent_payment_method_options_us_bank_account = {
@@ -8181,7 +8181,7 @@ export type t_payment_intent_payment_method_options_us_bank_account = {
 
 export type t_payment_intent_processing = {
   card?: t_payment_intent_card_processing
-  type: "card" | UnknownEnumStringValue
+  type: "card"
 }
 
 export type t_payment_intent_processing_customer_notification = {
@@ -8227,12 +8227,12 @@ export type t_payment_link = {
   line_items?: {
     data: t_item[]
     has_more: boolean
-    object: "list" | UnknownEnumStringValue
+    object: "list"
     url: string
   }
   livemode: boolean
   metadata: Record<string, string>
-  object: "payment_link" | UnknownEnumStringValue
+  object: "payment_link"
   on_behalf_of?: string | t_account | null
   optional_items?: t_payment_links_resource_optional_item[] | null
   payment_intent_data?: t_payment_links_resource_payment_intent_data | null
@@ -8348,7 +8348,7 @@ export type t_payment_links_resource_custom_fields_dropdown_option = {
 
 export type t_payment_links_resource_custom_fields_label = {
   custom?: string | null
-  type: "custom" | UnknownEnumStringValue
+  type: "custom"
 }
 
 export type t_payment_links_resource_custom_fields_numeric = {
@@ -8747,7 +8747,7 @@ export type t_payment_method = {
   multibanco?: t_payment_method_multibanco
   naver_pay?: t_payment_method_naver_pay
   nz_bank_account?: t_payment_method_nz_bank_account
-  object: "payment_method" | UnknownEnumStringValue
+  object: "payment_method"
   oxxo?: t_payment_method_oxxo
   p24?: t_payment_method_p24
   pay_by_bank?: t_payment_method_pay_by_bank
@@ -9027,7 +9027,7 @@ export type t_payment_method_configuration = {
   name: string
   naver_pay?: t_payment_method_config_resource_payment_method_properties
   nz_bank_account?: t_payment_method_config_resource_payment_method_properties
-  object: "payment_method_configuration" | UnknownEnumStringValue
+  object: "payment_method_configuration"
   oxxo?: t_payment_method_config_resource_payment_method_properties
   p24?: t_payment_method_config_resource_payment_method_properties
   parent?: string | null
@@ -9226,7 +9226,7 @@ export type t_payment_method_details_card_installments = {
 
 export type t_payment_method_details_card_installments_plan = {
   count?: number | null
-  interval?: "month" | UnknownEnumStringValue | null
+  interval?: "month" | null
   type: "bonus" | "fixed_count" | "revolving" | UnknownEnumStringValue
 }
 
@@ -9270,7 +9270,7 @@ export type t_payment_method_details_card_present = {
 
 export type t_payment_method_details_card_present_offline = {
   stored_at?: number | null
-  type?: "deferred" | UnknownEnumStringValue | null
+  type?: "deferred" | null
 }
 
 export type t_payment_method_details_card_present_receipt = {
@@ -9759,7 +9759,7 @@ export type t_payment_method_domain = {
   klarna: t_payment_method_domain_resource_payment_method_status
   link: t_payment_method_domain_resource_payment_method_status
   livemode: boolean
-  object: "payment_method_domain" | UnknownEnumStringValue
+  object: "payment_method_domain"
   paypal: t_payment_method_domain_resource_payment_method_status
 }
 
@@ -9964,15 +9964,15 @@ export type t_payment_method_nz_bank_account = {
 }
 
 export type t_payment_method_options_affirm = {
-  capture_method?: "manual" | UnknownEnumStringValue
+  capture_method?: "manual"
   preferred_locale?: string
-  setup_future_usage?: "none" | UnknownEnumStringValue
+  setup_future_usage?: "none"
 }
 
 export type t_payment_method_options_afterpay_clearpay = {
-  capture_method?: "manual" | UnknownEnumStringValue
+  capture_method?: "manual"
   reference?: string | null
-  setup_future_usage?: "none" | UnknownEnumStringValue
+  setup_future_usage?: "none"
 }
 
 export type t_payment_method_options_alipay = {
@@ -9980,11 +9980,11 @@ export type t_payment_method_options_alipay = {
 }
 
 export type t_payment_method_options_alma = {
-  capture_method?: "manual" | UnknownEnumStringValue
+  capture_method?: "manual"
 }
 
 export type t_payment_method_options_amazon_pay = {
-  capture_method?: "manual" | UnknownEnumStringValue
+  capture_method?: "manual"
   setup_future_usage?: "none" | "off_session" | UnknownEnumStringValue
 }
 
@@ -9994,7 +9994,7 @@ export type t_payment_method_options_bancontact = {
 }
 
 export type t_payment_method_options_billie = {
-  capture_method?: "manual" | UnknownEnumStringValue
+  capture_method?: "manual"
 }
 
 export type t_payment_method_options_boleto = {
@@ -10027,7 +10027,7 @@ export type t_payment_method_options_card_mandate_options = {
   interval_count?: number | null
   reference: string
   start_date: number
-  supported_types?: ("india" | UnknownEnumStringValue)[] | null
+  supported_types?: "india"[] | null
 }
 
 export type t_payment_method_options_card_present = {
@@ -10045,7 +10045,7 @@ export type t_payment_method_options_card_present_routing = {
 }
 
 export type t_payment_method_options_cashapp = {
-  capture_method?: "manual" | UnknownEnumStringValue
+  capture_method?: "manual"
   setup_future_usage?:
     | "none"
     | "off_session"
@@ -10054,13 +10054,13 @@ export type t_payment_method_options_cashapp = {
 }
 
 export type t_payment_method_options_crypto = {
-  setup_future_usage?: "none" | UnknownEnumStringValue
+  setup_future_usage?: "none"
 }
 
 export type t_payment_method_options_customer_balance = {
   bank_transfer?: t_payment_method_options_customer_balance_bank_transfer
-  funding_type?: "bank_transfer" | UnknownEnumStringValue | null
-  setup_future_usage?: "none" | UnknownEnumStringValue
+  funding_type?: "bank_transfer" | null
+  setup_future_usage?: "none"
 }
 
 export type t_payment_method_options_customer_balance_bank_transfer = {
@@ -10090,15 +10090,15 @@ export type t_payment_method_options_customer_balance_eu_bank_account = {
 }
 
 export type t_payment_method_options_fpx = {
-  setup_future_usage?: "none" | UnknownEnumStringValue
+  setup_future_usage?: "none"
 }
 
 export type t_payment_method_options_giropay = {
-  setup_future_usage?: "none" | UnknownEnumStringValue
+  setup_future_usage?: "none"
 }
 
 export type t_payment_method_options_grabpay = {
-  setup_future_usage?: "none" | UnknownEnumStringValue
+  setup_future_usage?: "none"
 }
 
 export type t_payment_method_options_ideal = {
@@ -10108,7 +10108,7 @@ export type t_payment_method_options_ideal = {
 export type t_payment_method_options_interac_present = Record<string, unknown>
 
 export type t_payment_method_options_klarna = {
-  capture_method?: "manual" | UnknownEnumStringValue
+  capture_method?: "manual"
   preferred_locale?: string | null
   setup_future_usage?:
     | "none"
@@ -10122,35 +10122,35 @@ export type t_payment_method_options_konbini = {
   expires_after_days?: number | null
   expires_at?: number | null
   product_description?: string | null
-  setup_future_usage?: "none" | UnknownEnumStringValue
+  setup_future_usage?: "none"
 }
 
 export type t_payment_method_options_kr_card = {
-  capture_method?: "manual" | UnknownEnumStringValue
+  capture_method?: "manual"
   setup_future_usage?: "none" | "off_session" | UnknownEnumStringValue
 }
 
 export type t_payment_method_options_multibanco = {
-  setup_future_usage?: "none" | UnknownEnumStringValue
+  setup_future_usage?: "none"
 }
 
 export type t_payment_method_options_oxxo = {
   expires_after_days: number
-  setup_future_usage?: "none" | UnknownEnumStringValue
+  setup_future_usage?: "none"
 }
 
 export type t_payment_method_options_p24 = {
-  setup_future_usage?: "none" | UnknownEnumStringValue
+  setup_future_usage?: "none"
 }
 
 export type t_payment_method_options_pay_by_bank = Record<string, unknown>
 
 export type t_payment_method_options_paynow = {
-  setup_future_usage?: "none" | UnknownEnumStringValue
+  setup_future_usage?: "none"
 }
 
 export type t_payment_method_options_paypal = {
-  capture_method?: "manual" | UnknownEnumStringValue
+  capture_method?: "manual"
   preferred_locale?: string | null
   reference?: string | null
   setup_future_usage?: "none" | "off_session" | UnknownEnumStringValue
@@ -10159,20 +10159,20 @@ export type t_payment_method_options_paypal = {
 export type t_payment_method_options_pix = {
   expires_after_seconds?: number | null
   expires_at?: number | null
-  setup_future_usage?: "none" | UnknownEnumStringValue
+  setup_future_usage?: "none"
 }
 
 export type t_payment_method_options_promptpay = {
-  setup_future_usage?: "none" | UnknownEnumStringValue
+  setup_future_usage?: "none"
 }
 
 export type t_payment_method_options_revolut_pay = {
-  capture_method?: "manual" | UnknownEnumStringValue
+  capture_method?: "manual"
   setup_future_usage?: "none" | "off_session" | UnknownEnumStringValue
 }
 
 export type t_payment_method_options_satispay = {
-  capture_method?: "manual" | UnknownEnumStringValue
+  capture_method?: "manual"
 }
 
 export type t_payment_method_options_sofort = {
@@ -10190,21 +10190,21 @@ export type t_payment_method_options_sofort = {
 }
 
 export type t_payment_method_options_twint = {
-  setup_future_usage?: "none" | UnknownEnumStringValue
+  setup_future_usage?: "none"
 }
 
 export type t_payment_method_options_us_bank_account_mandate_options = {
-  collection_method?: "paper" | UnknownEnumStringValue
+  collection_method?: "paper"
 }
 
 export type t_payment_method_options_wechat_pay = {
   app_id?: string | null
   client?: "android" | "ios" | "web" | UnknownEnumStringValue | null
-  setup_future_usage?: "none" | UnknownEnumStringValue
+  setup_future_usage?: "none"
 }
 
 export type t_payment_method_options_zip = {
-  setup_future_usage?: "none" | UnknownEnumStringValue
+  setup_future_usage?: "none"
 }
 
 export type t_payment_method_oxxo = Record<string, unknown>
@@ -10365,7 +10365,7 @@ export type t_payment_pages_checkout_session_collected_information = {
 
 export type t_payment_pages_checkout_session_consent = {
   promotions?: "opt_in" | "opt_out" | UnknownEnumStringValue | null
-  terms_of_service?: "accepted" | UnknownEnumStringValue | null
+  terms_of_service?: "accepted" | null
 }
 
 export type t_payment_pages_checkout_session_consent_collection = {
@@ -10399,7 +10399,7 @@ export type t_payment_pages_checkout_session_custom_fields_dropdown = {
 
 export type t_payment_pages_checkout_session_custom_fields_label = {
   custom?: string | null
-  type: "custom" | UnknownEnumStringValue
+  type: "custom"
 }
 
 export type t_payment_pages_checkout_session_custom_fields_numeric = {
@@ -10927,7 +10927,7 @@ export type t_payout = {
   livemode: boolean
   metadata?: Record<string, string> | null
   method: string
-  object: "payout" | UnknownEnumStringValue
+  object: "payout"
   original_payout?: string | t_payout | null
   reconciliation_status:
     | "completed"
@@ -10982,7 +10982,7 @@ export type t_person = {
   maiden_name?: string | null
   metadata?: Record<string, string>
   nationality?: string | null
-  object: "person" | UnknownEnumStringValue
+  object: "person"
   phone?: string | null
   political_exposure?: "existing" | "none" | UnknownEnumStringValue
   registered_address?: t_address
@@ -11101,7 +11101,7 @@ export type t_plan = {
   metadata?: Record<string, string> | null
   meter?: string | null
   nickname?: string | null
-  object: "plan" | UnknownEnumStringValue
+  object: "plan"
   product?: string | t_product | t_deleted_product | null
   tiers?: t_plan_tier[]
   tiers_mode?: "graduated" | "volume" | UnknownEnumStringValue | null
@@ -11203,7 +11203,7 @@ export type t_portal_flows_flow_subscription_update_confirm = {
 
 export type t_portal_flows_retention = {
   coupon_offer?: t_portal_flows_coupon_offer | null
-  type: "coupon_offer" | UnknownEnumStringValue
+  type: "coupon_offer"
 }
 
 export type t_portal_flows_subscription_update_confirm_discount = {
@@ -11308,7 +11308,7 @@ export type t_price = {
   lookup_key?: string | null
   metadata: Record<string, string>
   nickname?: string | null
-  object: "price" | UnknownEnumStringValue
+  object: "price"
   product: string | t_product | t_deleted_product
   recurring?: t_recurring | null
   tax_behavior?:
@@ -11344,7 +11344,7 @@ export type t_product = {
   marketing_features: t_product_marketing_feature[]
   metadata: Record<string, string>
   name: string
-  object: "product" | UnknownEnumStringValue
+  object: "product"
   package_dimensions?: t_package_dimensions | null
   shippable?: boolean | null
   statement_descriptor?: string | null
@@ -11358,7 +11358,7 @@ export type t_product_feature = {
   entitlement_feature: t_entitlements_feature
   id: string
   livemode: boolean
-  object: "product_feature" | UnknownEnumStringValue
+  object: "product_feature"
 }
 
 export type t_product_marketing_feature = {
@@ -11376,7 +11376,7 @@ export type t_promotion_code = {
   livemode: boolean
   max_redemptions?: number | null
   metadata?: Record<string, string> | null
-  object: "promotion_code" | UnknownEnumStringValue
+  object: "promotion_code"
   restrictions: t_promotion_codes_resource_restrictions
   times_redeemed: number
 }
@@ -11420,13 +11420,13 @@ export type t_quote = {
   line_items?: {
     data: t_item[]
     has_more: boolean
-    object: "list" | UnknownEnumStringValue
+    object: "list"
     url: string
   }
   livemode: boolean
   metadata: Record<string, string>
   number?: string | null
-  object: "quote" | UnknownEnumStringValue
+  object: "quote"
   on_behalf_of?: string | t_account | null
   status: "accepted" | "canceled" | "draft" | "open" | UnknownEnumStringValue
   status_transitions: t_quotes_resource_status_transitions
@@ -11510,7 +11510,7 @@ export type t_quotes_resource_upfront = {
   line_items?: {
     data: t_item[]
     has_more: boolean
-    object: "list" | UnknownEnumStringValue
+    object: "list"
     url: string
   }
   total_details: t_quotes_resource_total_details
@@ -11523,7 +11523,7 @@ export type t_radar_early_fraud_warning = {
   fraud_type: string
   id: string
   livemode: boolean
-  object: "radar.early_fraud_warning" | UnknownEnumStringValue
+  object: "radar.early_fraud_warning"
   payment_intent?: string | t_payment_intent
 }
 
@@ -11547,13 +11547,13 @@ export type t_radar_value_list = {
   list_items: {
     data: t_radar_value_list_item[]
     has_more: boolean
-    object: "list" | UnknownEnumStringValue
+    object: "list"
     url: string
   }
   livemode: boolean
   metadata: Record<string, string>
   name: string
-  object: "radar.value_list" | UnknownEnumStringValue
+  object: "radar.value_list"
 }
 
 export type t_radar_value_list_item = {
@@ -11561,7 +11561,7 @@ export type t_radar_value_list_item = {
   created_by: string
   id: string
   livemode: boolean
-  object: "radar.value_list_item" | UnknownEnumStringValue
+  object: "radar.value_list_item"
   value: string
   value_list: string
 }
@@ -11587,7 +11587,7 @@ export type t_radar_review_resource_session = {
 
 export type t_received_payment_method_details_financial_account = {
   id: string
-  network: "stripe" | UnknownEnumStringValue
+  network: "stripe"
 }
 
 export type t_recurring = {
@@ -11611,7 +11611,7 @@ export type t_refund = {
   instructions_email?: string
   metadata?: Record<string, string> | null
   next_action?: t_refund_next_action
-  object: "refund" | UnknownEnumStringValue
+  object: "refund"
   payment_intent?: string | t_payment_intent | null
   pending_reason?:
     | "charge_pending"
@@ -11751,7 +11751,7 @@ export type t_reporting_report_run = {
   error?: string | null
   id: string
   livemode: boolean
-  object: "reporting.report_run" | UnknownEnumStringValue
+  object: "reporting.report_run"
   parameters: t_financial_reporting_finance_report_run_run_parameters
   report_type: string
   result?: t_file | null
@@ -11766,7 +11766,7 @@ export type t_reporting_report_type = {
   id: string
   livemode: boolean
   name: string
-  object: "reporting.report_type" | UnknownEnumStringValue
+  object: "reporting.report_type"
   updated: number
   version: number
 }
@@ -11776,7 +11776,7 @@ export type t_reserve_transaction = {
   currency: string
   description?: string | null
   id: string
-  object: "reserve_transaction" | UnknownEnumStringValue
+  object: "reserve_transaction"
 }
 
 export type t_review = {
@@ -11796,7 +11796,7 @@ export type t_review = {
   ip_address?: string | null
   ip_address_location?: t_radar_review_resource_location | null
   livemode: boolean
-  object: "review" | UnknownEnumStringValue
+  object: "review"
   open: boolean
   opened_reason: "manual" | "rule" | UnknownEnumStringValue
   payment_intent?: string | t_payment_intent
@@ -11806,7 +11806,7 @@ export type t_review = {
 
 export type t_revolut_pay_underlying_payment_method_funding_details = {
   card?: t_payment_method_details_passthrough_card
-  type?: "card" | UnknownEnumStringValue | null
+  type?: "card" | null
 }
 
 export type t_rule = {
@@ -11822,7 +11822,7 @@ export type t_scheduled_query_run = {
   file?: t_file | null
   id: string
   livemode: boolean
-  object: "scheduled_query_run" | UnknownEnumStringValue
+  object: "scheduled_query_run"
   result_available_until: number
   sql: string
   status: string
@@ -11830,7 +11830,7 @@ export type t_scheduled_query_run = {
 }
 
 export type t_schedules_phase_automatic_tax = {
-  disabled_reason?: "requires_location_inputs" | UnknownEnumStringValue | null
+  disabled_reason?: "requires_location_inputs" | null
   enabled: boolean
   liability?: t_connect_account_reference | null
 }
@@ -11853,7 +11853,7 @@ export type t_setup_attempt = {
   flow_directions?: ("inbound" | "outbound" | UnknownEnumStringValue)[] | null
   id: string
   livemode: boolean
-  object: "setup_attempt" | UnknownEnumStringValue
+  object: "setup_attempt"
   on_behalf_of?: string | t_account | null
   payment_method: string | t_payment_method
   payment_method_details: t_setup_attempt_payment_method_details
@@ -12090,7 +12090,7 @@ export type t_setup_intent = {
   mandate?: string | t_mandate | null
   metadata?: Record<string, string> | null
   next_action?: t_setup_intent_next_action | null
-  object: "setup_intent" | UnknownEnumStringValue
+  object: "setup_intent"
   on_behalf_of?: string | t_account | null
   payment_method?: string | t_payment_method | null
   payment_method_configuration_details?: t_payment_method_config_biz_payment_method_configuration_details | null
@@ -12225,7 +12225,7 @@ export type t_setup_intent_payment_method_options_card_mandate_options = {
   interval_count?: number | null
   reference: string
   start_date: number
-  supported_types?: ("india" | UnknownEnumStringValue)[] | null
+  supported_types?: "india"[] | null
 }
 
 export type t_setup_intent_payment_method_options_card_present = Record<
@@ -12304,7 +12304,7 @@ export type t_shipping_rate = {
   id: string
   livemode: boolean
   metadata: Record<string, string>
-  object: "shipping_rate" | UnknownEnumStringValue
+  object: "shipping_rate"
   tax_behavior?:
     | "exclusive"
     | "inclusive"
@@ -12312,7 +12312,7 @@ export type t_shipping_rate = {
     | UnknownEnumStringValue
     | null
   tax_code?: string | t_tax_code | null
-  type: "fixed_amount" | UnknownEnumStringValue
+  type: "fixed_amount"
 }
 
 export type t_shipping_rate_currency_option = {
@@ -12351,7 +12351,7 @@ export type t_sigma_sigma_api_query = {
   id: string
   livemode: boolean
   name: string
-  object: "sigma.sigma_api_query" | UnknownEnumStringValue
+  object: "sigma.sigma_api_query"
   sql: string
 }
 
@@ -12389,7 +12389,7 @@ export type t_source = {
   livemode: boolean
   metadata?: Record<string, string> | null
   multibanco?: t_source_type_multibanco
-  object: "source" | UnknownEnumStringValue
+  object: "source"
   owner?: t_source_owner | null
   p24?: t_source_type_p24
   receiver?: t_source_receiver_flow
@@ -12436,7 +12436,7 @@ export type t_source_mandate_notification = {
   created: number
   id: string
   livemode: boolean
-  object: "source_mandate_notification" | UnknownEnumStringValue
+  object: "source_mandate_notification"
   reason: string
   sepa_debit?: t_source_mandate_notification_sepa_debit_data
   source: t_source
@@ -12511,7 +12511,7 @@ export type t_source_transaction = {
   gbp_credit_transfer?: t_source_transaction_gbp_credit_transfer_data
   id: string
   livemode: boolean
-  object: "source_transaction" | UnknownEnumStringValue
+  object: "source_transaction"
   paper_check?: t_source_transaction_paper_check_data
   sepa_credit_transfer?: t_source_transaction_sepa_credit_transfer_data
   source: string
@@ -12811,14 +12811,14 @@ export type t_subscription = {
   items: {
     data: t_subscription_item[]
     has_more: boolean
-    object: "list" | UnknownEnumStringValue
+    object: "list"
     url: string
   }
   latest_invoice?: string | t_invoice | null
   livemode: boolean
   metadata: Record<string, string>
   next_pending_invoice_item_invoice?: number | null
-  object: "subscription" | UnknownEnumStringValue
+  object: "subscription"
   on_behalf_of?: string | t_account | null
   pause_collection?: t_subscriptions_resource_pause_collection | null
   payment_settings?: t_subscriptions_resource_payment_settings | null
@@ -12845,7 +12845,7 @@ export type t_subscription = {
 }
 
 export type t_subscription_automatic_tax = {
-  disabled_reason?: "requires_location_inputs" | UnknownEnumStringValue | null
+  disabled_reason?: "requires_location_inputs" | null
   enabled: boolean
   liability?: t_connect_account_reference | null
 }
@@ -12863,7 +12863,7 @@ export type t_subscription_item = {
   discounts: (string | t_discount)[]
   id: string
   metadata: Record<string, string>
-  object: "subscription_item" | UnknownEnumStringValue
+  object: "subscription_item"
   price: t_price
   quantity?: number
   subscription: string
@@ -12918,7 +12918,7 @@ export type t_subscription_schedule = {
   id: string
   livemode: boolean
   metadata?: Record<string, string> | null
-  object: "subscription_schedule" | UnknownEnumStringValue
+  object: "subscription_schedule"
   phases: t_subscription_schedule_phase_configuration[]
   released_at?: number | null
   released_subscription?: string | null
@@ -13007,7 +13007,7 @@ export type t_subscription_schedules_resource_default_settings = {
 }
 
 export type t_subscription_schedules_resource_default_settings_automatic_tax = {
-  disabled_reason?: "requires_location_inputs" | UnknownEnumStringValue | null
+  disabled_reason?: "requires_location_inputs" | null
   enabled: boolean
   liability?: t_connect_account_reference | null
 }
@@ -13137,11 +13137,11 @@ export type t_tax_calculation = {
   line_items?: {
     data: t_tax_calculation_line_item[]
     has_more: boolean
-    object: "list" | UnknownEnumStringValue
+    object: "list"
     url: string
   } | null
   livemode: boolean
-  object: "tax.calculation" | UnknownEnumStringValue
+  object: "tax.calculation"
   ship_from_details?: t_tax_product_resource_ship_from_details | null
   shipping_cost?: t_tax_product_resource_tax_calculation_shipping_cost | null
   tax_amount_exclusive: number
@@ -13156,7 +13156,7 @@ export type t_tax_calculation_line_item = {
   id: string
   livemode: boolean
   metadata?: Record<string, string> | null
-  object: "tax.calculation_line_item" | UnknownEnumStringValue
+  object: "tax.calculation_line_item"
   product?: string | null
   quantity: number
   reference: string
@@ -13173,7 +13173,7 @@ export type t_tax_registration = {
   expires_at?: number | null
   id: string
   livemode: boolean
-  object: "tax.registration" | UnknownEnumStringValue
+  object: "tax.registration"
   status: "active" | "expired" | "scheduled" | UnknownEnumStringValue
 }
 
@@ -13181,7 +13181,7 @@ export type t_tax_settings = {
   defaults: t_tax_product_resource_tax_settings_defaults
   head_office?: t_tax_product_resource_tax_settings_head_office | null
   livemode: boolean
-  object: "tax.settings" | UnknownEnumStringValue
+  object: "tax.settings"
   status: "active" | "pending" | UnknownEnumStringValue
   status_details: t_tax_product_resource_tax_settings_status_details
 }
@@ -13195,12 +13195,12 @@ export type t_tax_transaction = {
   line_items?: {
     data: t_tax_transaction_line_item[]
     has_more: boolean
-    object: "list" | UnknownEnumStringValue
+    object: "list"
     url: string
   } | null
   livemode: boolean
   metadata?: Record<string, string> | null
-  object: "tax.transaction" | UnknownEnumStringValue
+  object: "tax.transaction"
   posted_at: number
   reference: string
   reversal?: t_tax_product_resource_tax_transaction_resource_reversal | null
@@ -13216,7 +13216,7 @@ export type t_tax_transaction_line_item = {
   id: string
   livemode: boolean
   metadata?: Record<string, string> | null
-  object: "tax.transaction_line_item" | UnknownEnumStringValue
+  object: "tax.transaction_line_item"
   product?: string | null
   quantity: number
   reference: string
@@ -13230,12 +13230,12 @@ export type t_tax_code = {
   description: string
   id: string
   name: string
-  object: "tax_code" | UnknownEnumStringValue
+  object: "tax_code"
 }
 
 export type t_tax_deducted_at_source = {
   id: string
-  object: "tax_deducted_at_source" | UnknownEnumStringValue
+  object: "tax_deducted_at_source"
   period_end: number
   period_start: number
   tax_deduction_account_number: string
@@ -13254,7 +13254,7 @@ export type t_tax_id = {
   customer?: string | t_customer | null
   id: string
   livemode: boolean
-  object: "tax_id" | UnknownEnumStringValue
+  object: "tax_id"
   owner?: t_tax_i_ds_owner | null
   type:
     | "ad_nrt"
@@ -13497,13 +13497,13 @@ export type t_tax_product_registrations_resource_country_options_canada = {
 }
 
 export type t_tax_product_registrations_resource_country_options_default = {
-  type: "standard" | UnknownEnumStringValue
+  type: "standard"
 }
 
 export type t_tax_product_registrations_resource_country_options_default_inbound_goods =
   {
     standard?: t_tax_product_registrations_resource_country_options_default_standard
-    type: "standard" | UnknownEnumStringValue
+    type: "standard"
   }
 
 export type t_tax_product_registrations_resource_country_options_default_standard =
@@ -13533,7 +13533,7 @@ export type t_tax_product_registrations_resource_country_options_europe = {
 }
 
 export type t_tax_product_registrations_resource_country_options_simplified = {
-  type: "simplified" | UnknownEnumStringValue
+  type: "simplified"
 }
 
 export type t_tax_product_registrations_resource_country_options_united_states =
@@ -13901,7 +13901,7 @@ export type t_tax_rate = {
     | null
   livemode: boolean
   metadata?: Record<string, string> | null
-  object: "tax_rate" | UnknownEnumStringValue
+  object: "tax_rate"
   percentage: number
   rate_type?: "flat_amount" | "percentage" | UnknownEnumStringValue | null
   state?: string | null
@@ -13935,7 +13935,7 @@ export type t_terminal_configuration = {
   is_account_default?: boolean | null
   livemode: boolean
   name?: string | null
-  object: "terminal.configuration" | UnknownEnumStringValue
+  object: "terminal.configuration"
   offline?: t_terminal_configuration_configuration_resource_offline_config
   reboot_window?: t_terminal_configuration_configuration_resource_reboot_window
   stripe_s700?: t_terminal_configuration_configuration_resource_device_type_specific_config
@@ -13946,7 +13946,7 @@ export type t_terminal_configuration = {
 
 export type t_terminal_connection_token = {
   location?: string
-  object: "terminal.connection_token" | UnknownEnumStringValue
+  object: "terminal.connection_token"
   secret: string
 }
 
@@ -13957,7 +13957,7 @@ export type t_terminal_location = {
   id: string
   livemode: boolean
   metadata: Record<string, string>
-  object: "terminal.location" | UnknownEnumStringValue
+  object: "terminal.location"
 }
 
 export type t_terminal_reader = {
@@ -13980,7 +13980,7 @@ export type t_terminal_reader = {
   livemode: boolean
   location?: string | t_terminal_location | null
   metadata: Record<string, string>
-  object: "terminal.reader" | UnknownEnumStringValue
+  object: "terminal.reader"
   serial_number: string
   status?: "offline" | "online" | UnknownEnumStringValue | null
 }
@@ -14220,7 +14220,7 @@ export type t_terminal_reader_reader_resource_selection = {
 
 export type t_terminal_reader_reader_resource_set_reader_display_action = {
   cart?: t_terminal_reader_reader_resource_cart | null
-  type: "cart" | UnknownEnumStringValue
+  type: "cart"
 }
 
 export type t_terminal_reader_reader_resource_signature = {
@@ -14249,7 +14249,7 @@ export type t_test_helpers_test_clock = {
   id: string
   livemode: boolean
   name?: string | null
-  object: "test_helpers.test_clock" | UnknownEnumStringValue
+  object: "test_helpers.test_clock"
   status: "advancing" | "internal_failure" | "ready" | UnknownEnumStringValue
   status_details: t_billing_clocks_resource_status_details_status_details
 }
@@ -14336,14 +14336,14 @@ export type t_three_d_secure_usage = {
 
 export type t_thresholds_resource_usage_alert_filter = {
   customer?: string | t_customer | null
-  type: "customer" | UnknownEnumStringValue
+  type: "customer"
 }
 
 export type t_thresholds_resource_usage_threshold_config = {
   filters?: t_thresholds_resource_usage_alert_filter[] | null
   gte: number
   meter: string | t_billing_meter
-  recurrence: "one_time" | UnknownEnumStringValue
+  recurrence: "one_time"
 }
 
 export type t_token = {
@@ -14353,7 +14353,7 @@ export type t_token = {
   created: number
   id: string
   livemode: boolean
-  object: "token" | UnknownEnumStringValue
+  object: "token"
   type: string
   used: boolean
 }
@@ -14374,7 +14374,7 @@ export type t_topup = {
   id: string
   livemode: boolean
   metadata: Record<string, string>
-  object: "topup" | UnknownEnumStringValue
+  object: "topup"
   source?: t_source | null
   statement_descriptor?: string | null
   status:
@@ -14399,11 +14399,11 @@ export type t_transfer = {
   id: string
   livemode: boolean
   metadata: Record<string, string>
-  object: "transfer" | UnknownEnumStringValue
+  object: "transfer"
   reversals: {
     data: t_transfer_reversal[]
     has_more: boolean
-    object: "list" | UnknownEnumStringValue
+    object: "list"
     url: string
   }
   reversed: boolean
@@ -14425,7 +14425,7 @@ export type t_transfer_reversal = {
   destination_payment_refund?: string | t_refund | null
   id: string
   metadata?: Record<string, string> | null
-  object: "transfer_reversal" | UnknownEnumStringValue
+  object: "transfer_reversal"
   source_refund?: string | t_refund | null
   transfer: string | t_transfer
 }
@@ -14468,7 +14468,7 @@ export type t_treasury_credit_reversal = {
   livemode: boolean
   metadata: Record<string, string>
   network: "ach" | "stripe" | UnknownEnumStringValue
-  object: "treasury.credit_reversal" | UnknownEnumStringValue
+  object: "treasury.credit_reversal"
   received_credit: string
   status: "canceled" | "posted" | "processing" | UnknownEnumStringValue
   status_transitions: t_treasury_received_credits_resource_status_transitions
@@ -14486,7 +14486,7 @@ export type t_treasury_debit_reversal = {
   livemode: boolean
   metadata: Record<string, string>
   network: "ach" | "card" | UnknownEnumStringValue
-  object: "treasury.debit_reversal" | UnknownEnumStringValue
+  object: "treasury.debit_reversal"
   received_debit: string
   status: "failed" | "processing" | "succeeded" | UnknownEnumStringValue
   status_transitions: t_treasury_received_debits_resource_status_transitions
@@ -14518,7 +14518,7 @@ export type t_treasury_financial_account = {
   livemode: boolean
   metadata?: Record<string, string> | null
   nickname?: string | null
-  object: "treasury.financial_account" | UnknownEnumStringValue
+  object: "treasury.financial_account"
   pending_features?: (
     | "card_issuing"
     | "deposit_insurance"
@@ -14559,7 +14559,7 @@ export type t_treasury_financial_account_features = {
   financial_addresses?: t_treasury_financial_accounts_resource_financial_addresses_features
   inbound_transfers?: t_treasury_financial_accounts_resource_inbound_transfers
   intra_stripe_flows?: t_treasury_financial_accounts_resource_toggle_settings
-  object: "treasury.financial_account_features" | UnknownEnumStringValue
+  object: "treasury.financial_account_features"
   outbound_payments?: t_treasury_financial_accounts_resource_outbound_payments
   outbound_transfers?: t_treasury_financial_accounts_resource_outbound_transfers
 }
@@ -14577,7 +14577,7 @@ export type t_treasury_inbound_transfer = {
   linked_flows: t_treasury_inbound_transfers_resource_inbound_transfer_resource_linked_flows
   livemode: boolean
   metadata: Record<string, string>
-  object: "treasury.inbound_transfer" | UnknownEnumStringValue
+  object: "treasury.inbound_transfer"
   origin_payment_method?: string | null
   origin_payment_method_details?: t_inbound_transfers | null
   returned?: boolean | null
@@ -14608,7 +14608,7 @@ export type t_treasury_outbound_payment = {
   id: string
   livemode: boolean
   metadata: Record<string, string>
-  object: "treasury.outbound_payment" | UnknownEnumStringValue
+  object: "treasury.outbound_payment"
   returned_details?: t_treasury_outbound_payments_resource_returned_status | null
   statement_descriptor: string
   status:
@@ -14637,7 +14637,7 @@ export type t_treasury_outbound_transfer = {
   id: string
   livemode: boolean
   metadata: Record<string, string>
-  object: "treasury.outbound_transfer" | UnknownEnumStringValue
+  object: "treasury.outbound_transfer"
   returned_details?: t_treasury_outbound_transfers_resource_returned_details | null
   statement_descriptor: string
   status:
@@ -14676,7 +14676,7 @@ export type t_treasury_received_credit = {
     | "stripe"
     | "us_domestic_wire"
     | UnknownEnumStringValue
-  object: "treasury.received_credit" | UnknownEnumStringValue
+  object: "treasury.received_credit"
   reversal_details?: t_treasury_received_credits_resource_reversal_details | null
   status: "failed" | "succeeded" | UnknownEnumStringValue
   transaction?: string | t_treasury_transaction | null
@@ -14702,7 +14702,7 @@ export type t_treasury_received_debit = {
   linked_flows: t_treasury_received_debits_resource_linked_flows
   livemode: boolean
   network: "ach" | "card" | "stripe" | UnknownEnumStringValue
-  object: "treasury.received_debit" | UnknownEnumStringValue
+  object: "treasury.received_debit"
   reversal_details?: t_treasury_received_debits_resource_reversal_details | null
   status: "failed" | "succeeded" | UnknownEnumStringValue
   transaction?: string | t_treasury_transaction | null
@@ -14717,7 +14717,7 @@ export type t_treasury_transaction = {
   entries?: {
     data: t_treasury_transaction_entry[]
     has_more: boolean
-    object: "list" | UnknownEnumStringValue
+    object: "list"
     url: string
   } | null
   financial_account: string
@@ -14736,7 +14736,7 @@ export type t_treasury_transaction = {
     | UnknownEnumStringValue
   id: string
   livemode: boolean
-  object: "treasury.transaction" | UnknownEnumStringValue
+  object: "treasury.transaction"
   status: "open" | "posted" | "void" | UnknownEnumStringValue
   status_transitions: t_treasury_transactions_resource_abstract_transaction_resource_status_transitions
 }
@@ -14762,7 +14762,7 @@ export type t_treasury_transaction_entry = {
     | UnknownEnumStringValue
   id: string
   livemode: boolean
-  object: "treasury.transaction_entry" | UnknownEnumStringValue
+  object: "treasury.transaction_entry"
   transaction: string | t_treasury_transaction
   type:
     | "credit_reversal"
@@ -14820,7 +14820,7 @@ export type t_treasury_financial_accounts_resource_closed_status_details = {
 export type t_treasury_financial_accounts_resource_financial_address = {
   aba?: t_treasury_financial_accounts_resource_aba_record
   supported_networks?: ("ach" | "us_domestic_wire" | UnknownEnumStringValue)[]
-  type: "aba" | UnknownEnumStringValue
+  type: "aba"
 }
 
 export type t_treasury_financial_accounts_resource_financial_addresses_features =
@@ -15087,7 +15087,7 @@ export type t_treasury_shared_resource_billing_details = {
 
 export type t_treasury_shared_resource_initiating_payment_method_details_initiating_payment_method_details =
   {
-    balance?: "payments" | UnknownEnumStringValue
+    balance?: "payments"
     billing_details: t_treasury_shared_resource_billing_details
     financial_account?: t_received_payment_method_details_financial_account
     issuing_card?: string
@@ -15160,7 +15160,7 @@ export type t_webhook_endpoint = {
   id: string
   livemode: boolean
   metadata: Record<string, string>
-  object: "webhook_endpoint" | UnknownEnumStringValue
+  object: "webhook_endpoint"
   secret?: string
   status: string
   url: string
@@ -15201,7 +15201,7 @@ export type t_DeleteSubscriptionItemsItemRequestBody = {
 
 export type t_DeleteSubscriptionsSubscriptionExposedIdRequestBody = {
   cancellation_details?: {
-    comment?: string | "" | UnknownEnumStringValue
+    comment?: string | ""
     feedback?:
       | ""
       | "customer_service"
@@ -15393,7 +15393,7 @@ export type t_PostAccountsRequestBody = {
             files?: string[]
           }
         }
-        object?: "bank_account" | UnknownEnumStringValue
+        object?: "bank_account"
         routing_number?: string
       }
     | string
@@ -15429,7 +15429,7 @@ export type t_PostAccountsRequestBody = {
     }
     support_email?: string
     support_phone?: string
-    support_url?: string | "" | UnknownEnumStringValue
+    support_url?: string | ""
     url?: string
   }
   business_type?:
@@ -15675,7 +15675,6 @@ export type t_PostAccountsRequestBody = {
           year: number
         }
       | ""
-      | UnknownEnumStringValue
     registration_number?: string
     structure?:
       | ""
@@ -15760,7 +15759,7 @@ export type t_PostAccountsRequestBody = {
   expand?: string[]
   external_account?: string
   groups?: {
-    payments_pricing?: string | "" | UnknownEnumStringValue
+    payments_pricing?: string | ""
   }
   individual?: {
     address?: {
@@ -15796,12 +15795,11 @@ export type t_PostAccountsRequestBody = {
           year: number
         }
       | ""
-      | UnknownEnumStringValue
     email?: string
     first_name?: string
     first_name_kana?: string
     first_name_kanji?: string
-    full_name_aliases?: string[] | "" | UnknownEnumStringValue
+    full_name_aliases?: string[] | ""
     gender?: string
     id_number?: string
     id_number_secondary?: string
@@ -15809,7 +15807,7 @@ export type t_PostAccountsRequestBody = {
     last_name_kana?: string
     last_name_kanji?: string
     maiden_name?: string
-    metadata?: Record<string, string> | "" | UnknownEnumStringValue
+    metadata?: Record<string, string> | ""
     phone?: string
     political_exposure?: "existing" | "none" | UnknownEnumStringValue
     registered_address?: {
@@ -15824,7 +15822,7 @@ export type t_PostAccountsRequestBody = {
       director?: boolean
       executive?: boolean
       owner?: boolean
-      percent_ownership?: number | "" | UnknownEnumStringValue
+      percent_ownership?: number | ""
       title?: string
     }
     ssn_last_4?: string
@@ -15839,7 +15837,7 @@ export type t_PostAccountsRequestBody = {
       }
     }
   }
-  metadata?: Record<string, string> | "" | UnknownEnumStringValue
+  metadata?: Record<string, string> | ""
   settings?: {
     bacs_debit_payments?: {
       display_name?: string
@@ -15854,7 +15852,7 @@ export type t_PostAccountsRequestBody = {
       tos_acceptance?: {
         date?: number
         ip?: string
-        user_agent?: string | "" | UnknownEnumStringValue
+        user_agent?: string | ""
       }
     }
     card_payments?: {
@@ -15863,8 +15861,8 @@ export type t_PostAccountsRequestBody = {
         cvc_failure?: boolean
       }
       statement_descriptor_prefix?: string
-      statement_descriptor_prefix_kana?: string | "" | UnknownEnumStringValue
-      statement_descriptor_prefix_kanji?: string | "" | UnknownEnumStringValue
+      statement_descriptor_prefix_kana?: string | ""
+      statement_descriptor_prefix_kanji?: string | ""
     }
     invoices?: {
       hosted_payment_method_save?:
@@ -15881,7 +15879,7 @@ export type t_PostAccountsRequestBody = {
     payouts?: {
       debit_negative_balances?: boolean
       schedule?: {
-        delay_days?: "minimum" | UnknownEnumStringValue | number
+        delay_days?: "minimum" | number
         interval?:
           | "daily"
           | "manual"
@@ -15916,7 +15914,7 @@ export type t_PostAccountsRequestBody = {
       tos_acceptance?: {
         date?: number
         ip?: string
-        user_agent?: string | "" | UnknownEnumStringValue
+        user_agent?: string | ""
       }
     }
   }
@@ -15963,7 +15961,7 @@ export type t_PostAccountsAccountRequestBody = {
     }
     support_email?: string
     support_phone?: string
-    support_url?: string | "" | UnknownEnumStringValue
+    support_url?: string | ""
     url?: string
   }
   business_type?:
@@ -16209,7 +16207,6 @@ export type t_PostAccountsAccountRequestBody = {
           year: number
         }
       | ""
-      | UnknownEnumStringValue
     registration_number?: string
     structure?:
       | ""
@@ -16281,7 +16278,7 @@ export type t_PostAccountsAccountRequestBody = {
   expand?: string[]
   external_account?: string
   groups?: {
-    payments_pricing?: string | "" | UnknownEnumStringValue
+    payments_pricing?: string | ""
   }
   individual?: {
     address?: {
@@ -16317,12 +16314,11 @@ export type t_PostAccountsAccountRequestBody = {
           year: number
         }
       | ""
-      | UnknownEnumStringValue
     email?: string
     first_name?: string
     first_name_kana?: string
     first_name_kanji?: string
-    full_name_aliases?: string[] | "" | UnknownEnumStringValue
+    full_name_aliases?: string[] | ""
     gender?: string
     id_number?: string
     id_number_secondary?: string
@@ -16330,7 +16326,7 @@ export type t_PostAccountsAccountRequestBody = {
     last_name_kana?: string
     last_name_kanji?: string
     maiden_name?: string
-    metadata?: Record<string, string> | "" | UnknownEnumStringValue
+    metadata?: Record<string, string> | ""
     phone?: string
     political_exposure?: "existing" | "none" | UnknownEnumStringValue
     registered_address?: {
@@ -16345,7 +16341,7 @@ export type t_PostAccountsAccountRequestBody = {
       director?: boolean
       executive?: boolean
       owner?: boolean
-      percent_ownership?: number | "" | UnknownEnumStringValue
+      percent_ownership?: number | ""
       title?: string
     }
     ssn_last_4?: string
@@ -16360,7 +16356,7 @@ export type t_PostAccountsAccountRequestBody = {
       }
     }
   }
-  metadata?: Record<string, string> | "" | UnknownEnumStringValue
+  metadata?: Record<string, string> | ""
   settings?: {
     bacs_debit_payments?: {
       display_name?: string
@@ -16375,7 +16371,7 @@ export type t_PostAccountsAccountRequestBody = {
       tos_acceptance?: {
         date?: number
         ip?: string
-        user_agent?: string | "" | UnknownEnumStringValue
+        user_agent?: string | ""
       }
     }
     card_payments?: {
@@ -16384,11 +16380,11 @@ export type t_PostAccountsAccountRequestBody = {
         cvc_failure?: boolean
       }
       statement_descriptor_prefix?: string
-      statement_descriptor_prefix_kana?: string | "" | UnknownEnumStringValue
-      statement_descriptor_prefix_kanji?: string | "" | UnknownEnumStringValue
+      statement_descriptor_prefix_kana?: string | ""
+      statement_descriptor_prefix_kanji?: string | ""
     }
     invoices?: {
-      default_account_tax_ids?: string[] | "" | UnknownEnumStringValue
+      default_account_tax_ids?: string[] | ""
       hosted_payment_method_save?:
         | "always"
         | "never"
@@ -16403,7 +16399,7 @@ export type t_PostAccountsAccountRequestBody = {
     payouts?: {
       debit_negative_balances?: boolean
       schedule?: {
-        delay_days?: "minimum" | UnknownEnumStringValue | number
+        delay_days?: "minimum" | number
         interval?:
           | "daily"
           | "manual"
@@ -16438,7 +16434,7 @@ export type t_PostAccountsAccountRequestBody = {
       tos_acceptance?: {
         date?: number
         ip?: string
-        user_agent?: string | "" | UnknownEnumStringValue
+        user_agent?: string | ""
       }
     }
   }
@@ -16469,7 +16465,7 @@ export type t_PostAccountsAccountBankAccountsRequestBody = {
             files?: string[]
           }
         }
-        object?: "bank_account" | UnknownEnumStringValue
+        object?: "bank_account"
         routing_number?: string
       }
     | string
@@ -16503,7 +16499,7 @@ export type t_PostAccountsAccountBankAccountsIdRequestBody = {
   exp_month?: string
   exp_year?: string
   expand?: string[]
-  metadata?: Record<string, string> | "" | UnknownEnumStringValue
+  metadata?: Record<string, string> | ""
   name?: string
 }
 
@@ -16531,7 +16527,7 @@ export type t_PostAccountsAccountExternalAccountsRequestBody = {
             files?: string[]
           }
         }
-        object?: "bank_account" | UnknownEnumStringValue
+        object?: "bank_account"
         routing_number?: string
       }
     | string
@@ -16565,7 +16561,7 @@ export type t_PostAccountsAccountExternalAccountsIdRequestBody = {
   exp_month?: string
   exp_year?: string
   expand?: string[]
-  metadata?: Record<string, string> | "" | UnknownEnumStringValue
+  metadata?: Record<string, string> | ""
   name?: string
 }
 
@@ -16578,7 +16574,7 @@ export type t_PostAccountsAccountPeopleRequestBody = {
     account?: {
       date?: number
       ip?: string
-      user_agent?: string | "" | UnknownEnumStringValue
+      user_agent?: string | ""
     }
   }
   address?: {
@@ -16614,16 +16610,15 @@ export type t_PostAccountsAccountPeopleRequestBody = {
         year: number
       }
     | ""
-    | UnknownEnumStringValue
   documents?: {
     company_authorization?: {
-      files?: (string | "" | UnknownEnumStringValue)[]
+      files?: (string | "")[]
     }
     passport?: {
-      files?: (string | "" | UnknownEnumStringValue)[]
+      files?: (string | "")[]
     }
     visa?: {
-      files?: (string | "" | UnknownEnumStringValue)[]
+      files?: (string | "")[]
     }
   }
   email?: string
@@ -16631,7 +16626,7 @@ export type t_PostAccountsAccountPeopleRequestBody = {
   first_name?: string
   first_name_kana?: string
   first_name_kanji?: string
-  full_name_aliases?: string[] | "" | UnknownEnumStringValue
+  full_name_aliases?: string[] | ""
   gender?: string
   id_number?: string
   id_number_secondary?: string
@@ -16639,7 +16634,7 @@ export type t_PostAccountsAccountPeopleRequestBody = {
   last_name_kana?: string
   last_name_kanji?: string
   maiden_name?: string
-  metadata?: Record<string, string> | "" | UnknownEnumStringValue
+  metadata?: Record<string, string> | ""
   nationality?: string
   person_token?: string
   phone?: string
@@ -16658,7 +16653,7 @@ export type t_PostAccountsAccountPeopleRequestBody = {
     executive?: boolean
     legal_guardian?: boolean
     owner?: boolean
-    percent_ownership?: number | "" | UnknownEnumStringValue
+    percent_ownership?: number | ""
     representative?: boolean
     title?: string
   }
@@ -16726,7 +16721,7 @@ export type t_PostAccountsAccountPeoplePersonRequestBody = {
     account?: {
       date?: number
       ip?: string
-      user_agent?: string | "" | UnknownEnumStringValue
+      user_agent?: string | ""
     }
   }
   address?: {
@@ -16762,16 +16757,15 @@ export type t_PostAccountsAccountPeoplePersonRequestBody = {
         year: number
       }
     | ""
-    | UnknownEnumStringValue
   documents?: {
     company_authorization?: {
-      files?: (string | "" | UnknownEnumStringValue)[]
+      files?: (string | "")[]
     }
     passport?: {
-      files?: (string | "" | UnknownEnumStringValue)[]
+      files?: (string | "")[]
     }
     visa?: {
-      files?: (string | "" | UnknownEnumStringValue)[]
+      files?: (string | "")[]
     }
   }
   email?: string
@@ -16779,7 +16773,7 @@ export type t_PostAccountsAccountPeoplePersonRequestBody = {
   first_name?: string
   first_name_kana?: string
   first_name_kanji?: string
-  full_name_aliases?: string[] | "" | UnknownEnumStringValue
+  full_name_aliases?: string[] | ""
   gender?: string
   id_number?: string
   id_number_secondary?: string
@@ -16787,7 +16781,7 @@ export type t_PostAccountsAccountPeoplePersonRequestBody = {
   last_name_kana?: string
   last_name_kanji?: string
   maiden_name?: string
-  metadata?: Record<string, string> | "" | UnknownEnumStringValue
+  metadata?: Record<string, string> | ""
   nationality?: string
   person_token?: string
   phone?: string
@@ -16806,7 +16800,7 @@ export type t_PostAccountsAccountPeoplePersonRequestBody = {
     executive?: boolean
     legal_guardian?: boolean
     owner?: boolean
-    percent_ownership?: number | "" | UnknownEnumStringValue
+    percent_ownership?: number | ""
     representative?: boolean
     title?: string
   }
@@ -16874,7 +16868,7 @@ export type t_PostAccountsAccountPersonsRequestBody = {
     account?: {
       date?: number
       ip?: string
-      user_agent?: string | "" | UnknownEnumStringValue
+      user_agent?: string | ""
     }
   }
   address?: {
@@ -16910,16 +16904,15 @@ export type t_PostAccountsAccountPersonsRequestBody = {
         year: number
       }
     | ""
-    | UnknownEnumStringValue
   documents?: {
     company_authorization?: {
-      files?: (string | "" | UnknownEnumStringValue)[]
+      files?: (string | "")[]
     }
     passport?: {
-      files?: (string | "" | UnknownEnumStringValue)[]
+      files?: (string | "")[]
     }
     visa?: {
-      files?: (string | "" | UnknownEnumStringValue)[]
+      files?: (string | "")[]
     }
   }
   email?: string
@@ -16927,7 +16920,7 @@ export type t_PostAccountsAccountPersonsRequestBody = {
   first_name?: string
   first_name_kana?: string
   first_name_kanji?: string
-  full_name_aliases?: string[] | "" | UnknownEnumStringValue
+  full_name_aliases?: string[] | ""
   gender?: string
   id_number?: string
   id_number_secondary?: string
@@ -16935,7 +16928,7 @@ export type t_PostAccountsAccountPersonsRequestBody = {
   last_name_kana?: string
   last_name_kanji?: string
   maiden_name?: string
-  metadata?: Record<string, string> | "" | UnknownEnumStringValue
+  metadata?: Record<string, string> | ""
   nationality?: string
   person_token?: string
   phone?: string
@@ -16954,7 +16947,7 @@ export type t_PostAccountsAccountPersonsRequestBody = {
     executive?: boolean
     legal_guardian?: boolean
     owner?: boolean
-    percent_ownership?: number | "" | UnknownEnumStringValue
+    percent_ownership?: number | ""
     representative?: boolean
     title?: string
   }
@@ -17022,7 +17015,7 @@ export type t_PostAccountsAccountPersonsPersonRequestBody = {
     account?: {
       date?: number
       ip?: string
-      user_agent?: string | "" | UnknownEnumStringValue
+      user_agent?: string | ""
     }
   }
   address?: {
@@ -17058,16 +17051,15 @@ export type t_PostAccountsAccountPersonsPersonRequestBody = {
         year: number
       }
     | ""
-    | UnknownEnumStringValue
   documents?: {
     company_authorization?: {
-      files?: (string | "" | UnknownEnumStringValue)[]
+      files?: (string | "")[]
     }
     passport?: {
-      files?: (string | "" | UnknownEnumStringValue)[]
+      files?: (string | "")[]
     }
     visa?: {
-      files?: (string | "" | UnknownEnumStringValue)[]
+      files?: (string | "")[]
     }
   }
   email?: string
@@ -17075,7 +17067,7 @@ export type t_PostAccountsAccountPersonsPersonRequestBody = {
   first_name?: string
   first_name_kana?: string
   first_name_kanji?: string
-  full_name_aliases?: string[] | "" | UnknownEnumStringValue
+  full_name_aliases?: string[] | ""
   gender?: string
   id_number?: string
   id_number_secondary?: string
@@ -17083,7 +17075,7 @@ export type t_PostAccountsAccountPersonsPersonRequestBody = {
   last_name_kana?: string
   last_name_kanji?: string
   maiden_name?: string
-  metadata?: Record<string, string> | "" | UnknownEnumStringValue
+  metadata?: Record<string, string> | ""
   nationality?: string
   person_token?: string
   phone?: string
@@ -17102,7 +17094,7 @@ export type t_PostAccountsAccountPersonsPersonRequestBody = {
     executive?: boolean
     legal_guardian?: boolean
     owner?: boolean
-    percent_ownership?: number | "" | UnknownEnumStringValue
+    percent_ownership?: number | ""
     representative?: boolean
     title?: string
   }
@@ -17177,7 +17169,7 @@ export type t_PostApplePayDomainsRequestBody = {
 
 export type t_PostApplicationFeesFeeRefundsIdRequestBody = {
   expand?: string[]
-  metadata?: Record<string, string> | "" | UnknownEnumStringValue
+  metadata?: Record<string, string> | ""
 }
 
 export type t_PostApplicationFeesIdRefundRequestBody = {
@@ -17213,17 +17205,17 @@ export type t_PostAppsSecretsDeleteRequestBody = {
 }
 
 export type t_PostBillingAlertsRequestBody = {
-  alert_type: "usage_threshold" | UnknownEnumStringValue
+  alert_type: "usage_threshold"
   expand?: string[]
   title: string
   usage_threshold?: {
     filters?: {
       customer?: string
-      type: "customer" | UnknownEnumStringValue
+      type: "customer"
     }[]
     gte: number
     meter: string
-    recurrence: "one_time" | UnknownEnumStringValue
+    recurrence: "one_time"
   }
 }
 
@@ -17245,11 +17237,11 @@ export type t_PostBillingCreditGrantsRequestBody = {
       currency: string
       value: number
     }
-    type: "monetary" | UnknownEnumStringValue
+    type: "monetary"
   }
   applicability_config: {
     scope: {
-      price_type?: "metered" | UnknownEnumStringValue
+      price_type?: "metered"
       prices?: {
         id: string
       }[]
@@ -17267,7 +17259,7 @@ export type t_PostBillingCreditGrantsRequestBody = {
 
 export type t_PostBillingCreditGrantsIdRequestBody = {
   expand?: string[]
-  expires_at?: number | "" | UnknownEnumStringValue
+  expires_at?: number | ""
   metadata?: Record<string, string>
 }
 
@@ -17285,7 +17277,7 @@ export type t_PostBillingMeterEventAdjustmentsRequestBody = {
   }
   event_name: string
   expand?: string[]
-  type: "cancel" | UnknownEnumStringValue
+  type: "cancel"
 }
 
 export type t_PostBillingMeterEventsRequestBody = {
@@ -17299,7 +17291,7 @@ export type t_PostBillingMeterEventsRequestBody = {
 export type t_PostBillingMetersRequestBody = {
   customer_mapping?: {
     event_payload_key: string
-    type: "by_id" | UnknownEnumStringValue
+    type: "by_id"
   }
   default_aggregation: {
     formula: "count" | "last" | "sum" | UnknownEnumStringValue
@@ -17328,11 +17320,11 @@ export type t_PostBillingMetersIdReactivateRequestBody = {
 
 export type t_PostBillingPortalConfigurationsRequestBody = {
   business_profile?: {
-    headline?: string | "" | UnknownEnumStringValue
+    headline?: string | ""
     privacy_policy_url?: string
     terms_of_service_url?: string
   }
-  default_return_url?: string | "" | UnknownEnumStringValue
+  default_return_url?: string | ""
   expand?: string[]
   features: {
     customer_update?: {
@@ -17347,7 +17339,6 @@ export type t_PostBillingPortalConfigurationsRequestBody = {
             | UnknownEnumStringValue
           )[]
         | ""
-        | UnknownEnumStringValue
       enabled: boolean
     }
     invoice_history?: {
@@ -17372,7 +17363,6 @@ export type t_PostBillingPortalConfigurationsRequestBody = {
               | UnknownEnumStringValue
             )[]
           | ""
-          | UnknownEnumStringValue
       }
       enabled: boolean
       mode?: "at_period_end" | "immediately" | UnknownEnumStringValue
@@ -17386,7 +17376,6 @@ export type t_PostBillingPortalConfigurationsRequestBody = {
       default_allowed_updates?:
         | ("price" | "promotion_code" | "quantity" | UnknownEnumStringValue)[]
         | ""
-        | UnknownEnumStringValue
       enabled: boolean
       products?:
         | {
@@ -17399,7 +17388,6 @@ export type t_PostBillingPortalConfigurationsRequestBody = {
             product: string
           }[]
         | ""
-        | UnknownEnumStringValue
       proration_behavior?:
         | "always_invoice"
         | "create_prorations"
@@ -17424,11 +17412,11 @@ export type t_PostBillingPortalConfigurationsRequestBody = {
 export type t_PostBillingPortalConfigurationsConfigurationRequestBody = {
   active?: boolean
   business_profile?: {
-    headline?: string | "" | UnknownEnumStringValue
-    privacy_policy_url?: string | "" | UnknownEnumStringValue
-    terms_of_service_url?: string | "" | UnknownEnumStringValue
+    headline?: string | ""
+    privacy_policy_url?: string | ""
+    terms_of_service_url?: string | ""
   }
-  default_return_url?: string | "" | UnknownEnumStringValue
+  default_return_url?: string | ""
   expand?: string[]
   features?: {
     customer_update?: {
@@ -17443,7 +17431,6 @@ export type t_PostBillingPortalConfigurationsConfigurationRequestBody = {
             | UnknownEnumStringValue
           )[]
         | ""
-        | UnknownEnumStringValue
       enabled?: boolean
     }
     invoice_history?: {
@@ -17468,7 +17455,6 @@ export type t_PostBillingPortalConfigurationsConfigurationRequestBody = {
               | UnknownEnumStringValue
             )[]
           | ""
-          | UnknownEnumStringValue
       }
       enabled?: boolean
       mode?: "at_period_end" | "immediately" | UnknownEnumStringValue
@@ -17482,7 +17468,6 @@ export type t_PostBillingPortalConfigurationsConfigurationRequestBody = {
       default_allowed_updates?:
         | ("price" | "promotion_code" | "quantity" | UnknownEnumStringValue)[]
         | ""
-        | UnknownEnumStringValue
       enabled?: boolean
       products?:
         | {
@@ -17495,7 +17480,6 @@ export type t_PostBillingPortalConfigurationsConfigurationRequestBody = {
             product: string
           }[]
         | ""
-        | UnknownEnumStringValue
       proration_behavior?:
         | "always_invoice"
         | "create_prorations"
@@ -17510,14 +17494,13 @@ export type t_PostBillingPortalConfigurationsConfigurationRequestBody = {
                 | UnknownEnumStringValue
             }[]
           | ""
-          | UnknownEnumStringValue
       }
     }
   }
   login_page?: {
     enabled: boolean
   }
-  metadata?: Record<string, string> | "" | UnknownEnumStringValue
+  metadata?: Record<string, string> | ""
 }
 
 export type t_PostBillingPortalSessionsRequestBody = {
@@ -17543,7 +17526,7 @@ export type t_PostBillingPortalSessionsRequestBody = {
         coupon_offer: {
           coupon: string
         }
-        type: "coupon_offer" | UnknownEnumStringValue
+        type: "coupon_offer"
       }
       subscription: string
     }
@@ -17641,7 +17624,7 @@ export type t_PostChargesRequestBody = {
         metadata?: Record<string, string>
         name?: string
         number: string
-        object?: "card" | UnknownEnumStringValue
+        object?: "card"
       }
     | string
   currency?: string
@@ -17654,7 +17637,7 @@ export type t_PostChargesRequestBody = {
       }
     | string
   expand?: string[]
-  metadata?: Record<string, string> | "" | UnknownEnumStringValue
+  metadata?: Record<string, string> | ""
   on_behalf_of?: string
   radar_options?: {
     session?: string
@@ -17691,7 +17674,7 @@ export type t_PostChargesChargeRequestBody = {
   fraud_details?: {
     user_report: "" | "fraudulent" | "safe" | UnknownEnumStringValue
   }
-  metadata?: Record<string, string> | "" | UnknownEnumStringValue
+  metadata?: Record<string, string> | ""
   receipt_email?: string
   shipping?: {
     address: {
@@ -17743,40 +17726,40 @@ export type t_PostChargesChargeDisputeRequestBody = {
       | {
           visa_compelling_evidence_3?: {
             disputed_transaction?: {
-              customer_account_id?: string | "" | UnknownEnumStringValue
-              customer_device_fingerprint?: string | "" | UnknownEnumStringValue
-              customer_device_id?: string | "" | UnknownEnumStringValue
-              customer_email_address?: string | "" | UnknownEnumStringValue
-              customer_purchase_ip?: string | "" | UnknownEnumStringValue
+              customer_account_id?: string | ""
+              customer_device_fingerprint?: string | ""
+              customer_device_id?: string | ""
+              customer_email_address?: string | ""
+              customer_purchase_ip?: string | ""
               merchandise_or_services?:
                 | "merchandise"
                 | "services"
                 | UnknownEnumStringValue
-              product_description?: string | "" | UnknownEnumStringValue
+              product_description?: string | ""
               shipping_address?: {
-                city?: string | "" | UnknownEnumStringValue
-                country?: string | "" | UnknownEnumStringValue
-                line1?: string | "" | UnknownEnumStringValue
-                line2?: string | "" | UnknownEnumStringValue
-                postal_code?: string | "" | UnknownEnumStringValue
-                state?: string | "" | UnknownEnumStringValue
+                city?: string | ""
+                country?: string | ""
+                line1?: string | ""
+                line2?: string | ""
+                postal_code?: string | ""
+                state?: string | ""
               }
             }
             prior_undisputed_transactions?: {
               charge: string
-              customer_account_id?: string | "" | UnknownEnumStringValue
-              customer_device_fingerprint?: string | "" | UnknownEnumStringValue
-              customer_device_id?: string | "" | UnknownEnumStringValue
-              customer_email_address?: string | "" | UnknownEnumStringValue
-              customer_purchase_ip?: string | "" | UnknownEnumStringValue
-              product_description?: string | "" | UnknownEnumStringValue
+              customer_account_id?: string | ""
+              customer_device_fingerprint?: string | ""
+              customer_device_id?: string | ""
+              customer_email_address?: string | ""
+              customer_purchase_ip?: string | ""
+              product_description?: string | ""
               shipping_address?: {
-                city?: string | "" | UnknownEnumStringValue
-                country?: string | "" | UnknownEnumStringValue
-                line1?: string | "" | UnknownEnumStringValue
-                line2?: string | "" | UnknownEnumStringValue
-                postal_code?: string | "" | UnknownEnumStringValue
-                state?: string | "" | UnknownEnumStringValue
+                city?: string | ""
+                country?: string | ""
+                line1?: string | ""
+                line2?: string | ""
+                postal_code?: string | ""
+                state?: string | ""
               }
             }[]
           }
@@ -17785,7 +17768,6 @@ export type t_PostChargesChargeDisputeRequestBody = {
           }
         }
       | ""
-      | UnknownEnumStringValue
     product_description?: string
     receipt?: string
     refund_policy?: string
@@ -17802,7 +17784,7 @@ export type t_PostChargesChargeDisputeRequestBody = {
     uncategorized_text?: string
   }
   expand?: string[]
-  metadata?: Record<string, string> | "" | UnknownEnumStringValue
+  metadata?: Record<string, string> | ""
   submit?: boolean
 }
 
@@ -17814,7 +17796,7 @@ export type t_PostChargesChargeRefundRequestBody = {
   amount?: number
   expand?: string[]
   instructions_email?: string
-  metadata?: Record<string, string> | "" | UnknownEnumStringValue
+  metadata?: Record<string, string> | ""
   payment_intent?: string
   reason?:
     | "duplicate"
@@ -17831,8 +17813,8 @@ export type t_PostChargesChargeRefundsRequestBody = {
   customer?: string
   expand?: string[]
   instructions_email?: string
-  metadata?: Record<string, string> | "" | UnknownEnumStringValue
-  origin?: "customer_balance" | UnknownEnumStringValue
+  metadata?: Record<string, string> | ""
+  origin?: "customer_balance"
   payment_intent?: string
   reason?:
     | "duplicate"
@@ -17845,7 +17827,7 @@ export type t_PostChargesChargeRefundsRequestBody = {
 
 export type t_PostChargesChargeRefundsRefundRequestBody = {
   expand?: string[]
-  metadata?: Record<string, string> | "" | UnknownEnumStringValue
+  metadata?: Record<string, string> | ""
 }
 
 export type t_PostCheckoutSessionsRequestBody = {
@@ -17888,7 +17870,7 @@ export type t_PostCheckoutSessionsRequestBody = {
     key: string
     label: {
       custom: string
-      type: "custom" | UnknownEnumStringValue
+      type: "custom"
     }
     numeric?: {
       default_value?: string
@@ -17909,25 +17891,21 @@ export type t_PostCheckoutSessionsRequestBody = {
           message: string
         }
       | ""
-      | UnknownEnumStringValue
     shipping_address?:
       | {
           message: string
         }
       | ""
-      | UnknownEnumStringValue
     submit?:
       | {
           message: string
         }
       | ""
-      | UnknownEnumStringValue
     terms_of_service_acceptance?:
       | {
           message: string
         }
       | ""
-      | UnknownEnumStringValue
   }
   customer?: string
   customer_creation?: "always" | "if_required" | UnknownEnumStringValue
@@ -17946,14 +17924,13 @@ export type t_PostCheckoutSessionsRequestBody = {
   invoice_creation?: {
     enabled: boolean
     invoice_data?: {
-      account_tax_ids?: string[] | "" | UnknownEnumStringValue
+      account_tax_ids?: string[] | ""
       custom_fields?:
         | {
             name: string
             value: string
           }[]
         | ""
-        | UnknownEnumStringValue
       description?: string
       footer?: string
       issuer?: {
@@ -17971,7 +17948,6 @@ export type t_PostCheckoutSessionsRequestBody = {
             template?: string
           }
         | ""
-        | UnknownEnumStringValue
     }
   }
   line_items?: {
@@ -18109,7 +18085,7 @@ export type t_PostCheckoutSessionsRequestBody = {
     acss_debit?: {
       currency?: "cad" | "usd" | UnknownEnumStringValue
       mandate_options?: {
-        custom_mandate_url?: string | "" | UnknownEnumStringValue
+        custom_mandate_url?: string | ""
         default_for?: ("invoice" | "subscription" | UnknownEnumStringValue)[]
         interval_description?: string
         payment_schedule?:
@@ -18132,24 +18108,24 @@ export type t_PostCheckoutSessionsRequestBody = {
         | UnknownEnumStringValue
     }
     affirm?: {
-      setup_future_usage?: "none" | UnknownEnumStringValue
+      setup_future_usage?: "none"
     }
     afterpay_clearpay?: {
-      setup_future_usage?: "none" | UnknownEnumStringValue
+      setup_future_usage?: "none"
     }
     alipay?: {
-      setup_future_usage?: "none" | UnknownEnumStringValue
+      setup_future_usage?: "none"
     }
     amazon_pay?: {
       setup_future_usage?: "none" | "off_session" | UnknownEnumStringValue
     }
     au_becs_debit?: {
-      setup_future_usage?: "none" | UnknownEnumStringValue
+      setup_future_usage?: "none"
       target_date?: string
     }
     bacs_debit?: {
       mandate_options?: {
-        reference_prefix?: string | "" | UnknownEnumStringValue
+        reference_prefix?: string | ""
       }
       setup_future_usage?:
         | "none"
@@ -18159,7 +18135,7 @@ export type t_PostCheckoutSessionsRequestBody = {
       target_date?: string
     }
     bancontact?: {
-      setup_future_usage?: "none" | UnknownEnumStringValue
+      setup_future_usage?: "none"
     }
     boleto?: {
       expires_after_days?: number
@@ -18231,30 +18207,30 @@ export type t_PostCheckoutSessionsRequestBody = {
           | "us_bank_transfer"
           | UnknownEnumStringValue
       }
-      funding_type?: "bank_transfer" | UnknownEnumStringValue
-      setup_future_usage?: "none" | UnknownEnumStringValue
+      funding_type?: "bank_transfer"
+      setup_future_usage?: "none"
     }
     eps?: {
-      setup_future_usage?: "none" | UnknownEnumStringValue
+      setup_future_usage?: "none"
     }
     fpx?: {
-      setup_future_usage?: "none" | UnknownEnumStringValue
+      setup_future_usage?: "none"
     }
     giropay?: {
-      setup_future_usage?: "none" | UnknownEnumStringValue
+      setup_future_usage?: "none"
     }
     grabpay?: {
-      setup_future_usage?: "none" | UnknownEnumStringValue
+      setup_future_usage?: "none"
     }
     ideal?: {
-      setup_future_usage?: "none" | UnknownEnumStringValue
+      setup_future_usage?: "none"
     }
     kakao_pay?: {
-      capture_method?: "manual" | UnknownEnumStringValue
+      capture_method?: "manual"
       setup_future_usage?: "none" | "off_session" | UnknownEnumStringValue
     }
     klarna?: {
-      setup_future_usage?: "none" | UnknownEnumStringValue
+      setup_future_usage?: "none"
       subscriptions?:
         | {
             interval: "day" | "month" | "week" | "year" | UnknownEnumStringValue
@@ -18267,43 +18243,42 @@ export type t_PostCheckoutSessionsRequestBody = {
             reference: string
           }[]
         | ""
-        | UnknownEnumStringValue
     }
     konbini?: {
       expires_after_days?: number
-      setup_future_usage?: "none" | UnknownEnumStringValue
+      setup_future_usage?: "none"
     }
     kr_card?: {
-      capture_method?: "manual" | UnknownEnumStringValue
+      capture_method?: "manual"
       setup_future_usage?: "none" | "off_session" | UnknownEnumStringValue
     }
     link?: {
       setup_future_usage?: "none" | "off_session" | UnknownEnumStringValue
     }
     mobilepay?: {
-      setup_future_usage?: "none" | UnknownEnumStringValue
+      setup_future_usage?: "none"
     }
     multibanco?: {
-      setup_future_usage?: "none" | UnknownEnumStringValue
+      setup_future_usage?: "none"
     }
     naver_pay?: {
-      capture_method?: "manual" | UnknownEnumStringValue
+      capture_method?: "manual"
       setup_future_usage?: "none" | "off_session" | UnknownEnumStringValue
     }
     oxxo?: {
       expires_after_days?: number
-      setup_future_usage?: "none" | UnknownEnumStringValue
+      setup_future_usage?: "none"
     }
     p24?: {
-      setup_future_usage?: "none" | UnknownEnumStringValue
+      setup_future_usage?: "none"
       tos_shown_and_accepted?: boolean
     }
     pay_by_bank?: Record<string, unknown>
     payco?: {
-      capture_method?: "manual" | UnknownEnumStringValue
+      capture_method?: "manual"
     }
     paynow?: {
-      setup_future_usage?: "none" | UnknownEnumStringValue
+      setup_future_usage?: "none"
     }
     paypal?: {
       capture_method?: "" | "manual" | UnknownEnumStringValue
@@ -18336,17 +18311,17 @@ export type t_PostCheckoutSessionsRequestBody = {
     }
     pix?: {
       expires_after_seconds?: number
-      setup_future_usage?: "none" | UnknownEnumStringValue
+      setup_future_usage?: "none"
     }
     revolut_pay?: {
       setup_future_usage?: "none" | "off_session" | UnknownEnumStringValue
     }
     samsung_pay?: {
-      capture_method?: "manual" | UnknownEnumStringValue
+      capture_method?: "manual"
     }
     sepa_debit?: {
       mandate_options?: {
-        reference_prefix?: string | "" | UnknownEnumStringValue
+        reference_prefix?: string | ""
       }
       setup_future_usage?:
         | "none"
@@ -18356,7 +18331,7 @@ export type t_PostCheckoutSessionsRequestBody = {
       target_date?: string
     }
     sofort?: {
-      setup_future_usage?: "none" | UnknownEnumStringValue
+      setup_future_usage?: "none"
     }
     swish?: {
       reference?: string
@@ -18388,7 +18363,7 @@ export type t_PostCheckoutSessionsRequestBody = {
     wechat_pay?: {
       app_id?: string
       client: "android" | "ios" | "web" | UnknownEnumStringValue
-      setup_future_usage?: "none" | UnknownEnumStringValue
+      setup_future_usage?: "none"
     }
   }
   payment_method_types?: (
@@ -18763,7 +18738,7 @@ export type t_PostCheckoutSessionsRequestBody = {
         | "unspecified"
         | UnknownEnumStringValue
       tax_code?: string
-      type?: "fixed_amount" | UnknownEnumStringValue
+      type?: "fixed_amount"
     }
   }[]
   submit_type?:
@@ -18834,7 +18809,7 @@ export type t_PostCheckoutSessionsSessionRequestBody = {
     }
   }
   expand?: string[]
-  metadata?: Record<string, string> | "" | UnknownEnumStringValue
+  metadata?: Record<string, string> | ""
   shipping_options?:
     | {
         shipping_rate?: string
@@ -18884,11 +18859,10 @@ export type t_PostCheckoutSessionsSessionRequestBody = {
             | "unspecified"
             | UnknownEnumStringValue
           tax_code?: string
-          type?: "fixed_amount" | UnknownEnumStringValue
+          type?: "fixed_amount"
         }
       }[]
     | ""
-    | UnknownEnumStringValue
 }
 
 export type t_PostCheckoutSessionsSessionExpireRequestBody = {
@@ -18910,10 +18884,9 @@ export type t_PostClimateOrdersRequestBody = {
 export type t_PostClimateOrdersOrderRequestBody = {
   beneficiary?:
     | {
-        public_name: string | "" | UnknownEnumStringValue
+        public_name: string | ""
       }
     | ""
-    | UnknownEnumStringValue
   expand?: string[]
   metadata?: Record<string, string>
 }
@@ -18939,7 +18912,7 @@ export type t_PostCouponsRequestBody = {
   expand?: string[]
   id?: string
   max_redemptions?: number
-  metadata?: Record<string, string> | "" | UnknownEnumStringValue
+  metadata?: Record<string, string> | ""
   name?: string
   percent_off?: number
   redeem_by?: number
@@ -18953,7 +18926,7 @@ export type t_PostCouponsCouponRequestBody = {
     }
   >
   expand?: string[]
-  metadata?: Record<string, string> | "" | UnknownEnumStringValue
+  metadata?: Record<string, string> | ""
   name?: string
 }
 
@@ -18976,8 +18949,7 @@ export type t_PostCreditNotesRequestBody = {
           taxable_amount: number
         }[]
       | ""
-      | UnknownEnumStringValue
-    tax_rates?: string[] | "" | UnknownEnumStringValue
+    tax_rates?: string[] | ""
     type: "custom_line_item" | "invoice_line_item" | UnknownEnumStringValue
     unit_amount?: number
     unit_amount_decimal?: string
@@ -19057,7 +19029,6 @@ export type t_PostCustomersRequestBody = {
         state?: string
       }
     | ""
-    | UnknownEnumStringValue
   balance?: number
   cash_balance?: {
     settings?: {
@@ -19079,7 +19050,6 @@ export type t_PostCustomersRequestBody = {
           value: string
         }[]
       | ""
-      | UnknownEnumStringValue
     default_payment_method?: string
     footer?: string
     rendering_options?:
@@ -19092,9 +19062,8 @@ export type t_PostCustomersRequestBody = {
           template?: string
         }
       | ""
-      | UnknownEnumStringValue
   }
-  metadata?: Record<string, string> | "" | UnknownEnumStringValue
+  metadata?: Record<string, string> | ""
   name?: string
   next_invoice_sequence?: number
   payment_method?: string
@@ -19114,10 +19083,9 @@ export type t_PostCustomersRequestBody = {
         phone?: string
       }
     | ""
-    | UnknownEnumStringValue
   source?: string
   tax?: {
-    ip_address?: string | "" | UnknownEnumStringValue
+    ip_address?: string | ""
     validate_location?: "deferred" | "immediately" | UnknownEnumStringValue
   }
   tax_exempt?: "" | "exempt" | "none" | "reverse" | UnknownEnumStringValue
@@ -19250,7 +19218,6 @@ export type t_PostCustomersCustomerRequestBody = {
         state?: string
       }
     | ""
-    | UnknownEnumStringValue
   balance?: number
   bank_account?:
     | {
@@ -19259,7 +19226,7 @@ export type t_PostCustomersCustomerRequestBody = {
         account_number: string
         country: string
         currency?: string
-        object?: "bank_account" | UnknownEnumStringValue
+        object?: "bank_account"
         routing_number?: string
       }
     | string
@@ -19277,7 +19244,7 @@ export type t_PostCustomersCustomerRequestBody = {
         metadata?: Record<string, string>
         name?: string
         number: string
-        object?: "card" | UnknownEnumStringValue
+        object?: "card"
       }
     | string
   cash_balance?: {
@@ -19304,7 +19271,6 @@ export type t_PostCustomersCustomerRequestBody = {
           value: string
         }[]
       | ""
-      | UnknownEnumStringValue
     default_payment_method?: string
     footer?: string
     rendering_options?:
@@ -19317,9 +19283,8 @@ export type t_PostCustomersCustomerRequestBody = {
           template?: string
         }
       | ""
-      | UnknownEnumStringValue
   }
-  metadata?: Record<string, string> | "" | UnknownEnumStringValue
+  metadata?: Record<string, string> | ""
   name?: string
   next_invoice_sequence?: number
   phone?: string
@@ -19338,10 +19303,9 @@ export type t_PostCustomersCustomerRequestBody = {
         phone?: string
       }
     | ""
-    | UnknownEnumStringValue
   source?: string
   tax?: {
-    ip_address?: string | "" | UnknownEnumStringValue
+    ip_address?: string | ""
     validate_location?:
       | "auto"
       | "deferred"
@@ -19356,13 +19320,13 @@ export type t_PostCustomersCustomerBalanceTransactionsRequestBody = {
   currency: string
   description?: string
   expand?: string[]
-  metadata?: Record<string, string> | "" | UnknownEnumStringValue
+  metadata?: Record<string, string> | ""
 }
 
 export type t_PostCustomersCustomerBalanceTransactionsTransactionRequestBody = {
   description?: string
   expand?: string[]
-  metadata?: Record<string, string> | "" | UnknownEnumStringValue
+  metadata?: Record<string, string> | ""
 }
 
 export type t_PostCustomersCustomerBankAccountsRequestBody = {
@@ -19374,7 +19338,7 @@ export type t_PostCustomersCustomerBankAccountsRequestBody = {
         account_number: string
         country: string
         currency?: string
-        object?: "bank_account" | UnknownEnumStringValue
+        object?: "bank_account"
         routing_number?: string
       }
     | string
@@ -19392,7 +19356,7 @@ export type t_PostCustomersCustomerBankAccountsRequestBody = {
         metadata?: Record<string, string>
         name?: string
         number: string
-        object?: "card" | UnknownEnumStringValue
+        object?: "card"
       }
     | string
   expand?: string[]
@@ -19412,7 +19376,7 @@ export type t_PostCustomersCustomerBankAccountsIdRequestBody = {
   exp_month?: string
   exp_year?: string
   expand?: string[]
-  metadata?: Record<string, string> | "" | UnknownEnumStringValue
+  metadata?: Record<string, string> | ""
   name?: string
   owner?: {
     address?: {
@@ -19443,7 +19407,7 @@ export type t_PostCustomersCustomerCardsRequestBody = {
         account_number: string
         country: string
         currency?: string
-        object?: "bank_account" | UnknownEnumStringValue
+        object?: "bank_account"
         routing_number?: string
       }
     | string
@@ -19461,7 +19425,7 @@ export type t_PostCustomersCustomerCardsRequestBody = {
         metadata?: Record<string, string>
         name?: string
         number: string
-        object?: "card" | UnknownEnumStringValue
+        object?: "card"
       }
     | string
   expand?: string[]
@@ -19481,7 +19445,7 @@ export type t_PostCustomersCustomerCardsIdRequestBody = {
   exp_month?: string
   exp_year?: string
   expand?: string[]
-  metadata?: Record<string, string> | "" | UnknownEnumStringValue
+  metadata?: Record<string, string> | ""
   name?: string
   owner?: {
     address?: {
@@ -19531,7 +19495,7 @@ export type t_PostCustomersCustomerFundingInstructionsRequestBody = {
   }
   currency: string
   expand?: string[]
-  funding_type: "bank_transfer" | UnknownEnumStringValue
+  funding_type: "bank_transfer"
 }
 
 export type t_PostCustomersCustomerSourcesRequestBody = {
@@ -19543,7 +19507,7 @@ export type t_PostCustomersCustomerSourcesRequestBody = {
         account_number: string
         country: string
         currency?: string
-        object?: "bank_account" | UnknownEnumStringValue
+        object?: "bank_account"
         routing_number?: string
       }
     | string
@@ -19561,7 +19525,7 @@ export type t_PostCustomersCustomerSourcesRequestBody = {
         metadata?: Record<string, string>
         name?: string
         number: string
-        object?: "card" | UnknownEnumStringValue
+        object?: "card"
       }
     | string
   expand?: string[]
@@ -19581,7 +19545,7 @@ export type t_PostCustomersCustomerSourcesIdRequestBody = {
   exp_month?: string
   exp_year?: string
   expand?: string[]
-  metadata?: Record<string, string> | "" | UnknownEnumStringValue
+  metadata?: Record<string, string> | ""
   name?: string
   owner?: {
     address?: {
@@ -19623,9 +19587,9 @@ export type t_PostCustomersCustomerSubscriptionsRequestBody = {
       unit_amount_decimal?: string
     }
     quantity?: number
-    tax_rates?: string[] | "" | UnknownEnumStringValue
+    tax_rates?: string[] | ""
   }[]
-  application_fee_percent?: number | "" | UnknownEnumStringValue
+  application_fee_percent?: number | ""
   automatic_tax?: {
     enabled: boolean
     liability?: {
@@ -19641,7 +19605,6 @@ export type t_PostCustomersCustomerSubscriptionsRequestBody = {
         reset_billing_cycle_anchor?: boolean
       }
     | ""
-    | UnknownEnumStringValue
   cancel_at?:
     | number
     | "max_period_end"
@@ -19656,7 +19619,7 @@ export type t_PostCustomersCustomerSubscriptionsRequestBody = {
   days_until_due?: number
   default_payment_method?: string
   default_source?: string
-  default_tax_rates?: string[] | "" | UnknownEnumStringValue
+  default_tax_rates?: string[] | ""
   discounts?:
     | {
         coupon?: string
@@ -19664,10 +19627,9 @@ export type t_PostCustomersCustomerSubscriptionsRequestBody = {
         promotion_code?: string
       }[]
     | ""
-    | UnknownEnumStringValue
   expand?: string[]
   invoice_settings?: {
-    account_tax_ids?: string[] | "" | UnknownEnumStringValue
+    account_tax_ids?: string[] | ""
     issuer?: {
       account?: string
       type: "account" | "self" | UnknownEnumStringValue
@@ -19679,7 +19641,6 @@ export type t_PostCustomersCustomerSubscriptionsRequestBody = {
           usage_gte: number
         }
       | ""
-      | UnknownEnumStringValue
     discounts?:
       | {
           coupon?: string
@@ -19687,7 +19648,6 @@ export type t_PostCustomersCustomerSubscriptionsRequestBody = {
           promotion_code?: string
         }[]
       | ""
-      | UnknownEnumStringValue
     metadata?: Record<string, string>
     price?: string
     price_data?: {
@@ -19706,9 +19666,9 @@ export type t_PostCustomersCustomerSubscriptionsRequestBody = {
       unit_amount_decimal?: string
     }
     quantity?: number
-    tax_rates?: string[] | "" | UnknownEnumStringValue
+    tax_rates?: string[] | ""
   }[]
-  metadata?: Record<string, string> | "" | UnknownEnumStringValue
+  metadata?: Record<string, string> | ""
   off_session?: boolean
   payment_behavior?:
     | "allow_incomplete"
@@ -19733,7 +19693,6 @@ export type t_PostCustomersCustomerSubscriptionsRequestBody = {
               | UnknownEnumStringValue
           }
         | ""
-        | UnknownEnumStringValue
       bancontact?:
         | {
             preferred_language?:
@@ -19744,7 +19703,6 @@ export type t_PostCustomersCustomerSubscriptionsRequestBody = {
               | UnknownEnumStringValue
           }
         | ""
-        | UnknownEnumStringValue
       card?:
         | {
             mandate_options?: {
@@ -19774,7 +19732,6 @@ export type t_PostCustomersCustomerSubscriptionsRequestBody = {
               | UnknownEnumStringValue
           }
         | ""
-        | UnknownEnumStringValue
       customer_balance?:
         | {
             bank_transfer?: {
@@ -19786,9 +19743,8 @@ export type t_PostCustomersCustomerSubscriptionsRequestBody = {
             funding_type?: string
           }
         | ""
-        | UnknownEnumStringValue
-      konbini?: Record<string, unknown> | "" | UnknownEnumStringValue
-      sepa_debit?: Record<string, unknown> | "" | UnknownEnumStringValue
+      konbini?: Record<string, unknown> | ""
+      sepa_debit?: Record<string, unknown> | ""
       us_bank_account?:
         | {
             financial_connections?: {
@@ -19820,7 +19776,6 @@ export type t_PostCustomersCustomerSubscriptionsRequestBody = {
               | UnknownEnumStringValue
           }
         | ""
-        | UnknownEnumStringValue
     }
     payment_method_types?:
       | (
@@ -19866,7 +19821,6 @@ export type t_PostCustomersCustomerSubscriptionsRequestBody = {
           | UnknownEnumStringValue
         )[]
       | ""
-      | UnknownEnumStringValue
     save_default_payment_method?:
       | "off"
       | "on_subscription"
@@ -19878,7 +19832,6 @@ export type t_PostCustomersCustomerSubscriptionsRequestBody = {
         interval_count?: number
       }
     | ""
-    | UnknownEnumStringValue
   proration_behavior?:
     | "always_invoice"
     | "create_prorations"
@@ -19888,7 +19841,7 @@ export type t_PostCustomersCustomerSubscriptionsRequestBody = {
     amount_percent?: number
     destination: string
   }
-  trial_end?: "now" | UnknownEnumStringValue | number
+  trial_end?: "now" | number
   trial_from_plan?: boolean
   trial_period_days?: number
   trial_settings?: {
@@ -19923,9 +19876,9 @@ export type t_PostCustomersCustomerSubscriptionsSubscriptionExposedIdRequestBody
         unit_amount_decimal?: string
       }
       quantity?: number
-      tax_rates?: string[] | "" | UnknownEnumStringValue
+      tax_rates?: string[] | ""
     }[]
-    application_fee_percent?: number | "" | UnknownEnumStringValue
+    application_fee_percent?: number | ""
     automatic_tax?: {
       enabled: boolean
       liability?: {
@@ -19940,16 +19893,15 @@ export type t_PostCustomersCustomerSubscriptionsSubscriptionExposedIdRequestBody
           reset_billing_cycle_anchor?: boolean
         }
       | ""
-      | UnknownEnumStringValue
     cancel_at?:
       | number
       | ""
-      | UnknownEnumStringValue
       | "max_period_end"
       | "min_period_end"
+      | UnknownEnumStringValue
     cancel_at_period_end?: boolean
     cancellation_details?: {
-      comment?: string | "" | UnknownEnumStringValue
+      comment?: string | ""
       feedback?:
         | ""
         | "customer_service"
@@ -19968,8 +19920,8 @@ export type t_PostCustomersCustomerSubscriptionsSubscriptionExposedIdRequestBody
       | UnknownEnumStringValue
     days_until_due?: number
     default_payment_method?: string
-    default_source?: string | "" | UnknownEnumStringValue
-    default_tax_rates?: string[] | "" | UnknownEnumStringValue
+    default_source?: string | ""
+    default_tax_rates?: string[] | ""
     discounts?:
       | {
           coupon?: string
@@ -19977,10 +19929,9 @@ export type t_PostCustomersCustomerSubscriptionsSubscriptionExposedIdRequestBody
           promotion_code?: string
         }[]
       | ""
-      | UnknownEnumStringValue
     expand?: string[]
     invoice_settings?: {
-      account_tax_ids?: string[] | "" | UnknownEnumStringValue
+      account_tax_ids?: string[] | ""
       issuer?: {
         account?: string
         type: "account" | "self" | UnknownEnumStringValue
@@ -19992,7 +19943,6 @@ export type t_PostCustomersCustomerSubscriptionsSubscriptionExposedIdRequestBody
             usage_gte: number
           }
         | ""
-        | UnknownEnumStringValue
       clear_usage?: boolean
       deleted?: boolean
       discounts?:
@@ -20002,9 +19952,8 @@ export type t_PostCustomersCustomerSubscriptionsSubscriptionExposedIdRequestBody
             promotion_code?: string
           }[]
         | ""
-        | UnknownEnumStringValue
       id?: string
-      metadata?: Record<string, string> | "" | UnknownEnumStringValue
+      metadata?: Record<string, string> | ""
       price?: string
       price_data?: {
         currency: string
@@ -20022,9 +19971,9 @@ export type t_PostCustomersCustomerSubscriptionsSubscriptionExposedIdRequestBody
         unit_amount_decimal?: string
       }
       quantity?: number
-      tax_rates?: string[] | "" | UnknownEnumStringValue
+      tax_rates?: string[] | ""
     }[]
-    metadata?: Record<string, string> | "" | UnknownEnumStringValue
+    metadata?: Record<string, string> | ""
     off_session?: boolean
     pause_collection?:
       | {
@@ -20036,7 +19985,6 @@ export type t_PostCustomersCustomerSubscriptionsSubscriptionExposedIdRequestBody
           resumes_at?: number
         }
       | ""
-      | UnknownEnumStringValue
     payment_behavior?:
       | "allow_incomplete"
       | "default_incomplete"
@@ -20060,7 +20008,6 @@ export type t_PostCustomersCustomerSubscriptionsSubscriptionExposedIdRequestBody
                 | UnknownEnumStringValue
             }
           | ""
-          | UnknownEnumStringValue
         bancontact?:
           | {
               preferred_language?:
@@ -20071,7 +20018,6 @@ export type t_PostCustomersCustomerSubscriptionsSubscriptionExposedIdRequestBody
                 | UnknownEnumStringValue
             }
           | ""
-          | UnknownEnumStringValue
         card?:
           | {
               mandate_options?: {
@@ -20101,7 +20047,6 @@ export type t_PostCustomersCustomerSubscriptionsSubscriptionExposedIdRequestBody
                 | UnknownEnumStringValue
             }
           | ""
-          | UnknownEnumStringValue
         customer_balance?:
           | {
               bank_transfer?: {
@@ -20113,9 +20058,8 @@ export type t_PostCustomersCustomerSubscriptionsSubscriptionExposedIdRequestBody
               funding_type?: string
             }
           | ""
-          | UnknownEnumStringValue
-        konbini?: Record<string, unknown> | "" | UnknownEnumStringValue
-        sepa_debit?: Record<string, unknown> | "" | UnknownEnumStringValue
+        konbini?: Record<string, unknown> | ""
+        sepa_debit?: Record<string, unknown> | ""
         us_bank_account?:
           | {
               financial_connections?: {
@@ -20147,7 +20091,6 @@ export type t_PostCustomersCustomerSubscriptionsSubscriptionExposedIdRequestBody
                 | UnknownEnumStringValue
             }
           | ""
-          | UnknownEnumStringValue
       }
       payment_method_types?:
         | (
@@ -20193,7 +20136,6 @@ export type t_PostCustomersCustomerSubscriptionsSubscriptionExposedIdRequestBody
             | UnknownEnumStringValue
           )[]
         | ""
-        | UnknownEnumStringValue
       save_default_payment_method?:
         | "off"
         | "on_subscription"
@@ -20205,7 +20147,6 @@ export type t_PostCustomersCustomerSubscriptionsSubscriptionExposedIdRequestBody
           interval_count?: number
         }
       | ""
-      | UnknownEnumStringValue
     proration_behavior?:
       | "always_invoice"
       | "create_prorations"
@@ -20218,8 +20159,7 @@ export type t_PostCustomersCustomerSubscriptionsSubscriptionExposedIdRequestBody
           destination: string
         }
       | ""
-      | UnknownEnumStringValue
-    trial_end?: "now" | UnknownEnumStringValue | number
+    trial_end?: "now" | number
     trial_from_plan?: boolean
     trial_settings?: {
       end_behavior: {
@@ -20368,40 +20308,40 @@ export type t_PostDisputesDisputeRequestBody = {
       | {
           visa_compelling_evidence_3?: {
             disputed_transaction?: {
-              customer_account_id?: string | "" | UnknownEnumStringValue
-              customer_device_fingerprint?: string | "" | UnknownEnumStringValue
-              customer_device_id?: string | "" | UnknownEnumStringValue
-              customer_email_address?: string | "" | UnknownEnumStringValue
-              customer_purchase_ip?: string | "" | UnknownEnumStringValue
+              customer_account_id?: string | ""
+              customer_device_fingerprint?: string | ""
+              customer_device_id?: string | ""
+              customer_email_address?: string | ""
+              customer_purchase_ip?: string | ""
               merchandise_or_services?:
                 | "merchandise"
                 | "services"
                 | UnknownEnumStringValue
-              product_description?: string | "" | UnknownEnumStringValue
+              product_description?: string | ""
               shipping_address?: {
-                city?: string | "" | UnknownEnumStringValue
-                country?: string | "" | UnknownEnumStringValue
-                line1?: string | "" | UnknownEnumStringValue
-                line2?: string | "" | UnknownEnumStringValue
-                postal_code?: string | "" | UnknownEnumStringValue
-                state?: string | "" | UnknownEnumStringValue
+                city?: string | ""
+                country?: string | ""
+                line1?: string | ""
+                line2?: string | ""
+                postal_code?: string | ""
+                state?: string | ""
               }
             }
             prior_undisputed_transactions?: {
               charge: string
-              customer_account_id?: string | "" | UnknownEnumStringValue
-              customer_device_fingerprint?: string | "" | UnknownEnumStringValue
-              customer_device_id?: string | "" | UnknownEnumStringValue
-              customer_email_address?: string | "" | UnknownEnumStringValue
-              customer_purchase_ip?: string | "" | UnknownEnumStringValue
-              product_description?: string | "" | UnknownEnumStringValue
+              customer_account_id?: string | ""
+              customer_device_fingerprint?: string | ""
+              customer_device_id?: string | ""
+              customer_email_address?: string | ""
+              customer_purchase_ip?: string | ""
+              product_description?: string | ""
               shipping_address?: {
-                city?: string | "" | UnknownEnumStringValue
-                country?: string | "" | UnknownEnumStringValue
-                line1?: string | "" | UnknownEnumStringValue
-                line2?: string | "" | UnknownEnumStringValue
-                postal_code?: string | "" | UnknownEnumStringValue
-                state?: string | "" | UnknownEnumStringValue
+                city?: string | ""
+                country?: string | ""
+                line1?: string | ""
+                line2?: string | ""
+                postal_code?: string | ""
+                state?: string | ""
               }
             }[]
           }
@@ -20410,7 +20350,6 @@ export type t_PostDisputesDisputeRequestBody = {
           }
         }
       | ""
-      | UnknownEnumStringValue
     product_description?: string
     receipt?: string
     refund_policy?: string
@@ -20427,7 +20366,7 @@ export type t_PostDisputesDisputeRequestBody = {
     uncategorized_text?: string
   }
   expand?: string[]
-  metadata?: Record<string, string> | "" | UnknownEnumStringValue
+  metadata?: Record<string, string> | ""
   submit?: boolean
 }
 
@@ -20445,7 +20384,7 @@ export type t_PostEntitlementsFeaturesRequestBody = {
 export type t_PostEntitlementsFeaturesIdRequestBody = {
   active?: boolean
   expand?: string[]
-  metadata?: Record<string, string> | "" | UnknownEnumStringValue
+  metadata?: Record<string, string> | ""
   name?: string
 }
 
@@ -20481,7 +20420,7 @@ export type t_PostExternalAccountsIdRequestBody = {
   exp_month?: string
   exp_year?: string
   expand?: string[]
-  metadata?: Record<string, string> | "" | UnknownEnumStringValue
+  metadata?: Record<string, string> | ""
   name?: string
 }
 
@@ -20489,13 +20428,13 @@ export type t_PostFileLinksRequestBody = {
   expand?: string[]
   expires_at?: number
   file: string
-  metadata?: Record<string, string> | "" | UnknownEnumStringValue
+  metadata?: Record<string, string> | ""
 }
 
 export type t_PostFileLinksLinkRequestBody = {
   expand?: string[]
-  expires_at?: "now" | UnknownEnumStringValue | number | ""
-  metadata?: Record<string, string> | "" | UnknownEnumStringValue
+  expires_at?: "now" | number | ""
+  metadata?: Record<string, string> | ""
 }
 
 export type t_PostFinancialConnectionsAccountsAccountDisconnectRequestBody = {
@@ -20514,12 +20453,12 @@ export type t_PostFinancialConnectionsAccountsAccountRefreshRequestBody = {
 
 export type t_PostFinancialConnectionsAccountsAccountSubscribeRequestBody = {
   expand?: string[]
-  features: ("transactions" | UnknownEnumStringValue)[]
+  features: "transactions"[]
 }
 
 export type t_PostFinancialConnectionsAccountsAccountUnsubscribeRequestBody = {
   expand?: string[]
-  features: ("transactions" | UnknownEnumStringValue)[]
+  features: "transactions"[]
 }
 
 export type t_PostFinancialConnectionsSessionsRequestBody = {
@@ -20596,7 +20535,6 @@ export type t_PostIdentityVerificationSessionsRequestBody = {
           require_matching_selfie?: boolean
         }
       | ""
-      | UnknownEnumStringValue
   }
   provided_details?: {
     email?: string
@@ -20629,7 +20567,6 @@ export type t_PostIdentityVerificationSessionsSessionRequestBody = {
           require_matching_selfie?: boolean
         }
       | ""
-      | UnknownEnumStringValue
   }
   provided_details?: {
     email?: string
@@ -20667,10 +20604,9 @@ export type t_PostInvoiceitemsRequestBody = {
         promotion_code?: string
       }[]
     | ""
-    | UnknownEnumStringValue
   expand?: string[]
   invoice?: string
-  metadata?: Record<string, string> | "" | UnknownEnumStringValue
+  metadata?: Record<string, string> | ""
   period?: {
     end: number
     start: number
@@ -20696,7 +20632,7 @@ export type t_PostInvoiceitemsRequestBody = {
     | "inclusive"
     | "unspecified"
     | UnknownEnumStringValue
-  tax_code?: string | "" | UnknownEnumStringValue
+  tax_code?: string | ""
   tax_rates?: string[]
   unit_amount_decimal?: string
 }
@@ -20712,9 +20648,8 @@ export type t_PostInvoiceitemsInvoiceitemRequestBody = {
         promotion_code?: string
       }[]
     | ""
-    | UnknownEnumStringValue
   expand?: string[]
-  metadata?: Record<string, string> | "" | UnknownEnumStringValue
+  metadata?: Record<string, string> | ""
   period?: {
     end: number
     start: number
@@ -20739,13 +20674,13 @@ export type t_PostInvoiceitemsInvoiceitemRequestBody = {
     | "inclusive"
     | "unspecified"
     | UnknownEnumStringValue
-  tax_code?: string | "" | UnknownEnumStringValue
-  tax_rates?: string[] | "" | UnknownEnumStringValue
+  tax_code?: string | ""
+  tax_rates?: string[] | ""
   unit_amount_decimal?: string
 }
 
 export type t_PostInvoicesRequestBody = {
-  account_tax_ids?: string[] | "" | UnknownEnumStringValue
+  account_tax_ids?: string[] | ""
   application_fee_amount?: number
   auto_advance?: boolean
   automatic_tax?: {
@@ -20767,7 +20702,6 @@ export type t_PostInvoicesRequestBody = {
         value: string
       }[]
     | ""
-    | UnknownEnumStringValue
   customer?: string
   days_until_due?: number
   default_payment_method?: string
@@ -20781,24 +20715,23 @@ export type t_PostInvoicesRequestBody = {
         promotion_code?: string
       }[]
     | ""
-    | UnknownEnumStringValue
   due_date?: number
   effective_at?: number
   expand?: string[]
   footer?: string
   from_invoice?: {
-    action: "revision" | UnknownEnumStringValue
+    action: "revision"
     invoice: string
   }
   issuer?: {
     account?: string
     type: "account" | "self" | UnknownEnumStringValue
   }
-  metadata?: Record<string, string> | "" | UnknownEnumStringValue
+  metadata?: Record<string, string> | ""
   number?: string
   on_behalf_of?: string
   payment_settings?: {
-    default_mandate?: string | "" | UnknownEnumStringValue
+    default_mandate?: string | ""
     payment_method_options?: {
       acss_debit?:
         | {
@@ -20815,7 +20748,6 @@ export type t_PostInvoicesRequestBody = {
               | UnknownEnumStringValue
           }
         | ""
-        | UnknownEnumStringValue
       bancontact?:
         | {
             preferred_language?:
@@ -20826,7 +20758,6 @@ export type t_PostInvoicesRequestBody = {
               | UnknownEnumStringValue
           }
         | ""
-        | UnknownEnumStringValue
       card?:
         | {
             installments?: {
@@ -20834,7 +20765,7 @@ export type t_PostInvoicesRequestBody = {
               plan?:
                 | {
                     count?: number
-                    interval?: "month" | UnknownEnumStringValue
+                    interval?: "month"
                     type:
                       | "bonus"
                       | "fixed_count"
@@ -20842,7 +20773,6 @@ export type t_PostInvoicesRequestBody = {
                       | UnknownEnumStringValue
                   }
                 | ""
-                | UnknownEnumStringValue
             }
             request_three_d_secure?:
               | "any"
@@ -20851,7 +20781,6 @@ export type t_PostInvoicesRequestBody = {
               | UnknownEnumStringValue
           }
         | ""
-        | UnknownEnumStringValue
       customer_balance?:
         | {
             bank_transfer?: {
@@ -20863,9 +20792,8 @@ export type t_PostInvoicesRequestBody = {
             funding_type?: string
           }
         | ""
-        | UnknownEnumStringValue
-      konbini?: Record<string, unknown> | "" | UnknownEnumStringValue
-      sepa_debit?: Record<string, unknown> | "" | UnknownEnumStringValue
+      konbini?: Record<string, unknown> | ""
+      sepa_debit?: Record<string, unknown> | ""
       us_bank_account?:
         | {
             financial_connections?: {
@@ -20897,7 +20825,6 @@ export type t_PostInvoicesRequestBody = {
               | UnknownEnumStringValue
           }
         | ""
-        | UnknownEnumStringValue
     }
     payment_method_types?:
       | (
@@ -20943,7 +20870,6 @@ export type t_PostInvoicesRequestBody = {
           | UnknownEnumStringValue
         )[]
       | ""
-      | UnknownEnumStringValue
   }
   pending_invoice_items_behavior?:
     | "exclude"
@@ -20959,7 +20885,7 @@ export type t_PostInvoicesRequestBody = {
       page_size?: "a4" | "auto" | "letter" | UnknownEnumStringValue
     }
     template?: string
-    template_version?: number | "" | UnknownEnumStringValue
+    template_version?: number | ""
   }
   shipping_cost?: {
     shipping_rate?: string
@@ -21009,7 +20935,7 @@ export type t_PostInvoicesRequestBody = {
         | "unspecified"
         | UnknownEnumStringValue
       tax_code?: string
-      type?: "fixed_amount" | UnknownEnumStringValue
+      type?: "fixed_amount"
     }
   }
   shipping_details?: {
@@ -21022,7 +20948,7 @@ export type t_PostInvoicesRequestBody = {
       state?: string
     }
     name: string
-    phone?: string | "" | UnknownEnumStringValue
+    phone?: string | ""
   }
   statement_descriptor?: string
   subscription?: string
@@ -21053,7 +20979,6 @@ export type t_PostInvoicesCreatePreviewRequestBody = {
           state?: string
         }
       | ""
-      | UnknownEnumStringValue
     shipping?:
       | {
           address: {
@@ -21068,9 +20993,8 @@ export type t_PostInvoicesCreatePreviewRequestBody = {
           phone?: string
         }
       | ""
-      | UnknownEnumStringValue
     tax?: {
-      ip_address?: string | "" | UnknownEnumStringValue
+      ip_address?: string | ""
     }
     tax_exempt?: "" | "exempt" | "none" | "reverse" | UnknownEnumStringValue
     tax_ids?: {
@@ -21196,7 +21120,6 @@ export type t_PostInvoicesCreatePreviewRequestBody = {
         promotion_code?: string
       }[]
     | ""
-    | UnknownEnumStringValue
   expand?: string[]
   invoice_items?: {
     amount?: number
@@ -21210,9 +21133,8 @@ export type t_PostInvoicesCreatePreviewRequestBody = {
           promotion_code?: string
         }[]
       | ""
-      | UnknownEnumStringValue
     invoiceitem?: string
-    metadata?: Record<string, string> | "" | UnknownEnumStringValue
+    metadata?: Record<string, string> | ""
     period?: {
       end: number
       start: number
@@ -21235,8 +21157,8 @@ export type t_PostInvoicesCreatePreviewRequestBody = {
       | "inclusive"
       | "unspecified"
       | UnknownEnumStringValue
-    tax_code?: string | "" | UnknownEnumStringValue
-    tax_rates?: string[] | "" | UnknownEnumStringValue
+    tax_code?: string | ""
+    tax_rates?: string[] | ""
     unit_amount?: number
     unit_amount_decimal?: string
   }[]
@@ -21244,7 +21166,7 @@ export type t_PostInvoicesCreatePreviewRequestBody = {
     account?: string
     type: "account" | "self" | UnknownEnumStringValue
   }
-  on_behalf_of?: string | "" | UnknownEnumStringValue
+  on_behalf_of?: string | ""
   preview_mode?: "next" | "recurring" | UnknownEnumStringValue
   schedule?: string
   schedule_details?: {
@@ -21272,7 +21194,7 @@ export type t_PostInvoicesCreatePreviewRequestBody = {
           unit_amount_decimal?: string
         }
         quantity?: number
-        tax_rates?: string[] | "" | UnknownEnumStringValue
+        tax_rates?: string[] | ""
       }[]
       application_fee_percent?: number
       automatic_tax?: {
@@ -21292,14 +21214,13 @@ export type t_PostInvoicesCreatePreviewRequestBody = {
             reset_billing_cycle_anchor?: boolean
           }
         | ""
-        | UnknownEnumStringValue
       collection_method?:
         | "charge_automatically"
         | "send_invoice"
         | UnknownEnumStringValue
       default_payment_method?: string
-      default_tax_rates?: string[] | "" | UnknownEnumStringValue
-      description?: string | "" | UnknownEnumStringValue
+      default_tax_rates?: string[] | ""
+      description?: string | ""
       discounts?:
         | {
             coupon?: string
@@ -21307,14 +21228,13 @@ export type t_PostInvoicesCreatePreviewRequestBody = {
             promotion_code?: string
           }[]
         | ""
-        | UnknownEnumStringValue
       duration?: {
         interval: "day" | "month" | "week" | "year" | UnknownEnumStringValue
         interval_count?: number
       }
-      end_date?: number | "now" | UnknownEnumStringValue
+      end_date?: number | "now"
       invoice_settings?: {
-        account_tax_ids?: string[] | "" | UnknownEnumStringValue
+        account_tax_ids?: string[] | ""
         days_until_due?: number
         issuer?: {
           account?: string
@@ -21327,7 +21247,6 @@ export type t_PostInvoicesCreatePreviewRequestBody = {
               usage_gte: number
             }
           | ""
-          | UnknownEnumStringValue
         discounts?:
           | {
               coupon?: string
@@ -21335,7 +21254,6 @@ export type t_PostInvoicesCreatePreviewRequestBody = {
               promotion_code?: string
             }[]
           | ""
-          | UnknownEnumStringValue
         metadata?: Record<string, string>
         price?: string
         price_data?: {
@@ -21354,7 +21272,7 @@ export type t_PostInvoicesCreatePreviewRequestBody = {
           unit_amount_decimal?: string
         }
         quantity?: number
-        tax_rates?: string[] | "" | UnknownEnumStringValue
+        tax_rates?: string[] | ""
       }[]
       iterations?: number
       metadata?: Record<string, string>
@@ -21364,13 +21282,13 @@ export type t_PostInvoicesCreatePreviewRequestBody = {
         | "create_prorations"
         | "none"
         | UnknownEnumStringValue
-      start_date?: number | "now" | UnknownEnumStringValue
+      start_date?: number | "now"
       transfer_data?: {
         amount_percent?: number
         destination: string
       }
       trial?: boolean
-      trial_end?: number | "now" | UnknownEnumStringValue
+      trial_end?: number | "now"
     }[]
     proration_behavior?:
       | "always_invoice"
@@ -21387,19 +21305,18 @@ export type t_PostInvoicesCreatePreviewRequestBody = {
     cancel_at?:
       | number
       | ""
-      | UnknownEnumStringValue
       | "max_period_end"
       | "min_period_end"
+      | UnknownEnumStringValue
     cancel_at_period_end?: boolean
     cancel_now?: boolean
-    default_tax_rates?: string[] | "" | UnknownEnumStringValue
+    default_tax_rates?: string[] | ""
     items?: {
       billing_thresholds?:
         | {
             usage_gte: number
           }
         | ""
-        | UnknownEnumStringValue
       clear_usage?: boolean
       deleted?: boolean
       discounts?:
@@ -21409,9 +21326,8 @@ export type t_PostInvoicesCreatePreviewRequestBody = {
             promotion_code?: string
           }[]
         | ""
-        | UnknownEnumStringValue
       id?: string
-      metadata?: Record<string, string> | "" | UnknownEnumStringValue
+      metadata?: Record<string, string> | ""
       price?: string
       price_data?: {
         currency: string
@@ -21429,7 +21345,7 @@ export type t_PostInvoicesCreatePreviewRequestBody = {
         unit_amount_decimal?: string
       }
       quantity?: number
-      tax_rates?: string[] | "" | UnknownEnumStringValue
+      tax_rates?: string[] | ""
     }[]
     proration_behavior?:
       | "always_invoice"
@@ -21437,14 +21353,14 @@ export type t_PostInvoicesCreatePreviewRequestBody = {
       | "none"
       | UnknownEnumStringValue
     proration_date?: number
-    resume_at?: "now" | UnknownEnumStringValue
+    resume_at?: "now"
     start_date?: number
-    trial_end?: "now" | UnknownEnumStringValue | number
+    trial_end?: "now" | number
   }
 }
 
 export type t_PostInvoicesInvoiceRequestBody = {
-  account_tax_ids?: string[] | "" | UnknownEnumStringValue
+  account_tax_ids?: string[] | ""
   application_fee_amount?: number
   auto_advance?: boolean
   automatic_tax?: {
@@ -21465,11 +21381,10 @@ export type t_PostInvoicesInvoiceRequestBody = {
         value: string
       }[]
     | ""
-    | UnknownEnumStringValue
   days_until_due?: number
   default_payment_method?: string
-  default_source?: string | "" | UnknownEnumStringValue
-  default_tax_rates?: string[] | "" | UnknownEnumStringValue
+  default_source?: string | ""
+  default_tax_rates?: string[] | ""
   description?: string
   discounts?:
     | {
@@ -21478,20 +21393,19 @@ export type t_PostInvoicesInvoiceRequestBody = {
         promotion_code?: string
       }[]
     | ""
-    | UnknownEnumStringValue
   due_date?: number
-  effective_at?: number | "" | UnknownEnumStringValue
+  effective_at?: number | ""
   expand?: string[]
   footer?: string
   issuer?: {
     account?: string
     type: "account" | "self" | UnknownEnumStringValue
   }
-  metadata?: Record<string, string> | "" | UnknownEnumStringValue
-  number?: string | "" | UnknownEnumStringValue
-  on_behalf_of?: string | "" | UnknownEnumStringValue
+  metadata?: Record<string, string> | ""
+  number?: string | ""
+  on_behalf_of?: string | ""
   payment_settings?: {
-    default_mandate?: string | "" | UnknownEnumStringValue
+    default_mandate?: string | ""
     payment_method_options?: {
       acss_debit?:
         | {
@@ -21508,7 +21422,6 @@ export type t_PostInvoicesInvoiceRequestBody = {
               | UnknownEnumStringValue
           }
         | ""
-        | UnknownEnumStringValue
       bancontact?:
         | {
             preferred_language?:
@@ -21519,7 +21432,6 @@ export type t_PostInvoicesInvoiceRequestBody = {
               | UnknownEnumStringValue
           }
         | ""
-        | UnknownEnumStringValue
       card?:
         | {
             installments?: {
@@ -21527,7 +21439,7 @@ export type t_PostInvoicesInvoiceRequestBody = {
               plan?:
                 | {
                     count?: number
-                    interval?: "month" | UnknownEnumStringValue
+                    interval?: "month"
                     type:
                       | "bonus"
                       | "fixed_count"
@@ -21535,7 +21447,6 @@ export type t_PostInvoicesInvoiceRequestBody = {
                       | UnknownEnumStringValue
                   }
                 | ""
-                | UnknownEnumStringValue
             }
             request_three_d_secure?:
               | "any"
@@ -21544,7 +21455,6 @@ export type t_PostInvoicesInvoiceRequestBody = {
               | UnknownEnumStringValue
           }
         | ""
-        | UnknownEnumStringValue
       customer_balance?:
         | {
             bank_transfer?: {
@@ -21556,9 +21466,8 @@ export type t_PostInvoicesInvoiceRequestBody = {
             funding_type?: string
           }
         | ""
-        | UnknownEnumStringValue
-      konbini?: Record<string, unknown> | "" | UnknownEnumStringValue
-      sepa_debit?: Record<string, unknown> | "" | UnknownEnumStringValue
+      konbini?: Record<string, unknown> | ""
+      sepa_debit?: Record<string, unknown> | ""
       us_bank_account?:
         | {
             financial_connections?: {
@@ -21590,7 +21499,6 @@ export type t_PostInvoicesInvoiceRequestBody = {
               | UnknownEnumStringValue
           }
         | ""
-        | UnknownEnumStringValue
     }
     payment_method_types?:
       | (
@@ -21636,7 +21544,6 @@ export type t_PostInvoicesInvoiceRequestBody = {
           | UnknownEnumStringValue
         )[]
       | ""
-      | UnknownEnumStringValue
   }
   rendering?: {
     amount_tax_display?:
@@ -21648,7 +21555,7 @@ export type t_PostInvoicesInvoiceRequestBody = {
       page_size?: "a4" | "auto" | "letter" | UnknownEnumStringValue
     }
     template?: string
-    template_version?: number | "" | UnknownEnumStringValue
+    template_version?: number | ""
   }
   shipping_cost?:
     | {
@@ -21699,11 +21606,10 @@ export type t_PostInvoicesInvoiceRequestBody = {
             | "unspecified"
             | UnknownEnumStringValue
           tax_code?: string
-          type?: "fixed_amount" | UnknownEnumStringValue
+          type?: "fixed_amount"
         }
       }
     | ""
-    | UnknownEnumStringValue
   shipping_details?:
     | {
         address: {
@@ -21715,10 +21621,9 @@ export type t_PostInvoicesInvoiceRequestBody = {
           state?: string
         }
         name: string
-        phone?: string | "" | UnknownEnumStringValue
+        phone?: string | ""
       }
     | ""
-    | UnknownEnumStringValue
   statement_descriptor?: string
   transfer_data?:
     | {
@@ -21726,12 +21631,11 @@ export type t_PostInvoicesInvoiceRequestBody = {
         destination: string
       }
     | ""
-    | UnknownEnumStringValue
 }
 
 export type t_PostInvoicesInvoiceAddLinesRequestBody = {
   expand?: string[]
-  invoice_metadata?: Record<string, string> | "" | UnknownEnumStringValue
+  invoice_metadata?: Record<string, string> | ""
   lines: {
     amount?: number
     description?: string
@@ -21743,9 +21647,8 @@ export type t_PostInvoicesInvoiceAddLinesRequestBody = {
           promotion_code?: string
         }[]
       | ""
-      | UnknownEnumStringValue
     invoice_item?: string
-    metadata?: Record<string, string> | "" | UnknownEnumStringValue
+    metadata?: Record<string, string> | ""
     period?: {
       end: number
       start: number
@@ -21828,8 +21731,7 @@ export type t_PostInvoicesInvoiceAddLinesRequestBody = {
           taxable_amount: number
         }[]
       | ""
-      | UnknownEnumStringValue
-    tax_rates?: string[] | "" | UnknownEnumStringValue
+    tax_rates?: string[] | ""
   }[]
 }
 
@@ -21854,9 +21756,8 @@ export type t_PostInvoicesInvoiceLinesLineItemIdRequestBody = {
         promotion_code?: string
       }[]
     | ""
-    | UnknownEnumStringValue
   expand?: string[]
-  metadata?: Record<string, string> | "" | UnknownEnumStringValue
+  metadata?: Record<string, string> | ""
   period?: {
     end: number
     start: number
@@ -21939,8 +21840,7 @@ export type t_PostInvoicesInvoiceLinesLineItemIdRequestBody = {
         taxable_amount: number
       }[]
     | ""
-    | UnknownEnumStringValue
-  tax_rates?: string[] | "" | UnknownEnumStringValue
+  tax_rates?: string[] | ""
 }
 
 export type t_PostInvoicesInvoiceMarkUncollectibleRequestBody = {
@@ -21950,7 +21850,7 @@ export type t_PostInvoicesInvoiceMarkUncollectibleRequestBody = {
 export type t_PostInvoicesInvoicePayRequestBody = {
   expand?: string[]
   forgive?: boolean
-  mandate?: string | "" | UnknownEnumStringValue
+  mandate?: string | ""
   off_session?: boolean
   paid_out_of_band?: boolean
   payment_method?: string
@@ -21959,7 +21859,7 @@ export type t_PostInvoicesInvoicePayRequestBody = {
 
 export type t_PostInvoicesInvoiceRemoveLinesRequestBody = {
   expand?: string[]
-  invoice_metadata?: Record<string, string> | "" | UnknownEnumStringValue
+  invoice_metadata?: Record<string, string> | ""
   lines: {
     behavior: "delete" | "unassign" | UnknownEnumStringValue
     id: string
@@ -21972,7 +21872,7 @@ export type t_PostInvoicesInvoiceSendRequestBody = {
 
 export type t_PostInvoicesInvoiceUpdateLinesRequestBody = {
   expand?: string[]
-  invoice_metadata?: Record<string, string> | "" | UnknownEnumStringValue
+  invoice_metadata?: Record<string, string> | ""
   lines: {
     amount?: number
     description?: string
@@ -21984,9 +21884,8 @@ export type t_PostInvoicesInvoiceUpdateLinesRequestBody = {
           promotion_code?: string
         }[]
       | ""
-      | UnknownEnumStringValue
     id: string
-    metadata?: Record<string, string> | "" | UnknownEnumStringValue
+    metadata?: Record<string, string> | ""
     period?: {
       end: number
       start: number
@@ -22069,8 +21968,7 @@ export type t_PostInvoicesInvoiceUpdateLinesRequestBody = {
           taxable_amount: number
         }[]
       | ""
-      | UnknownEnumStringValue
-    tax_rates?: string[] | "" | UnknownEnumStringValue
+    tax_rates?: string[] | ""
   }[]
 }
 
@@ -22080,18 +21978,18 @@ export type t_PostInvoicesInvoiceVoidRequestBody = {
 
 export type t_PostIssuingAuthorizationsAuthorizationRequestBody = {
   expand?: string[]
-  metadata?: Record<string, string> | "" | UnknownEnumStringValue
+  metadata?: Record<string, string> | ""
 }
 
 export type t_PostIssuingAuthorizationsAuthorizationApproveRequestBody = {
   amount?: number
   expand?: string[]
-  metadata?: Record<string, string> | "" | UnknownEnumStringValue
+  metadata?: Record<string, string> | ""
 }
 
 export type t_PostIssuingAuthorizationsAuthorizationDeclineRequestBody = {
   expand?: string[]
-  metadata?: Record<string, string> | "" | UnknownEnumStringValue
+  metadata?: Record<string, string> | ""
 }
 
 export type t_PostIssuingCardholdersRequestBody = {
@@ -22115,7 +22013,7 @@ export type t_PostIssuingCardholdersRequestBody = {
       user_terms_acceptance?: {
         date?: number
         ip?: string
-        user_agent?: string | "" | UnknownEnumStringValue
+        user_agent?: string | ""
       }
     }
     dob?: {
@@ -23078,7 +22976,7 @@ export type t_PostIssuingCardholdersCardholderRequestBody = {
       user_terms_acceptance?: {
         date?: number
         ip?: string
-        user_agent?: string | "" | UnknownEnumStringValue
+        user_agent?: string | ""
       }
     }
     dob?: {
@@ -24035,7 +23933,7 @@ export type t_PostIssuingCardsRequestBody = {
     | "lost"
     | "stolen"
     | UnknownEnumStringValue
-  second_line?: string | "" | UnknownEnumStringValue
+  second_line?: string | ""
   shipping?: {
     address: {
       city: string
@@ -24977,7 +24875,7 @@ export type t_PostIssuingCardsRequestBody = {
 export type t_PostIssuingCardsCardRequestBody = {
   cancellation_reason?: "lost" | "stolen" | UnknownEnumStringValue
   expand?: string[]
-  metadata?: Record<string, string> | "" | UnknownEnumStringValue
+  metadata?: Record<string, string> | ""
   personalization_design?: string
   pin?: {
     encrypted_number?: string
@@ -25924,82 +25822,75 @@ export type t_PostIssuingDisputesRequestBody = {
   evidence?: {
     canceled?:
       | {
-          additional_documentation?: string | "" | UnknownEnumStringValue
-          canceled_at?: number | "" | UnknownEnumStringValue
-          cancellation_policy_provided?: boolean | "" | UnknownEnumStringValue
-          cancellation_reason?: string | "" | UnknownEnumStringValue
-          expected_at?: number | "" | UnknownEnumStringValue
-          explanation?: string | "" | UnknownEnumStringValue
-          product_description?: string | "" | UnknownEnumStringValue
+          additional_documentation?: string | ""
+          canceled_at?: number | ""
+          cancellation_policy_provided?: boolean | ""
+          cancellation_reason?: string | ""
+          expected_at?: number | ""
+          explanation?: string | ""
+          product_description?: string | ""
           product_type?: "" | "merchandise" | "service" | UnknownEnumStringValue
           return_status?:
             | ""
             | "merchant_rejected"
             | "successful"
             | UnknownEnumStringValue
-          returned_at?: number | "" | UnknownEnumStringValue
+          returned_at?: number | ""
         }
       | ""
-      | UnknownEnumStringValue
     duplicate?:
       | {
-          additional_documentation?: string | "" | UnknownEnumStringValue
-          card_statement?: string | "" | UnknownEnumStringValue
-          cash_receipt?: string | "" | UnknownEnumStringValue
-          check_image?: string | "" | UnknownEnumStringValue
-          explanation?: string | "" | UnknownEnumStringValue
+          additional_documentation?: string | ""
+          card_statement?: string | ""
+          cash_receipt?: string | ""
+          check_image?: string | ""
+          explanation?: string | ""
           original_transaction?: string
         }
       | ""
-      | UnknownEnumStringValue
     fraudulent?:
       | {
-          additional_documentation?: string | "" | UnknownEnumStringValue
-          explanation?: string | "" | UnknownEnumStringValue
+          additional_documentation?: string | ""
+          explanation?: string | ""
         }
       | ""
-      | UnknownEnumStringValue
     merchandise_not_as_described?:
       | {
-          additional_documentation?: string | "" | UnknownEnumStringValue
-          explanation?: string | "" | UnknownEnumStringValue
-          received_at?: number | "" | UnknownEnumStringValue
-          return_description?: string | "" | UnknownEnumStringValue
+          additional_documentation?: string | ""
+          explanation?: string | ""
+          received_at?: number | ""
+          return_description?: string | ""
           return_status?:
             | ""
             | "merchant_rejected"
             | "successful"
             | UnknownEnumStringValue
-          returned_at?: number | "" | UnknownEnumStringValue
+          returned_at?: number | ""
         }
       | ""
-      | UnknownEnumStringValue
     no_valid_authorization?:
       | {
-          additional_documentation?: string | "" | UnknownEnumStringValue
-          explanation?: string | "" | UnknownEnumStringValue
+          additional_documentation?: string | ""
+          explanation?: string | ""
         }
       | ""
-      | UnknownEnumStringValue
     not_received?:
       | {
-          additional_documentation?: string | "" | UnknownEnumStringValue
-          expected_at?: number | "" | UnknownEnumStringValue
-          explanation?: string | "" | UnknownEnumStringValue
-          product_description?: string | "" | UnknownEnumStringValue
+          additional_documentation?: string | ""
+          expected_at?: number | ""
+          explanation?: string | ""
+          product_description?: string | ""
           product_type?: "" | "merchandise" | "service" | UnknownEnumStringValue
         }
       | ""
-      | UnknownEnumStringValue
     other?:
       | {
-          additional_documentation?: string | "" | UnknownEnumStringValue
-          explanation?: string | "" | UnknownEnumStringValue
-          product_description?: string | "" | UnknownEnumStringValue
+          additional_documentation?: string | ""
+          explanation?: string | ""
+          product_description?: string | ""
           product_type?: "" | "merchandise" | "service" | UnknownEnumStringValue
         }
       | ""
-      | UnknownEnumStringValue
     reason?:
       | "canceled"
       | "duplicate"
@@ -26012,14 +25903,13 @@ export type t_PostIssuingDisputesRequestBody = {
       | UnknownEnumStringValue
     service_not_as_described?:
       | {
-          additional_documentation?: string | "" | UnknownEnumStringValue
-          canceled_at?: number | "" | UnknownEnumStringValue
-          cancellation_reason?: string | "" | UnknownEnumStringValue
-          explanation?: string | "" | UnknownEnumStringValue
-          received_at?: number | "" | UnknownEnumStringValue
+          additional_documentation?: string | ""
+          canceled_at?: number | ""
+          cancellation_reason?: string | ""
+          explanation?: string | ""
+          received_at?: number | ""
         }
       | ""
-      | UnknownEnumStringValue
   }
   expand?: string[]
   metadata?: Record<string, string>
@@ -26034,82 +25924,75 @@ export type t_PostIssuingDisputesDisputeRequestBody = {
   evidence?: {
     canceled?:
       | {
-          additional_documentation?: string | "" | UnknownEnumStringValue
-          canceled_at?: number | "" | UnknownEnumStringValue
-          cancellation_policy_provided?: boolean | "" | UnknownEnumStringValue
-          cancellation_reason?: string | "" | UnknownEnumStringValue
-          expected_at?: number | "" | UnknownEnumStringValue
-          explanation?: string | "" | UnknownEnumStringValue
-          product_description?: string | "" | UnknownEnumStringValue
+          additional_documentation?: string | ""
+          canceled_at?: number | ""
+          cancellation_policy_provided?: boolean | ""
+          cancellation_reason?: string | ""
+          expected_at?: number | ""
+          explanation?: string | ""
+          product_description?: string | ""
           product_type?: "" | "merchandise" | "service" | UnknownEnumStringValue
           return_status?:
             | ""
             | "merchant_rejected"
             | "successful"
             | UnknownEnumStringValue
-          returned_at?: number | "" | UnknownEnumStringValue
+          returned_at?: number | ""
         }
       | ""
-      | UnknownEnumStringValue
     duplicate?:
       | {
-          additional_documentation?: string | "" | UnknownEnumStringValue
-          card_statement?: string | "" | UnknownEnumStringValue
-          cash_receipt?: string | "" | UnknownEnumStringValue
-          check_image?: string | "" | UnknownEnumStringValue
-          explanation?: string | "" | UnknownEnumStringValue
+          additional_documentation?: string | ""
+          card_statement?: string | ""
+          cash_receipt?: string | ""
+          check_image?: string | ""
+          explanation?: string | ""
           original_transaction?: string
         }
       | ""
-      | UnknownEnumStringValue
     fraudulent?:
       | {
-          additional_documentation?: string | "" | UnknownEnumStringValue
-          explanation?: string | "" | UnknownEnumStringValue
+          additional_documentation?: string | ""
+          explanation?: string | ""
         }
       | ""
-      | UnknownEnumStringValue
     merchandise_not_as_described?:
       | {
-          additional_documentation?: string | "" | UnknownEnumStringValue
-          explanation?: string | "" | UnknownEnumStringValue
-          received_at?: number | "" | UnknownEnumStringValue
-          return_description?: string | "" | UnknownEnumStringValue
+          additional_documentation?: string | ""
+          explanation?: string | ""
+          received_at?: number | ""
+          return_description?: string | ""
           return_status?:
             | ""
             | "merchant_rejected"
             | "successful"
             | UnknownEnumStringValue
-          returned_at?: number | "" | UnknownEnumStringValue
+          returned_at?: number | ""
         }
       | ""
-      | UnknownEnumStringValue
     no_valid_authorization?:
       | {
-          additional_documentation?: string | "" | UnknownEnumStringValue
-          explanation?: string | "" | UnknownEnumStringValue
+          additional_documentation?: string | ""
+          explanation?: string | ""
         }
       | ""
-      | UnknownEnumStringValue
     not_received?:
       | {
-          additional_documentation?: string | "" | UnknownEnumStringValue
-          expected_at?: number | "" | UnknownEnumStringValue
-          explanation?: string | "" | UnknownEnumStringValue
-          product_description?: string | "" | UnknownEnumStringValue
+          additional_documentation?: string | ""
+          expected_at?: number | ""
+          explanation?: string | ""
+          product_description?: string | ""
           product_type?: "" | "merchandise" | "service" | UnknownEnumStringValue
         }
       | ""
-      | UnknownEnumStringValue
     other?:
       | {
-          additional_documentation?: string | "" | UnknownEnumStringValue
-          explanation?: string | "" | UnknownEnumStringValue
-          product_description?: string | "" | UnknownEnumStringValue
+          additional_documentation?: string | ""
+          explanation?: string | ""
+          product_description?: string | ""
           product_type?: "" | "merchandise" | "service" | UnknownEnumStringValue
         }
       | ""
-      | UnknownEnumStringValue
     reason?:
       | "canceled"
       | "duplicate"
@@ -26122,31 +26005,30 @@ export type t_PostIssuingDisputesDisputeRequestBody = {
       | UnknownEnumStringValue
     service_not_as_described?:
       | {
-          additional_documentation?: string | "" | UnknownEnumStringValue
-          canceled_at?: number | "" | UnknownEnumStringValue
-          cancellation_reason?: string | "" | UnknownEnumStringValue
-          explanation?: string | "" | UnknownEnumStringValue
-          received_at?: number | "" | UnknownEnumStringValue
+          additional_documentation?: string | ""
+          canceled_at?: number | ""
+          cancellation_reason?: string | ""
+          explanation?: string | ""
+          received_at?: number | ""
         }
       | ""
-      | UnknownEnumStringValue
   }
   expand?: string[]
-  metadata?: Record<string, string> | "" | UnknownEnumStringValue
+  metadata?: Record<string, string> | ""
 }
 
 export type t_PostIssuingDisputesDisputeSubmitRequestBody = {
   expand?: string[]
-  metadata?: Record<string, string> | "" | UnknownEnumStringValue
+  metadata?: Record<string, string> | ""
 }
 
 export type t_PostIssuingPersonalizationDesignsRequestBody = {
   card_logo?: string
   carrier_text?: {
-    footer_body?: string | "" | UnknownEnumStringValue
-    footer_title?: string | "" | UnknownEnumStringValue
-    header_body?: string | "" | UnknownEnumStringValue
-    header_title?: string | "" | UnknownEnumStringValue
+    footer_body?: string | ""
+    footer_title?: string | ""
+    header_body?: string | ""
+    header_title?: string | ""
   }
   expand?: string[]
   lookup_key?: string
@@ -26161,20 +26043,19 @@ export type t_PostIssuingPersonalizationDesignsRequestBody = {
 
 export type t_PostIssuingPersonalizationDesignsPersonalizationDesignRequestBody =
   {
-    card_logo?: string | "" | UnknownEnumStringValue
+    card_logo?: string | ""
     carrier_text?:
       | {
-          footer_body?: string | "" | UnknownEnumStringValue
-          footer_title?: string | "" | UnknownEnumStringValue
-          header_body?: string | "" | UnknownEnumStringValue
-          header_title?: string | "" | UnknownEnumStringValue
+          footer_body?: string | ""
+          footer_title?: string | ""
+          header_body?: string | ""
+          header_title?: string | ""
         }
       | ""
-      | UnknownEnumStringValue
     expand?: string[]
-    lookup_key?: string | "" | UnknownEnumStringValue
+    lookup_key?: string | ""
     metadata?: Record<string, string>
-    name?: string | "" | UnknownEnumStringValue
+    name?: string | ""
     physical_bundle?: string
     preferences?: {
       is_default: boolean
@@ -26194,7 +26075,7 @@ export type t_PostIssuingTokensTokenRequestBody = {
 
 export type t_PostIssuingTransactionsTransactionRequestBody = {
   expand?: string[]
-  metadata?: Record<string, string> | "" | UnknownEnumStringValue
+  metadata?: Record<string, string> | ""
 }
 
 export type t_PostLinkAccountSessionsRequestBody = {
@@ -26279,7 +26160,6 @@ export type t_PostPaymentIntentsRequestBody = {
         }
       }
     | ""
-    | UnknownEnumStringValue
   metadata?: Record<string, string>
   off_session?: boolean | "one_off" | "recurring" | UnknownEnumStringValue
   on_behalf_of?: string
@@ -26322,10 +26202,9 @@ export type t_PostPaymentIntentsRequestBody = {
             state?: string
           }
         | ""
-        | UnknownEnumStringValue
-      email?: string | "" | UnknownEnumStringValue
-      name?: string | "" | UnknownEnumStringValue
-      phone?: string | "" | UnknownEnumStringValue
+      email?: string | ""
+      name?: string | ""
+      phone?: string | ""
       tax_id?: string
     }
     blik?: Record<string, unknown>
@@ -26556,7 +26435,7 @@ export type t_PostPaymentIntentsRequestBody = {
     acss_debit?:
       | {
           mandate_options?: {
-            custom_mandate_url?: string | "" | UnknownEnumStringValue
+            custom_mandate_url?: string | ""
             interval_description?: string
             payment_schedule?:
               | "combined"
@@ -26579,23 +26458,20 @@ export type t_PostPaymentIntentsRequestBody = {
             | UnknownEnumStringValue
         }
       | ""
-      | UnknownEnumStringValue
     affirm?:
       | {
           capture_method?: "" | "manual" | UnknownEnumStringValue
           preferred_locale?: string
-          setup_future_usage?: "none" | UnknownEnumStringValue
+          setup_future_usage?: "none"
         }
       | ""
-      | UnknownEnumStringValue
     afterpay_clearpay?:
       | {
           capture_method?: "" | "manual" | UnknownEnumStringValue
           reference?: string
-          setup_future_usage?: "none" | UnknownEnumStringValue
+          setup_future_usage?: "none"
         }
       | ""
-      | UnknownEnumStringValue
     alipay?:
       | {
           setup_future_usage?:
@@ -26605,13 +26481,11 @@ export type t_PostPaymentIntentsRequestBody = {
             | UnknownEnumStringValue
         }
       | ""
-      | UnknownEnumStringValue
     alma?:
       | {
           capture_method?: "" | "manual" | UnknownEnumStringValue
         }
       | ""
-      | UnknownEnumStringValue
     amazon_pay?:
       | {
           capture_method?: "" | "manual" | UnknownEnumStringValue
@@ -26622,7 +26496,6 @@ export type t_PostPaymentIntentsRequestBody = {
             | UnknownEnumStringValue
         }
       | ""
-      | UnknownEnumStringValue
     au_becs_debit?:
       | {
           setup_future_usage?:
@@ -26634,11 +26507,10 @@ export type t_PostPaymentIntentsRequestBody = {
           target_date?: string
         }
       | ""
-      | UnknownEnumStringValue
     bacs_debit?:
       | {
           mandate_options?: {
-            reference_prefix?: string | "" | UnknownEnumStringValue
+            reference_prefix?: string | ""
           }
           setup_future_usage?:
             | ""
@@ -26649,7 +26521,6 @@ export type t_PostPaymentIntentsRequestBody = {
           target_date?: string
         }
       | ""
-      | UnknownEnumStringValue
     bancontact?:
       | {
           preferred_language?:
@@ -26665,20 +26536,17 @@ export type t_PostPaymentIntentsRequestBody = {
             | UnknownEnumStringValue
         }
       | ""
-      | UnknownEnumStringValue
     billie?:
       | {
           capture_method?: "" | "manual" | UnknownEnumStringValue
         }
       | ""
-      | UnknownEnumStringValue
     blik?:
       | {
           code?: string
           setup_future_usage?: "" | "none" | UnknownEnumStringValue
         }
       | ""
-      | UnknownEnumStringValue
     boleto?:
       | {
           expires_after_days?: number
@@ -26690,7 +26558,6 @@ export type t_PostPaymentIntentsRequestBody = {
             | UnknownEnumStringValue
         }
       | ""
-      | UnknownEnumStringValue
     card?:
       | {
           capture_method?: "" | "manual" | UnknownEnumStringValue
@@ -26700,7 +26567,7 @@ export type t_PostPaymentIntentsRequestBody = {
             plan?:
               | {
                   count?: number
-                  interval?: "month" | UnknownEnumStringValue
+                  interval?: "month"
                   type:
                     | "bonus"
                     | "fixed_count"
@@ -26708,7 +26575,6 @@ export type t_PostPaymentIntentsRequestBody = {
                     | UnknownEnumStringValue
                 }
               | ""
-              | UnknownEnumStringValue
           }
           mandate_options?: {
             amount: number
@@ -26725,7 +26591,7 @@ export type t_PostPaymentIntentsRequestBody = {
             interval_count?: number
             reference: string
             start_date: number
-            supported_types?: ("india" | UnknownEnumStringValue)[]
+            supported_types?: "india"[]
           }
           network?:
             | "amex"
@@ -26770,14 +26636,8 @@ export type t_PostPaymentIntentsRequestBody = {
             | "off_session"
             | "on_session"
             | UnknownEnumStringValue
-          statement_descriptor_suffix_kana?:
-            | string
-            | ""
-            | UnknownEnumStringValue
-          statement_descriptor_suffix_kanji?:
-            | string
-            | ""
-            | UnknownEnumStringValue
+          statement_descriptor_suffix_kana?: string | ""
+          statement_descriptor_suffix_kanji?: string | ""
           three_d_secure?: {
             ares_trans_status?:
               | "A"
@@ -26817,7 +26677,6 @@ export type t_PostPaymentIntentsRequestBody = {
           }
         }
       | ""
-      | UnknownEnumStringValue
     card_present?:
       | {
           request_extended_authorization?: boolean
@@ -26830,7 +26689,6 @@ export type t_PostPaymentIntentsRequestBody = {
           }
         }
       | ""
-      | UnknownEnumStringValue
     cashapp?:
       | {
           capture_method?: "" | "manual" | UnknownEnumStringValue
@@ -26842,13 +26700,11 @@ export type t_PostPaymentIntentsRequestBody = {
             | UnknownEnumStringValue
         }
       | ""
-      | UnknownEnumStringValue
     crypto?:
       | {
-          setup_future_usage?: "none" | UnknownEnumStringValue
+          setup_future_usage?: "none"
         }
       | ""
-      | UnknownEnumStringValue
     customer_balance?:
       | {
           bank_transfer?: {
@@ -26873,35 +26729,30 @@ export type t_PostPaymentIntentsRequestBody = {
               | "us_bank_transfer"
               | UnknownEnumStringValue
           }
-          funding_type?: "bank_transfer" | UnknownEnumStringValue
-          setup_future_usage?: "none" | UnknownEnumStringValue
+          funding_type?: "bank_transfer"
+          setup_future_usage?: "none"
         }
       | ""
-      | UnknownEnumStringValue
     eps?:
       | {
-          setup_future_usage?: "none" | UnknownEnumStringValue
+          setup_future_usage?: "none"
         }
       | ""
-      | UnknownEnumStringValue
     fpx?:
       | {
-          setup_future_usage?: "none" | UnknownEnumStringValue
+          setup_future_usage?: "none"
         }
       | ""
-      | UnknownEnumStringValue
     giropay?:
       | {
-          setup_future_usage?: "none" | UnknownEnumStringValue
+          setup_future_usage?: "none"
         }
       | ""
-      | UnknownEnumStringValue
     grabpay?:
       | {
-          setup_future_usage?: "none" | UnknownEnumStringValue
+          setup_future_usage?: "none"
         }
       | ""
-      | UnknownEnumStringValue
     ideal?:
       | {
           setup_future_usage?:
@@ -26911,8 +26762,7 @@ export type t_PostPaymentIntentsRequestBody = {
             | UnknownEnumStringValue
         }
       | ""
-      | UnknownEnumStringValue
-    interac_present?: Record<string, unknown> | "" | UnknownEnumStringValue
+    interac_present?: Record<string, unknown> | ""
     kakao_pay?:
       | {
           capture_method?: "" | "manual" | UnknownEnumStringValue
@@ -26923,7 +26773,6 @@ export type t_PostPaymentIntentsRequestBody = {
             | UnknownEnumStringValue
         }
       | ""
-      | UnknownEnumStringValue
     klarna?:
       | {
           capture_method?: "" | "manual" | UnknownEnumStringValue
@@ -27009,20 +26858,17 @@ export type t_PostPaymentIntentsRequestBody = {
                 reference: string
               }[]
             | ""
-            | UnknownEnumStringValue
         }
       | ""
-      | UnknownEnumStringValue
     konbini?:
       | {
-          confirmation_number?: string | "" | UnknownEnumStringValue
-          expires_after_days?: number | "" | UnknownEnumStringValue
-          expires_at?: number | "" | UnknownEnumStringValue
-          product_description?: string | "" | UnknownEnumStringValue
-          setup_future_usage?: "none" | UnknownEnumStringValue
+          confirmation_number?: string | ""
+          expires_after_days?: number | ""
+          expires_at?: number | ""
+          product_description?: string | ""
+          setup_future_usage?: "none"
         }
       | ""
-      | UnknownEnumStringValue
     kr_card?:
       | {
           capture_method?: "" | "manual" | UnknownEnumStringValue
@@ -27033,7 +26879,6 @@ export type t_PostPaymentIntentsRequestBody = {
             | UnknownEnumStringValue
         }
       | ""
-      | UnknownEnumStringValue
     link?:
       | {
           capture_method?: "" | "manual" | UnknownEnumStringValue
@@ -27044,20 +26889,17 @@ export type t_PostPaymentIntentsRequestBody = {
             | UnknownEnumStringValue
         }
       | ""
-      | UnknownEnumStringValue
     mobilepay?:
       | {
           capture_method?: "" | "manual" | UnknownEnumStringValue
-          setup_future_usage?: "none" | UnknownEnumStringValue
+          setup_future_usage?: "none"
         }
       | ""
-      | UnknownEnumStringValue
     multibanco?:
       | {
-          setup_future_usage?: "none" | UnknownEnumStringValue
+          setup_future_usage?: "none"
         }
       | ""
-      | UnknownEnumStringValue
     naver_pay?:
       | {
           capture_method?: "" | "manual" | UnknownEnumStringValue
@@ -27068,7 +26910,6 @@ export type t_PostPaymentIntentsRequestBody = {
             | UnknownEnumStringValue
         }
       | ""
-      | UnknownEnumStringValue
     nz_bank_account?:
       | {
           setup_future_usage?:
@@ -27080,34 +26921,29 @@ export type t_PostPaymentIntentsRequestBody = {
           target_date?: string
         }
       | ""
-      | UnknownEnumStringValue
     oxxo?:
       | {
           expires_after_days?: number
-          setup_future_usage?: "none" | UnknownEnumStringValue
+          setup_future_usage?: "none"
         }
       | ""
-      | UnknownEnumStringValue
     p24?:
       | {
-          setup_future_usage?: "none" | UnknownEnumStringValue
+          setup_future_usage?: "none"
           tos_shown_and_accepted?: boolean
         }
       | ""
-      | UnknownEnumStringValue
-    pay_by_bank?: Record<string, unknown> | "" | UnknownEnumStringValue
+    pay_by_bank?: Record<string, unknown> | ""
     payco?:
       | {
           capture_method?: "" | "manual" | UnknownEnumStringValue
         }
       | ""
-      | UnknownEnumStringValue
     paynow?:
       | {
-          setup_future_usage?: "none" | UnknownEnumStringValue
+          setup_future_usage?: "none"
         }
       | ""
-      | UnknownEnumStringValue
     paypal?:
       | {
           capture_method?: "" | "manual" | UnknownEnumStringValue
@@ -27143,21 +26979,18 @@ export type t_PostPaymentIntentsRequestBody = {
             | UnknownEnumStringValue
         }
       | ""
-      | UnknownEnumStringValue
     pix?:
       | {
           expires_after_seconds?: number
           expires_at?: number
-          setup_future_usage?: "none" | UnknownEnumStringValue
+          setup_future_usage?: "none"
         }
       | ""
-      | UnknownEnumStringValue
     promptpay?:
       | {
-          setup_future_usage?: "none" | UnknownEnumStringValue
+          setup_future_usage?: "none"
         }
       | ""
-      | UnknownEnumStringValue
     revolut_pay?:
       | {
           capture_method?: "" | "manual" | UnknownEnumStringValue
@@ -27168,23 +27001,20 @@ export type t_PostPaymentIntentsRequestBody = {
             | UnknownEnumStringValue
         }
       | ""
-      | UnknownEnumStringValue
     samsung_pay?:
       | {
           capture_method?: "" | "manual" | UnknownEnumStringValue
         }
       | ""
-      | UnknownEnumStringValue
     satispay?:
       | {
           capture_method?: "" | "manual" | UnknownEnumStringValue
         }
       | ""
-      | UnknownEnumStringValue
     sepa_debit?:
       | {
           mandate_options?: {
-            reference_prefix?: string | "" | UnknownEnumStringValue
+            reference_prefix?: string | ""
           }
           setup_future_usage?:
             | ""
@@ -27195,7 +27025,6 @@ export type t_PostPaymentIntentsRequestBody = {
           target_date?: string
         }
       | ""
-      | UnknownEnumStringValue
     sofort?:
       | {
           preferred_language?:
@@ -27215,20 +27044,17 @@ export type t_PostPaymentIntentsRequestBody = {
             | UnknownEnumStringValue
         }
       | ""
-      | UnknownEnumStringValue
     swish?:
       | {
-          reference?: string | "" | UnknownEnumStringValue
-          setup_future_usage?: "none" | UnknownEnumStringValue
+          reference?: string | ""
+          setup_future_usage?: "none"
         }
       | ""
-      | UnknownEnumStringValue
     twint?:
       | {
-          setup_future_usage?: "none" | UnknownEnumStringValue
+          setup_future_usage?: "none"
         }
       | ""
-      | UnknownEnumStringValue
     us_bank_account?:
       | {
           financial_connections?: {
@@ -27279,21 +27105,18 @@ export type t_PostPaymentIntentsRequestBody = {
             | UnknownEnumStringValue
         }
       | ""
-      | UnknownEnumStringValue
     wechat_pay?:
       | {
           app_id?: string
           client?: "android" | "ios" | "web" | UnknownEnumStringValue
-          setup_future_usage?: "none" | UnknownEnumStringValue
+          setup_future_usage?: "none"
         }
       | ""
-      | UnknownEnumStringValue
     zip?:
       | {
-          setup_future_usage?: "none" | UnknownEnumStringValue
+          setup_future_usage?: "none"
         }
       | ""
-      | UnknownEnumStringValue
   }
   payment_method_types?: string[]
   radar_options?: {
@@ -27328,7 +27151,7 @@ export type t_PostPaymentIntentsRequestBody = {
 
 export type t_PostPaymentIntentsIntentRequestBody = {
   amount?: number
-  application_fee_amount?: number | "" | UnknownEnumStringValue
+  application_fee_amount?: number | ""
   capture_method?:
     | "automatic"
     | "automatic_async"
@@ -27338,7 +27161,7 @@ export type t_PostPaymentIntentsIntentRequestBody = {
   customer?: string
   description?: string
   expand?: string[]
-  metadata?: Record<string, string> | "" | UnknownEnumStringValue
+  metadata?: Record<string, string> | ""
   payment_method?: string
   payment_method_configuration?: string
   payment_method_data?: {
@@ -27378,10 +27201,9 @@ export type t_PostPaymentIntentsIntentRequestBody = {
             state?: string
           }
         | ""
-        | UnknownEnumStringValue
-      email?: string | "" | UnknownEnumStringValue
-      name?: string | "" | UnknownEnumStringValue
-      phone?: string | "" | UnknownEnumStringValue
+      email?: string | ""
+      name?: string | ""
+      phone?: string | ""
       tax_id?: string
     }
     blik?: Record<string, unknown>
@@ -27612,7 +27434,7 @@ export type t_PostPaymentIntentsIntentRequestBody = {
     acss_debit?:
       | {
           mandate_options?: {
-            custom_mandate_url?: string | "" | UnknownEnumStringValue
+            custom_mandate_url?: string | ""
             interval_description?: string
             payment_schedule?:
               | "combined"
@@ -27635,23 +27457,20 @@ export type t_PostPaymentIntentsIntentRequestBody = {
             | UnknownEnumStringValue
         }
       | ""
-      | UnknownEnumStringValue
     affirm?:
       | {
           capture_method?: "" | "manual" | UnknownEnumStringValue
           preferred_locale?: string
-          setup_future_usage?: "none" | UnknownEnumStringValue
+          setup_future_usage?: "none"
         }
       | ""
-      | UnknownEnumStringValue
     afterpay_clearpay?:
       | {
           capture_method?: "" | "manual" | UnknownEnumStringValue
           reference?: string
-          setup_future_usage?: "none" | UnknownEnumStringValue
+          setup_future_usage?: "none"
         }
       | ""
-      | UnknownEnumStringValue
     alipay?:
       | {
           setup_future_usage?:
@@ -27661,13 +27480,11 @@ export type t_PostPaymentIntentsIntentRequestBody = {
             | UnknownEnumStringValue
         }
       | ""
-      | UnknownEnumStringValue
     alma?:
       | {
           capture_method?: "" | "manual" | UnknownEnumStringValue
         }
       | ""
-      | UnknownEnumStringValue
     amazon_pay?:
       | {
           capture_method?: "" | "manual" | UnknownEnumStringValue
@@ -27678,7 +27495,6 @@ export type t_PostPaymentIntentsIntentRequestBody = {
             | UnknownEnumStringValue
         }
       | ""
-      | UnknownEnumStringValue
     au_becs_debit?:
       | {
           setup_future_usage?:
@@ -27690,11 +27506,10 @@ export type t_PostPaymentIntentsIntentRequestBody = {
           target_date?: string
         }
       | ""
-      | UnknownEnumStringValue
     bacs_debit?:
       | {
           mandate_options?: {
-            reference_prefix?: string | "" | UnknownEnumStringValue
+            reference_prefix?: string | ""
           }
           setup_future_usage?:
             | ""
@@ -27705,7 +27520,6 @@ export type t_PostPaymentIntentsIntentRequestBody = {
           target_date?: string
         }
       | ""
-      | UnknownEnumStringValue
     bancontact?:
       | {
           preferred_language?:
@@ -27721,20 +27535,17 @@ export type t_PostPaymentIntentsIntentRequestBody = {
             | UnknownEnumStringValue
         }
       | ""
-      | UnknownEnumStringValue
     billie?:
       | {
           capture_method?: "" | "manual" | UnknownEnumStringValue
         }
       | ""
-      | UnknownEnumStringValue
     blik?:
       | {
           code?: string
           setup_future_usage?: "" | "none" | UnknownEnumStringValue
         }
       | ""
-      | UnknownEnumStringValue
     boleto?:
       | {
           expires_after_days?: number
@@ -27746,7 +27557,6 @@ export type t_PostPaymentIntentsIntentRequestBody = {
             | UnknownEnumStringValue
         }
       | ""
-      | UnknownEnumStringValue
     card?:
       | {
           capture_method?: "" | "manual" | UnknownEnumStringValue
@@ -27756,7 +27566,7 @@ export type t_PostPaymentIntentsIntentRequestBody = {
             plan?:
               | {
                   count?: number
-                  interval?: "month" | UnknownEnumStringValue
+                  interval?: "month"
                   type:
                     | "bonus"
                     | "fixed_count"
@@ -27764,7 +27574,6 @@ export type t_PostPaymentIntentsIntentRequestBody = {
                     | UnknownEnumStringValue
                 }
               | ""
-              | UnknownEnumStringValue
           }
           mandate_options?: {
             amount: number
@@ -27781,7 +27590,7 @@ export type t_PostPaymentIntentsIntentRequestBody = {
             interval_count?: number
             reference: string
             start_date: number
-            supported_types?: ("india" | UnknownEnumStringValue)[]
+            supported_types?: "india"[]
           }
           network?:
             | "amex"
@@ -27826,14 +27635,8 @@ export type t_PostPaymentIntentsIntentRequestBody = {
             | "off_session"
             | "on_session"
             | UnknownEnumStringValue
-          statement_descriptor_suffix_kana?:
-            | string
-            | ""
-            | UnknownEnumStringValue
-          statement_descriptor_suffix_kanji?:
-            | string
-            | ""
-            | UnknownEnumStringValue
+          statement_descriptor_suffix_kana?: string | ""
+          statement_descriptor_suffix_kanji?: string | ""
           three_d_secure?: {
             ares_trans_status?:
               | "A"
@@ -27873,7 +27676,6 @@ export type t_PostPaymentIntentsIntentRequestBody = {
           }
         }
       | ""
-      | UnknownEnumStringValue
     card_present?:
       | {
           request_extended_authorization?: boolean
@@ -27886,7 +27688,6 @@ export type t_PostPaymentIntentsIntentRequestBody = {
           }
         }
       | ""
-      | UnknownEnumStringValue
     cashapp?:
       | {
           capture_method?: "" | "manual" | UnknownEnumStringValue
@@ -27898,13 +27699,11 @@ export type t_PostPaymentIntentsIntentRequestBody = {
             | UnknownEnumStringValue
         }
       | ""
-      | UnknownEnumStringValue
     crypto?:
       | {
-          setup_future_usage?: "none" | UnknownEnumStringValue
+          setup_future_usage?: "none"
         }
       | ""
-      | UnknownEnumStringValue
     customer_balance?:
       | {
           bank_transfer?: {
@@ -27929,35 +27728,30 @@ export type t_PostPaymentIntentsIntentRequestBody = {
               | "us_bank_transfer"
               | UnknownEnumStringValue
           }
-          funding_type?: "bank_transfer" | UnknownEnumStringValue
-          setup_future_usage?: "none" | UnknownEnumStringValue
+          funding_type?: "bank_transfer"
+          setup_future_usage?: "none"
         }
       | ""
-      | UnknownEnumStringValue
     eps?:
       | {
-          setup_future_usage?: "none" | UnknownEnumStringValue
+          setup_future_usage?: "none"
         }
       | ""
-      | UnknownEnumStringValue
     fpx?:
       | {
-          setup_future_usage?: "none" | UnknownEnumStringValue
+          setup_future_usage?: "none"
         }
       | ""
-      | UnknownEnumStringValue
     giropay?:
       | {
-          setup_future_usage?: "none" | UnknownEnumStringValue
+          setup_future_usage?: "none"
         }
       | ""
-      | UnknownEnumStringValue
     grabpay?:
       | {
-          setup_future_usage?: "none" | UnknownEnumStringValue
+          setup_future_usage?: "none"
         }
       | ""
-      | UnknownEnumStringValue
     ideal?:
       | {
           setup_future_usage?:
@@ -27967,8 +27761,7 @@ export type t_PostPaymentIntentsIntentRequestBody = {
             | UnknownEnumStringValue
         }
       | ""
-      | UnknownEnumStringValue
-    interac_present?: Record<string, unknown> | "" | UnknownEnumStringValue
+    interac_present?: Record<string, unknown> | ""
     kakao_pay?:
       | {
           capture_method?: "" | "manual" | UnknownEnumStringValue
@@ -27979,7 +27772,6 @@ export type t_PostPaymentIntentsIntentRequestBody = {
             | UnknownEnumStringValue
         }
       | ""
-      | UnknownEnumStringValue
     klarna?:
       | {
           capture_method?: "" | "manual" | UnknownEnumStringValue
@@ -28065,20 +27857,17 @@ export type t_PostPaymentIntentsIntentRequestBody = {
                 reference: string
               }[]
             | ""
-            | UnknownEnumStringValue
         }
       | ""
-      | UnknownEnumStringValue
     konbini?:
       | {
-          confirmation_number?: string | "" | UnknownEnumStringValue
-          expires_after_days?: number | "" | UnknownEnumStringValue
-          expires_at?: number | "" | UnknownEnumStringValue
-          product_description?: string | "" | UnknownEnumStringValue
-          setup_future_usage?: "none" | UnknownEnumStringValue
+          confirmation_number?: string | ""
+          expires_after_days?: number | ""
+          expires_at?: number | ""
+          product_description?: string | ""
+          setup_future_usage?: "none"
         }
       | ""
-      | UnknownEnumStringValue
     kr_card?:
       | {
           capture_method?: "" | "manual" | UnknownEnumStringValue
@@ -28089,7 +27878,6 @@ export type t_PostPaymentIntentsIntentRequestBody = {
             | UnknownEnumStringValue
         }
       | ""
-      | UnknownEnumStringValue
     link?:
       | {
           capture_method?: "" | "manual" | UnknownEnumStringValue
@@ -28100,20 +27888,17 @@ export type t_PostPaymentIntentsIntentRequestBody = {
             | UnknownEnumStringValue
         }
       | ""
-      | UnknownEnumStringValue
     mobilepay?:
       | {
           capture_method?: "" | "manual" | UnknownEnumStringValue
-          setup_future_usage?: "none" | UnknownEnumStringValue
+          setup_future_usage?: "none"
         }
       | ""
-      | UnknownEnumStringValue
     multibanco?:
       | {
-          setup_future_usage?: "none" | UnknownEnumStringValue
+          setup_future_usage?: "none"
         }
       | ""
-      | UnknownEnumStringValue
     naver_pay?:
       | {
           capture_method?: "" | "manual" | UnknownEnumStringValue
@@ -28124,7 +27909,6 @@ export type t_PostPaymentIntentsIntentRequestBody = {
             | UnknownEnumStringValue
         }
       | ""
-      | UnknownEnumStringValue
     nz_bank_account?:
       | {
           setup_future_usage?:
@@ -28136,34 +27920,29 @@ export type t_PostPaymentIntentsIntentRequestBody = {
           target_date?: string
         }
       | ""
-      | UnknownEnumStringValue
     oxxo?:
       | {
           expires_after_days?: number
-          setup_future_usage?: "none" | UnknownEnumStringValue
+          setup_future_usage?: "none"
         }
       | ""
-      | UnknownEnumStringValue
     p24?:
       | {
-          setup_future_usage?: "none" | UnknownEnumStringValue
+          setup_future_usage?: "none"
           tos_shown_and_accepted?: boolean
         }
       | ""
-      | UnknownEnumStringValue
-    pay_by_bank?: Record<string, unknown> | "" | UnknownEnumStringValue
+    pay_by_bank?: Record<string, unknown> | ""
     payco?:
       | {
           capture_method?: "" | "manual" | UnknownEnumStringValue
         }
       | ""
-      | UnknownEnumStringValue
     paynow?:
       | {
-          setup_future_usage?: "none" | UnknownEnumStringValue
+          setup_future_usage?: "none"
         }
       | ""
-      | UnknownEnumStringValue
     paypal?:
       | {
           capture_method?: "" | "manual" | UnknownEnumStringValue
@@ -28199,21 +27978,18 @@ export type t_PostPaymentIntentsIntentRequestBody = {
             | UnknownEnumStringValue
         }
       | ""
-      | UnknownEnumStringValue
     pix?:
       | {
           expires_after_seconds?: number
           expires_at?: number
-          setup_future_usage?: "none" | UnknownEnumStringValue
+          setup_future_usage?: "none"
         }
       | ""
-      | UnknownEnumStringValue
     promptpay?:
       | {
-          setup_future_usage?: "none" | UnknownEnumStringValue
+          setup_future_usage?: "none"
         }
       | ""
-      | UnknownEnumStringValue
     revolut_pay?:
       | {
           capture_method?: "" | "manual" | UnknownEnumStringValue
@@ -28224,23 +28000,20 @@ export type t_PostPaymentIntentsIntentRequestBody = {
             | UnknownEnumStringValue
         }
       | ""
-      | UnknownEnumStringValue
     samsung_pay?:
       | {
           capture_method?: "" | "manual" | UnknownEnumStringValue
         }
       | ""
-      | UnknownEnumStringValue
     satispay?:
       | {
           capture_method?: "" | "manual" | UnknownEnumStringValue
         }
       | ""
-      | UnknownEnumStringValue
     sepa_debit?:
       | {
           mandate_options?: {
-            reference_prefix?: string | "" | UnknownEnumStringValue
+            reference_prefix?: string | ""
           }
           setup_future_usage?:
             | ""
@@ -28251,7 +28024,6 @@ export type t_PostPaymentIntentsIntentRequestBody = {
           target_date?: string
         }
       | ""
-      | UnknownEnumStringValue
     sofort?:
       | {
           preferred_language?:
@@ -28271,20 +28043,17 @@ export type t_PostPaymentIntentsIntentRequestBody = {
             | UnknownEnumStringValue
         }
       | ""
-      | UnknownEnumStringValue
     swish?:
       | {
-          reference?: string | "" | UnknownEnumStringValue
-          setup_future_usage?: "none" | UnknownEnumStringValue
+          reference?: string | ""
+          setup_future_usage?: "none"
         }
       | ""
-      | UnknownEnumStringValue
     twint?:
       | {
-          setup_future_usage?: "none" | UnknownEnumStringValue
+          setup_future_usage?: "none"
         }
       | ""
-      | UnknownEnumStringValue
     us_bank_account?:
       | {
           financial_connections?: {
@@ -28335,24 +28104,21 @@ export type t_PostPaymentIntentsIntentRequestBody = {
             | UnknownEnumStringValue
         }
       | ""
-      | UnknownEnumStringValue
     wechat_pay?:
       | {
           app_id?: string
           client?: "android" | "ios" | "web" | UnknownEnumStringValue
-          setup_future_usage?: "none" | UnknownEnumStringValue
+          setup_future_usage?: "none"
         }
       | ""
-      | UnknownEnumStringValue
     zip?:
       | {
-          setup_future_usage?: "none" | UnknownEnumStringValue
+          setup_future_usage?: "none"
         }
       | ""
-      | UnknownEnumStringValue
   }
   payment_method_types?: string[]
-  receipt_email?: string | "" | UnknownEnumStringValue
+  receipt_email?: string | ""
   setup_future_usage?:
     | ""
     | "off_session"
@@ -28374,7 +28140,6 @@ export type t_PostPaymentIntentsIntentRequestBody = {
         tracking_number?: string
       }
     | ""
-    | UnknownEnumStringValue
   statement_descriptor?: string
   statement_descriptor_suffix?: string
   transfer_data?: {
@@ -28404,7 +28169,7 @@ export type t_PostPaymentIntentsIntentCaptureRequestBody = {
   application_fee_amount?: number
   expand?: string[]
   final_capture?: boolean
-  metadata?: Record<string, string> | "" | UnknownEnumStringValue
+  metadata?: Record<string, string> | ""
   statement_descriptor?: string
   statement_descriptor_suffix?: string
   transfer_data?: {
@@ -28436,14 +28201,13 @@ export type t_PostPaymentIntentsIntentConfirmRequestBody = {
         }
       }
     | ""
-    | UnknownEnumStringValue
     | {
         customer_acceptance: {
           online: {
             ip_address?: string
             user_agent?: string
           }
-          type: "online" | UnknownEnumStringValue
+          type: "online"
         }
       }
   off_session?: boolean | "one_off" | "recurring" | UnknownEnumStringValue
@@ -28485,10 +28249,9 @@ export type t_PostPaymentIntentsIntentConfirmRequestBody = {
             state?: string
           }
         | ""
-        | UnknownEnumStringValue
-      email?: string | "" | UnknownEnumStringValue
-      name?: string | "" | UnknownEnumStringValue
-      phone?: string | "" | UnknownEnumStringValue
+      email?: string | ""
+      name?: string | ""
+      phone?: string | ""
       tax_id?: string
     }
     blik?: Record<string, unknown>
@@ -28719,7 +28482,7 @@ export type t_PostPaymentIntentsIntentConfirmRequestBody = {
     acss_debit?:
       | {
           mandate_options?: {
-            custom_mandate_url?: string | "" | UnknownEnumStringValue
+            custom_mandate_url?: string | ""
             interval_description?: string
             payment_schedule?:
               | "combined"
@@ -28742,23 +28505,20 @@ export type t_PostPaymentIntentsIntentConfirmRequestBody = {
             | UnknownEnumStringValue
         }
       | ""
-      | UnknownEnumStringValue
     affirm?:
       | {
           capture_method?: "" | "manual" | UnknownEnumStringValue
           preferred_locale?: string
-          setup_future_usage?: "none" | UnknownEnumStringValue
+          setup_future_usage?: "none"
         }
       | ""
-      | UnknownEnumStringValue
     afterpay_clearpay?:
       | {
           capture_method?: "" | "manual" | UnknownEnumStringValue
           reference?: string
-          setup_future_usage?: "none" | UnknownEnumStringValue
+          setup_future_usage?: "none"
         }
       | ""
-      | UnknownEnumStringValue
     alipay?:
       | {
           setup_future_usage?:
@@ -28768,13 +28528,11 @@ export type t_PostPaymentIntentsIntentConfirmRequestBody = {
             | UnknownEnumStringValue
         }
       | ""
-      | UnknownEnumStringValue
     alma?:
       | {
           capture_method?: "" | "manual" | UnknownEnumStringValue
         }
       | ""
-      | UnknownEnumStringValue
     amazon_pay?:
       | {
           capture_method?: "" | "manual" | UnknownEnumStringValue
@@ -28785,7 +28543,6 @@ export type t_PostPaymentIntentsIntentConfirmRequestBody = {
             | UnknownEnumStringValue
         }
       | ""
-      | UnknownEnumStringValue
     au_becs_debit?:
       | {
           setup_future_usage?:
@@ -28797,11 +28554,10 @@ export type t_PostPaymentIntentsIntentConfirmRequestBody = {
           target_date?: string
         }
       | ""
-      | UnknownEnumStringValue
     bacs_debit?:
       | {
           mandate_options?: {
-            reference_prefix?: string | "" | UnknownEnumStringValue
+            reference_prefix?: string | ""
           }
           setup_future_usage?:
             | ""
@@ -28812,7 +28568,6 @@ export type t_PostPaymentIntentsIntentConfirmRequestBody = {
           target_date?: string
         }
       | ""
-      | UnknownEnumStringValue
     bancontact?:
       | {
           preferred_language?:
@@ -28828,20 +28583,17 @@ export type t_PostPaymentIntentsIntentConfirmRequestBody = {
             | UnknownEnumStringValue
         }
       | ""
-      | UnknownEnumStringValue
     billie?:
       | {
           capture_method?: "" | "manual" | UnknownEnumStringValue
         }
       | ""
-      | UnknownEnumStringValue
     blik?:
       | {
           code?: string
           setup_future_usage?: "" | "none" | UnknownEnumStringValue
         }
       | ""
-      | UnknownEnumStringValue
     boleto?:
       | {
           expires_after_days?: number
@@ -28853,7 +28605,6 @@ export type t_PostPaymentIntentsIntentConfirmRequestBody = {
             | UnknownEnumStringValue
         }
       | ""
-      | UnknownEnumStringValue
     card?:
       | {
           capture_method?: "" | "manual" | UnknownEnumStringValue
@@ -28863,7 +28614,7 @@ export type t_PostPaymentIntentsIntentConfirmRequestBody = {
             plan?:
               | {
                   count?: number
-                  interval?: "month" | UnknownEnumStringValue
+                  interval?: "month"
                   type:
                     | "bonus"
                     | "fixed_count"
@@ -28871,7 +28622,6 @@ export type t_PostPaymentIntentsIntentConfirmRequestBody = {
                     | UnknownEnumStringValue
                 }
               | ""
-              | UnknownEnumStringValue
           }
           mandate_options?: {
             amount: number
@@ -28888,7 +28638,7 @@ export type t_PostPaymentIntentsIntentConfirmRequestBody = {
             interval_count?: number
             reference: string
             start_date: number
-            supported_types?: ("india" | UnknownEnumStringValue)[]
+            supported_types?: "india"[]
           }
           network?:
             | "amex"
@@ -28933,14 +28683,8 @@ export type t_PostPaymentIntentsIntentConfirmRequestBody = {
             | "off_session"
             | "on_session"
             | UnknownEnumStringValue
-          statement_descriptor_suffix_kana?:
-            | string
-            | ""
-            | UnknownEnumStringValue
-          statement_descriptor_suffix_kanji?:
-            | string
-            | ""
-            | UnknownEnumStringValue
+          statement_descriptor_suffix_kana?: string | ""
+          statement_descriptor_suffix_kanji?: string | ""
           three_d_secure?: {
             ares_trans_status?:
               | "A"
@@ -28980,7 +28724,6 @@ export type t_PostPaymentIntentsIntentConfirmRequestBody = {
           }
         }
       | ""
-      | UnknownEnumStringValue
     card_present?:
       | {
           request_extended_authorization?: boolean
@@ -28993,7 +28736,6 @@ export type t_PostPaymentIntentsIntentConfirmRequestBody = {
           }
         }
       | ""
-      | UnknownEnumStringValue
     cashapp?:
       | {
           capture_method?: "" | "manual" | UnknownEnumStringValue
@@ -29005,13 +28747,11 @@ export type t_PostPaymentIntentsIntentConfirmRequestBody = {
             | UnknownEnumStringValue
         }
       | ""
-      | UnknownEnumStringValue
     crypto?:
       | {
-          setup_future_usage?: "none" | UnknownEnumStringValue
+          setup_future_usage?: "none"
         }
       | ""
-      | UnknownEnumStringValue
     customer_balance?:
       | {
           bank_transfer?: {
@@ -29036,35 +28776,30 @@ export type t_PostPaymentIntentsIntentConfirmRequestBody = {
               | "us_bank_transfer"
               | UnknownEnumStringValue
           }
-          funding_type?: "bank_transfer" | UnknownEnumStringValue
-          setup_future_usage?: "none" | UnknownEnumStringValue
+          funding_type?: "bank_transfer"
+          setup_future_usage?: "none"
         }
       | ""
-      | UnknownEnumStringValue
     eps?:
       | {
-          setup_future_usage?: "none" | UnknownEnumStringValue
+          setup_future_usage?: "none"
         }
       | ""
-      | UnknownEnumStringValue
     fpx?:
       | {
-          setup_future_usage?: "none" | UnknownEnumStringValue
+          setup_future_usage?: "none"
         }
       | ""
-      | UnknownEnumStringValue
     giropay?:
       | {
-          setup_future_usage?: "none" | UnknownEnumStringValue
+          setup_future_usage?: "none"
         }
       | ""
-      | UnknownEnumStringValue
     grabpay?:
       | {
-          setup_future_usage?: "none" | UnknownEnumStringValue
+          setup_future_usage?: "none"
         }
       | ""
-      | UnknownEnumStringValue
     ideal?:
       | {
           setup_future_usage?:
@@ -29074,8 +28809,7 @@ export type t_PostPaymentIntentsIntentConfirmRequestBody = {
             | UnknownEnumStringValue
         }
       | ""
-      | UnknownEnumStringValue
-    interac_present?: Record<string, unknown> | "" | UnknownEnumStringValue
+    interac_present?: Record<string, unknown> | ""
     kakao_pay?:
       | {
           capture_method?: "" | "manual" | UnknownEnumStringValue
@@ -29086,7 +28820,6 @@ export type t_PostPaymentIntentsIntentConfirmRequestBody = {
             | UnknownEnumStringValue
         }
       | ""
-      | UnknownEnumStringValue
     klarna?:
       | {
           capture_method?: "" | "manual" | UnknownEnumStringValue
@@ -29172,20 +28905,17 @@ export type t_PostPaymentIntentsIntentConfirmRequestBody = {
                 reference: string
               }[]
             | ""
-            | UnknownEnumStringValue
         }
       | ""
-      | UnknownEnumStringValue
     konbini?:
       | {
-          confirmation_number?: string | "" | UnknownEnumStringValue
-          expires_after_days?: number | "" | UnknownEnumStringValue
-          expires_at?: number | "" | UnknownEnumStringValue
-          product_description?: string | "" | UnknownEnumStringValue
-          setup_future_usage?: "none" | UnknownEnumStringValue
+          confirmation_number?: string | ""
+          expires_after_days?: number | ""
+          expires_at?: number | ""
+          product_description?: string | ""
+          setup_future_usage?: "none"
         }
       | ""
-      | UnknownEnumStringValue
     kr_card?:
       | {
           capture_method?: "" | "manual" | UnknownEnumStringValue
@@ -29196,7 +28926,6 @@ export type t_PostPaymentIntentsIntentConfirmRequestBody = {
             | UnknownEnumStringValue
         }
       | ""
-      | UnknownEnumStringValue
     link?:
       | {
           capture_method?: "" | "manual" | UnknownEnumStringValue
@@ -29207,20 +28936,17 @@ export type t_PostPaymentIntentsIntentConfirmRequestBody = {
             | UnknownEnumStringValue
         }
       | ""
-      | UnknownEnumStringValue
     mobilepay?:
       | {
           capture_method?: "" | "manual" | UnknownEnumStringValue
-          setup_future_usage?: "none" | UnknownEnumStringValue
+          setup_future_usage?: "none"
         }
       | ""
-      | UnknownEnumStringValue
     multibanco?:
       | {
-          setup_future_usage?: "none" | UnknownEnumStringValue
+          setup_future_usage?: "none"
         }
       | ""
-      | UnknownEnumStringValue
     naver_pay?:
       | {
           capture_method?: "" | "manual" | UnknownEnumStringValue
@@ -29231,7 +28957,6 @@ export type t_PostPaymentIntentsIntentConfirmRequestBody = {
             | UnknownEnumStringValue
         }
       | ""
-      | UnknownEnumStringValue
     nz_bank_account?:
       | {
           setup_future_usage?:
@@ -29243,34 +28968,29 @@ export type t_PostPaymentIntentsIntentConfirmRequestBody = {
           target_date?: string
         }
       | ""
-      | UnknownEnumStringValue
     oxxo?:
       | {
           expires_after_days?: number
-          setup_future_usage?: "none" | UnknownEnumStringValue
+          setup_future_usage?: "none"
         }
       | ""
-      | UnknownEnumStringValue
     p24?:
       | {
-          setup_future_usage?: "none" | UnknownEnumStringValue
+          setup_future_usage?: "none"
           tos_shown_and_accepted?: boolean
         }
       | ""
-      | UnknownEnumStringValue
-    pay_by_bank?: Record<string, unknown> | "" | UnknownEnumStringValue
+    pay_by_bank?: Record<string, unknown> | ""
     payco?:
       | {
           capture_method?: "" | "manual" | UnknownEnumStringValue
         }
       | ""
-      | UnknownEnumStringValue
     paynow?:
       | {
-          setup_future_usage?: "none" | UnknownEnumStringValue
+          setup_future_usage?: "none"
         }
       | ""
-      | UnknownEnumStringValue
     paypal?:
       | {
           capture_method?: "" | "manual" | UnknownEnumStringValue
@@ -29306,21 +29026,18 @@ export type t_PostPaymentIntentsIntentConfirmRequestBody = {
             | UnknownEnumStringValue
         }
       | ""
-      | UnknownEnumStringValue
     pix?:
       | {
           expires_after_seconds?: number
           expires_at?: number
-          setup_future_usage?: "none" | UnknownEnumStringValue
+          setup_future_usage?: "none"
         }
       | ""
-      | UnknownEnumStringValue
     promptpay?:
       | {
-          setup_future_usage?: "none" | UnknownEnumStringValue
+          setup_future_usage?: "none"
         }
       | ""
-      | UnknownEnumStringValue
     revolut_pay?:
       | {
           capture_method?: "" | "manual" | UnknownEnumStringValue
@@ -29331,23 +29048,20 @@ export type t_PostPaymentIntentsIntentConfirmRequestBody = {
             | UnknownEnumStringValue
         }
       | ""
-      | UnknownEnumStringValue
     samsung_pay?:
       | {
           capture_method?: "" | "manual" | UnknownEnumStringValue
         }
       | ""
-      | UnknownEnumStringValue
     satispay?:
       | {
           capture_method?: "" | "manual" | UnknownEnumStringValue
         }
       | ""
-      | UnknownEnumStringValue
     sepa_debit?:
       | {
           mandate_options?: {
-            reference_prefix?: string | "" | UnknownEnumStringValue
+            reference_prefix?: string | ""
           }
           setup_future_usage?:
             | ""
@@ -29358,7 +29072,6 @@ export type t_PostPaymentIntentsIntentConfirmRequestBody = {
           target_date?: string
         }
       | ""
-      | UnknownEnumStringValue
     sofort?:
       | {
           preferred_language?:
@@ -29378,20 +29091,17 @@ export type t_PostPaymentIntentsIntentConfirmRequestBody = {
             | UnknownEnumStringValue
         }
       | ""
-      | UnknownEnumStringValue
     swish?:
       | {
-          reference?: string | "" | UnknownEnumStringValue
-          setup_future_usage?: "none" | UnknownEnumStringValue
+          reference?: string | ""
+          setup_future_usage?: "none"
         }
       | ""
-      | UnknownEnumStringValue
     twint?:
       | {
-          setup_future_usage?: "none" | UnknownEnumStringValue
+          setup_future_usage?: "none"
         }
       | ""
-      | UnknownEnumStringValue
     us_bank_account?:
       | {
           financial_connections?: {
@@ -29442,27 +29152,24 @@ export type t_PostPaymentIntentsIntentConfirmRequestBody = {
             | UnknownEnumStringValue
         }
       | ""
-      | UnknownEnumStringValue
     wechat_pay?:
       | {
           app_id?: string
           client?: "android" | "ios" | "web" | UnknownEnumStringValue
-          setup_future_usage?: "none" | UnknownEnumStringValue
+          setup_future_usage?: "none"
         }
       | ""
-      | UnknownEnumStringValue
     zip?:
       | {
-          setup_future_usage?: "none" | UnknownEnumStringValue
+          setup_future_usage?: "none"
         }
       | ""
-      | UnknownEnumStringValue
   }
   payment_method_types?: string[]
   radar_options?: {
     session?: string
   }
-  receipt_email?: string | "" | UnknownEnumStringValue
+  receipt_email?: string | ""
   return_url?: string
   setup_future_usage?:
     | ""
@@ -29485,7 +29192,6 @@ export type t_PostPaymentIntentsIntentConfirmRequestBody = {
         tracking_number?: string
       }
     | ""
-    | UnknownEnumStringValue
   use_stripe_sdk?: boolean
 }
 
@@ -29548,7 +29254,7 @@ export type t_PostPaymentLinksRequestBody = {
     key: string
     label: {
       custom: string
-      type: "custom" | UnknownEnumStringValue
+      type: "custom"
     }
     numeric?: {
       default_value?: string
@@ -29569,25 +29275,21 @@ export type t_PostPaymentLinksRequestBody = {
           message: string
         }
       | ""
-      | UnknownEnumStringValue
     shipping_address?:
       | {
           message: string
         }
       | ""
-      | UnknownEnumStringValue
     submit?:
       | {
           message: string
         }
       | ""
-      | UnknownEnumStringValue
     terms_of_service_acceptance?:
       | {
           message: string
         }
       | ""
-      | UnknownEnumStringValue
   }
   customer_creation?: "always" | "if_required" | UnknownEnumStringValue
   expand?: string[]
@@ -29595,21 +29297,20 @@ export type t_PostPaymentLinksRequestBody = {
   invoice_creation?: {
     enabled: boolean
     invoice_data?: {
-      account_tax_ids?: string[] | "" | UnknownEnumStringValue
+      account_tax_ids?: string[] | ""
       custom_fields?:
         | {
             name: string
             value: string
           }[]
         | ""
-        | UnknownEnumStringValue
       description?: string
       footer?: string
       issuer?: {
         account?: string
         type: "account" | "self" | UnknownEnumStringValue
       }
-      metadata?: Record<string, string> | "" | UnknownEnumStringValue
+      metadata?: Record<string, string> | ""
       rendering_options?:
         | {
             amount_tax_display?:
@@ -29620,7 +29321,6 @@ export type t_PostPaymentLinksRequestBody = {
             template?: string
           }
         | ""
-        | UnknownEnumStringValue
     }
   }
   line_items: {
@@ -30042,7 +29742,7 @@ export type t_PostPaymentLinksPaymentLinkRequestBody = {
         key: string
         label: {
           custom: string
-          type: "custom" | UnknownEnumStringValue
+          type: "custom"
         }
         numeric?: {
           default_value?: string
@@ -30058,54 +29758,48 @@ export type t_PostPaymentLinksPaymentLinkRequestBody = {
         type: "dropdown" | "numeric" | "text" | UnknownEnumStringValue
       }[]
     | ""
-    | UnknownEnumStringValue
   custom_text?: {
     after_submit?:
       | {
           message: string
         }
       | ""
-      | UnknownEnumStringValue
     shipping_address?:
       | {
           message: string
         }
       | ""
-      | UnknownEnumStringValue
     submit?:
       | {
           message: string
         }
       | ""
-      | UnknownEnumStringValue
     terms_of_service_acceptance?:
       | {
           message: string
         }
       | ""
-      | UnknownEnumStringValue
   }
   customer_creation?: "always" | "if_required" | UnknownEnumStringValue
   expand?: string[]
-  inactive_message?: string | "" | UnknownEnumStringValue
+  inactive_message?: string | ""
   invoice_creation?: {
     enabled: boolean
     invoice_data?: {
-      account_tax_ids?: string[] | "" | UnknownEnumStringValue
+      account_tax_ids?: string[] | ""
       custom_fields?:
         | {
             name: string
             value: string
           }[]
         | ""
-        | UnknownEnumStringValue
       description?: string
       footer?: string
       issuer?: {
         account?: string
         type: "account" | "self" | UnknownEnumStringValue
       }
-      metadata?: Record<string, string> | "" | UnknownEnumStringValue
+      metadata?: Record<string, string> | ""
       rendering_options?:
         | {
             amount_tax_display?:
@@ -30116,7 +29810,6 @@ export type t_PostPaymentLinksPaymentLinkRequestBody = {
             template?: string
           }
         | ""
-        | UnknownEnumStringValue
     }
   }
   line_items?: {
@@ -30130,11 +29823,11 @@ export type t_PostPaymentLinksPaymentLinkRequestBody = {
   }[]
   metadata?: Record<string, string>
   payment_intent_data?: {
-    description?: string | "" | UnknownEnumStringValue
-    metadata?: Record<string, string> | "" | UnknownEnumStringValue
-    statement_descriptor?: string | "" | UnknownEnumStringValue
-    statement_descriptor_suffix?: string | "" | UnknownEnumStringValue
-    transfer_group?: string | "" | UnknownEnumStringValue
+    description?: string | ""
+    metadata?: Record<string, string> | ""
+    statement_descriptor?: string | ""
+    statement_descriptor_suffix?: string | ""
+    transfer_group?: string | ""
   }
   payment_method_collection?: "always" | "if_required" | UnknownEnumStringValue
   payment_method_types?:
@@ -30179,7 +29872,6 @@ export type t_PostPaymentLinksPaymentLinkRequestBody = {
         | UnknownEnumStringValue
       )[]
     | ""
-    | UnknownEnumStringValue
   phone_number_collection?: {
     enabled: boolean
   }
@@ -30190,7 +29882,6 @@ export type t_PostPaymentLinksPaymentLinkRequestBody = {
         }
       }
     | ""
-    | UnknownEnumStringValue
   shipping_address_collection?:
     | {
         allowed_countries: (
@@ -30436,7 +30127,6 @@ export type t_PostPaymentLinksPaymentLinkRequestBody = {
         )[]
       }
     | ""
-    | UnknownEnumStringValue
   submit_type?:
     | "auto"
     | "book"
@@ -30451,8 +30141,8 @@ export type t_PostPaymentLinksPaymentLinkRequestBody = {
         type: "account" | "self" | UnknownEnumStringValue
       }
     }
-    metadata?: Record<string, string> | "" | UnknownEnumStringValue
-    trial_period_days?: number | "" | UnknownEnumStringValue
+    metadata?: Record<string, string> | ""
+    trial_period_days?: number | ""
     trial_settings?:
       | {
           end_behavior: {
@@ -30464,7 +30154,6 @@ export type t_PostPaymentLinksPaymentLinkRequestBody = {
           }
         }
       | ""
-      | UnknownEnumStringValue
   }
   tax_id_collection?: {
     enabled: boolean
@@ -31056,10 +30745,9 @@ export type t_PostPaymentMethodsRequestBody = {
           state?: string
         }
       | ""
-      | UnknownEnumStringValue
-    email?: string | "" | UnknownEnumStringValue
-    name?: string | "" | UnknownEnumStringValue
-    phone?: string | "" | UnknownEnumStringValue
+    email?: string | ""
+    name?: string | ""
+    phone?: string | ""
     tax_id?: string
   }
   blik?: Record<string, unknown>
@@ -31325,10 +31013,9 @@ export type t_PostPaymentMethodsPaymentMethodRequestBody = {
           state?: string
         }
       | ""
-      | UnknownEnumStringValue
-    email?: string | "" | UnknownEnumStringValue
-    name?: string | "" | UnknownEnumStringValue
-    phone?: string | "" | UnknownEnumStringValue
+    email?: string | ""
+    name?: string | ""
+    phone?: string | ""
     tax_id?: string
   }
   card?: {
@@ -31345,7 +31032,7 @@ export type t_PostPaymentMethodsPaymentMethodRequestBody = {
   }
   expand?: string[]
   link?: Record<string, unknown>
-  metadata?: Record<string, string> | "" | UnknownEnumStringValue
+  metadata?: Record<string, string> | ""
   pay_by_bank?: Record<string, unknown>
   us_bank_account?: {
     account_holder_type?: "company" | "individual" | UnknownEnumStringValue
@@ -31376,7 +31063,7 @@ export type t_PostPayoutsRequestBody = {
 
 export type t_PostPayoutsPayoutRequestBody = {
   expand?: string[]
-  metadata?: Record<string, string> | "" | UnknownEnumStringValue
+  metadata?: Record<string, string> | ""
 }
 
 export type t_PostPayoutsPayoutCancelRequestBody = {
@@ -31398,7 +31085,7 @@ export type t_PostPlansRequestBody = {
   id?: string
   interval: "day" | "month" | "week" | "year" | UnknownEnumStringValue
   interval_count?: number
-  metadata?: Record<string, string> | "" | UnknownEnumStringValue
+  metadata?: Record<string, string> | ""
   meter?: string
   nickname?: string
   product?:
@@ -31417,7 +31104,7 @@ export type t_PostPlansRequestBody = {
     flat_amount_decimal?: string
     unit_amount?: number
     unit_amount_decimal?: string
-    up_to: "inf" | UnknownEnumStringValue | number
+    up_to: "inf" | number
   }[]
   tiers_mode?: "graduated" | "volume" | UnknownEnumStringValue
   transform_usage?: {
@@ -31431,7 +31118,7 @@ export type t_PostPlansRequestBody = {
 export type t_PostPlansPlanRequestBody = {
   active?: boolean
   expand?: string[]
-  metadata?: Record<string, string> | "" | UnknownEnumStringValue
+  metadata?: Record<string, string> | ""
   nickname?: string
   product?: string
   trial_period_days?: number
@@ -31460,7 +31147,7 @@ export type t_PostPricesRequestBody = {
         flat_amount_decimal?: string
         unit_amount?: number
         unit_amount_decimal?: string
-        up_to: "inf" | UnknownEnumStringValue | number
+        up_to: "inf" | number
       }[]
       unit_amount?: number
       unit_amount_decimal?: string
@@ -31502,7 +31189,7 @@ export type t_PostPricesRequestBody = {
     flat_amount_decimal?: string
     unit_amount?: number
     unit_amount_decimal?: string
-    up_to: "inf" | UnknownEnumStringValue | number
+    up_to: "inf" | number
   }[]
   tiers_mode?: "graduated" | "volume" | UnknownEnumStringValue
   transfer_lookup_key?: boolean
@@ -31536,17 +31223,16 @@ export type t_PostPricesPriceRequestBody = {
             flat_amount_decimal?: string
             unit_amount?: number
             unit_amount_decimal?: string
-            up_to: "inf" | UnknownEnumStringValue | number
+            up_to: "inf" | number
           }[]
           unit_amount?: number
           unit_amount_decimal?: string
         }
       >
     | ""
-    | UnknownEnumStringValue
   expand?: string[]
   lookup_key?: string
-  metadata?: Record<string, string> | "" | UnknownEnumStringValue
+  metadata?: Record<string, string> | ""
   nickname?: string
   tax_behavior?:
     | "exclusive"
@@ -31579,7 +31265,7 @@ export type t_PostProductsRequestBody = {
           flat_amount_decimal?: string
           unit_amount?: number
           unit_amount_decimal?: string
-          up_to: "inf" | UnknownEnumStringValue | number
+          up_to: "inf" | number
         }[]
         unit_amount?: number
         unit_amount_decimal?: string
@@ -31629,16 +31315,15 @@ export type t_PostProductsRequestBody = {
 export type t_PostProductsIdRequestBody = {
   active?: boolean
   default_price?: string
-  description?: string | "" | UnknownEnumStringValue
+  description?: string | ""
   expand?: string[]
-  images?: string[] | "" | UnknownEnumStringValue
+  images?: string[] | ""
   marketing_features?:
     | {
         name: string
       }[]
     | ""
-    | UnknownEnumStringValue
-  metadata?: Record<string, string> | "" | UnknownEnumStringValue
+  metadata?: Record<string, string> | ""
   name?: string
   package_dimensions?:
     | {
@@ -31648,12 +31333,11 @@ export type t_PostProductsIdRequestBody = {
         width: number
       }
     | ""
-    | UnknownEnumStringValue
   shippable?: boolean
   statement_descriptor?: string
-  tax_code?: string | "" | UnknownEnumStringValue
-  unit_label?: string | "" | UnknownEnumStringValue
-  url?: string | "" | UnknownEnumStringValue
+  tax_code?: string | ""
+  unit_label?: string | ""
+  url?: string | ""
 }
 
 export type t_PostProductsProductFeaturesRequestBody = {
@@ -31686,7 +31370,7 @@ export type t_PostPromotionCodesRequestBody = {
 export type t_PostPromotionCodesPromotionCodeRequestBody = {
   active?: boolean
   expand?: string[]
-  metadata?: Record<string, string> | "" | UnknownEnumStringValue
+  metadata?: Record<string, string> | ""
   restrictions?: {
     currency_options?: Record<
       string,
@@ -31698,8 +31382,8 @@ export type t_PostPromotionCodesPromotionCodeRequestBody = {
 }
 
 export type t_PostQuotesRequestBody = {
-  application_fee_amount?: number | "" | UnknownEnumStringValue
-  application_fee_percent?: number | "" | UnknownEnumStringValue
+  application_fee_amount?: number | ""
+  application_fee_percent?: number | ""
   automatic_tax?: {
     enabled: boolean
     liability?: {
@@ -31712,8 +31396,8 @@ export type t_PostQuotesRequestBody = {
     | "send_invoice"
     | UnknownEnumStringValue
   customer?: string
-  default_tax_rates?: string[] | "" | UnknownEnumStringValue
-  description?: string | "" | UnknownEnumStringValue
+  default_tax_rates?: string[] | ""
+  description?: string | ""
   discounts?:
     | {
         coupon?: string
@@ -31721,15 +31405,14 @@ export type t_PostQuotesRequestBody = {
         promotion_code?: string
       }[]
     | ""
-    | UnknownEnumStringValue
   expand?: string[]
   expires_at?: number
-  footer?: string | "" | UnknownEnumStringValue
+  footer?: string | ""
   from_quote?: {
     is_revision?: boolean
     quote: string
   }
-  header?: string | "" | UnknownEnumStringValue
+  header?: string | ""
   invoice_settings?: {
     days_until_due?: number
     issuer?: {
@@ -31745,7 +31428,6 @@ export type t_PostQuotesRequestBody = {
           promotion_code?: string
         }[]
       | ""
-      | UnknownEnumStringValue
     price?: string
     price_data?: {
       currency: string
@@ -31763,18 +31445,18 @@ export type t_PostQuotesRequestBody = {
       unit_amount_decimal?: string
     }
     quantity?: number
-    tax_rates?: string[] | "" | UnknownEnumStringValue
+    tax_rates?: string[] | ""
   }[]
   metadata?: Record<string, string>
-  on_behalf_of?: string | "" | UnknownEnumStringValue
+  on_behalf_of?: string | ""
   subscription_data?: {
     billing_mode?: {
       type: "classic" | "flexible" | UnknownEnumStringValue
     }
     description?: string
-    effective_date?: "current_period_end" | UnknownEnumStringValue | number | ""
+    effective_date?: "current_period_end" | number | ""
     metadata?: Record<string, string>
-    trial_period_days?: number | "" | UnknownEnumStringValue
+    trial_period_days?: number | ""
   }
   test_clock?: string
   transfer_data?:
@@ -31784,12 +31466,11 @@ export type t_PostQuotesRequestBody = {
         destination: string
       }
     | ""
-    | UnknownEnumStringValue
 }
 
 export type t_PostQuotesQuoteRequestBody = {
-  application_fee_amount?: number | "" | UnknownEnumStringValue
-  application_fee_percent?: number | "" | UnknownEnumStringValue
+  application_fee_amount?: number | ""
+  application_fee_percent?: number | ""
   automatic_tax?: {
     enabled: boolean
     liability?: {
@@ -31802,8 +31483,8 @@ export type t_PostQuotesQuoteRequestBody = {
     | "send_invoice"
     | UnknownEnumStringValue
   customer?: string
-  default_tax_rates?: string[] | "" | UnknownEnumStringValue
-  description?: string | "" | UnknownEnumStringValue
+  default_tax_rates?: string[] | ""
+  description?: string | ""
   discounts?:
     | {
         coupon?: string
@@ -31811,11 +31492,10 @@ export type t_PostQuotesQuoteRequestBody = {
         promotion_code?: string
       }[]
     | ""
-    | UnknownEnumStringValue
   expand?: string[]
   expires_at?: number
-  footer?: string | "" | UnknownEnumStringValue
-  header?: string | "" | UnknownEnumStringValue
+  footer?: string | ""
+  header?: string | ""
   invoice_settings?: {
     days_until_due?: number
     issuer?: {
@@ -31831,7 +31511,6 @@ export type t_PostQuotesQuoteRequestBody = {
           promotion_code?: string
         }[]
       | ""
-      | UnknownEnumStringValue
     id?: string
     price?: string
     price_data?: {
@@ -31850,15 +31529,15 @@ export type t_PostQuotesQuoteRequestBody = {
       unit_amount_decimal?: string
     }
     quantity?: number
-    tax_rates?: string[] | "" | UnknownEnumStringValue
+    tax_rates?: string[] | ""
   }[]
   metadata?: Record<string, string>
-  on_behalf_of?: string | "" | UnknownEnumStringValue
+  on_behalf_of?: string | ""
   subscription_data?: {
-    description?: string | "" | UnknownEnumStringValue
-    effective_date?: "current_period_end" | UnknownEnumStringValue | number | ""
+    description?: string | ""
+    effective_date?: "current_period_end" | number | ""
     metadata?: Record<string, string>
-    trial_period_days?: number | "" | UnknownEnumStringValue
+    trial_period_days?: number | ""
   }
   transfer_data?:
     | {
@@ -31867,7 +31546,6 @@ export type t_PostQuotesQuoteRequestBody = {
         destination: string
       }
     | ""
-    | UnknownEnumStringValue
 }
 
 export type t_PostQuotesQuoteAcceptRequestBody = {
@@ -31922,8 +31600,8 @@ export type t_PostRefundsRequestBody = {
   customer?: string
   expand?: string[]
   instructions_email?: string
-  metadata?: Record<string, string> | "" | UnknownEnumStringValue
-  origin?: "customer_balance" | UnknownEnumStringValue
+  metadata?: Record<string, string> | ""
+  origin?: "customer_balance"
   payment_intent?: string
   reason?:
     | "duplicate"
@@ -31936,7 +31614,7 @@ export type t_PostRefundsRequestBody = {
 
 export type t_PostRefundsRefundRequestBody = {
   expand?: string[]
-  metadata?: Record<string, string> | "" | UnknownEnumStringValue
+  metadata?: Record<string, string> | ""
 }
 
 export type t_PostRefundsRefundCancelRequestBody = {
@@ -32625,7 +32303,6 @@ export type t_PostSetupIntentsRequestBody = {
         }
       }
     | ""
-    | UnknownEnumStringValue
   metadata?: Record<string, string>
   on_behalf_of?: string
   payment_method?: string
@@ -32667,10 +32344,9 @@ export type t_PostSetupIntentsRequestBody = {
             state?: string
           }
         | ""
-        | UnknownEnumStringValue
-      email?: string | "" | UnknownEnumStringValue
-      name?: string | "" | UnknownEnumStringValue
-      phone?: string | "" | UnknownEnumStringValue
+      email?: string | ""
+      name?: string | ""
+      phone?: string | ""
       tax_id?: string
     }
     blik?: Record<string, unknown>
@@ -32901,7 +32577,7 @@ export type t_PostSetupIntentsRequestBody = {
     acss_debit?: {
       currency?: "cad" | "usd" | UnknownEnumStringValue
       mandate_options?: {
-        custom_mandate_url?: string | "" | UnknownEnumStringValue
+        custom_mandate_url?: string | ""
         default_for?: ("invoice" | "subscription" | UnknownEnumStringValue)[]
         interval_description?: string
         payment_schedule?:
@@ -32920,7 +32596,7 @@ export type t_PostSetupIntentsRequestBody = {
     amazon_pay?: Record<string, unknown>
     bacs_debit?: {
       mandate_options?: {
-        reference_prefix?: string | "" | UnknownEnumStringValue
+        reference_prefix?: string | ""
       }
     }
     card?: {
@@ -32940,7 +32616,7 @@ export type t_PostSetupIntentsRequestBody = {
         interval_count?: number
         reference: string
         start_date: number
-        supported_types?: ("india" | UnknownEnumStringValue)[]
+        supported_types?: "india"[]
       }
       network?:
         | "amex"
@@ -33074,7 +32750,6 @@ export type t_PostSetupIntentsRequestBody = {
             reference: string
           }[]
         | ""
-        | UnknownEnumStringValue
     }
     link?: Record<string, unknown>
     paypal?: {
@@ -33082,7 +32757,7 @@ export type t_PostSetupIntentsRequestBody = {
     }
     sepa_debit?: {
       mandate_options?: {
-        reference_prefix?: string | "" | UnknownEnumStringValue
+        reference_prefix?: string | ""
       }
     }
     us_bank_account?: {
@@ -33138,7 +32813,7 @@ export type t_PostSetupIntentsIntentRequestBody = {
   description?: string
   expand?: string[]
   flow_directions?: ("inbound" | "outbound" | UnknownEnumStringValue)[]
-  metadata?: Record<string, string> | "" | UnknownEnumStringValue
+  metadata?: Record<string, string> | ""
   payment_method?: string
   payment_method_configuration?: string
   payment_method_data?: {
@@ -33178,10 +32853,9 @@ export type t_PostSetupIntentsIntentRequestBody = {
             state?: string
           }
         | ""
-        | UnknownEnumStringValue
-      email?: string | "" | UnknownEnumStringValue
-      name?: string | "" | UnknownEnumStringValue
-      phone?: string | "" | UnknownEnumStringValue
+      email?: string | ""
+      name?: string | ""
+      phone?: string | ""
       tax_id?: string
     }
     blik?: Record<string, unknown>
@@ -33412,7 +33086,7 @@ export type t_PostSetupIntentsIntentRequestBody = {
     acss_debit?: {
       currency?: "cad" | "usd" | UnknownEnumStringValue
       mandate_options?: {
-        custom_mandate_url?: string | "" | UnknownEnumStringValue
+        custom_mandate_url?: string | ""
         default_for?: ("invoice" | "subscription" | UnknownEnumStringValue)[]
         interval_description?: string
         payment_schedule?:
@@ -33431,7 +33105,7 @@ export type t_PostSetupIntentsIntentRequestBody = {
     amazon_pay?: Record<string, unknown>
     bacs_debit?: {
       mandate_options?: {
-        reference_prefix?: string | "" | UnknownEnumStringValue
+        reference_prefix?: string | ""
       }
     }
     card?: {
@@ -33451,7 +33125,7 @@ export type t_PostSetupIntentsIntentRequestBody = {
         interval_count?: number
         reference: string
         start_date: number
-        supported_types?: ("india" | UnknownEnumStringValue)[]
+        supported_types?: "india"[]
       }
       network?:
         | "amex"
@@ -33585,7 +33259,6 @@ export type t_PostSetupIntentsIntentRequestBody = {
             reference: string
           }[]
         | ""
-        | UnknownEnumStringValue
     }
     link?: Record<string, unknown>
     paypal?: {
@@ -33593,7 +33266,7 @@ export type t_PostSetupIntentsIntentRequestBody = {
     }
     sepa_debit?: {
       mandate_options?: {
-        reference_prefix?: string | "" | UnknownEnumStringValue
+        reference_prefix?: string | ""
       }
     }
     us_bank_account?: {
@@ -33662,14 +33335,13 @@ export type t_PostSetupIntentsIntentConfirmRequestBody = {
         }
       }
     | ""
-    | UnknownEnumStringValue
     | {
         customer_acceptance: {
           online: {
             ip_address?: string
             user_agent?: string
           }
-          type: "online" | UnknownEnumStringValue
+          type: "online"
         }
       }
   payment_method?: string
@@ -33710,10 +33382,9 @@ export type t_PostSetupIntentsIntentConfirmRequestBody = {
             state?: string
           }
         | ""
-        | UnknownEnumStringValue
-      email?: string | "" | UnknownEnumStringValue
-      name?: string | "" | UnknownEnumStringValue
-      phone?: string | "" | UnknownEnumStringValue
+      email?: string | ""
+      name?: string | ""
+      phone?: string | ""
       tax_id?: string
     }
     blik?: Record<string, unknown>
@@ -33944,7 +33615,7 @@ export type t_PostSetupIntentsIntentConfirmRequestBody = {
     acss_debit?: {
       currency?: "cad" | "usd" | UnknownEnumStringValue
       mandate_options?: {
-        custom_mandate_url?: string | "" | UnknownEnumStringValue
+        custom_mandate_url?: string | ""
         default_for?: ("invoice" | "subscription" | UnknownEnumStringValue)[]
         interval_description?: string
         payment_schedule?:
@@ -33963,7 +33634,7 @@ export type t_PostSetupIntentsIntentConfirmRequestBody = {
     amazon_pay?: Record<string, unknown>
     bacs_debit?: {
       mandate_options?: {
-        reference_prefix?: string | "" | UnknownEnumStringValue
+        reference_prefix?: string | ""
       }
     }
     card?: {
@@ -33983,7 +33654,7 @@ export type t_PostSetupIntentsIntentConfirmRequestBody = {
         interval_count?: number
         reference: string
         start_date: number
-        supported_types?: ("india" | UnknownEnumStringValue)[]
+        supported_types?: "india"[]
       }
       network?:
         | "amex"
@@ -34117,7 +33788,6 @@ export type t_PostSetupIntentsIntentConfirmRequestBody = {
             reference: string
           }[]
         | ""
-        | UnknownEnumStringValue
     }
     link?: Record<string, unknown>
     paypal?: {
@@ -34125,7 +33795,7 @@ export type t_PostSetupIntentsIntentConfirmRequestBody = {
     }
     sepa_debit?: {
       mandate_options?: {
-        reference_prefix?: string | "" | UnknownEnumStringValue
+        reference_prefix?: string | ""
       }
     }
     us_bank_account?: {
@@ -34223,7 +33893,7 @@ export type t_PostShippingRatesRequestBody = {
     | "unspecified"
     | UnknownEnumStringValue
   tax_code?: string
-  type?: "fixed_amount" | UnknownEnumStringValue
+  type?: "fixed_amount"
 }
 
 export type t_PostShippingRatesShippingRateTokenRequestBody = {
@@ -34242,7 +33912,7 @@ export type t_PostShippingRatesShippingRateTokenRequestBody = {
       }
     >
   }
-  metadata?: Record<string, string> | "" | UnknownEnumStringValue
+  metadata?: Record<string, string> | ""
   tax_behavior?:
     | "exclusive"
     | "inclusive"
@@ -34288,7 +33958,7 @@ export type t_PostSourcesRequestBody = {
       type?: "offline" | "online" | UnknownEnumStringValue
       user_agent?: string
     }
-    amount?: number | "" | UnknownEnumStringValue
+    amount?: number | ""
     currency?: string
     interval?: "one_time" | "scheduled" | "variable" | UnknownEnumStringValue
     notification_method?:
@@ -34378,7 +34048,7 @@ export type t_PostSourcesSourceRequestBody = {
       type?: "offline" | "online" | UnknownEnumStringValue
       user_agent?: string
     }
-    amount?: number | "" | UnknownEnumStringValue
+    amount?: number | ""
     currency?: string
     interval?: "one_time" | "scheduled" | "variable" | UnknownEnumStringValue
     notification_method?:
@@ -34389,7 +34059,7 @@ export type t_PostSourcesSourceRequestBody = {
       | "stripe_email"
       | UnknownEnumStringValue
   }
-  metadata?: Record<string, string> | "" | UnknownEnumStringValue
+  metadata?: Record<string, string> | ""
   owner?: {
     address?: {
       city?: string
@@ -34440,7 +34110,6 @@ export type t_PostSubscriptionItemsRequestBody = {
         usage_gte: number
       }
     | ""
-    | UnknownEnumStringValue
   discounts?:
     | {
         coupon?: string
@@ -34448,7 +34117,6 @@ export type t_PostSubscriptionItemsRequestBody = {
         promotion_code?: string
       }[]
     | ""
-    | UnknownEnumStringValue
   expand?: string[]
   metadata?: Record<string, string>
   payment_behavior?:
@@ -34481,7 +34149,7 @@ export type t_PostSubscriptionItemsRequestBody = {
   proration_date?: number
   quantity?: number
   subscription: string
-  tax_rates?: string[] | "" | UnknownEnumStringValue
+  tax_rates?: string[] | ""
 }
 
 export type t_PostSubscriptionItemsItemRequestBody = {
@@ -34490,7 +34158,6 @@ export type t_PostSubscriptionItemsItemRequestBody = {
         usage_gte: number
       }
     | ""
-    | UnknownEnumStringValue
   discounts?:
     | {
         coupon?: string
@@ -34498,9 +34165,8 @@ export type t_PostSubscriptionItemsItemRequestBody = {
         promotion_code?: string
       }[]
     | ""
-    | UnknownEnumStringValue
   expand?: string[]
-  metadata?: Record<string, string> | "" | UnknownEnumStringValue
+  metadata?: Record<string, string> | ""
   off_session?: boolean
   payment_behavior?:
     | "allow_incomplete"
@@ -34531,7 +34197,7 @@ export type t_PostSubscriptionItemsItemRequestBody = {
     | UnknownEnumStringValue
   proration_date?: number
   quantity?: number
-  tax_rates?: string[] | "" | UnknownEnumStringValue
+  tax_rates?: string[] | ""
 }
 
 export type t_PostSubscriptionSchedulesRequestBody = {
@@ -34555,29 +34221,27 @@ export type t_PostSubscriptionSchedulesRequestBody = {
           reset_billing_cycle_anchor?: boolean
         }
       | ""
-      | UnknownEnumStringValue
     collection_method?:
       | "charge_automatically"
       | "send_invoice"
       | UnknownEnumStringValue
     default_payment_method?: string
-    description?: string | "" | UnknownEnumStringValue
+    description?: string | ""
     invoice_settings?: {
-      account_tax_ids?: string[] | "" | UnknownEnumStringValue
+      account_tax_ids?: string[] | ""
       days_until_due?: number
       issuer?: {
         account?: string
         type: "account" | "self" | UnknownEnumStringValue
       }
     }
-    on_behalf_of?: string | "" | UnknownEnumStringValue
+    on_behalf_of?: string | ""
     transfer_data?:
       | {
           amount_percent?: number
           destination: string
         }
       | ""
-      | UnknownEnumStringValue
   }
   end_behavior?:
     | "cancel"
@@ -34587,7 +34251,7 @@ export type t_PostSubscriptionSchedulesRequestBody = {
     | UnknownEnumStringValue
   expand?: string[]
   from_subscription?: string
-  metadata?: Record<string, string> | "" | UnknownEnumStringValue
+  metadata?: Record<string, string> | ""
   phases?: {
     add_invoice_items?: {
       discounts?: {
@@ -34608,7 +34272,7 @@ export type t_PostSubscriptionSchedulesRequestBody = {
         unit_amount_decimal?: string
       }
       quantity?: number
-      tax_rates?: string[] | "" | UnknownEnumStringValue
+      tax_rates?: string[] | ""
     }[]
     application_fee_percent?: number
     automatic_tax?: {
@@ -34625,15 +34289,14 @@ export type t_PostSubscriptionSchedulesRequestBody = {
           reset_billing_cycle_anchor?: boolean
         }
       | ""
-      | UnknownEnumStringValue
     collection_method?:
       | "charge_automatically"
       | "send_invoice"
       | UnknownEnumStringValue
     currency?: string
     default_payment_method?: string
-    default_tax_rates?: string[] | "" | UnknownEnumStringValue
-    description?: string | "" | UnknownEnumStringValue
+    default_tax_rates?: string[] | ""
+    description?: string | ""
     discounts?:
       | {
           coupon?: string
@@ -34641,14 +34304,13 @@ export type t_PostSubscriptionSchedulesRequestBody = {
           promotion_code?: string
         }[]
       | ""
-      | UnknownEnumStringValue
     duration?: {
       interval: "day" | "month" | "week" | "year" | UnknownEnumStringValue
       interval_count?: number
     }
     end_date?: number
     invoice_settings?: {
-      account_tax_ids?: string[] | "" | UnknownEnumStringValue
+      account_tax_ids?: string[] | ""
       days_until_due?: number
       issuer?: {
         account?: string
@@ -34661,7 +34323,6 @@ export type t_PostSubscriptionSchedulesRequestBody = {
             usage_gte: number
           }
         | ""
-        | UnknownEnumStringValue
       discounts?:
         | {
             coupon?: string
@@ -34669,7 +34330,6 @@ export type t_PostSubscriptionSchedulesRequestBody = {
             promotion_code?: string
           }[]
         | ""
-        | UnknownEnumStringValue
       metadata?: Record<string, string>
       price?: string
       price_data?: {
@@ -34688,7 +34348,7 @@ export type t_PostSubscriptionSchedulesRequestBody = {
         unit_amount_decimal?: string
       }
       quantity?: number
-      tax_rates?: string[] | "" | UnknownEnumStringValue
+      tax_rates?: string[] | ""
     }[]
     iterations?: number
     metadata?: Record<string, string>
@@ -34705,7 +34365,7 @@ export type t_PostSubscriptionSchedulesRequestBody = {
     trial?: boolean
     trial_end?: number
   }[]
-  start_date?: number | "now" | UnknownEnumStringValue
+  start_date?: number | "now"
 }
 
 export type t_PostSubscriptionSchedulesScheduleRequestBody = {
@@ -34725,29 +34385,27 @@ export type t_PostSubscriptionSchedulesScheduleRequestBody = {
           reset_billing_cycle_anchor?: boolean
         }
       | ""
-      | UnknownEnumStringValue
     collection_method?:
       | "charge_automatically"
       | "send_invoice"
       | UnknownEnumStringValue
     default_payment_method?: string
-    description?: string | "" | UnknownEnumStringValue
+    description?: string | ""
     invoice_settings?: {
-      account_tax_ids?: string[] | "" | UnknownEnumStringValue
+      account_tax_ids?: string[] | ""
       days_until_due?: number
       issuer?: {
         account?: string
         type: "account" | "self" | UnknownEnumStringValue
       }
     }
-    on_behalf_of?: string | "" | UnknownEnumStringValue
+    on_behalf_of?: string | ""
     transfer_data?:
       | {
           amount_percent?: number
           destination: string
         }
       | ""
-      | UnknownEnumStringValue
   }
   end_behavior?:
     | "cancel"
@@ -34756,7 +34414,7 @@ export type t_PostSubscriptionSchedulesScheduleRequestBody = {
     | "renew"
     | UnknownEnumStringValue
   expand?: string[]
-  metadata?: Record<string, string> | "" | UnknownEnumStringValue
+  metadata?: Record<string, string> | ""
   phases?: {
     add_invoice_items?: {
       discounts?: {
@@ -34777,7 +34435,7 @@ export type t_PostSubscriptionSchedulesScheduleRequestBody = {
         unit_amount_decimal?: string
       }
       quantity?: number
-      tax_rates?: string[] | "" | UnknownEnumStringValue
+      tax_rates?: string[] | ""
     }[]
     application_fee_percent?: number
     automatic_tax?: {
@@ -34794,14 +34452,13 @@ export type t_PostSubscriptionSchedulesScheduleRequestBody = {
           reset_billing_cycle_anchor?: boolean
         }
       | ""
-      | UnknownEnumStringValue
     collection_method?:
       | "charge_automatically"
       | "send_invoice"
       | UnknownEnumStringValue
     default_payment_method?: string
-    default_tax_rates?: string[] | "" | UnknownEnumStringValue
-    description?: string | "" | UnknownEnumStringValue
+    default_tax_rates?: string[] | ""
+    description?: string | ""
     discounts?:
       | {
           coupon?: string
@@ -34809,14 +34466,13 @@ export type t_PostSubscriptionSchedulesScheduleRequestBody = {
           promotion_code?: string
         }[]
       | ""
-      | UnknownEnumStringValue
     duration?: {
       interval: "day" | "month" | "week" | "year" | UnknownEnumStringValue
       interval_count?: number
     }
-    end_date?: number | "now" | UnknownEnumStringValue
+    end_date?: number | "now"
     invoice_settings?: {
-      account_tax_ids?: string[] | "" | UnknownEnumStringValue
+      account_tax_ids?: string[] | ""
       days_until_due?: number
       issuer?: {
         account?: string
@@ -34829,7 +34485,6 @@ export type t_PostSubscriptionSchedulesScheduleRequestBody = {
             usage_gte: number
           }
         | ""
-        | UnknownEnumStringValue
       discounts?:
         | {
             coupon?: string
@@ -34837,7 +34492,6 @@ export type t_PostSubscriptionSchedulesScheduleRequestBody = {
             promotion_code?: string
           }[]
         | ""
-        | UnknownEnumStringValue
       metadata?: Record<string, string>
       price?: string
       price_data?: {
@@ -34856,7 +34510,7 @@ export type t_PostSubscriptionSchedulesScheduleRequestBody = {
         unit_amount_decimal?: string
       }
       quantity?: number
-      tax_rates?: string[] | "" | UnknownEnumStringValue
+      tax_rates?: string[] | ""
     }[]
     iterations?: number
     metadata?: Record<string, string>
@@ -34866,13 +34520,13 @@ export type t_PostSubscriptionSchedulesScheduleRequestBody = {
       | "create_prorations"
       | "none"
       | UnknownEnumStringValue
-    start_date?: number | "now" | UnknownEnumStringValue
+    start_date?: number | "now"
     transfer_data?: {
       amount_percent?: number
       destination: string
     }
     trial?: boolean
-    trial_end?: number | "now" | UnknownEnumStringValue
+    trial_end?: number | "now"
   }[]
   proration_behavior?:
     | "always_invoice"
@@ -34912,9 +34566,9 @@ export type t_PostSubscriptionsRequestBody = {
       unit_amount_decimal?: string
     }
     quantity?: number
-    tax_rates?: string[] | "" | UnknownEnumStringValue
+    tax_rates?: string[] | ""
   }[]
-  application_fee_percent?: number | "" | UnknownEnumStringValue
+  application_fee_percent?: number | ""
   automatic_tax?: {
     enabled: boolean
     liability?: {
@@ -34940,7 +34594,6 @@ export type t_PostSubscriptionsRequestBody = {
         reset_billing_cycle_anchor?: boolean
       }
     | ""
-    | UnknownEnumStringValue
   cancel_at?:
     | number
     | "max_period_end"
@@ -34956,7 +34609,7 @@ export type t_PostSubscriptionsRequestBody = {
   days_until_due?: number
   default_payment_method?: string
   default_source?: string
-  default_tax_rates?: string[] | "" | UnknownEnumStringValue
+  default_tax_rates?: string[] | ""
   description?: string
   discounts?:
     | {
@@ -34965,10 +34618,9 @@ export type t_PostSubscriptionsRequestBody = {
         promotion_code?: string
       }[]
     | ""
-    | UnknownEnumStringValue
   expand?: string[]
   invoice_settings?: {
-    account_tax_ids?: string[] | "" | UnknownEnumStringValue
+    account_tax_ids?: string[] | ""
     issuer?: {
       account?: string
       type: "account" | "self" | UnknownEnumStringValue
@@ -34980,7 +34632,6 @@ export type t_PostSubscriptionsRequestBody = {
           usage_gte: number
         }
       | ""
-      | UnknownEnumStringValue
     discounts?:
       | {
           coupon?: string
@@ -34988,7 +34639,6 @@ export type t_PostSubscriptionsRequestBody = {
           promotion_code?: string
         }[]
       | ""
-      | UnknownEnumStringValue
     metadata?: Record<string, string>
     price?: string
     price_data?: {
@@ -35007,11 +34657,11 @@ export type t_PostSubscriptionsRequestBody = {
       unit_amount_decimal?: string
     }
     quantity?: number
-    tax_rates?: string[] | "" | UnknownEnumStringValue
+    tax_rates?: string[] | ""
   }[]
-  metadata?: Record<string, string> | "" | UnknownEnumStringValue
+  metadata?: Record<string, string> | ""
   off_session?: boolean
-  on_behalf_of?: string | "" | UnknownEnumStringValue
+  on_behalf_of?: string | ""
   payment_behavior?:
     | "allow_incomplete"
     | "default_incomplete"
@@ -35035,7 +34685,6 @@ export type t_PostSubscriptionsRequestBody = {
               | UnknownEnumStringValue
           }
         | ""
-        | UnknownEnumStringValue
       bancontact?:
         | {
             preferred_language?:
@@ -35046,7 +34695,6 @@ export type t_PostSubscriptionsRequestBody = {
               | UnknownEnumStringValue
           }
         | ""
-        | UnknownEnumStringValue
       card?:
         | {
             mandate_options?: {
@@ -35076,7 +34724,6 @@ export type t_PostSubscriptionsRequestBody = {
               | UnknownEnumStringValue
           }
         | ""
-        | UnknownEnumStringValue
       customer_balance?:
         | {
             bank_transfer?: {
@@ -35088,9 +34735,8 @@ export type t_PostSubscriptionsRequestBody = {
             funding_type?: string
           }
         | ""
-        | UnknownEnumStringValue
-      konbini?: Record<string, unknown> | "" | UnknownEnumStringValue
-      sepa_debit?: Record<string, unknown> | "" | UnknownEnumStringValue
+      konbini?: Record<string, unknown> | ""
+      sepa_debit?: Record<string, unknown> | ""
       us_bank_account?:
         | {
             financial_connections?: {
@@ -35122,7 +34768,6 @@ export type t_PostSubscriptionsRequestBody = {
               | UnknownEnumStringValue
           }
         | ""
-        | UnknownEnumStringValue
     }
     payment_method_types?:
       | (
@@ -35168,7 +34813,6 @@ export type t_PostSubscriptionsRequestBody = {
           | UnknownEnumStringValue
         )[]
       | ""
-      | UnknownEnumStringValue
     save_default_payment_method?:
       | "off"
       | "on_subscription"
@@ -35180,7 +34824,6 @@ export type t_PostSubscriptionsRequestBody = {
         interval_count?: number
       }
     | ""
-    | UnknownEnumStringValue
   proration_behavior?:
     | "always_invoice"
     | "create_prorations"
@@ -35190,7 +34833,7 @@ export type t_PostSubscriptionsRequestBody = {
     amount_percent?: number
     destination: string
   }
-  trial_end?: "now" | UnknownEnumStringValue | number
+  trial_end?: "now" | number
   trial_from_plan?: boolean
   trial_period_days?: number
   trial_settings?: {
@@ -35224,9 +34867,9 @@ export type t_PostSubscriptionsSubscriptionExposedIdRequestBody = {
       unit_amount_decimal?: string
     }
     quantity?: number
-    tax_rates?: string[] | "" | UnknownEnumStringValue
+    tax_rates?: string[] | ""
   }[]
-  application_fee_percent?: number | "" | UnknownEnumStringValue
+  application_fee_percent?: number | ""
   automatic_tax?: {
     enabled: boolean
     liability?: {
@@ -35241,16 +34884,15 @@ export type t_PostSubscriptionsSubscriptionExposedIdRequestBody = {
         reset_billing_cycle_anchor?: boolean
       }
     | ""
-    | UnknownEnumStringValue
   cancel_at?:
     | number
     | ""
-    | UnknownEnumStringValue
     | "max_period_end"
     | "min_period_end"
+    | UnknownEnumStringValue
   cancel_at_period_end?: boolean
   cancellation_details?: {
-    comment?: string | "" | UnknownEnumStringValue
+    comment?: string | ""
     feedback?:
       | ""
       | "customer_service"
@@ -35269,9 +34911,9 @@ export type t_PostSubscriptionsSubscriptionExposedIdRequestBody = {
     | UnknownEnumStringValue
   days_until_due?: number
   default_payment_method?: string
-  default_source?: string | "" | UnknownEnumStringValue
-  default_tax_rates?: string[] | "" | UnknownEnumStringValue
-  description?: string | "" | UnknownEnumStringValue
+  default_source?: string | ""
+  default_tax_rates?: string[] | ""
+  description?: string | ""
   discounts?:
     | {
         coupon?: string
@@ -35279,10 +34921,9 @@ export type t_PostSubscriptionsSubscriptionExposedIdRequestBody = {
         promotion_code?: string
       }[]
     | ""
-    | UnknownEnumStringValue
   expand?: string[]
   invoice_settings?: {
-    account_tax_ids?: string[] | "" | UnknownEnumStringValue
+    account_tax_ids?: string[] | ""
     issuer?: {
       account?: string
       type: "account" | "self" | UnknownEnumStringValue
@@ -35294,7 +34935,6 @@ export type t_PostSubscriptionsSubscriptionExposedIdRequestBody = {
           usage_gte: number
         }
       | ""
-      | UnknownEnumStringValue
     clear_usage?: boolean
     deleted?: boolean
     discounts?:
@@ -35304,9 +34944,8 @@ export type t_PostSubscriptionsSubscriptionExposedIdRequestBody = {
           promotion_code?: string
         }[]
       | ""
-      | UnknownEnumStringValue
     id?: string
-    metadata?: Record<string, string> | "" | UnknownEnumStringValue
+    metadata?: Record<string, string> | ""
     price?: string
     price_data?: {
       currency: string
@@ -35324,11 +34963,11 @@ export type t_PostSubscriptionsSubscriptionExposedIdRequestBody = {
       unit_amount_decimal?: string
     }
     quantity?: number
-    tax_rates?: string[] | "" | UnknownEnumStringValue
+    tax_rates?: string[] | ""
   }[]
-  metadata?: Record<string, string> | "" | UnknownEnumStringValue
+  metadata?: Record<string, string> | ""
   off_session?: boolean
-  on_behalf_of?: string | "" | UnknownEnumStringValue
+  on_behalf_of?: string | ""
   pause_collection?:
     | {
         behavior:
@@ -35339,7 +34978,6 @@ export type t_PostSubscriptionsSubscriptionExposedIdRequestBody = {
         resumes_at?: number
       }
     | ""
-    | UnknownEnumStringValue
   payment_behavior?:
     | "allow_incomplete"
     | "default_incomplete"
@@ -35363,7 +35001,6 @@ export type t_PostSubscriptionsSubscriptionExposedIdRequestBody = {
               | UnknownEnumStringValue
           }
         | ""
-        | UnknownEnumStringValue
       bancontact?:
         | {
             preferred_language?:
@@ -35374,7 +35011,6 @@ export type t_PostSubscriptionsSubscriptionExposedIdRequestBody = {
               | UnknownEnumStringValue
           }
         | ""
-        | UnknownEnumStringValue
       card?:
         | {
             mandate_options?: {
@@ -35404,7 +35040,6 @@ export type t_PostSubscriptionsSubscriptionExposedIdRequestBody = {
               | UnknownEnumStringValue
           }
         | ""
-        | UnknownEnumStringValue
       customer_balance?:
         | {
             bank_transfer?: {
@@ -35416,9 +35051,8 @@ export type t_PostSubscriptionsSubscriptionExposedIdRequestBody = {
             funding_type?: string
           }
         | ""
-        | UnknownEnumStringValue
-      konbini?: Record<string, unknown> | "" | UnknownEnumStringValue
-      sepa_debit?: Record<string, unknown> | "" | UnknownEnumStringValue
+      konbini?: Record<string, unknown> | ""
+      sepa_debit?: Record<string, unknown> | ""
       us_bank_account?:
         | {
             financial_connections?: {
@@ -35450,7 +35084,6 @@ export type t_PostSubscriptionsSubscriptionExposedIdRequestBody = {
               | UnknownEnumStringValue
           }
         | ""
-        | UnknownEnumStringValue
     }
     payment_method_types?:
       | (
@@ -35496,7 +35129,6 @@ export type t_PostSubscriptionsSubscriptionExposedIdRequestBody = {
           | UnknownEnumStringValue
         )[]
       | ""
-      | UnknownEnumStringValue
     save_default_payment_method?:
       | "off"
       | "on_subscription"
@@ -35508,7 +35140,6 @@ export type t_PostSubscriptionsSubscriptionExposedIdRequestBody = {
         interval_count?: number
       }
     | ""
-    | UnknownEnumStringValue
   proration_behavior?:
     | "always_invoice"
     | "create_prorations"
@@ -35521,8 +35152,7 @@ export type t_PostSubscriptionsSubscriptionExposedIdRequestBody = {
         destination: string
       }
     | ""
-    | UnknownEnumStringValue
-  trial_end?: "now" | UnknownEnumStringValue | number
+  trial_end?: "now" | number
   trial_from_plan?: boolean
   trial_settings?: {
     end_behavior: {
@@ -35537,7 +35167,7 @@ export type t_PostSubscriptionsSubscriptionExposedIdRequestBody = {
 
 export type t_PostSubscriptionsSubscriptionMigrateRequestBody = {
   billing_mode: {
-    type: "flexible" | UnknownEnumStringValue
+    type: "flexible"
   }
   expand?: string[]
 }
@@ -35558,12 +35188,12 @@ export type t_PostTaxCalculationsRequestBody = {
   customer?: string
   customer_details?: {
     address?: {
-      city?: string | "" | UnknownEnumStringValue
+      city?: string | ""
       country: string
-      line1?: string | "" | UnknownEnumStringValue
-      line2?: string | "" | UnknownEnumStringValue
-      postal_code?: string | "" | UnknownEnumStringValue
-      state?: string | "" | UnknownEnumStringValue
+      line1?: string | ""
+      line2?: string | ""
+      postal_code?: string | ""
+      state?: string | ""
     }
     address_source?: "billing" | "shipping" | UnknownEnumStringValue
     ip_address?: string
@@ -35700,12 +35330,12 @@ export type t_PostTaxCalculationsRequestBody = {
   }[]
   ship_from_details?: {
     address: {
-      city?: string | "" | UnknownEnumStringValue
+      city?: string | ""
       country: string
-      line1?: string | "" | UnknownEnumStringValue
-      line2?: string | "" | UnknownEnumStringValue
-      postal_code?: string | "" | UnknownEnumStringValue
-      state?: string | "" | UnknownEnumStringValue
+      line1?: string | ""
+      line2?: string | ""
+      postal_code?: string | ""
+      state?: string | ""
     }
   }
   shipping_cost?: {
@@ -35880,7 +35510,7 @@ export type t_PostTaxRatesTaxRateRequestBody = {
   display_name?: string
   expand?: string[]
   jurisdiction?: string
-  metadata?: Record<string, string> | "" | UnknownEnumStringValue
+  metadata?: Record<string, string> | ""
   state?: string
   tax_type?:
     | "amusement_tax"
@@ -35901,7 +35531,7 @@ export type t_PostTaxRatesTaxRateRequestBody = {
 }
 
 export type t_PostTaxRegistrationsRequestBody = {
-  active_from: "now" | UnknownEnumStringValue | number
+  active_from: "now" | number
   country: string
   country_options: {
     ae?: {
@@ -35911,7 +35541,7 @@ export type t_PostTaxRegistrationsRequestBody = {
           | "standard"
           | UnknownEnumStringValue
       }
-      type: "standard" | UnknownEnumStringValue
+      type: "standard"
     }
     al?: {
       standard?: {
@@ -35920,10 +35550,10 @@ export type t_PostTaxRegistrationsRequestBody = {
           | "standard"
           | UnknownEnumStringValue
       }
-      type: "standard" | UnknownEnumStringValue
+      type: "standard"
     }
     am?: {
-      type: "simplified" | UnknownEnumStringValue
+      type: "simplified"
     }
     ao?: {
       standard?: {
@@ -35932,7 +35562,7 @@ export type t_PostTaxRegistrationsRequestBody = {
           | "standard"
           | UnknownEnumStringValue
       }
-      type: "standard" | UnknownEnumStringValue
+      type: "standard"
     }
     at?: {
       standard?: {
@@ -35956,7 +35586,7 @@ export type t_PostTaxRegistrationsRequestBody = {
           | "standard"
           | UnknownEnumStringValue
       }
-      type: "standard" | UnknownEnumStringValue
+      type: "standard"
     }
     aw?: {
       standard?: {
@@ -35965,10 +35595,10 @@ export type t_PostTaxRegistrationsRequestBody = {
           | "standard"
           | UnknownEnumStringValue
       }
-      type: "standard" | UnknownEnumStringValue
+      type: "standard"
     }
     az?: {
-      type: "simplified" | UnknownEnumStringValue
+      type: "simplified"
     }
     ba?: {
       standard?: {
@@ -35977,7 +35607,7 @@ export type t_PostTaxRegistrationsRequestBody = {
           | "standard"
           | UnknownEnumStringValue
       }
-      type: "standard" | UnknownEnumStringValue
+      type: "standard"
     }
     bb?: {
       standard?: {
@@ -35986,7 +35616,7 @@ export type t_PostTaxRegistrationsRequestBody = {
           | "standard"
           | UnknownEnumStringValue
       }
-      type: "standard" | UnknownEnumStringValue
+      type: "standard"
     }
     bd?: {
       standard?: {
@@ -35995,7 +35625,7 @@ export type t_PostTaxRegistrationsRequestBody = {
           | "standard"
           | UnknownEnumStringValue
       }
-      type: "standard" | UnknownEnumStringValue
+      type: "standard"
     }
     be?: {
       standard?: {
@@ -36019,7 +35649,7 @@ export type t_PostTaxRegistrationsRequestBody = {
           | "standard"
           | UnknownEnumStringValue
       }
-      type: "standard" | UnknownEnumStringValue
+      type: "standard"
     }
     bg?: {
       standard?: {
@@ -36043,10 +35673,10 @@ export type t_PostTaxRegistrationsRequestBody = {
           | "standard"
           | UnknownEnumStringValue
       }
-      type: "standard" | UnknownEnumStringValue
+      type: "standard"
     }
     bj?: {
-      type: "simplified" | UnknownEnumStringValue
+      type: "simplified"
     }
     bs?: {
       standard?: {
@@ -36055,10 +35685,10 @@ export type t_PostTaxRegistrationsRequestBody = {
           | "standard"
           | UnknownEnumStringValue
       }
-      type: "standard" | UnknownEnumStringValue
+      type: "standard"
     }
     by?: {
-      type: "simplified" | UnknownEnumStringValue
+      type: "simplified"
     }
     ca?: {
       province_standard?: {
@@ -36077,7 +35707,7 @@ export type t_PostTaxRegistrationsRequestBody = {
           | "standard"
           | UnknownEnumStringValue
       }
-      type: "standard" | UnknownEnumStringValue
+      type: "standard"
     }
     ch?: {
       standard?: {
@@ -36086,22 +35716,22 @@ export type t_PostTaxRegistrationsRequestBody = {
           | "standard"
           | UnknownEnumStringValue
       }
-      type: "standard" | UnknownEnumStringValue
+      type: "standard"
     }
     cl?: {
-      type: "simplified" | UnknownEnumStringValue
+      type: "simplified"
     }
     cm?: {
-      type: "simplified" | UnknownEnumStringValue
+      type: "simplified"
     }
     co?: {
-      type: "simplified" | UnknownEnumStringValue
+      type: "simplified"
     }
     cr?: {
-      type: "simplified" | UnknownEnumStringValue
+      type: "simplified"
     }
     cv?: {
-      type: "simplified" | UnknownEnumStringValue
+      type: "simplified"
     }
     cy?: {
       standard?: {
@@ -36164,7 +35794,7 @@ export type t_PostTaxRegistrationsRequestBody = {
         | UnknownEnumStringValue
     }
     ec?: {
-      type: "simplified" | UnknownEnumStringValue
+      type: "simplified"
     }
     ee?: {
       standard?: {
@@ -36182,7 +35812,7 @@ export type t_PostTaxRegistrationsRequestBody = {
         | UnknownEnumStringValue
     }
     eg?: {
-      type: "simplified" | UnknownEnumStringValue
+      type: "simplified"
     }
     es?: {
       standard?: {
@@ -36206,7 +35836,7 @@ export type t_PostTaxRegistrationsRequestBody = {
           | "standard"
           | UnknownEnumStringValue
       }
-      type: "standard" | UnknownEnumStringValue
+      type: "standard"
     }
     fi?: {
       standard?: {
@@ -36245,10 +35875,10 @@ export type t_PostTaxRegistrationsRequestBody = {
           | "standard"
           | UnknownEnumStringValue
       }
-      type: "standard" | UnknownEnumStringValue
+      type: "standard"
     }
     ge?: {
-      type: "simplified" | UnknownEnumStringValue
+      type: "simplified"
     }
     gn?: {
       standard?: {
@@ -36257,7 +35887,7 @@ export type t_PostTaxRegistrationsRequestBody = {
           | "standard"
           | UnknownEnumStringValue
       }
-      type: "standard" | UnknownEnumStringValue
+      type: "standard"
     }
     gr?: {
       standard?: {
@@ -36305,7 +35935,7 @@ export type t_PostTaxRegistrationsRequestBody = {
         | UnknownEnumStringValue
     }
     id?: {
-      type: "simplified" | UnknownEnumStringValue
+      type: "simplified"
     }
     ie?: {
       standard?: {
@@ -36323,7 +35953,7 @@ export type t_PostTaxRegistrationsRequestBody = {
         | UnknownEnumStringValue
     }
     in?: {
-      type: "simplified" | UnknownEnumStringValue
+      type: "simplified"
     }
     is?: {
       standard?: {
@@ -36332,7 +35962,7 @@ export type t_PostTaxRegistrationsRequestBody = {
           | "standard"
           | UnknownEnumStringValue
       }
-      type: "standard" | UnknownEnumStringValue
+      type: "standard"
     }
     it?: {
       standard?: {
@@ -36356,25 +35986,25 @@ export type t_PostTaxRegistrationsRequestBody = {
           | "standard"
           | UnknownEnumStringValue
       }
-      type: "standard" | UnknownEnumStringValue
+      type: "standard"
     }
     ke?: {
-      type: "simplified" | UnknownEnumStringValue
+      type: "simplified"
     }
     kg?: {
-      type: "simplified" | UnknownEnumStringValue
+      type: "simplified"
     }
     kh?: {
-      type: "simplified" | UnknownEnumStringValue
+      type: "simplified"
     }
     kr?: {
-      type: "simplified" | UnknownEnumStringValue
+      type: "simplified"
     }
     kz?: {
-      type: "simplified" | UnknownEnumStringValue
+      type: "simplified"
     }
     la?: {
-      type: "simplified" | UnknownEnumStringValue
+      type: "simplified"
     }
     lt?: {
       standard?: {
@@ -36422,10 +36052,10 @@ export type t_PostTaxRegistrationsRequestBody = {
         | UnknownEnumStringValue
     }
     ma?: {
-      type: "simplified" | UnknownEnumStringValue
+      type: "simplified"
     }
     md?: {
-      type: "simplified" | UnknownEnumStringValue
+      type: "simplified"
     }
     me?: {
       standard?: {
@@ -36434,7 +36064,7 @@ export type t_PostTaxRegistrationsRequestBody = {
           | "standard"
           | UnknownEnumStringValue
       }
-      type: "standard" | UnknownEnumStringValue
+      type: "standard"
     }
     mk?: {
       standard?: {
@@ -36443,7 +36073,7 @@ export type t_PostTaxRegistrationsRequestBody = {
           | "standard"
           | UnknownEnumStringValue
       }
-      type: "standard" | UnknownEnumStringValue
+      type: "standard"
     }
     mr?: {
       standard?: {
@@ -36452,7 +36082,7 @@ export type t_PostTaxRegistrationsRequestBody = {
           | "standard"
           | UnknownEnumStringValue
       }
-      type: "standard" | UnknownEnumStringValue
+      type: "standard"
     }
     mt?: {
       standard?: {
@@ -36470,13 +36100,13 @@ export type t_PostTaxRegistrationsRequestBody = {
         | UnknownEnumStringValue
     }
     mx?: {
-      type: "simplified" | UnknownEnumStringValue
+      type: "simplified"
     }
     my?: {
-      type: "simplified" | UnknownEnumStringValue
+      type: "simplified"
     }
     ng?: {
-      type: "simplified" | UnknownEnumStringValue
+      type: "simplified"
     }
     nl?: {
       standard?: {
@@ -36500,10 +36130,10 @@ export type t_PostTaxRegistrationsRequestBody = {
           | "standard"
           | UnknownEnumStringValue
       }
-      type: "standard" | UnknownEnumStringValue
+      type: "standard"
     }
     np?: {
-      type: "simplified" | UnknownEnumStringValue
+      type: "simplified"
     }
     nz?: {
       standard?: {
@@ -36512,7 +36142,7 @@ export type t_PostTaxRegistrationsRequestBody = {
           | "standard"
           | UnknownEnumStringValue
       }
-      type: "standard" | UnknownEnumStringValue
+      type: "standard"
     }
     om?: {
       standard?: {
@@ -36521,13 +36151,13 @@ export type t_PostTaxRegistrationsRequestBody = {
           | "standard"
           | UnknownEnumStringValue
       }
-      type: "standard" | UnknownEnumStringValue
+      type: "standard"
     }
     pe?: {
-      type: "simplified" | UnknownEnumStringValue
+      type: "simplified"
     }
     ph?: {
-      type: "simplified" | UnknownEnumStringValue
+      type: "simplified"
     }
     pl?: {
       standard?: {
@@ -36581,13 +36211,13 @@ export type t_PostTaxRegistrationsRequestBody = {
           | "standard"
           | UnknownEnumStringValue
       }
-      type: "standard" | UnknownEnumStringValue
+      type: "standard"
     }
     ru?: {
-      type: "simplified" | UnknownEnumStringValue
+      type: "simplified"
     }
     sa?: {
-      type: "simplified" | UnknownEnumStringValue
+      type: "simplified"
     }
     se?: {
       standard?: {
@@ -36611,7 +36241,7 @@ export type t_PostTaxRegistrationsRequestBody = {
           | "standard"
           | UnknownEnumStringValue
       }
-      type: "standard" | UnknownEnumStringValue
+      type: "standard"
     }
     si?: {
       standard?: {
@@ -36644,7 +36274,7 @@ export type t_PostTaxRegistrationsRequestBody = {
         | UnknownEnumStringValue
     }
     sn?: {
-      type: "simplified" | UnknownEnumStringValue
+      type: "simplified"
     }
     sr?: {
       standard?: {
@@ -36653,25 +36283,25 @@ export type t_PostTaxRegistrationsRequestBody = {
           | "standard"
           | UnknownEnumStringValue
       }
-      type: "standard" | UnknownEnumStringValue
+      type: "standard"
     }
     th?: {
-      type: "simplified" | UnknownEnumStringValue
+      type: "simplified"
     }
     tj?: {
-      type: "simplified" | UnknownEnumStringValue
+      type: "simplified"
     }
     tr?: {
-      type: "simplified" | UnknownEnumStringValue
+      type: "simplified"
     }
     tz?: {
-      type: "simplified" | UnknownEnumStringValue
+      type: "simplified"
     }
     ua?: {
-      type: "simplified" | UnknownEnumStringValue
+      type: "simplified"
     }
     ug?: {
-      type: "simplified" | UnknownEnumStringValue
+      type: "simplified"
     }
     us?: {
       local_amusement_tax?: {
@@ -36706,13 +36336,13 @@ export type t_PostTaxRegistrationsRequestBody = {
           | "standard"
           | UnknownEnumStringValue
       }
-      type: "standard" | UnknownEnumStringValue
+      type: "standard"
     }
     uz?: {
-      type: "simplified" | UnknownEnumStringValue
+      type: "simplified"
     }
     vn?: {
-      type: "simplified" | UnknownEnumStringValue
+      type: "simplified"
     }
     za?: {
       standard?: {
@@ -36721,10 +36351,10 @@ export type t_PostTaxRegistrationsRequestBody = {
           | "standard"
           | UnknownEnumStringValue
       }
-      type: "standard" | UnknownEnumStringValue
+      type: "standard"
     }
     zm?: {
-      type: "simplified" | UnknownEnumStringValue
+      type: "simplified"
     }
     zw?: {
       standard?: {
@@ -36733,7 +36363,7 @@ export type t_PostTaxRegistrationsRequestBody = {
           | "standard"
           | UnknownEnumStringValue
       }
-      type: "standard" | UnknownEnumStringValue
+      type: "standard"
     }
   }
   expand?: string[]
@@ -36741,9 +36371,9 @@ export type t_PostTaxRegistrationsRequestBody = {
 }
 
 export type t_PostTaxRegistrationsIdRequestBody = {
-  active_from?: "now" | UnknownEnumStringValue | number
+  active_from?: "now" | number
   expand?: string[]
-  expires_at?: "now" | UnknownEnumStringValue | number | ""
+  expires_at?: "now" | number | ""
 }
 
 export type t_PostTaxSettingsRequestBody = {
@@ -36799,7 +36429,7 @@ export type t_PostTaxTransactionsCreateReversalRequestBody = {
 
 export type t_PostTerminalConfigurationsRequestBody = {
   bbpos_wisepos_e?: {
-    splashscreen?: string | "" | UnknownEnumStringValue
+    splashscreen?: string | ""
   }
   expand?: string[]
   name?: string
@@ -36808,13 +36438,12 @@ export type t_PostTerminalConfigurationsRequestBody = {
         enabled: boolean
       }
     | ""
-    | UnknownEnumStringValue
   reboot_window?: {
     end_hour: number
     start_hour: number
   }
   stripe_s700?: {
-    splashscreen?: string | "" | UnknownEnumStringValue
+    splashscreen?: string | ""
   }
   tipping?:
     | {
@@ -36920,9 +36549,8 @@ export type t_PostTerminalConfigurationsRequestBody = {
         }
       }
     | ""
-    | UnknownEnumStringValue
   verifone_p400?: {
-    splashscreen?: string | "" | UnknownEnumStringValue
+    splashscreen?: string | ""
   }
   wifi?:
     | {
@@ -36950,16 +36578,14 @@ export type t_PostTerminalConfigurationsRequestBody = {
           | UnknownEnumStringValue
       }
     | ""
-    | UnknownEnumStringValue
 }
 
 export type t_PostTerminalConfigurationsConfigurationRequestBody = {
   bbpos_wisepos_e?:
     | {
-        splashscreen?: string | "" | UnknownEnumStringValue
+        splashscreen?: string | ""
       }
     | ""
-    | UnknownEnumStringValue
   expand?: string[]
   name?: string
   offline?:
@@ -36967,20 +36593,17 @@ export type t_PostTerminalConfigurationsConfigurationRequestBody = {
         enabled: boolean
       }
     | ""
-    | UnknownEnumStringValue
   reboot_window?:
     | {
         end_hour: number
         start_hour: number
       }
     | ""
-    | UnknownEnumStringValue
   stripe_s700?:
     | {
-        splashscreen?: string | "" | UnknownEnumStringValue
+        splashscreen?: string | ""
       }
     | ""
-    | UnknownEnumStringValue
   tipping?:
     | {
         aed?: {
@@ -37085,13 +36708,11 @@ export type t_PostTerminalConfigurationsConfigurationRequestBody = {
         }
       }
     | ""
-    | UnknownEnumStringValue
   verifone_p400?:
     | {
-        splashscreen?: string | "" | UnknownEnumStringValue
+        splashscreen?: string | ""
       }
     | ""
-    | UnknownEnumStringValue
   wifi?:
     | {
         enterprise_eap_peap?: {
@@ -37118,7 +36739,6 @@ export type t_PostTerminalConfigurationsConfigurationRequestBody = {
           | UnknownEnumStringValue
       }
     | ""
-    | UnknownEnumStringValue
 }
 
 export type t_PostTerminalConnectionTokensRequestBody = {
@@ -37138,7 +36758,7 @@ export type t_PostTerminalLocationsRequestBody = {
   configuration_overrides?: string
   display_name: string
   expand?: string[]
-  metadata?: Record<string, string> | "" | UnknownEnumStringValue
+  metadata?: Record<string, string> | ""
 }
 
 export type t_PostTerminalLocationsLocationRequestBody = {
@@ -37150,24 +36770,24 @@ export type t_PostTerminalLocationsLocationRequestBody = {
     postal_code?: string
     state?: string
   }
-  configuration_overrides?: string | "" | UnknownEnumStringValue
-  display_name?: string | "" | UnknownEnumStringValue
+  configuration_overrides?: string | ""
+  display_name?: string | ""
   expand?: string[]
-  metadata?: Record<string, string> | "" | UnknownEnumStringValue
+  metadata?: Record<string, string> | ""
 }
 
 export type t_PostTerminalReadersRequestBody = {
   expand?: string[]
   label?: string
   location?: string
-  metadata?: Record<string, string> | "" | UnknownEnumStringValue
+  metadata?: Record<string, string> | ""
   registration_code: string
 }
 
 export type t_PostTerminalReadersReaderRequestBody = {
   expand?: string[]
-  label?: string | "" | UnknownEnumStringValue
-  metadata?: Record<string, string> | "" | UnknownEnumStringValue
+  label?: string | ""
+  metadata?: Record<string, string> | ""
 }
 
 export type t_PostTerminalReadersReaderCancelActionRequestBody = {
@@ -37285,7 +36905,7 @@ export type t_PostTerminalReadersReaderSetReaderDisplayRequestBody = {
     total: number
   }
   expand?: string[]
-  type: "cart" | UnknownEnumStringValue
+  type: "cart"
 }
 
 export type t_PostTestHelpersConfirmationTokensRequestBody = {
@@ -37328,10 +36948,9 @@ export type t_PostTestHelpersConfirmationTokensRequestBody = {
             state?: string
           }
         | ""
-        | UnknownEnumStringValue
-      email?: string | "" | UnknownEnumStringValue
-      name?: string | "" | UnknownEnumStringValue
-      phone?: string | "" | UnknownEnumStringValue
+      email?: string | ""
+      name?: string | ""
+      phone?: string | ""
       tax_id?: string
     }
     blik?: Record<string, unknown>
@@ -37563,7 +37182,7 @@ export type t_PostTestHelpersConfirmationTokensRequestBody = {
       installments?: {
         plan: {
           count?: number
-          interval?: "month" | UnknownEnumStringValue
+          interval?: "month"
           type: "bonus" | "fixed_count" | "revolving" | UnknownEnumStringValue
         }
       }
@@ -37581,7 +37200,7 @@ export type t_PostTestHelpersConfirmationTokensRequestBody = {
       state?: string
     }
     name: string
-    phone?: string | "" | UnknownEnumStringValue
+    phone?: string | ""
   }
 }
 
@@ -39209,7 +38828,7 @@ export type t_PostTestHelpersTreasuryReceivedCreditsRequestBody = {
   expand?: string[]
   financial_account: string
   initiating_payment_method_details?: {
-    type: "us_bank_account" | UnknownEnumStringValue
+    type: "us_bank_account"
     us_bank_account?: {
       account_holder_name?: string
       account_number?: string
@@ -39226,14 +38845,14 @@ export type t_PostTestHelpersTreasuryReceivedDebitsRequestBody = {
   expand?: string[]
   financial_account: string
   initiating_payment_method_details?: {
-    type: "us_bank_account" | UnknownEnumStringValue
+    type: "us_bank_account"
     us_bank_account?: {
       account_holder_name?: string
       account_number?: string
       routing_number?: string
     }
   }
-  network: "ach" | UnknownEnumStringValue
+  network: "ach"
 }
 
 export type t_PostTokensRequestBody = {
@@ -39303,7 +38922,6 @@ export type t_PostTokensRequestBody = {
             year: number
           }
         | ""
-        | UnknownEnumStringValue
       registration_number?: string
       structure?:
         | ""
@@ -39375,12 +38993,11 @@ export type t_PostTokensRequestBody = {
             year: number
           }
         | ""
-        | UnknownEnumStringValue
       email?: string
       first_name?: string
       first_name_kana?: string
       first_name_kanji?: string
-      full_name_aliases?: string[] | "" | UnknownEnumStringValue
+      full_name_aliases?: string[] | ""
       gender?: string
       id_number?: string
       id_number_secondary?: string
@@ -39388,7 +39005,7 @@ export type t_PostTokensRequestBody = {
       last_name_kana?: string
       last_name_kanji?: string
       maiden_name?: string
-      metadata?: Record<string, string> | "" | UnknownEnumStringValue
+      metadata?: Record<string, string> | ""
       phone?: string
       political_exposure?: "existing" | "none" | UnknownEnumStringValue
       registered_address?: {
@@ -39403,7 +39020,7 @@ export type t_PostTokensRequestBody = {
         director?: boolean
         executive?: boolean
         owner?: boolean
-        percent_ownership?: number | "" | UnknownEnumStringValue
+        percent_ownership?: number | ""
         title?: string
       }
       ssn_last_4?: string
@@ -39468,7 +39085,7 @@ export type t_PostTokensRequestBody = {
       account?: {
         date?: number
         ip?: string
-        user_agent?: string | "" | UnknownEnumStringValue
+        user_agent?: string | ""
       }
     }
     address?: {
@@ -39504,23 +39121,22 @@ export type t_PostTokensRequestBody = {
           year: number
         }
       | ""
-      | UnknownEnumStringValue
     documents?: {
       company_authorization?: {
-        files?: (string | "" | UnknownEnumStringValue)[]
+        files?: (string | "")[]
       }
       passport?: {
-        files?: (string | "" | UnknownEnumStringValue)[]
+        files?: (string | "")[]
       }
       visa?: {
-        files?: (string | "" | UnknownEnumStringValue)[]
+        files?: (string | "")[]
       }
     }
     email?: string
     first_name?: string
     first_name_kana?: string
     first_name_kanji?: string
-    full_name_aliases?: string[] | "" | UnknownEnumStringValue
+    full_name_aliases?: string[] | ""
     gender?: string
     id_number?: string
     id_number_secondary?: string
@@ -39528,7 +39144,7 @@ export type t_PostTokensRequestBody = {
     last_name_kana?: string
     last_name_kanji?: string
     maiden_name?: string
-    metadata?: Record<string, string> | "" | UnknownEnumStringValue
+    metadata?: Record<string, string> | ""
     nationality?: string
     phone?: string
     political_exposure?: "existing" | "none" | UnknownEnumStringValue
@@ -39546,7 +39162,7 @@ export type t_PostTokensRequestBody = {
       executive?: boolean
       legal_guardian?: boolean
       owner?: boolean
-      percent_ownership?: number | "" | UnknownEnumStringValue
+      percent_ownership?: number | ""
       representative?: boolean
       title?: string
     }
@@ -39618,7 +39234,7 @@ export type t_PostTopupsRequestBody = {
   currency: string
   description?: string
   expand?: string[]
-  metadata?: Record<string, string> | "" | UnknownEnumStringValue
+  metadata?: Record<string, string> | ""
   source?: string
   statement_descriptor?: string
   transfer_group?: string
@@ -39627,7 +39243,7 @@ export type t_PostTopupsRequestBody = {
 export type t_PostTopupsTopupRequestBody = {
   description?: string
   expand?: string[]
-  metadata?: Record<string, string> | "" | UnknownEnumStringValue
+  metadata?: Record<string, string> | ""
 }
 
 export type t_PostTopupsTopupCancelRequestBody = {
@@ -39650,19 +39266,19 @@ export type t_PostTransfersIdReversalsRequestBody = {
   amount?: number
   description?: string
   expand?: string[]
-  metadata?: Record<string, string> | "" | UnknownEnumStringValue
+  metadata?: Record<string, string> | ""
   refund_application_fee?: boolean
 }
 
 export type t_PostTransfersTransferRequestBody = {
   description?: string
   expand?: string[]
-  metadata?: Record<string, string> | "" | UnknownEnumStringValue
+  metadata?: Record<string, string> | ""
 }
 
 export type t_PostTransfersTransferReversalsIdRequestBody = {
   expand?: string[]
-  metadata?: Record<string, string> | "" | UnknownEnumStringValue
+  metadata?: Record<string, string> | ""
 }
 
 export type t_PostTreasuryCreditReversalsRequestBody = {
@@ -39717,7 +39333,7 @@ export type t_PostTreasuryFinancialAccountsRequestBody = {
     }
   }
   metadata?: Record<string, string>
-  nickname?: string | "" | UnknownEnumStringValue
+  nickname?: string | ""
   platform_restrictions?: {
     inbound_flows?: "restricted" | "unrestricted" | UnknownEnumStringValue
     outbound_flows?: "restricted" | "unrestricted" | UnknownEnumStringValue
@@ -39770,7 +39386,7 @@ export type t_PostTreasuryFinancialAccountsFinancialAccountRequestBody = {
     type: "financial_account" | "payment_method" | UnknownEnumStringValue
   }
   metadata?: Record<string, string>
-  nickname?: string | "" | UnknownEnumStringValue
+  nickname?: string | ""
   platform_restrictions?: {
     inbound_flows?: "restricted" | "unrestricted" | UnknownEnumStringValue
     outbound_flows?: "restricted" | "unrestricted" | UnknownEnumStringValue
@@ -39859,10 +39475,9 @@ export type t_PostTreasuryOutboundPaymentsRequestBody = {
             state?: string
           }
         | ""
-        | UnknownEnumStringValue
-      email?: string | "" | UnknownEnumStringValue
-      name?: string | "" | UnknownEnumStringValue
-      phone?: string | "" | UnknownEnumStringValue
+      email?: string | ""
+      name?: string | ""
+      phone?: string | ""
     }
     financial_account?: string
     metadata?: Record<string, string>
@@ -39881,7 +39496,6 @@ export type t_PostTreasuryOutboundPaymentsRequestBody = {
           network?: "ach" | "us_domestic_wire" | UnknownEnumStringValue
         }
       | ""
-      | UnknownEnumStringValue
   }
   end_user_details?: {
     ip_address?: string
@@ -39904,7 +39518,7 @@ export type t_PostTreasuryOutboundTransfersRequestBody = {
   destination_payment_method?: string
   destination_payment_method_data?: {
     financial_account?: string
-    type: "financial_account" | UnknownEnumStringValue
+    type: "financial_account"
   }
   destination_payment_method_options?: {
     us_bank_account?:
@@ -39912,7 +39526,6 @@ export type t_PostTreasuryOutboundTransfersRequestBody = {
           network?: "ach" | "us_domestic_wire" | UnknownEnumStringValue
         }
       | ""
-      | UnknownEnumStringValue
   }
   expand?: string[]
   financial_account: string
@@ -40042,7 +39655,7 @@ export type t_PostWebhookEndpointsRequestBody = {
     | "2025-07-30.basil"
     | UnknownEnumStringValue
   connect?: boolean
-  description?: string | "" | UnknownEnumStringValue
+  description?: string | ""
   enabled_events: (
     | "*"
     | "account.application.authorized"
@@ -40290,12 +39903,12 @@ export type t_PostWebhookEndpointsRequestBody = {
     | UnknownEnumStringValue
   )[]
   expand?: string[]
-  metadata?: Record<string, string> | "" | UnknownEnumStringValue
+  metadata?: Record<string, string> | ""
   url: string
 }
 
 export type t_PostWebhookEndpointsWebhookEndpointRequestBody = {
-  description?: string | "" | UnknownEnumStringValue
+  description?: string | ""
   disabled?: boolean
   enabled_events?: (
     | "*"
@@ -40544,6 +40157,6 @@ export type t_PostWebhookEndpointsWebhookEndpointRequestBody = {
     | UnknownEnumStringValue
   )[]
   expand?: string[]
-  metadata?: Record<string, string> | "" | UnknownEnumStringValue
+  metadata?: Record<string, string> | ""
   url?: string
 }

--- a/integration-tests/typescript-koa/src/generated/api.github.com.yaml/generated.ts
+++ b/integration-tests/typescript-koa/src/generated/api.github.com.yaml/generated.ts
@@ -28477,7 +28477,7 @@ export function createRouter(
     ecosystem: z.string().optional(),
     package: z.string().optional(),
     epss_percentage: z.string().optional(),
-    has: z.union([z.string(), z.array(z.enum(["patch"]))]).optional(),
+    has: z.union([z.string(), z.array(z.literal("patch"))]).optional(),
     scope: z.enum(["development", "runtime"]).optional(),
     sort: z
       .enum(["created", "updated", "epss_percentage"])
@@ -37997,7 +37997,7 @@ export function createRouter(
     ecosystem: z.string().optional(),
     package: z.string().optional(),
     epss_percentage: z.string().optional(),
-    has: z.union([z.string(), z.array(z.enum(["patch"]))]).optional(),
+    has: z.union([z.string(), z.array(z.literal("patch"))]).optional(),
     scope: z.enum(["development", "runtime"]).optional(),
     sort: z
       .enum(["created", "updated", "epss_percentage"])
@@ -41102,7 +41102,7 @@ export function createRouter(
     exclude: z
       .preprocess(
         (it: unknown) => (Array.isArray(it) || it === undefined ? it : [it]),
-        z.array(z.enum(["repositories"])),
+        z.array(z.literal("repositories")),
       )
       .optional(),
   })
@@ -41200,7 +41200,7 @@ export function createRouter(
     exclude: z
       .preprocess(
         (it: unknown) => (Array.isArray(it) || it === undefined ? it : [it]),
-        z.array(z.enum(["repositories"])),
+        z.array(z.literal("repositories")),
       )
       .optional(),
   })
@@ -42681,7 +42681,7 @@ export function createRouter(
   const orgsListPatGrantRequestsQuerySchema = z.object({
     per_page: z.coerce.number().optional().default(30),
     page: z.coerce.number().optional().default(1),
-    sort: z.enum(["created_at"]).optional().default("created_at"),
+    sort: z.literal("created_at").optional().default("created_at"),
     direction: z.enum(["asc", "desc"]).optional().default("desc"),
     owner: z
       .preprocess(
@@ -42967,7 +42967,7 @@ export function createRouter(
   const orgsListPatGrantsQuerySchema = z.object({
     per_page: z.coerce.number().optional().default(30),
     page: z.coerce.number().optional().default(1),
-    sort: z.enum(["created_at"]).optional().default("created_at"),
+    sort: z.literal("created_at").optional().default("created_at"),
     direction: z.enum(["asc", "desc"]).optional().default("desc"),
     owner: z
       .preprocess(
@@ -56479,7 +56479,7 @@ export function createRouter(
     ref: s_code_scanning_ref.optional(),
     sarif_id: s_code_scanning_analysis_sarif_id.optional(),
     direction: z.enum(["asc", "desc"]).optional().default("desc"),
-    sort: z.enum(["created"]).optional().default("created"),
+    sort: z.literal("created").optional().default("created"),
   })
 
   const codeScanningListRecentAnalysesResponseValidator =
@@ -60027,7 +60027,7 @@ export function createRouter(
     package: z.string().optional(),
     manifest: z.string().optional(),
     epss_percentage: z.string().optional(),
-    has: z.union([z.string(), z.array(z.enum(["patch"]))]).optional(),
+    has: z.union([z.string(), z.array(z.literal("patch"))]).optional(),
     scope: z.enum(["development", "runtime"]).optional(),
     sort: z
       .enum(["created", "updated", "epss_percentage"])
@@ -74392,7 +74392,7 @@ export function createRouter(
 
   const searchCodeQuerySchema = z.object({
     q: z.string(),
-    sort: z.enum(["indexed"]).optional(),
+    sort: z.literal("indexed").optional(),
     order: z.enum(["desc", "asc"]).optional().default("desc"),
     per_page: z.coerce.number().optional().default(30),
     page: z.coerce.number().optional().default(1),

--- a/integration-tests/typescript-koa/src/generated/api.github.com.yaml/schemas.ts
+++ b/integration-tests/typescript-koa/src/generated/api.github.com.yaml/schemas.ts
@@ -267,21 +267,21 @@ export const s_app_permissions = z.object({
   single_file: z.enum(["read", "write"]).optional(),
   statuses: z.enum(["read", "write"]).optional(),
   vulnerability_alerts: z.enum(["read", "write"]).optional(),
-  workflows: z.enum(["write"]).optional(),
+  workflows: z.literal("write").optional(),
   members: z.enum(["read", "write"]).optional(),
   organization_administration: z.enum(["read", "write"]).optional(),
   organization_custom_roles: z.enum(["read", "write"]).optional(),
   organization_custom_org_roles: z.enum(["read", "write"]).optional(),
   organization_custom_properties: z.enum(["read", "write", "admin"]).optional(),
-  organization_copilot_seat_management: z.enum(["write"]).optional(),
+  organization_copilot_seat_management: z.literal("write").optional(),
   organization_announcement_banners: z.enum(["read", "write"]).optional(),
-  organization_events: z.enum(["read"]).optional(),
+  organization_events: z.literal("read").optional(),
   organization_hooks: z.enum(["read", "write"]).optional(),
   organization_personal_access_tokens: z.enum(["read", "write"]).optional(),
   organization_personal_access_token_requests: z
     .enum(["read", "write"])
     .optional(),
-  organization_plan: z.enum(["read"]).optional(),
+  organization_plan: z.literal("read").optional(),
   organization_projects: z.enum(["read", "write", "admin"]).optional(),
   organization_packages: z.enum(["read", "write"]).optional(),
   organization_secrets: z.enum(["read", "write"]).optional(),
@@ -293,7 +293,7 @@ export const s_app_permissions = z.object({
   git_ssh_keys: z.enum(["read", "write"]).optional(),
   gpg_keys: z.enum(["read", "write"]).optional(),
   interaction_limits: z.enum(["read", "write"]).optional(),
-  profile: z.enum(["write"]).optional(),
+  profile: z.literal("write").optional(),
   starring: z.enum(["read", "write"]).optional(),
 })
 
@@ -705,7 +705,7 @@ export const s_code_scanning_default_setup = z.object({
   query_suite: z.enum(["default", "extended"]).optional(),
   threat_model: z.enum(["remote", "remote_and_local"]).optional(),
   updated_at: z.iso.datetime({offset: true}).nullable().optional(),
-  schedule: z.enum(["weekly"]).nullable().optional(),
+  schedule: z.literal("weekly").nullable().optional(),
 })
 
 export const s_code_scanning_default_setup_options = z
@@ -1004,7 +1004,7 @@ export const s_content_directory = z.array(
 )
 
 export const s_content_file = z.object({
-  type: z.enum(["file"]),
+  type: z.literal("file"),
   encoding: z.string(),
   size: z.coerce.number(),
   name: z.string(),
@@ -1025,7 +1025,7 @@ export const s_content_file = z.object({
 })
 
 export const s_content_submodule = z.object({
-  type: z.enum(["submodule"]),
+  type: z.literal("submodule"),
   submodule_git_url: z.string(),
   size: z.coerce.number(),
   name: z.string(),
@@ -1043,7 +1043,7 @@ export const s_content_submodule = z.object({
 })
 
 export const s_content_symlink = z.object({
-  type: z.enum(["symlink"]),
+  type: z.literal("symlink"),
   target: z.string(),
   size: z.coerce.number(),
   name: z.string(),
@@ -2777,7 +2777,7 @@ export const s_repo_codespaces_secret = z.object({
 })
 
 export const s_repository_rule_branch_name_pattern = z.object({
-  type: z.enum(["branch_name_pattern"]),
+  type: z.literal("branch_name_pattern"),
   parameters: z
     .object({
       name: z.string().optional(),
@@ -2789,7 +2789,7 @@ export const s_repository_rule_branch_name_pattern = z.object({
 })
 
 export const s_repository_rule_commit_author_email_pattern = z.object({
-  type: z.enum(["commit_author_email_pattern"]),
+  type: z.literal("commit_author_email_pattern"),
   parameters: z
     .object({
       name: z.string().optional(),
@@ -2801,7 +2801,7 @@ export const s_repository_rule_commit_author_email_pattern = z.object({
 })
 
 export const s_repository_rule_commit_message_pattern = z.object({
-  type: z.enum(["commit_message_pattern"]),
+  type: z.literal("commit_message_pattern"),
   parameters: z
     .object({
       name: z.string().optional(),
@@ -2813,7 +2813,7 @@ export const s_repository_rule_commit_message_pattern = z.object({
 })
 
 export const s_repository_rule_committer_email_pattern = z.object({
-  type: z.enum(["committer_email_pattern"]),
+  type: z.literal("committer_email_pattern"),
   parameters: z
     .object({
       name: z.string().optional(),
@@ -2824,9 +2824,13 @@ export const s_repository_rule_committer_email_pattern = z.object({
     .optional(),
 })
 
-export const s_repository_rule_creation = z.object({type: z.enum(["creation"])})
+export const s_repository_rule_creation = z.object({
+  type: z.literal("creation"),
+})
 
-export const s_repository_rule_deletion = z.object({type: z.enum(["deletion"])})
+export const s_repository_rule_deletion = z.object({
+  type: z.literal("deletion"),
+})
 
 export const s_repository_rule_enforcement = z.enum([
   "disabled",
@@ -2835,33 +2839,33 @@ export const s_repository_rule_enforcement = z.enum([
 ])
 
 export const s_repository_rule_file_extension_restriction = z.object({
-  type: z.enum(["file_extension_restriction"]),
+  type: z.literal("file_extension_restriction"),
   parameters: z
     .object({restricted_file_extensions: z.array(z.string())})
     .optional(),
 })
 
 export const s_repository_rule_file_path_restriction = z.object({
-  type: z.enum(["file_path_restriction"]),
+  type: z.literal("file_path_restriction"),
   parameters: z.object({restricted_file_paths: z.array(z.string())}).optional(),
 })
 
 export const s_repository_rule_max_file_path_length = z.object({
-  type: z.enum(["max_file_path_length"]),
+  type: z.literal("max_file_path_length"),
   parameters: z
     .object({max_file_path_length: z.coerce.number().min(1).max(32767)})
     .optional(),
 })
 
 export const s_repository_rule_max_file_size = z.object({
-  type: z.enum(["max_file_size"]),
+  type: z.literal("max_file_size"),
   parameters: z
     .object({max_file_size: z.coerce.number().min(1).max(100)})
     .optional(),
 })
 
 export const s_repository_rule_merge_queue = z.object({
-  type: z.enum(["merge_queue"]),
+  type: z.literal("merge_queue"),
   parameters: z
     .object({
       check_response_timeout_minutes: z.coerce.number().min(1).max(360),
@@ -2876,7 +2880,7 @@ export const s_repository_rule_merge_queue = z.object({
 })
 
 export const s_repository_rule_non_fast_forward = z.object({
-  type: z.enum(["non_fast_forward"]),
+  type: z.literal("non_fast_forward"),
 })
 
 export const s_repository_rule_params_code_scanning_tool = z.object({
@@ -2904,7 +2908,7 @@ export const s_repository_rule_params_workflow_file_reference = z.object({
 })
 
 export const s_repository_rule_pull_request = z.object({
-  type: z.enum(["pull_request"]),
+  type: z.literal("pull_request"),
   parameters: z
     .object({
       allowed_merge_methods: z
@@ -2921,18 +2925,18 @@ export const s_repository_rule_pull_request = z.object({
 })
 
 export const s_repository_rule_required_deployments = z.object({
-  type: z.enum(["required_deployments"]),
+  type: z.literal("required_deployments"),
   parameters: z
     .object({required_deployment_environments: z.array(z.string())})
     .optional(),
 })
 
 export const s_repository_rule_required_linear_history = z.object({
-  type: z.enum(["required_linear_history"]),
+  type: z.literal("required_linear_history"),
 })
 
 export const s_repository_rule_required_signatures = z.object({
-  type: z.enum(["required_signatures"]),
+  type: z.literal("required_signatures"),
 })
 
 export const s_repository_rule_ruleset_info = z.object({
@@ -2942,7 +2946,7 @@ export const s_repository_rule_ruleset_info = z.object({
 })
 
 export const s_repository_rule_tag_name_pattern = z.object({
-  type: z.enum(["tag_name_pattern"]),
+  type: z.literal("tag_name_pattern"),
   parameters: z
     .object({
       name: z.string().optional(),
@@ -2954,7 +2958,7 @@ export const s_repository_rule_tag_name_pattern = z.object({
 })
 
 export const s_repository_rule_update = z.object({
-  type: z.enum(["update"]),
+  type: z.literal("update"),
   parameters: z
     .object({update_allows_fetch_and_merge: PermissiveBoolean})
     .optional(),
@@ -5341,7 +5345,7 @@ export const s_repository_collaborator_permission = z.object({
 })
 
 export const s_repository_rule_code_scanning = z.object({
-  type: z.enum(["code_scanning"]),
+  type: z.literal("code_scanning"),
   parameters: z
     .object({
       code_scanning_tools: z.array(s_repository_rule_params_code_scanning_tool),
@@ -5350,7 +5354,7 @@ export const s_repository_rule_code_scanning = z.object({
 })
 
 export const s_repository_rule_required_status_checks = z.object({
-  type: z.enum(["required_status_checks"]),
+  type: z.literal("required_status_checks"),
   parameters: z
     .object({
       do_not_enforce_on_create: PermissiveBoolean.optional(),
@@ -5386,7 +5390,7 @@ export const s_repository_rule_violation_error = z.object({
 })
 
 export const s_repository_rule_workflows = z.object({
-  type: z.enum(["workflows"]),
+  type: z.literal("workflows"),
   parameters: z
     .object({
       do_not_enforce_on_create: PermissiveBoolean.optional(),
@@ -9057,7 +9061,7 @@ export const s_MigrationsStartForOrgRequestBody = z.object({
   exclude_releases: PermissiveBoolean.optional().default(false),
   exclude_owner_projects: PermissiveBoolean.optional().default(false),
   org_metadata_only: PermissiveBoolean.optional().default(false),
-  exclude: z.array(z.enum(["repositories"])).optional(),
+  exclude: z.array(z.literal("repositories")).optional(),
 })
 
 export const s_OrgsConvertMemberToOutsideCollaboratorRequestBody = z.object({
@@ -9076,12 +9080,12 @@ export const s_OrgsReviewPatGrantRequestRequestBody = z.object({
 })
 
 export const s_OrgsUpdatePatAccessesRequestBody = z.object({
-  action: z.enum(["revoke"]),
+  action: z.literal("revoke"),
   pat_ids: z.array(z.coerce.number()).min(1).max(100),
 })
 
 export const s_OrgsUpdatePatAccessRequestBody = z.object({
-  action: z.enum(["revoke"]),
+  action: z.literal("revoke"),
 })
 
 export const s_PrivateRegistriesCreateOrgPrivateRegistryRequestBody = z.object({
@@ -9706,7 +9710,7 @@ export const s_ChecksCreateRequestBody = z.intersection(
   z.union([
     z.intersection(
       z.object({
-        status: z.enum(["completed"]),
+        status: z.literal("completed"),
         conclusion: z.enum([
           "action_required",
           "cancelled",
@@ -9802,7 +9806,7 @@ export const s_ChecksUpdateRequestBody = z.intersection(
   z.union([
     z.intersection(
       z.object({
-        status: z.enum(["completed"]).optional(),
+        status: z.literal("completed").optional(),
         conclusion: z.enum([
           "action_required",
           "cancelled",
@@ -10559,7 +10563,7 @@ export const s_PullsUpdateReviewRequestBody = z.object({body: z.string()})
 
 export const s_PullsDismissReviewRequestBody = z.object({
   message: z.string(),
-  event: z.enum(["DISMISS"]).optional(),
+  event: z.literal("DISMISS").optional(),
 })
 
 export const s_PullsSubmitReviewRequestBody = z.object({
@@ -10844,7 +10848,7 @@ export const s_UsersCreatePublicSshKeyForAuthenticatedUserRequestBody =
   })
 
 export const s_OrgsUpdateMembershipForAuthenticatedUserRequestBody = z.object({
-  state: z.enum(["active"]),
+  state: z.literal("active"),
 })
 
 export const s_MigrationsStartForAuthenticatedUserRequestBody = z.object({
@@ -10855,7 +10859,7 @@ export const s_MigrationsStartForAuthenticatedUserRequestBody = z.object({
   exclude_releases: PermissiveBoolean.optional(),
   exclude_owner_projects: PermissiveBoolean.optional(),
   org_metadata_only: PermissiveBoolean.optional().default(false),
-  exclude: z.array(z.enum(["repositories"])).optional(),
+  exclude: z.array(z.literal("repositories")).optional(),
   repositories: z.array(z.string()),
 })
 

--- a/integration-tests/typescript-koa/src/generated/azure-core-data-plane-service.tsp/schemas.ts
+++ b/integration-tests/typescript-koa/src/generated/azure-core-data-plane-service.tsp/schemas.ts
@@ -19,7 +19,7 @@ export const s_Azure_Core_eTag = z.string()
 export const s_Azure_Core_uuid = z.string()
 
 export const s_WidgetAnalytics = z.object({
-  id: z.enum(["current"]),
+  id: z.literal("current"),
   useCount: z.coerce.number(),
   repairCount: z.coerce.number(),
 })

--- a/integration-tests/typescript-koa/src/generated/azure-resource-manager.tsp/schemas.ts
+++ b/integration-tests/typescript-koa/src/generated/azure-resource-manager.tsp/schemas.ts
@@ -24,7 +24,7 @@ export const s_Azure_Core_azureLocation = z.string()
 export const s_Azure_Core_uuid = z.string()
 
 export const s_Azure_ResourceManager_CommonTypes_ActionType = z.union([
-  z.enum(["Internal"]),
+  z.literal("Internal"),
   z.string(),
 ])
 

--- a/integration-tests/typescript-koa/src/generated/okta.idp.yaml/generated.ts
+++ b/integration-tests/typescript-koa/src/generated/okta.idp.yaml/generated.ts
@@ -1687,11 +1687,11 @@ export function createRouter(
           _links: z.object({
             verify: z.object({
               href: z.string().min(1),
-              hints: z.object({allow: z.array(z.enum(["POST"]))}),
+              hints: z.object({allow: z.array(z.literal("POST"))}),
             }),
             poll: z.object({
               href: z.string().min(1),
-              hints: z.object({allow: z.array(z.enum(["GET"]))}),
+              hints: z.object({allow: z.array(z.literal("GET"))}),
             }),
           }),
         }),
@@ -2352,7 +2352,7 @@ export function createRouter(
               verify: z
                 .object({
                   href: z.string().min(1),
-                  hints: z.object({allow: z.array(z.enum(["GET"]))}),
+                  hints: z.object({allow: z.array(z.literal("GET"))}),
                 })
                 .optional(),
             })

--- a/integration-tests/typescript-koa/src/generated/okta.idp.yaml/schemas.ts
+++ b/integration-tests/typescript-koa/src/generated/okta.idp.yaml/schemas.ts
@@ -19,7 +19,7 @@ export const s_AppAuthenticatorEnrollment = z.object({
   device: z
     .object({
       id: z.string().optional(),
-      status: z.enum(["ACTIVE"]).optional(),
+      status: z.literal("ACTIVE").optional(),
       createdDate: z.iso.datetime({offset: true}).optional(),
       lastUpdated: z.iso.datetime({offset: true}).optional(),
       clientInstanceId: z.string().optional(),
@@ -52,7 +52,7 @@ export const s_AppAuthenticatorEnrollment = z.object({
                 .object({
                   href: z.string().min(1).optional(),
                   hints: z
-                    .object({allow: z.array(z.enum(["GET"])).optional()})
+                    .object({allow: z.array(z.literal("GET")).optional()})
                     .optional(),
                 })
                 .optional(),
@@ -159,9 +159,9 @@ export const s_Error = z.object({
 export const s_HttpMethod = z.enum(["DELETE", "GET", "POST", "PUT"])
 
 export const s_KeyEC = z.object({
-  crv: z.enum(["P-256"]),
+  crv: z.literal("P-256"),
   kid: z.string(),
-  kty: z.enum(["EC"]),
+  kty: z.literal("EC"),
   "okta:kpr": z.enum(["HARDWARE", "SOFTWARE"]),
   x: z.string(),
   y: z.string(),
@@ -170,7 +170,7 @@ export const s_KeyEC = z.object({
 export const s_KeyRSA = z.object({
   e: z.string(),
   kid: z.string(),
-  kty: z.enum(["RSA"]),
+  kty: z.literal("RSA"),
   n: z.string(),
   "okta:kpr": z.enum(["HARDWARE", "SOFTWARE"]),
 })
@@ -192,7 +192,7 @@ export const s_Organization = z.object({
         .object({
           href: z.string().min(1).optional(),
           hints: z
-            .object({allow: z.array(z.enum(["GET"])).optional()})
+            .object({allow: z.array(z.literal("GET")).optional()})
             .optional(),
         })
         .optional(),
@@ -279,12 +279,12 @@ export const s_Profile = z.object({
 
 export const s_PushNotificationChallenge = z.object({
   challenge: z.string().optional(),
-  payloadVersion: z.enum(["IDXv1"]).optional(),
+  payloadVersion: z.literal("IDXv1").optional(),
 })
 
 export const s_PushNotificationVerification = z.object({
   challengeResponse: z.string().optional(),
-  method: z.enum(["push"]).optional(),
+  method: z.literal("push").optional(),
 })
 
 export const s_Schema = z.object({

--- a/integration-tests/typescript-koa/src/generated/okta.oauth.yaml/schemas.ts
+++ b/integration-tests/typescript-koa/src/generated/okta.oauth.yaml/schemas.ts
@@ -71,7 +71,7 @@ export const s_Channel = z.enum(["push", "sms", "voice"])
 
 export const s_Claim = z.string()
 
-export const s_CodeChallengeMethod = z.enum(["S256"])
+export const s_CodeChallengeMethod = z.literal("S256")
 
 export const s_DeviceAuthorizeRequest = z.object({
   client_id: z.string().optional(),
@@ -228,7 +228,7 @@ export const s_SigningAlgorithm = z.enum([
 
 export const s_SubjectType = z.enum(["pairwise", "public"])
 
-export const s_TokenDeliveryMode = z.enum(["poll"])
+export const s_TokenDeliveryMode = z.literal("poll")
 
 export const s_TokenResponseTokenType = z.enum(["Bearer", "N_A"])
 
@@ -262,7 +262,7 @@ export const s_UserInfo = z.intersection(
 )
 
 export const s_sub_id = z.object({
-  format: z.enum(["opaque"]).optional(),
+  format: z.literal("opaque").optional(),
   id: z.string().optional(),
 })
 

--- a/integration-tests/typescript-koa/src/generated/stripe.yaml/generated.ts
+++ b/integration-tests/typescript-koa/src/generated/stripe.yaml/generated.ts
@@ -15113,7 +15113,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_account)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000).regex(new RegExp("^/v1/accounts")),
         }),
       ],
@@ -15608,7 +15608,7 @@ export function createRouter(
           z.object({
             data: z.array(z.lazy(() => s_capability)),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z.string().max(5000),
           }),
         ],
@@ -15813,7 +15813,7 @@ export function createRouter(
               z.union([z.lazy(() => s_bank_account), z.lazy(() => s_card)]),
             ),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z.string().max(5000),
           }),
         ],
@@ -16195,7 +16195,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_person)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000),
         }),
       ],
@@ -16526,7 +16526,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_person)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000),
         }),
       ],
@@ -16894,7 +16894,7 @@ export function createRouter(
         z.object({
           data: z.array(s_apple_pay_domain),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000).regex(new RegExp("^/v1/apple_pay/domains")),
         }),
       ],
@@ -17138,7 +17138,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_application_fee)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000).regex(new RegExp("^/v1/application_fees")),
         }),
       ],
@@ -17468,7 +17468,7 @@ export function createRouter(
           z.object({
             data: z.array(z.lazy(() => s_fee_refund)),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z.string().max(5000),
           }),
         ],
@@ -17614,7 +17614,7 @@ export function createRouter(
         z.object({
           data: z.array(s_apps_secret),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000).regex(new RegExp("^/v1/apps/secrets")),
         }),
       ],
@@ -17921,7 +17921,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_balance_transaction)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z
             .string()
             .max(5000)
@@ -18121,7 +18121,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_balance_transaction)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z
             .string()
             .max(5000)
@@ -18298,7 +18298,7 @@ export function createRouter(
   )
 
   const getBillingAlertsQuerySchema = z.object({
-    alert_type: z.enum(["usage_threshold"]).optional(),
+    alert_type: z.literal("usage_threshold").optional(),
     ending_before: z.string().max(5000).optional(),
     expand: z
       .preprocess(
@@ -18318,7 +18318,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_billing_alert)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000).regex(new RegExp("^/v1/billing/alerts")),
         }),
       ],
@@ -18640,7 +18640,7 @@ export function createRouter(
     filter: z.object({
       applicability_scope: z
         .object({
-          price_type: z.enum(["metered"]).optional(),
+          price_type: z.literal("metered").optional(),
           prices: z.array(z.object({id: z.string().max(5000)})).optional(),
         })
         .optional(),
@@ -18751,7 +18751,7 @@ export function createRouter(
           z.object({
             data: z.array(z.lazy(() => s_billing_credit_balance_transaction)),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z
               .string()
               .max(5000)
@@ -18934,7 +18934,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_billing_credit_grant)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z
             .string()
             .max(5000)
@@ -19362,7 +19362,7 @@ export function createRouter(
         z.object({
           data: z.array(s_billing_meter),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000).regex(new RegExp("^/v1/billing/meters")),
         }),
       ],
@@ -19644,7 +19644,7 @@ export function createRouter(
           z.object({
             data: z.array(s_billing_meter_event_summary),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z
               .string()
               .max(5000)
@@ -19821,7 +19821,7 @@ export function createRouter(
           z.object({
             data: z.array(s_billing_portal_configuration),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z
               .string()
               .max(5000)
@@ -20146,7 +20146,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_charge)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000).regex(new RegExp("^/v1/charges")),
         }),
       ],
@@ -20301,7 +20301,7 @@ export function createRouter(
           data: z.array(z.lazy(() => s_charge)),
           has_more: PermissiveBoolean,
           next_page: z.string().max(5000).nullable().optional(),
-          object: z.enum(["search_result"]),
+          object: z.literal("search_result"),
           total_count: z.coerce.number().optional(),
           url: z.string().max(5000),
         }),
@@ -20742,7 +20742,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_refund)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000),
         }),
       ],
@@ -21013,7 +21013,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_checkout_session)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000),
         }),
       ],
@@ -21348,7 +21348,7 @@ export function createRouter(
           z.object({
             data: z.array(z.lazy(() => s_item)),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z.string().max(5000),
           }),
         ],
@@ -21448,7 +21448,7 @@ export function createRouter(
         z.object({
           data: z.array(s_climate_order),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000).regex(new RegExp("^/v1/climate/orders")),
         }),
       ],
@@ -21727,7 +21727,7 @@ export function createRouter(
         z.object({
           data: z.array(s_climate_product),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000).regex(new RegExp("^/v1/climate/products")),
         }),
       ],
@@ -21877,7 +21877,7 @@ export function createRouter(
         z.object({
           data: z.array(s_climate_supplier),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000).regex(new RegExp("^/v1/climate/suppliers")),
         }),
       ],
@@ -22091,7 +22091,7 @@ export function createRouter(
         z.object({
           data: z.array(s_country_spec),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000).regex(new RegExp("^/v1/country_specs")),
         }),
       ],
@@ -22252,7 +22252,7 @@ export function createRouter(
         z.object({
           data: z.array(s_coupon),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000).regex(new RegExp("^/v1/coupons")),
         }),
       ],
@@ -22538,7 +22538,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_credit_note)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000),
         }),
       ],
@@ -22697,11 +22697,11 @@ export function createRouter(
                     taxable_amount: z.coerce.number(),
                   }),
                 ),
-                z.enum([""]),
+                z.literal(""),
               ])
               .optional(),
             tax_rates: z
-              .union([z.array(z.string().max(5000)), z.enum([""])])
+              .union([z.array(z.string().max(5000)), z.literal("")])
               .optional(),
             type: z.enum(["custom_line_item", "invoice_line_item"]),
             unit_amount: z.coerce.number().optional(),
@@ -22932,11 +22932,11 @@ export function createRouter(
                     taxable_amount: z.coerce.number(),
                   }),
                 ),
-                z.enum([""]),
+                z.literal(""),
               ])
               .optional(),
             tax_rates: z
-              .union([z.array(z.string().max(5000)), z.enum([""])])
+              .union([z.array(z.string().max(5000)), z.literal("")])
               .optional(),
             type: z.enum(["custom_line_item", "invoice_line_item"]),
             unit_amount: z.coerce.number().optional(),
@@ -22981,7 +22981,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_credit_note_line_item)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000),
         }),
       ],
@@ -23193,7 +23193,7 @@ export function createRouter(
           z.object({
             data: z.array(z.lazy(() => s_credit_note_line_item)),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z.string().max(5000),
           }),
         ],
@@ -23481,7 +23481,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_customer)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000).regex(new RegExp("^/v1/customers")),
         }),
       ],
@@ -23630,7 +23630,7 @@ export function createRouter(
           data: z.array(z.lazy(() => s_customer)),
           has_more: PermissiveBoolean,
           next_page: z.string().max(5000).nullable().optional(),
-          object: z.enum(["search_result"]),
+          object: z.literal("search_result"),
           total_count: z.coerce.number().optional(),
           url: z.string().max(5000),
         }),
@@ -23874,7 +23874,7 @@ export function createRouter(
           z.object({
             data: z.array(z.lazy(() => s_customer_balance_transaction)),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z.string().max(5000),
           }),
         ],
@@ -24164,7 +24164,7 @@ export function createRouter(
           z.object({
             data: z.array(z.lazy(() => s_bank_account)),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z.string().max(5000),
           }),
         ],
@@ -24560,7 +24560,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_card)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000),
         }),
       ],
@@ -25000,7 +25000,7 @@ export function createRouter(
           z.object({
             data: z.array(z.lazy(() => s_customer_cash_balance_transaction)),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z.string().max(5000),
           }),
         ],
@@ -25389,7 +25389,7 @@ export function createRouter(
           z.object({
             data: z.array(z.lazy(() => s_payment_method)),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z.string().max(5000),
           }),
         ],
@@ -25580,7 +25580,7 @@ export function createRouter(
               ]),
             ),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z.string().max(5000),
           }),
         ],
@@ -25969,7 +25969,7 @@ export function createRouter(
           z.object({
             data: z.array(z.lazy(() => s_subscription)),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z.string().max(5000),
           }),
         ],
@@ -26433,7 +26433,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_tax_id)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000),
         }),
       ],
@@ -26694,7 +26694,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_dispute)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000).regex(new RegExp("^/v1/disputes")),
         }),
       ],
@@ -26958,7 +26958,7 @@ export function createRouter(
           z.object({
             data: z.array(s_entitlements_active_entitlement),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z.string().max(5000),
           }),
         ],
@@ -27131,7 +27131,7 @@ export function createRouter(
         z.object({
           data: z.array(s_entitlements_feature),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z
             .string()
             .max(5000)
@@ -27487,7 +27487,7 @@ export function createRouter(
         z.object({
           data: z.array(s_event),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000).regex(new RegExp("^/v1/events")),
         }),
       ],
@@ -27663,7 +27663,7 @@ export function createRouter(
         z.object({
           data: z.array(s_exchange_rate),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000).regex(new RegExp("^/v1/exchange_rates")),
         }),
       ],
@@ -27871,7 +27871,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_file_link)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000).regex(new RegExp("^/v1/file_links")),
         }),
       ],
@@ -28149,7 +28149,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_file)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000).regex(new RegExp("^/v1/files")),
         }),
       ],
@@ -28357,7 +28357,7 @@ export function createRouter(
           z.object({
             data: z.array(z.lazy(() => s_financial_connections_account)),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z
               .string()
               .max(5000)
@@ -28603,7 +28603,7 @@ export function createRouter(
           z.object({
             data: z.array(s_financial_connections_account_owner),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z.string().max(5000),
           }),
         ],
@@ -28999,7 +28999,7 @@ export function createRouter(
           z.object({
             data: z.array(s_financial_connections_transaction),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z
               .string()
               .max(5000)
@@ -29203,7 +29203,7 @@ export function createRouter(
         z.object({
           data: z.array(s_forwarding_request),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000),
         }),
       ],
@@ -29425,7 +29425,7 @@ export function createRouter(
           z.object({
             data: z.array(s_identity_verification_report),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z
               .string()
               .max(5000)
@@ -29639,7 +29639,7 @@ export function createRouter(
           z.object({
             data: z.array(s_identity_verification_session),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z
               .string()
               .max(5000)
@@ -30034,7 +30034,7 @@ export function createRouter(
     payment: z
       .object({
         payment_intent: z.string().max(5000).optional(),
-        type: z.enum(["payment_intent"]),
+        type: z.literal("payment_intent"),
       })
       .optional(),
     starting_after: z.string().max(5000).optional(),
@@ -30048,7 +30048,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_invoice_payment)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000),
         }),
       ],
@@ -30227,7 +30227,7 @@ export function createRouter(
           z.object({
             data: z.array(s_invoice_rendering_template),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z.string().max(5000),
           }),
         ],
@@ -30513,7 +30513,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_invoiceitem)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000).regex(new RegExp("^/v1/invoiceitems")),
         }),
       ],
@@ -30848,7 +30848,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_invoice)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000).regex(new RegExp("^/v1/invoices")),
         }),
       ],
@@ -31062,7 +31062,7 @@ export function createRouter(
           data: z.array(z.lazy(() => s_invoice)),
           has_more: PermissiveBoolean,
           next_page: z.string().max(5000).nullable().optional(),
-          object: z.enum(["search_result"]),
+          object: z.literal("search_result"),
           total_count: z.coerce.number().optional(),
           url: z.string().max(5000),
         }),
@@ -31441,7 +31441,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_line_item)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000),
         }),
       ],
@@ -31886,7 +31886,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_issuing_authorization)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z
             .string()
             .max(5000)
@@ -32243,7 +32243,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_issuing_cardholder)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z
             .string()
             .max(5000)
@@ -32545,7 +32545,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_issuing_card)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000).regex(new RegExp("^/v1/issuing/cards")),
         }),
       ],
@@ -32840,7 +32840,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_issuing_dispute)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000).regex(new RegExp("^/v1/issuing/disputes")),
         }),
       ],
@@ -33162,7 +33162,7 @@ export function createRouter(
           z.object({
             data: z.array(z.lazy(() => s_issuing_personalization_design)),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z
               .string()
               .max(5000)
@@ -33461,7 +33461,7 @@ export function createRouter(
         z.object({
           data: z.array(s_issuing_physical_bundle),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z
             .string()
             .max(5000)
@@ -33759,7 +33759,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_issuing_token)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000),
         }),
       ],
@@ -33996,7 +33996,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_issuing_transaction)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z
             .string()
             .max(5000)
@@ -34350,7 +34350,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_financial_connections_account)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z
             .string()
             .max(5000)
@@ -34580,7 +34580,7 @@ export function createRouter(
           z.object({
             data: z.array(s_financial_connections_account_owner),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z.string().max(5000),
           }),
         ],
@@ -34805,7 +34805,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_payment_intent)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000).regex(new RegExp("^/v1/payment_intents")),
         }),
       ],
@@ -34948,7 +34948,7 @@ export function createRouter(
           data: z.array(z.lazy(() => s_payment_intent)),
           has_more: PermissiveBoolean,
           next_page: z.string().max(5000).nullable().optional(),
-          object: z.enum(["search_result"]),
+          object: z.literal("search_result"),
           total_count: z.coerce.number().optional(),
           url: z.string().max(5000),
         }),
@@ -35451,7 +35451,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_payment_link)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000).regex(new RegExp("^/v1/payment_links")),
         }),
       ],
@@ -35692,7 +35692,7 @@ export function createRouter(
           z.object({
             data: z.array(z.lazy(() => s_item)),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z.string().max(5000),
           }),
         ],
@@ -35774,7 +35774,7 @@ export function createRouter(
   )
 
   const getPaymentMethodConfigurationsQuerySchema = z.object({
-    application: z.union([z.string().max(100), z.enum([""])]).optional(),
+    application: z.union([z.string().max(100), z.literal("")]).optional(),
     ending_before: z.string().max(5000).optional(),
     expand: z
       .preprocess(
@@ -35794,7 +35794,7 @@ export function createRouter(
           z.object({
             data: z.array(s_payment_method_configuration),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z
               .string()
               .max(5000)
@@ -36062,7 +36062,7 @@ export function createRouter(
         z.object({
           data: z.array(s_payment_method_domain),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z
             .string()
             .max(5000)
@@ -36429,7 +36429,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_payment_method)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000).regex(new RegExp("^/v1/payment_methods")),
         }),
       ],
@@ -36797,7 +36797,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_payout)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000).regex(new RegExp("^/v1/payouts")),
         }),
       ],
@@ -37164,7 +37164,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_plan)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000).regex(new RegExp("^/v1/plans")),
         }),
       ],
@@ -37475,7 +37475,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_price)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000).regex(new RegExp("^/v1/prices")),
         }),
       ],
@@ -37655,7 +37655,7 @@ export function createRouter(
           data: z.array(z.lazy(() => s_price)),
           has_more: PermissiveBoolean,
           next_page: z.string().max(5000).nullable().optional(),
-          object: z.enum(["search_result"]),
+          object: z.literal("search_result"),
           total_count: z.coerce.number().optional(),
           url: z.string().max(5000),
         }),
@@ -37863,7 +37863,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_product)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000).regex(new RegExp("^/v1/products")),
         }),
       ],
@@ -38019,7 +38019,7 @@ export function createRouter(
           data: z.array(z.lazy(() => s_product)),
           has_more: PermissiveBoolean,
           next_page: z.string().max(5000).nullable().optional(),
-          object: z.enum(["search_result"]),
+          object: z.literal("search_result"),
           total_count: z.coerce.number().optional(),
           url: z.string().max(5000),
         }),
@@ -38248,7 +38248,7 @@ export function createRouter(
         z.object({
           data: z.array(s_product_feature),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000),
         }),
       ],
@@ -38511,7 +38511,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_promotion_code)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000).regex(new RegExp("^/v1/promotion_codes")),
         }),
       ],
@@ -38784,7 +38784,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_quote)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000).regex(new RegExp("^/v1/quotes")),
         }),
       ],
@@ -39121,7 +39121,7 @@ export function createRouter(
           z.object({
             data: z.array(z.lazy(() => s_item)),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z.string().max(5000),
           }),
         ],
@@ -39272,7 +39272,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_item)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000),
         }),
       ],
@@ -39437,7 +39437,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_radar_early_fraud_warning)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z
             .string()
             .max(5000)
@@ -39636,7 +39636,7 @@ export function createRouter(
         z.object({
           data: z.array(s_radar_value_list_item),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z
             .string()
             .max(5000)
@@ -39917,7 +39917,7 @@ export function createRouter(
         z.object({
           data: z.array(s_radar_value_list),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000).regex(new RegExp("^/v1/radar/value_lists")),
         }),
       ],
@@ -40229,7 +40229,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_refund)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000).regex(new RegExp("^/v1/refunds")),
         }),
       ],
@@ -40531,7 +40531,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_reporting_report_run)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z
             .string()
             .max(5000)
@@ -40738,7 +40738,7 @@ export function createRouter(
         z.object({
           data: z.array(s_reporting_report_type),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000),
         }),
       ],
@@ -40888,7 +40888,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_review)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000),
         }),
       ],
@@ -41105,7 +41105,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_setup_attempt)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000).regex(new RegExp("^/v1/setup_attempts")),
         }),
       ],
@@ -41226,7 +41226,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_setup_intent)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000).regex(new RegExp("^/v1/setup_intents")),
         }),
       ],
@@ -41654,7 +41654,7 @@ export function createRouter(
         z.object({
           data: z.array(s_shipping_rate),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000).regex(new RegExp("^/v1/shipping_rates")),
         }),
       ],
@@ -41965,7 +41965,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_scheduled_query_run)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z
             .string()
             .max(5000)
@@ -42343,7 +42343,7 @@ export function createRouter(
           z.object({
             data: z.array(s_source_transaction),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z.string().max(5000),
           }),
         ],
@@ -42564,7 +42564,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_subscription_item)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z
             .string()
             .max(5000)
@@ -42900,7 +42900,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_subscription_schedule)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z
             .string()
             .max(5000)
@@ -43371,7 +43371,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_subscription)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000).regex(new RegExp("^/v1/subscriptions")),
         }),
       ],
@@ -43572,7 +43572,7 @@ export function createRouter(
           data: z.array(z.lazy(() => s_subscription)),
           has_more: PermissiveBoolean,
           next_page: z.string().max(5000).nullable().optional(),
-          object: z.enum(["search_result"]),
+          object: z.literal("search_result"),
           total_count: z.coerce.number().optional(),
           url: z.string().max(5000),
         }),
@@ -44081,7 +44081,7 @@ export function createRouter(
           z.object({
             data: z.array(s_tax_calculation_line_item),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z
               .string()
               .max(5000)
@@ -44185,7 +44185,7 @@ export function createRouter(
         z.object({
           data: z.array(s_tax_registration),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000).regex(new RegExp("^/v1/tax/registrations")),
         }),
       ],
@@ -44657,7 +44657,7 @@ export function createRouter(
           z.object({
             data: z.array(s_tax_transaction_line_item),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z
               .string()
               .max(5000)
@@ -44760,7 +44760,7 @@ export function createRouter(
         z.object({
           data: z.array(s_tax_code),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000),
         }),
       ],
@@ -44911,7 +44911,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_tax_id)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000),
         }),
       ],
@@ -45153,7 +45153,7 @@ export function createRouter(
         z.object({
           data: z.array(s_tax_rate),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000).regex(new RegExp("^/v1/tax_rates")),
         }),
       ],
@@ -45404,7 +45404,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_terminal_configuration)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z
             .string()
             .max(5000)
@@ -45773,7 +45773,7 @@ export function createRouter(
         z.object({
           data: z.array(s_terminal_location),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z
             .string()
             .max(5000)
@@ -46081,7 +46081,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_terminal_reader)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000),
         }),
       ],
@@ -48116,7 +48116,7 @@ export function createRouter(
         z.object({
           data: z.array(s_test_helpers_test_clock),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z
             .string()
             .max(5000)
@@ -49175,7 +49175,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_topup)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000).regex(new RegExp("^/v1/topups")),
         }),
       ],
@@ -49489,7 +49489,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_transfer)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000).regex(new RegExp("^/v1/transfers")),
         }),
       ],
@@ -49641,7 +49641,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_transfer_reversal)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000),
         }),
       ],
@@ -50007,7 +50007,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_treasury_credit_reversal)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000),
         }),
       ],
@@ -50223,7 +50223,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_treasury_debit_reversal)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000),
         }),
       ],
@@ -50456,7 +50456,7 @@ export function createRouter(
           z.object({
             data: z.array(s_treasury_financial_account),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z
               .string()
               .max(5000)
@@ -50918,7 +50918,7 @@ export function createRouter(
           z.object({
             data: z.array(z.lazy(() => s_treasury_inbound_transfer)),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z.string().max(5000),
           }),
         ],
@@ -51194,7 +51194,7 @@ export function createRouter(
           z.object({
             data: z.array(z.lazy(() => s_treasury_outbound_payment)),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z
               .string()
               .max(5000)
@@ -51477,7 +51477,7 @@ export function createRouter(
           z.object({
             data: z.array(z.lazy(() => s_treasury_outbound_transfer)),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z.string().max(5000),
           }),
         ],
@@ -51753,7 +51753,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_treasury_received_credit)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000),
         }),
       ],
@@ -51930,7 +51930,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_treasury_received_debit)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000),
         }),
       ],
@@ -52120,7 +52120,7 @@ export function createRouter(
           z.object({
             data: z.array(z.lazy(() => s_treasury_transaction_entry)),
             has_more: PermissiveBoolean,
-            object: z.enum(["list"]),
+            object: z.literal("list"),
             url: z
               .string()
               .max(5000)
@@ -52354,7 +52354,7 @@ export function createRouter(
         z.object({
           data: z.array(z.lazy(() => s_treasury_transaction)),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000),
         }),
       ],
@@ -52559,7 +52559,7 @@ export function createRouter(
         z.object({
           data: z.array(s_webhook_endpoint),
           has_more: PermissiveBoolean,
-          object: z.enum(["list"]),
+          object: z.literal("list"),
           url: z.string().max(5000).regex(new RegExp("^/v1/webhook_endpoints")),
         }),
       ],

--- a/integration-tests/typescript-koa/src/generated/stripe.yaml/schemas.ts
+++ b/integration-tests/typescript-koa/src/generated/stripe.yaml/schemas.ts
@@ -327,7 +327,7 @@ export const s_account_group_membership = z.object({
 export const s_account_link = z.object({
   created: z.coerce.number(),
   expires_at: z.coerce.number(),
-  object: z.enum(["account_link"]),
+  object: z.literal("account_link"),
   url: z.string().max(5000),
 })
 
@@ -495,13 +495,13 @@ export const s_apple_pay_domain = z.object({
   domain_name: z.string().max(5000),
   id: z.string().max(5000),
   livemode: PermissiveBoolean,
-  object: z.enum(["apple_pay_domain"]),
+  object: z.literal("apple_pay_domain"),
 })
 
 export const s_application = z.object({
   id: z.string().max(5000),
   name: z.string().max(5000).nullable().optional(),
-  object: z.enum(["application"]),
+  object: z.literal("application"),
 })
 
 export const s_balance_amount_by_source_type = z.object({
@@ -600,7 +600,7 @@ export const s_billing_meter_event = z.object({
   event_name: z.string().max(100),
   identifier: z.string().max(5000),
   livemode: PermissiveBoolean,
-  object: z.enum(["billing.meter_event"]),
+  object: z.literal("billing.meter_event"),
   payload: z.record(z.string(), z.string().max(100)),
   timestamp: z.coerce.number(),
 })
@@ -611,7 +611,7 @@ export const s_billing_meter_event_summary = z.object({
   id: z.string().max(5000),
   livemode: PermissiveBoolean,
   meter: z.string().max(5000),
-  object: z.enum(["billing.meter_event_summary"]),
+  object: z.literal("billing.meter_event_summary"),
   start_time: z.coerce.number(),
 })
 
@@ -631,7 +631,7 @@ export const s_billing_meter_resource_billing_meter_value = z.object({
 
 export const s_billing_meter_resource_customer_mapping_settings = z.object({
   event_payload_key: z.string().max(5000),
-  type: z.enum(["by_id"]),
+  type: z.literal("by_id"),
 })
 
 export const s_cancellation_details = z.object({
@@ -683,15 +683,15 @@ export const s_checkout_acss_debit_mandate_options = z.object({
 })
 
 export const s_checkout_affirm_payment_method_options = z.object({
-  setup_future_usage: z.enum(["none"]).optional(),
+  setup_future_usage: z.literal("none").optional(),
 })
 
 export const s_checkout_afterpay_clearpay_payment_method_options = z.object({
-  setup_future_usage: z.enum(["none"]).optional(),
+  setup_future_usage: z.literal("none").optional(),
 })
 
 export const s_checkout_alipay_payment_method_options = z.object({
-  setup_future_usage: z.enum(["none"]).optional(),
+  setup_future_usage: z.literal("none").optional(),
 })
 
 export const s_checkout_amazon_pay_payment_method_options = z.object({
@@ -699,12 +699,12 @@ export const s_checkout_amazon_pay_payment_method_options = z.object({
 })
 
 export const s_checkout_au_becs_debit_payment_method_options = z.object({
-  setup_future_usage: z.enum(["none"]).optional(),
+  setup_future_usage: z.literal("none").optional(),
   target_date: z.string().max(5000).optional(),
 })
 
 export const s_checkout_bancontact_payment_method_options = z.object({
-  setup_future_usage: z.enum(["none"]).optional(),
+  setup_future_usage: z.literal("none").optional(),
 })
 
 export const s_checkout_boleto_payment_method_options = z.object({
@@ -717,31 +717,31 @@ export const s_checkout_card_installments_options = z.object({
 })
 
 export const s_checkout_cashapp_payment_method_options = z.object({
-  setup_future_usage: z.enum(["none"]).optional(),
+  setup_future_usage: z.literal("none").optional(),
 })
 
 export const s_checkout_eps_payment_method_options = z.object({
-  setup_future_usage: z.enum(["none"]).optional(),
+  setup_future_usage: z.literal("none").optional(),
 })
 
 export const s_checkout_fpx_payment_method_options = z.object({
-  setup_future_usage: z.enum(["none"]).optional(),
+  setup_future_usage: z.literal("none").optional(),
 })
 
 export const s_checkout_giropay_payment_method_options = z.object({
-  setup_future_usage: z.enum(["none"]).optional(),
+  setup_future_usage: z.literal("none").optional(),
 })
 
 export const s_checkout_grab_pay_payment_method_options = z.object({
-  setup_future_usage: z.enum(["none"]).optional(),
+  setup_future_usage: z.literal("none").optional(),
 })
 
 export const s_checkout_ideal_payment_method_options = z.object({
-  setup_future_usage: z.enum(["none"]).optional(),
+  setup_future_usage: z.literal("none").optional(),
 })
 
 export const s_checkout_kakao_pay_payment_method_options = z.object({
-  capture_method: z.enum(["manual"]).optional(),
+  capture_method: z.literal("manual").optional(),
   setup_future_usage: z.enum(["none", "off_session"]).optional(),
 })
 
@@ -751,11 +751,11 @@ export const s_checkout_klarna_payment_method_options = z.object({
 
 export const s_checkout_konbini_payment_method_options = z.object({
   expires_after_days: z.coerce.number().nullable().optional(),
-  setup_future_usage: z.enum(["none"]).optional(),
+  setup_future_usage: z.literal("none").optional(),
 })
 
 export const s_checkout_kr_card_payment_method_options = z.object({
-  capture_method: z.enum(["manual"]).optional(),
+  capture_method: z.literal("manual").optional(),
   setup_future_usage: z.enum(["none", "off_session"]).optional(),
 })
 
@@ -768,29 +768,29 @@ export const s_checkout_link_wallet_options = z.object({
 })
 
 export const s_checkout_mobilepay_payment_method_options = z.object({
-  setup_future_usage: z.enum(["none"]).optional(),
+  setup_future_usage: z.literal("none").optional(),
 })
 
 export const s_checkout_multibanco_payment_method_options = z.object({
-  setup_future_usage: z.enum(["none"]).optional(),
+  setup_future_usage: z.literal("none").optional(),
 })
 
 export const s_checkout_naver_pay_payment_method_options = z.object({
-  capture_method: z.enum(["manual"]).optional(),
+  capture_method: z.literal("manual").optional(),
   setup_future_usage: z.enum(["none", "off_session"]).optional(),
 })
 
 export const s_checkout_oxxo_payment_method_options = z.object({
   expires_after_days: z.coerce.number(),
-  setup_future_usage: z.enum(["none"]).optional(),
+  setup_future_usage: z.literal("none").optional(),
 })
 
 export const s_checkout_p24_payment_method_options = z.object({
-  setup_future_usage: z.enum(["none"]).optional(),
+  setup_future_usage: z.literal("none").optional(),
 })
 
 export const s_checkout_payco_payment_method_options = z.object({
-  capture_method: z.enum(["manual"]).optional(),
+  capture_method: z.literal("manual").optional(),
 })
 
 export const s_checkout_payment_method_options_mandate_options_bacs_debit =
@@ -800,11 +800,11 @@ export const s_checkout_payment_method_options_mandate_options_sepa_debit =
   z.object({reference_prefix: z.string().max(5000).optional()})
 
 export const s_checkout_paynow_payment_method_options = z.object({
-  setup_future_usage: z.enum(["none"]).optional(),
+  setup_future_usage: z.literal("none").optional(),
 })
 
 export const s_checkout_paypal_payment_method_options = z.object({
-  capture_method: z.enum(["manual"]).optional(),
+  capture_method: z.literal("manual").optional(),
   preferred_locale: z.string().max(5000).nullable().optional(),
   reference: z.string().max(5000).nullable().optional(),
   setup_future_usage: z.enum(["none", "off_session"]).optional(),
@@ -812,7 +812,7 @@ export const s_checkout_paypal_payment_method_options = z.object({
 
 export const s_checkout_pix_payment_method_options = z.object({
   expires_after_seconds: z.coerce.number().nullable().optional(),
-  setup_future_usage: z.enum(["none"]).optional(),
+  setup_future_usage: z.literal("none").optional(),
 })
 
 export const s_checkout_revolut_pay_payment_method_options = z.object({
@@ -820,11 +820,11 @@ export const s_checkout_revolut_pay_payment_method_options = z.object({
 })
 
 export const s_checkout_samsung_pay_payment_method_options = z.object({
-  capture_method: z.enum(["manual"]).optional(),
+  capture_method: z.literal("manual").optional(),
 })
 
 export const s_checkout_sofort_payment_method_options = z.object({
-  setup_future_usage: z.enum(["none"]).optional(),
+  setup_future_usage: z.literal("none").optional(),
 })
 
 export const s_checkout_swish_payment_method_options = z.object({
@@ -1010,142 +1010,142 @@ export const s_customer_tax_location = z.object({
 export const s_deleted_account = z.object({
   deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
-  object: z.enum(["account"]),
+  object: z.literal("account"),
 })
 
 export const s_deleted_apple_pay_domain = z.object({
   deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
-  object: z.enum(["apple_pay_domain"]),
+  object: z.literal("apple_pay_domain"),
 })
 
 export const s_deleted_application = z.object({
   deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
   name: z.string().max(5000).nullable().optional(),
-  object: z.enum(["application"]),
+  object: z.literal("application"),
 })
 
 export const s_deleted_bank_account = z.object({
   currency: z.string().max(5000).nullable().optional(),
   deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
-  object: z.enum(["bank_account"]),
+  object: z.literal("bank_account"),
 })
 
 export const s_deleted_card = z.object({
   currency: z.string().max(5000).nullable().optional(),
   deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
-  object: z.enum(["card"]),
+  object: z.literal("card"),
 })
 
 export const s_deleted_coupon = z.object({
   deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
-  object: z.enum(["coupon"]),
+  object: z.literal("coupon"),
 })
 
 export const s_deleted_customer = z.object({
   deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
-  object: z.enum(["customer"]),
+  object: z.literal("customer"),
 })
 
 export const s_deleted_invoice = z.object({
   deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
-  object: z.enum(["invoice"]),
+  object: z.literal("invoice"),
 })
 
 export const s_deleted_invoiceitem = z.object({
   deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
-  object: z.enum(["invoiceitem"]),
+  object: z.literal("invoiceitem"),
 })
 
 export const s_deleted_person = z.object({
   deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
-  object: z.enum(["person"]),
+  object: z.literal("person"),
 })
 
 export const s_deleted_plan = z.object({
   deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
-  object: z.enum(["plan"]),
+  object: z.literal("plan"),
 })
 
 export const s_deleted_price = z.object({
   deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
-  object: z.enum(["price"]),
+  object: z.literal("price"),
 })
 
 export const s_deleted_product = z.object({
   deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
-  object: z.enum(["product"]),
+  object: z.literal("product"),
 })
 
 export const s_deleted_product_feature = z.object({
   deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
-  object: z.enum(["product_feature"]),
+  object: z.literal("product_feature"),
 })
 
 export const s_deleted_radar_value_list = z.object({
   deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
-  object: z.enum(["radar.value_list"]),
+  object: z.literal("radar.value_list"),
 })
 
 export const s_deleted_radar_value_list_item = z.object({
   deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
-  object: z.enum(["radar.value_list_item"]),
+  object: z.literal("radar.value_list_item"),
 })
 
 export const s_deleted_subscription_item = z.object({
   deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
-  object: z.enum(["subscription_item"]),
+  object: z.literal("subscription_item"),
 })
 
 export const s_deleted_tax_id = z.object({
   deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
-  object: z.enum(["tax_id"]),
+  object: z.literal("tax_id"),
 })
 
 export const s_deleted_terminal_configuration = z.object({
   deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
-  object: z.enum(["terminal.configuration"]),
+  object: z.literal("terminal.configuration"),
 })
 
 export const s_deleted_terminal_location = z.object({
   deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
-  object: z.enum(["terminal.location"]),
+  object: z.literal("terminal.location"),
 })
 
 export const s_deleted_terminal_reader = z.object({
   deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
-  object: z.enum(["terminal.reader"]),
+  object: z.literal("terminal.reader"),
 })
 
 export const s_deleted_test_helpers_test_clock = z.object({
   deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
-  object: z.enum(["test_helpers.test_clock"]),
+  object: z.literal("test_helpers.test_clock"),
 })
 
 export const s_deleted_webhook_endpoint = z.object({
   deleted: PermissiveLiteralTrue,
   id: z.string().max(5000),
-  object: z.enum(["webhook_endpoint"]),
+  object: z.literal("webhook_endpoint"),
 })
 
 export const s_destination_details_unimplemented = z.record(
@@ -1215,7 +1215,7 @@ export const s_entitlements_feature = z.object({
   lookup_key: z.string().max(5000),
   metadata: z.record(z.string(), z.string().max(500)),
   name: z.string().max(80),
-  object: z.enum(["entitlements.feature"]),
+  object: z.literal("entitlements.feature"),
 })
 
 export const s_ephemeral_key = z.object({
@@ -1223,13 +1223,13 @@ export const s_ephemeral_key = z.object({
   expires: z.coerce.number(),
   id: z.string().max(5000),
   livemode: PermissiveBoolean,
-  object: z.enum(["ephemeral_key"]),
+  object: z.literal("ephemeral_key"),
   secret: z.string().max(5000).optional(),
 })
 
 export const s_exchange_rate = z.object({
   id: z.string().max(5000),
-  object: z.enum(["exchange_rate"]),
+  object: z.literal("exchange_rate"),
   rates: z.record(z.string(), z.coerce.number()),
 })
 
@@ -1245,7 +1245,7 @@ export const s_financial_connections_account_owner = z.object({
   email: z.string().max(5000).nullable().optional(),
   id: z.string().max(5000),
   name: z.string().max(5000),
-  object: z.enum(["financial_connections.account_owner"]),
+  object: z.literal("financial_connections.account_owner"),
   ownership: z.string().max(5000),
   phone: z.string().max(5000).nullable().optional(),
   raw_address: z.string().max(5000).nullable().optional(),
@@ -1502,7 +1502,7 @@ export const s_invoice_rendering_template = z.object({
   livemode: PermissiveBoolean,
   metadata: z.record(z.string(), z.string().max(500)).nullable().optional(),
   nickname: z.string().max(5000).nullable().optional(),
-  object: z.enum(["invoice_rendering_template"]),
+  object: z.literal("invoice_rendering_template"),
   status: z.enum(["active", "archived"]),
   version: z.coerce.number(),
 })
@@ -1693,7 +1693,7 @@ export const s_issuing_authorization_fleet_tax_data = z.object({
 })
 
 export const s_issuing_authorization_fraud_challenge = z.object({
-  channel: z.enum(["sms"]),
+  channel: z.literal("sms"),
   status: z.enum([
     "expired",
     "pending",
@@ -2567,7 +2567,7 @@ export const s_issuing_settlement = z.object({
   network: z.enum(["maestro", "visa"]),
   network_fees_amount: z.coerce.number(),
   network_settlement_identifier: z.string().max(5000),
-  object: z.enum(["issuing.settlement"]),
+  object: z.literal("issuing.settlement"),
   settlement_service: z.string().max(5000),
   status: z.enum(["complete", "pending"]),
   transaction_amount: z.coerce.number(),
@@ -2680,7 +2680,7 @@ export const s_legal_entity_ubo_declaration = z.object({
 
 export const s_login_link = z.object({
   created: z.coerce.number(),
-  object: z.enum(["login_link"]),
+  object: z.literal("login_link"),
   url: z.string().max(5000),
 })
 
@@ -2745,7 +2745,7 @@ export const s_mandate_single_use = z.object({
 })
 
 export const s_mandate_us_bank_account = z.object({
-  collection_method: z.enum(["paper"]).optional(),
+  collection_method: z.literal("paper").optional(),
 })
 
 export const s_networks = z.object({
@@ -2771,10 +2771,10 @@ export const s_online_acceptance = z.object({
 })
 
 export const s_outbound_payments_payment_method_details_financial_account =
-  z.object({id: z.string().max(5000), network: z.enum(["stripe"])})
+  z.object({id: z.string().max(5000), network: z.literal("stripe")})
 
 export const s_outbound_transfers_payment_method_details_financial_account =
-  z.object({id: z.string().max(5000), network: z.enum(["stripe"])})
+  z.object({id: z.string().max(5000), network: z.literal("stripe")})
 
 export const s_package_dimensions = z.object({
   height: z.coerce.number(),
@@ -2841,7 +2841,7 @@ export const s_payment_flows_private_payment_methods_financial_connections_commo
 
 export const s_payment_flows_private_payment_methods_kakao_pay_payment_method_options =
   z.object({
-    capture_method: z.enum(["manual"]).optional(),
+    capture_method: z.literal("manual").optional(),
     setup_future_usage: z.enum(["none", "off_session"]).optional(),
   })
 
@@ -2853,15 +2853,15 @@ export const s_payment_flows_private_payment_methods_klarna_dob = z.object({
 
 export const s_payment_flows_private_payment_methods_naver_pay_payment_method_options =
   z.object({
-    capture_method: z.enum(["manual"]).optional(),
+    capture_method: z.literal("manual").optional(),
     setup_future_usage: z.enum(["none", "off_session"]).optional(),
   })
 
 export const s_payment_flows_private_payment_methods_payco_payment_method_options =
-  z.object({capture_method: z.enum(["manual"]).optional()})
+  z.object({capture_method: z.literal("manual").optional()})
 
 export const s_payment_flows_private_payment_methods_samsung_pay_payment_method_options =
-  z.object({capture_method: z.enum(["manual"]).optional()})
+  z.object({capture_method: z.literal("manual").optional()})
 
 export const s_payment_intent_next_action_alipay_handle_redirect = z.object({
   native_data: z.string().max(5000).nullable().optional(),
@@ -2995,15 +2995,15 @@ export const s_payment_intent_payment_method_options_au_becs_debit = z.object({
 })
 
 export const s_payment_intent_payment_method_options_blik = z.object({
-  setup_future_usage: z.enum(["none"]).optional(),
+  setup_future_usage: z.literal("none").optional(),
 })
 
 export const s_payment_intent_payment_method_options_eps = z.object({
-  setup_future_usage: z.enum(["none"]).optional(),
+  setup_future_usage: z.literal("none").optional(),
 })
 
 export const s_payment_intent_payment_method_options_link = z.object({
-  capture_method: z.enum(["manual"]).optional(),
+  capture_method: z.literal("manual").optional(),
   setup_future_usage: z.enum(["none", "off_session"]).optional(),
 })
 
@@ -3025,8 +3025,8 @@ export const s_payment_intent_payment_method_options_mandate_options_sepa_debit 
   z.object({reference_prefix: z.string().max(5000).optional()})
 
 export const s_payment_intent_payment_method_options_mobilepay = z.object({
-  capture_method: z.enum(["manual"]).optional(),
-  setup_future_usage: z.enum(["none"]).optional(),
+  capture_method: z.literal("manual").optional(),
+  setup_future_usage: z.literal("none").optional(),
 })
 
 export const s_payment_intent_payment_method_options_nz_bank_account = z.object(
@@ -3040,7 +3040,7 @@ export const s_payment_intent_payment_method_options_nz_bank_account = z.object(
 
 export const s_payment_intent_payment_method_options_swish = z.object({
   reference: z.string().max(35).nullable().optional(),
-  setup_future_usage: z.enum(["none"]).optional(),
+  setup_future_usage: z.literal("none").optional(),
 })
 
 export const s_payment_intent_processing_customer_notification = z.object({
@@ -3067,7 +3067,7 @@ export const s_payment_links_resource_custom_fields_dropdown_option = z.object({
 
 export const s_payment_links_resource_custom_fields_label = z.object({
   custom: z.string().max(5000).nullable().optional(),
-  type: z.enum(["custom"]),
+  type: z.literal("custom"),
 })
 
 export const s_payment_links_resource_custom_fields_numeric = z.object({
@@ -3536,7 +3536,7 @@ export const s_payment_method_details_card_checks = z.object({
 
 export const s_payment_method_details_card_installments_plan = z.object({
   count: z.coerce.number().nullable().optional(),
-  interval: z.enum(["month"]).nullable().optional(),
+  interval: z.literal("month").nullable().optional(),
   type: z.enum(["bonus", "fixed_count", "revolving"]),
 })
 
@@ -3546,7 +3546,7 @@ export const s_payment_method_details_card_network_token = z.object({
 
 export const s_payment_method_details_card_present_offline = z.object({
   stored_at: z.coerce.number().nullable().optional(),
-  type: z.enum(["deferred"]).nullable().optional(),
+  type: z.literal("deferred").nullable().optional(),
 })
 
 export const s_payment_method_details_card_present_receipt = z.object({
@@ -4043,15 +4043,15 @@ export const s_payment_method_nz_bank_account = z.object({
 })
 
 export const s_payment_method_options_affirm = z.object({
-  capture_method: z.enum(["manual"]).optional(),
+  capture_method: z.literal("manual").optional(),
   preferred_locale: z.string().max(30).optional(),
-  setup_future_usage: z.enum(["none"]).optional(),
+  setup_future_usage: z.literal("none").optional(),
 })
 
 export const s_payment_method_options_afterpay_clearpay = z.object({
-  capture_method: z.enum(["manual"]).optional(),
+  capture_method: z.literal("manual").optional(),
   reference: z.string().max(5000).nullable().optional(),
-  setup_future_usage: z.enum(["none"]).optional(),
+  setup_future_usage: z.literal("none").optional(),
 })
 
 export const s_payment_method_options_alipay = z.object({
@@ -4059,11 +4059,11 @@ export const s_payment_method_options_alipay = z.object({
 })
 
 export const s_payment_method_options_alma = z.object({
-  capture_method: z.enum(["manual"]).optional(),
+  capture_method: z.literal("manual").optional(),
 })
 
 export const s_payment_method_options_amazon_pay = z.object({
-  capture_method: z.enum(["manual"]).optional(),
+  capture_method: z.literal("manual").optional(),
   setup_future_usage: z.enum(["none", "off_session"]).optional(),
 })
 
@@ -4073,7 +4073,7 @@ export const s_payment_method_options_bancontact = z.object({
 })
 
 export const s_payment_method_options_billie = z.object({
-  capture_method: z.enum(["manual"]).optional(),
+  capture_method: z.literal("manual").optional(),
 })
 
 export const s_payment_method_options_boleto = z.object({
@@ -4090,10 +4090,7 @@ export const s_payment_method_options_card_mandate_options = z.object({
   interval_count: z.coerce.number().nullable().optional(),
   reference: z.string().max(80),
   start_date: z.coerce.number(),
-  supported_types: z
-    .array(z.enum(["india"]))
-    .nullable()
-    .optional(),
+  supported_types: z.array(z.literal("india")).nullable().optional(),
 })
 
 export const s_payment_method_options_card_present_routing = z.object({
@@ -4104,27 +4101,27 @@ export const s_payment_method_options_card_present_routing = z.object({
 })
 
 export const s_payment_method_options_cashapp = z.object({
-  capture_method: z.enum(["manual"]).optional(),
+  capture_method: z.literal("manual").optional(),
   setup_future_usage: z.enum(["none", "off_session", "on_session"]).optional(),
 })
 
 export const s_payment_method_options_crypto = z.object({
-  setup_future_usage: z.enum(["none"]).optional(),
+  setup_future_usage: z.literal("none").optional(),
 })
 
 export const s_payment_method_options_customer_balance_eu_bank_account =
   z.object({country: z.enum(["BE", "DE", "ES", "FR", "IE", "NL"])})
 
 export const s_payment_method_options_fpx = z.object({
-  setup_future_usage: z.enum(["none"]).optional(),
+  setup_future_usage: z.literal("none").optional(),
 })
 
 export const s_payment_method_options_giropay = z.object({
-  setup_future_usage: z.enum(["none"]).optional(),
+  setup_future_usage: z.literal("none").optional(),
 })
 
 export const s_payment_method_options_grabpay = z.object({
-  setup_future_usage: z.enum(["none"]).optional(),
+  setup_future_usage: z.literal("none").optional(),
 })
 
 export const s_payment_method_options_ideal = z.object({
@@ -4137,7 +4134,7 @@ export const s_payment_method_options_interac_present = z.record(
 )
 
 export const s_payment_method_options_klarna = z.object({
-  capture_method: z.enum(["manual"]).optional(),
+  capture_method: z.literal("manual").optional(),
   preferred_locale: z.string().max(5000).nullable().optional(),
   setup_future_usage: z.enum(["none", "off_session", "on_session"]).optional(),
 })
@@ -4147,25 +4144,25 @@ export const s_payment_method_options_konbini = z.object({
   expires_after_days: z.coerce.number().nullable().optional(),
   expires_at: z.coerce.number().nullable().optional(),
   product_description: z.string().max(5000).nullable().optional(),
-  setup_future_usage: z.enum(["none"]).optional(),
+  setup_future_usage: z.literal("none").optional(),
 })
 
 export const s_payment_method_options_kr_card = z.object({
-  capture_method: z.enum(["manual"]).optional(),
+  capture_method: z.literal("manual").optional(),
   setup_future_usage: z.enum(["none", "off_session"]).optional(),
 })
 
 export const s_payment_method_options_multibanco = z.object({
-  setup_future_usage: z.enum(["none"]).optional(),
+  setup_future_usage: z.literal("none").optional(),
 })
 
 export const s_payment_method_options_oxxo = z.object({
   expires_after_days: z.coerce.number(),
-  setup_future_usage: z.enum(["none"]).optional(),
+  setup_future_usage: z.literal("none").optional(),
 })
 
 export const s_payment_method_options_p24 = z.object({
-  setup_future_usage: z.enum(["none"]).optional(),
+  setup_future_usage: z.literal("none").optional(),
 })
 
 export const s_payment_method_options_pay_by_bank = z.record(
@@ -4174,11 +4171,11 @@ export const s_payment_method_options_pay_by_bank = z.record(
 )
 
 export const s_payment_method_options_paynow = z.object({
-  setup_future_usage: z.enum(["none"]).optional(),
+  setup_future_usage: z.literal("none").optional(),
 })
 
 export const s_payment_method_options_paypal = z.object({
-  capture_method: z.enum(["manual"]).optional(),
+  capture_method: z.literal("manual").optional(),
   preferred_locale: z.string().max(5000).nullable().optional(),
   reference: z.string().max(5000).nullable().optional(),
   setup_future_usage: z.enum(["none", "off_session"]).optional(),
@@ -4187,20 +4184,20 @@ export const s_payment_method_options_paypal = z.object({
 export const s_payment_method_options_pix = z.object({
   expires_after_seconds: z.coerce.number().nullable().optional(),
   expires_at: z.coerce.number().nullable().optional(),
-  setup_future_usage: z.enum(["none"]).optional(),
+  setup_future_usage: z.literal("none").optional(),
 })
 
 export const s_payment_method_options_promptpay = z.object({
-  setup_future_usage: z.enum(["none"]).optional(),
+  setup_future_usage: z.literal("none").optional(),
 })
 
 export const s_payment_method_options_revolut_pay = z.object({
-  capture_method: z.enum(["manual"]).optional(),
+  capture_method: z.literal("manual").optional(),
   setup_future_usage: z.enum(["none", "off_session"]).optional(),
 })
 
 export const s_payment_method_options_satispay = z.object({
-  capture_method: z.enum(["manual"]).optional(),
+  capture_method: z.literal("manual").optional(),
 })
 
 export const s_payment_method_options_sofort = z.object({
@@ -4212,20 +4209,20 @@ export const s_payment_method_options_sofort = z.object({
 })
 
 export const s_payment_method_options_twint = z.object({
-  setup_future_usage: z.enum(["none"]).optional(),
+  setup_future_usage: z.literal("none").optional(),
 })
 
 export const s_payment_method_options_us_bank_account_mandate_options =
-  z.object({collection_method: z.enum(["paper"]).optional()})
+  z.object({collection_method: z.literal("paper").optional()})
 
 export const s_payment_method_options_wechat_pay = z.object({
   app_id: z.string().max(5000).nullable().optional(),
   client: z.enum(["android", "ios", "web"]).nullable().optional(),
-  setup_future_usage: z.enum(["none"]).optional(),
+  setup_future_usage: z.literal("none").optional(),
 })
 
 export const s_payment_method_options_zip = z.object({
-  setup_future_usage: z.enum(["none"]).optional(),
+  setup_future_usage: z.literal("none").optional(),
 })
 
 export const s_payment_method_oxxo = z.record(z.string(), z.unknown())
@@ -4343,7 +4340,7 @@ export const s_payment_pages_checkout_session_after_expiration_recovery =
 
 export const s_payment_pages_checkout_session_consent = z.object({
   promotions: z.enum(["opt_in", "opt_out"]).nullable().optional(),
-  terms_of_service: z.enum(["accepted"]).nullable().optional(),
+  terms_of_service: z.literal("accepted").nullable().optional(),
 })
 
 export const s_payment_pages_checkout_session_currency_conversion = z.object({
@@ -4355,7 +4352,7 @@ export const s_payment_pages_checkout_session_currency_conversion = z.object({
 
 export const s_payment_pages_checkout_session_custom_fields_label = z.object({
   custom: z.string().max(5000).nullable().optional(),
-  type: z.enum(["custom"]),
+  type: z.literal("custom"),
 })
 
 export const s_payment_pages_checkout_session_custom_fields_numeric = z.object({
@@ -5020,14 +5017,14 @@ export const s_radar_value_list_item = z.object({
   created_by: z.string().max(5000),
   id: z.string().max(5000),
   livemode: PermissiveBoolean,
-  object: z.enum(["radar.value_list_item"]),
+  object: z.literal("radar.value_list_item"),
   value: z.string().max(5000),
   value_list: z.string().max(5000),
 })
 
 export const s_received_payment_method_details_financial_account = z.object({
   id: z.string().max(5000),
-  network: z.enum(["stripe"]),
+  network: z.literal("stripe"),
 })
 
 export const s_recurring = z.object({
@@ -5112,7 +5109,7 @@ export const s_reporting_report_type = z.object({
   id: z.string().max(5000),
   livemode: PermissiveBoolean,
   name: z.string().max(5000),
-  object: z.enum(["reporting.report_type"]),
+  object: z.literal("reporting.report_type"),
   updated: z.coerce.number(),
   version: z.coerce.number(),
 })
@@ -5122,7 +5119,7 @@ export const s_reserve_transaction = z.object({
   currency: z.string(),
   description: z.string().max(5000).nullable().optional(),
   id: z.string().max(5000),
-  object: z.enum(["reserve_transaction"]),
+  object: z.literal("reserve_transaction"),
 })
 
 export const s_rule = z.object({
@@ -5251,10 +5248,7 @@ export const s_setup_intent_payment_method_options_card_mandate_options =
     interval_count: z.coerce.number().nullable().optional(),
     reference: z.string().max(80),
     start_date: z.coerce.number(),
-    supported_types: z
-      .array(z.enum(["india"]))
-      .nullable()
-      .optional(),
+    supported_types: z.array(z.literal("india")).nullable().optional(),
   })
 
 export const s_setup_intent_payment_method_options_card_present = z.record(
@@ -5320,7 +5314,7 @@ export const s_sigma_sigma_api_query = z.object({
   id: z.string().max(5000),
   livemode: PermissiveBoolean,
   name: z.string().max(5000),
-  object: z.enum(["sigma.sigma_api_query"]),
+  object: z.literal("sigma.sigma_api_query"),
   sql: z.string().max(5000),
 })
 
@@ -5657,12 +5651,12 @@ export const s_tax_code = z.object({
   description: z.string().max(5000),
   id: z.string().max(5000),
   name: z.string().max(5000),
-  object: z.enum(["tax_code"]),
+  object: z.literal("tax_code"),
 })
 
 export const s_tax_deducted_at_source = z.object({
   id: z.string().max(5000),
-  object: z.enum(["tax_deducted_at_source"]),
+  object: z.literal("tax_deducted_at_source"),
   period_end: z.coerce.number(),
   period_start: z.coerce.number(),
   tax_deduction_account_number: z.string().max(5000),
@@ -5678,7 +5672,7 @@ export const s_tax_product_registrations_resource_country_options_ca_province_st
   z.object({province: z.string().max(5000)})
 
 export const s_tax_product_registrations_resource_country_options_default =
-  z.object({type: z.enum(["standard"])})
+  z.object({type: z.literal("standard")})
 
 export const s_tax_product_registrations_resource_country_options_default_standard =
   z.object({place_of_supply_scheme: z.enum(["inbound_goods", "standard"])})
@@ -5693,7 +5687,7 @@ export const s_tax_product_registrations_resource_country_options_eu_standard =
   })
 
 export const s_tax_product_registrations_resource_country_options_simplified =
-  z.object({type: z.enum(["simplified"])})
+  z.object({type: z.literal("simplified")})
 
 export const s_tax_product_registrations_resource_country_options_us_local_amusement_tax =
   z.object({jurisdiction: z.string().max(5000)})
@@ -5937,7 +5931,7 @@ export const s_terminal_configuration_configuration_resource_reboot_window =
 
 export const s_terminal_connection_token = z.object({
   location: z.string().max(5000).optional(),
-  object: z.enum(["terminal.connection_token"]),
+  object: z.literal("terminal.connection_token"),
   secret: z.string().max(5000),
 })
 
@@ -6318,7 +6312,7 @@ export const s_webhook_endpoint = z.object({
   id: z.string().max(5000),
   livemode: PermissiveBoolean,
   metadata: z.record(z.string(), z.string().max(500)),
-  object: z.enum(["webhook_endpoint"]),
+  object: z.literal("webhook_endpoint"),
   secret: z.string().max(5000).optional(),
   status: z.string().max(5000),
   url: z.string().max(5000),
@@ -6505,7 +6499,7 @@ export const s_account_unification_account_controller = z.object({
 
 export const s_amazon_pay_underlying_payment_method_funding_details = z.object({
   card: s_payment_method_details_passthrough_card.optional(),
-  type: z.enum(["card"]).nullable().optional(),
+  type: z.literal("card").nullable().optional(),
 })
 
 export const s_apps_secret = z.object({
@@ -6515,7 +6509,7 @@ export const s_apps_secret = z.object({
   id: z.string().max(5000),
   livemode: PermissiveBoolean,
   name: z.string().max(5000),
-  object: z.enum(["apps.secret"]),
+  object: z.literal("apps.secret"),
   payload: z.string().max(5000).nullable().optional(),
   scope: s_secret_service_resource_scope,
 })
@@ -6547,7 +6541,7 @@ export const s_billing_bill_resource_invoice_item_parents_invoice_item_parent =
       s_billing_bill_resource_invoice_item_parents_invoice_item_subscription_parent
         .nullable()
         .optional(),
-    type: z.enum(["subscription_details"]),
+    type: z.literal("subscription_details"),
   })
 
 export const s_billing_bill_resource_invoicing_lines_common_proration_details =
@@ -6561,7 +6555,7 @@ export const s_billing_bill_resource_invoicing_lines_common_proration_details =
 export const s_billing_bill_resource_invoicing_pricing_pricing = z.object({
   price_details:
     s_billing_bill_resource_invoicing_pricing_pricing_price_details.optional(),
-  type: z.enum(["price_details"]),
+  type: z.literal("price_details"),
   unit_amount_decimal: z.string().nullable().optional(),
 })
 
@@ -6590,7 +6584,7 @@ export const s_billing_bill_resource_invoicing_taxes_tax = z.object({
     "zero_rated",
   ]),
   taxable_amount: z.coerce.number().nullable().optional(),
-  type: z.enum(["tax_rate_details"]),
+  type: z.literal("tax_rate_details"),
 })
 
 export const s_billing_clocks_resource_status_details_status_details = z.object(
@@ -6604,11 +6598,11 @@ export const s_billing_credit_grants_resource_amount = z.object({
   monetary: s_billing_credit_grants_resource_monetary_amount
     .nullable()
     .optional(),
-  type: z.enum(["monetary"]),
+  type: z.literal("monetary"),
 })
 
 export const s_billing_credit_grants_resource_scope = z.object({
-  price_type: z.enum(["metered"]).optional(),
+  price_type: z.literal("metered").optional(),
   prices: z.array(s_billing_credit_grants_resource_applicable_price).optional(),
 })
 
@@ -6629,7 +6623,7 @@ export const s_billing_meter = z.object({
   event_time_window: z.enum(["day", "hour"]).nullable().optional(),
   id: z.string().max(5000),
   livemode: PermissiveBoolean,
-  object: z.enum(["billing.meter"]),
+  object: z.literal("billing.meter"),
   status: z.enum(["active", "inactive"]),
   status_transitions: s_billing_meter_resource_billing_meter_status_transitions,
   updated: z.coerce.number(),
@@ -6642,16 +6636,16 @@ export const s_billing_meter_event_adjustment = z.object({
     .optional(),
   event_name: z.string().max(100),
   livemode: PermissiveBoolean,
-  object: z.enum(["billing.meter_event_adjustment"]),
+  object: z.literal("billing.meter_event_adjustment"),
   status: z.enum(["complete", "pending"]),
-  type: z.enum(["cancel"]),
+  type: z.literal("cancel"),
 })
 
 export const s_cash_balance = z.object({
   available: z.record(z.string(), z.coerce.number()).nullable().optional(),
   customer: z.string().max(5000),
   livemode: PermissiveBoolean,
-  object: z.enum(["cash_balance"]),
+  object: z.literal("cash_balance"),
   settings: s_customer_balance_customer_balance_settings,
 })
 
@@ -6742,7 +6736,7 @@ export const s_climate_supplier = z.object({
   livemode: PermissiveBoolean,
   locations: z.array(s_climate_removals_location),
   name: z.string().max(5000),
-  object: z.enum(["climate.supplier"]),
+  object: z.literal("climate.supplier"),
   removal_pathway: z.enum([
     "biomass_carbon_removal_and_storage",
     "direct_air_capture",
@@ -6842,7 +6836,7 @@ export const s_coupon = z.object({
   max_redemptions: z.coerce.number().nullable().optional(),
   metadata: z.record(z.string(), z.string().max(500)).nullable().optional(),
   name: z.string().max(5000).nullable().optional(),
-  object: z.enum(["coupon"]),
+  object: z.literal("coupon"),
   percent_off: z.coerce.number().nullable().optional(),
   redeem_by: z.coerce.number().nullable().optional(),
   times_redeemed: z.coerce.number(),
@@ -6967,7 +6961,7 @@ export const s_entitlements_active_entitlement = z.object({
   id: z.string().max(5000),
   livemode: PermissiveBoolean,
   lookup_key: z.string().max(5000),
-  object: z.enum(["entitlements.active_entitlement"]),
+  object: z.literal("entitlements.active_entitlement"),
 })
 
 export const s_event = z.object({
@@ -6978,7 +6972,7 @@ export const s_event = z.object({
   data: s_notification_event_data,
   id: z.string().max(5000),
   livemode: PermissiveBoolean,
-  object: z.enum(["event"]),
+  object: z.literal("event"),
   pending_webhooks: z.coerce.number(),
   request: s_notification_event_request.nullable().optional(),
   type: z.string().max(5000),
@@ -6994,11 +6988,11 @@ export const s_external_account_requirements = z.object({
 export const s_financial_connections_account_ownership = z.object({
   created: z.coerce.number(),
   id: z.string().max(5000),
-  object: z.enum(["financial_connections.account_ownership"]),
+  object: z.literal("financial_connections.account_ownership"),
   owners: z.object({
     data: z.array(s_financial_connections_account_owner),
     has_more: PermissiveBoolean,
-    object: z.enum(["list"]),
+    object: z.literal("list"),
     url: z.string().max(5000),
   }),
 })
@@ -7010,7 +7004,7 @@ export const s_financial_connections_transaction = z.object({
   description: z.string().max(5000),
   id: z.string().max(5000),
   livemode: PermissiveBoolean,
-  object: z.enum(["financial_connections.transaction"]),
+  object: z.literal("financial_connections.transaction"),
   status: z.enum(["pending", "posted", "void"]),
   status_transitions:
     s_bank_connections_resource_transaction_resource_status_transitions,
@@ -7022,7 +7016,7 @@ export const s_financial_connections_transaction = z.object({
 export const s_forwarded_request_details = z.object({
   body: z.string().max(5000),
   headers: z.array(s_forwarded_request_header),
-  http_method: z.enum(["POST"]),
+  http_method: z.literal("POST"),
 })
 
 export const s_forwarded_response_details = z.object({
@@ -8605,7 +8599,7 @@ export const s_issuing_physical_bundle = z.object({
   id: z.string().max(5000),
   livemode: PermissiveBoolean,
   name: z.string().max(5000),
-  object: z.enum(["issuing.physical_bundle"]),
+  object: z.literal("issuing.physical_bundle"),
   status: z.enum(["active", "inactive", "review"]),
   type: z.enum(["custom", "standard"]),
 })
@@ -9122,7 +9116,7 @@ export const s_portal_flows_flow_subscription_update_confirm = z.object({
 
 export const s_portal_flows_retention = z.object({
   coupon_offer: s_portal_flows_coupon_offer.nullable().optional(),
-  type: z.enum(["coupon_offer"]),
+  type: z.literal("coupon_offer"),
 })
 
 export const s_portal_resource_schedule_update_at_period_end = z.object({
@@ -9148,7 +9142,7 @@ export const s_product_feature = z.object({
   entitlement_feature: s_entitlements_feature,
   id: z.string().max(5000),
   livemode: PermissiveBoolean,
-  object: z.enum(["product_feature"]),
+  object: z.literal("product_feature"),
 })
 
 export const s_promotion_codes_resource_restrictions = z.object({
@@ -9188,13 +9182,13 @@ export const s_radar_value_list = z.object({
   list_items: z.object({
     data: z.array(s_radar_value_list_item),
     has_more: PermissiveBoolean,
-    object: z.enum(["list"]),
+    object: z.literal("list"),
     url: z.string().max(5000),
   }),
   livemode: PermissiveBoolean,
   metadata: z.record(z.string(), z.string().max(500)),
   name: z.string().max(5000),
-  object: z.enum(["radar.value_list"]),
+  object: z.literal("radar.value_list"),
 })
 
 export const s_refund_destination_details = z.object({
@@ -9241,7 +9235,7 @@ export const s_refund_next_action_display_details = z.object({
 export const s_revolut_pay_underlying_payment_method_funding_details = z.object(
   {
     card: s_payment_method_details_passthrough_card.optional(),
-    type: z.enum(["card"]).nullable().optional(),
+    type: z.literal("card").nullable().optional(),
   },
 )
 
@@ -9339,7 +9333,7 @@ export const s_source_transaction = z.object({
   gbp_credit_transfer: s_source_transaction_gbp_credit_transfer_data.optional(),
   id: z.string().max(5000),
   livemode: PermissiveBoolean,
-  object: z.enum(["source_transaction"]),
+  object: z.literal("source_transaction"),
   paper_check: s_source_transaction_paper_check_data.optional(),
   sepa_credit_transfer:
     s_source_transaction_sepa_credit_transfer_data.optional(),
@@ -9406,7 +9400,7 @@ export const s_tax_product_registrations_resource_country_options_default_inboun
   z.object({
     standard:
       s_tax_product_registrations_resource_country_options_default_standard.optional(),
-    type: z.enum(["standard"]),
+    type: z.literal("standard"),
   })
 
 export const s_tax_product_registrations_resource_country_options_europe =
@@ -9519,7 +9513,7 @@ export const s_tax_rate = z.object({
     .optional(),
   livemode: PermissiveBoolean,
   metadata: z.record(z.string(), z.string().max(500)).nullable().optional(),
-  object: z.enum(["tax_rate"]),
+  object: z.literal("tax_rate"),
   percentage: z.coerce.number(),
   rate_type: z.enum(["flat_amount", "percentage"]).nullable().optional(),
   state: z.string().max(5000).nullable().optional(),
@@ -9550,7 +9544,7 @@ export const s_tax_transaction_line_item = z.object({
   id: z.string().max(5000),
   livemode: PermissiveBoolean,
   metadata: z.record(z.string(), z.string().max(500)).nullable().optional(),
-  object: z.enum(["tax.transaction_line_item"]),
+  object: z.literal("tax.transaction_line_item"),
   product: z.string().max(5000).nullable().optional(),
   quantity: z.coerce.number(),
   reference: z.string().max(5000),
@@ -9605,7 +9599,7 @@ export const s_terminal_location = z.object({
   id: z.string().max(5000),
   livemode: PermissiveBoolean,
   metadata: z.record(z.string(), z.string().max(500)),
-  object: z.enum(["terminal.location"]),
+  object: z.literal("terminal.location"),
 })
 
 export const s_terminal_reader_reader_resource_cart = z.object({
@@ -9647,7 +9641,7 @@ export const s_treasury_financial_accounts_resource_financial_address =
   z.object({
     aba: s_treasury_financial_accounts_resource_aba_record.optional(),
     supported_networks: z.array(z.enum(["ach", "us_domestic_wire"])).optional(),
-    type: z.enum(["aba"]),
+    type: z.literal("aba"),
   })
 
 export const s_treasury_financial_accounts_resource_inbound_ach_toggle_settings =
@@ -9753,8 +9747,8 @@ export const s_card_generated_from_payment_method_details = z.object({
 export const s_checkout_customer_balance_payment_method_options = z.object({
   bank_transfer:
     s_checkout_customer_balance_bank_transfer_payment_method_options.optional(),
-  funding_type: z.enum(["bank_transfer"]).nullable().optional(),
-  setup_future_usage: z.enum(["none"]).optional(),
+  funding_type: z.literal("bank_transfer").nullable().optional(),
+  setup_future_usage: z.literal("none").optional(),
 })
 
 export const s_checkout_us_bank_account_payment_method_options = z.object({
@@ -9775,7 +9769,7 @@ export const s_climate_product = z.object({
   livemode: PermissiveBoolean,
   metric_tons_available: z.string(),
   name: z.string().max(5000),
-  object: z.enum(["climate.product"]),
+  object: z.literal("climate.product"),
   suppliers: z.array(s_climate_supplier),
 })
 
@@ -9825,7 +9819,7 @@ export const s_connect_embedded_account_session_create_components = z.object({
 export const s_country_spec = z.object({
   default_currency: z.string().max(5000),
   id: z.string().max(5000),
-  object: z.enum(["country_spec"]),
+  object: z.literal("country_spec"),
   supported_bank_account_currencies: z.record(
     z.string(),
     z.array(z.string().max(5000)),
@@ -9876,7 +9870,7 @@ export const s_forwarding_request = z.object({
   id: z.string().max(5000),
   livemode: PermissiveBoolean,
   metadata: z.record(z.string(), z.string().max(500)).nullable().optional(),
-  object: z.enum(["forwarding.request"]),
+  object: z.literal("forwarding.request"),
   payment_method: z.string().max(5000),
   replacements: z.array(
     z.enum([
@@ -9925,7 +9919,7 @@ export const s_identity_verification_report = z.object({
   id: z.string().max(5000),
   id_number: s_gelato_id_number_report.optional(),
   livemode: PermissiveBoolean,
-  object: z.enum(["identity.verification_report"]),
+  object: z.literal("identity.verification_report"),
   options: s_gelato_verification_report_options.optional(),
   phone: s_gelato_phone_report.optional(),
   selfie: s_gelato_selfie_report.optional(),
@@ -9937,7 +9931,7 @@ export const s_identity_verification_report = z.object({
 export const s_invoice_payment_method_options_customer_balance = z.object({
   bank_transfer:
     s_invoice_payment_method_options_customer_balance_bank_transfer.optional(),
-  funding_type: z.enum(["bank_transfer"]).nullable().optional(),
+  funding_type: z.literal("bank_transfer").nullable().optional(),
 })
 
 export const s_invoice_payment_method_options_us_bank_account = z.object({
@@ -10046,7 +10040,7 @@ export const s_payment_intent_next_action_konbini = z.object({
 })
 
 export const s_payment_intent_payment_method_options_card = z.object({
-  capture_method: z.enum(["manual"]).optional(),
+  capture_method: z.literal("manual").optional(),
   installments: s_payment_method_options_card_installments
     .nullable()
     .optional(),
@@ -10105,7 +10099,7 @@ export const s_payment_intent_payment_method_options_us_bank_account = z.object(
 
 export const s_payment_intent_processing = z.object({
   card: s_payment_intent_card_processing.optional(),
-  type: z.enum(["card"]),
+  type: z.literal("card"),
 })
 
 export const s_payment_intent_type_specific_payment_method_options_client =
@@ -10214,7 +10208,7 @@ export const s_payment_method_configuration = z.object({
     s_payment_method_config_resource_payment_method_properties.optional(),
   nz_bank_account:
     s_payment_method_config_resource_payment_method_properties.optional(),
-  object: z.enum(["payment_method_configuration"]),
+  object: z.literal("payment_method_configuration"),
   oxxo: s_payment_method_config_resource_payment_method_properties.optional(),
   p24: s_payment_method_config_resource_payment_method_properties.optional(),
   parent: z.string().max(5000).nullable().optional(),
@@ -10290,15 +10284,15 @@ export const s_payment_method_domain = z.object({
   klarna: s_payment_method_domain_resource_payment_method_status,
   link: s_payment_method_domain_resource_payment_method_status,
   livemode: PermissiveBoolean,
-  object: z.enum(["payment_method_domain"]),
+  object: z.literal("payment_method_domain"),
   paypal: s_payment_method_domain_resource_payment_method_status,
 })
 
 export const s_payment_method_options_customer_balance = z.object({
   bank_transfer:
     s_payment_method_options_customer_balance_bank_transfer.optional(),
-  funding_type: z.enum(["bank_transfer"]).nullable().optional(),
-  setup_future_usage: z.enum(["none"]).optional(),
+  funding_type: z.literal("bank_transfer").nullable().optional(),
+  setup_future_usage: z.literal("none").optional(),
 })
 
 export const s_payment_method_us_bank_account = z.object({
@@ -10397,7 +10391,7 @@ export const s_shipping_rate = z.object({
   id: z.string().max(5000),
   livemode: PermissiveBoolean,
   metadata: z.record(z.string(), z.string().max(500)),
-  object: z.enum(["shipping_rate"]),
+  object: z.literal("shipping_rate"),
   tax_behavior: z
     .enum(["exclusive", "inclusive", "unspecified"])
     .nullable()
@@ -10406,7 +10400,7 @@ export const s_shipping_rate = z.object({
     .union([z.string().max(5000), s_tax_code])
     .nullable()
     .optional(),
-  type: z.enum(["fixed_amount"]),
+  type: z.literal("fixed_amount"),
 })
 
 export const s_source_order = z.object({
@@ -10423,7 +10417,7 @@ export const s_tax_calculation_line_item = z.object({
   id: z.string().max(5000),
   livemode: PermissiveBoolean,
   metadata: z.record(z.string(), z.string().max(500)).nullable().optional(),
-  object: z.enum(["tax.calculation_line_item"]),
+  object: z.literal("tax.calculation_line_item"),
   product: z.string().max(5000).nullable().optional(),
   quantity: z.coerce.number(),
   reference: z.string().max(5000),
@@ -10494,7 +10488,7 @@ export const s_tax_settings = z.object({
     .nullable()
     .optional(),
   livemode: PermissiveBoolean,
-  object: z.enum(["tax.settings"]),
+  object: z.literal("tax.settings"),
   status: z.enum(["active", "pending"]),
   status_details: s_tax_product_resource_tax_settings_status_details,
 })
@@ -10509,7 +10503,7 @@ export const s_tax_transaction = z.object({
     .object({
       data: z.array(s_tax_transaction_line_item),
       has_more: PermissiveBoolean,
-      object: z.enum(["list"]),
+      object: z.literal("list"),
       url: z
         .string()
         .max(5000)
@@ -10519,7 +10513,7 @@ export const s_tax_transaction = z.object({
     .optional(),
   livemode: PermissiveBoolean,
   metadata: z.record(z.string(), z.string().max(500)).nullable().optional(),
-  object: z.enum(["tax.transaction"]),
+  object: z.literal("tax.transaction"),
   posted_at: z.coerce.number(),
   reference: z.string().max(5000),
   reversal: s_tax_product_resource_tax_transaction_resource_reversal
@@ -10557,7 +10551,7 @@ export const s_terminal_reader_reader_resource_input = z.object({
 export const s_terminal_reader_reader_resource_set_reader_display_action =
   z.object({
     cart: s_terminal_reader_reader_resource_cart.nullable().optional(),
-    type: z.enum(["cart"]),
+    type: z.literal("cart"),
   })
 
 export const s_test_helpers_test_clock = z.object({
@@ -10567,7 +10561,7 @@ export const s_test_helpers_test_clock = z.object({
   id: z.string().max(5000),
   livemode: PermissiveBoolean,
   name: z.string().max(5000).nullable().optional(),
-  object: z.enum(["test_helpers.test_clock"]),
+  object: z.literal("test_helpers.test_clock"),
   status: z.enum(["advancing", "internal_failure", "ready"]),
   status_details: s_billing_clocks_resource_status_details_status_details,
 })
@@ -10598,7 +10592,7 @@ export const s_treasury_financial_accounts_resource_outbound_transfers =
 
 export const s_treasury_shared_resource_initiating_payment_method_details_initiating_payment_method_details =
   z.object({
-    balance: z.enum(["payments"]).optional(),
+    balance: z.literal("payments").optional(),
     billing_details: s_treasury_shared_resource_billing_details,
     financial_account:
       s_received_payment_method_details_financial_account.optional(),
@@ -10620,7 +10614,7 @@ export const s_account_session = z.object({
   components: s_connect_embedded_account_session_create_components,
   expires_at: z.coerce.number(),
   livemode: PermissiveBoolean,
-  object: z.enum(["account_session"]),
+  object: z.literal("account_session"),
 })
 
 export const s_balance = z.object({
@@ -10629,7 +10623,7 @@ export const s_balance = z.object({
   instant_available: z.array(s_balance_amount_net).optional(),
   issuing: s_balance_detail.optional(),
   livemode: PermissiveBoolean,
-  object: z.enum(["balance"]),
+  object: z.literal("balance"),
   pending: z.array(s_balance_amount),
   refund_and_dispute_prefunding: s_balance_detail_ungated.optional(),
 })
@@ -10711,7 +10705,7 @@ export const s_climate_order = z.object({
   livemode: PermissiveBoolean,
   metadata: z.record(z.string(), z.string().max(500)),
   metric_tons: z.string(),
-  object: z.enum(["climate.order"]),
+  object: z.literal("climate.order"),
   product: z.union([z.string().max(5000), s_climate_product]),
   product_substituted_at: z.coerce.number().nullable().optional(),
   status: z.enum([
@@ -10755,7 +10749,7 @@ export const s_identity_verification_session = z.object({
     .optional(),
   livemode: PermissiveBoolean,
   metadata: z.record(z.string(), z.string().max(500)),
-  object: z.enum(["identity.verification_session"]),
+  object: z.literal("identity.verification_session"),
   options: s_gelato_verification_session_options.nullable().optional(),
   provided_details: s_gelato_provided_details.nullable().optional(),
   redaction: s_verification_session_redaction.nullable().optional(),
@@ -11296,7 +11290,7 @@ export const s_source = z.object({
   livemode: PermissiveBoolean,
   metadata: z.record(z.string(), z.string().max(500)).nullable().optional(),
   multibanco: s_source_type_multibanco.optional(),
-  object: z.enum(["source"]),
+  object: z.literal("source"),
   owner: s_source_owner.nullable().optional(),
   p24: s_source_type_p24.optional(),
   receiver: s_source_receiver_flow.optional(),
@@ -11356,7 +11350,7 @@ export const s_tax_calculation = z.object({
     .object({
       data: z.array(s_tax_calculation_line_item),
       has_more: PermissiveBoolean,
-      object: z.enum(["list"]),
+      object: z.literal("list"),
       url: z
         .string()
         .max(5000)
@@ -11365,7 +11359,7 @@ export const s_tax_calculation = z.object({
     .nullable()
     .optional(),
   livemode: PermissiveBoolean,
-  object: z.enum(["tax.calculation"]),
+  object: z.literal("tax.calculation"),
   ship_from_details: s_tax_product_resource_ship_from_details
     .nullable()
     .optional(),
@@ -11498,7 +11492,7 @@ export const s_treasury_financial_account_features = z.object({
     s_treasury_financial_accounts_resource_inbound_transfers.optional(),
   intra_stripe_flows:
     s_treasury_financial_accounts_resource_toggle_settings.optional(),
-  object: z.enum(["treasury.financial_account_features"]),
+  object: z.literal("treasury.financial_account_features"),
   outbound_payments:
     s_treasury_financial_accounts_resource_outbound_payments.optional(),
   outbound_transfers:
@@ -11520,16 +11514,16 @@ export const s_billing_portal_configuration = z.object({
   livemode: PermissiveBoolean,
   login_page: s_portal_login_page,
   metadata: z.record(z.string(), z.string().max(500)).nullable().optional(),
-  object: z.enum(["billing_portal.configuration"]),
+  object: z.literal("billing_portal.configuration"),
   updated: z.coerce.number(),
 })
 
 export const s_funding_instructions = z.object({
   bank_transfer: s_funding_instructions_bank_transfer,
   currency: z.string().max(5000),
-  funding_type: z.enum(["bank_transfer"]),
+  funding_type: z.literal("bank_transfer"),
   livemode: PermissiveBoolean,
-  object: z.enum(["funding_instructions"]),
+  object: z.literal("funding_instructions"),
 })
 
 export const s_invoices_payment_settings = z.object({
@@ -11628,7 +11622,7 @@ export const s_source_mandate_notification = z.object({
   created: z.coerce.number(),
   id: z.string().max(5000),
   livemode: PermissiveBoolean,
-  object: z.enum(["source_mandate_notification"]),
+  object: z.literal("source_mandate_notification"),
   reason: z.string().max(5000),
   sepa_debit: s_source_mandate_notification_sepa_debit_data.optional(),
   source: s_source,
@@ -11700,7 +11694,7 @@ export const s_tax_registration = z.object({
   expires_at: z.coerce.number().nullable().optional(),
   id: z.string().max(5000),
   livemode: PermissiveBoolean,
-  object: z.enum(["tax.registration"]),
+  object: z.literal("tax.registration"),
   status: z.enum(["active", "expired", "scheduled"]),
 })
 
@@ -11734,7 +11728,7 @@ export const s_treasury_financial_account = z.object({
   livemode: PermissiveBoolean,
   metadata: z.record(z.string(), z.string().max(500)).nullable().optional(),
   nickname: z.string().max(5000).nullable().optional(),
-  object: z.enum(["treasury.financial_account"]),
+  object: z.literal("treasury.financial_account"),
   pending_features: z
     .array(
       z.enum([
@@ -11840,7 +11834,7 @@ export const s_billing_portal_session = z.object({
     ])
     .nullable()
     .optional(),
-  object: z.enum(["billing_portal.session"]),
+  object: z.literal("billing_portal.session"),
   on_behalf_of: z.string().max(5000).nullable().optional(),
   return_url: z.string().max(5000).nullable().optional(),
   url: z.string().max(5000),
@@ -11867,7 +11861,7 @@ export const s_account: z.ZodType<t_account> = z.object({
         z.union([z.lazy(() => s_bank_account), z.lazy(() => s_card)]),
       ),
       has_more: PermissiveBoolean,
-      object: z.enum(["list"]),
+      object: z.literal("list"),
       url: z.string().max(5000),
     })
     .optional(),
@@ -11876,7 +11870,7 @@ export const s_account: z.ZodType<t_account> = z.object({
   id: z.string().max(5000),
   individual: z.lazy(() => s_person.optional()),
   metadata: z.record(z.string(), z.string().max(500)).optional(),
-  object: z.enum(["account"]),
+  object: z.literal("account"),
   payouts_enabled: PermissiveBoolean.optional(),
   requirements: s_account_requirements.optional(),
   settings: z
@@ -12133,7 +12127,7 @@ export const s_PostAccountsRequestBody = z.object({
               .optional(),
           })
           .optional(),
-        object: z.enum(["bank_account"]).optional(),
+        object: z.literal("bank_account").optional(),
         routing_number: z.string().max(5000).optional(),
       }),
       z.string().max(5000),
@@ -12178,7 +12172,7 @@ export const s_PostAccountsRequestBody = z.object({
         .optional(),
       support_email: z.string().optional(),
       support_phone: z.string().max(5000).optional(),
-      support_url: z.union([z.string(), z.enum([""])]).optional(),
+      support_url: z.union([z.string(), z.literal("")]).optional(),
       url: z.string().optional(),
     })
     .optional(),
@@ -12433,7 +12427,7 @@ export const s_PostAccountsRequestBody = z.object({
             month: z.coerce.number(),
             year: z.coerce.number(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       registration_number: z.string().max(5000).optional(),
@@ -12533,7 +12527,7 @@ export const s_PostAccountsRequestBody = z.object({
   groups: z
     .object({
       payments_pricing: z
-        .union([z.string().max(5000), z.enum([""])])
+        .union([z.string().max(5000), z.literal("")])
         .optional(),
     })
     .optional(),
@@ -12578,7 +12572,7 @@ export const s_PostAccountsRequestBody = z.object({
             month: z.coerce.number(),
             year: z.coerce.number(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       email: z.string().optional(),
@@ -12586,7 +12580,7 @@ export const s_PostAccountsRequestBody = z.object({
       first_name_kana: z.string().max(5000).optional(),
       first_name_kanji: z.string().max(5000).optional(),
       full_name_aliases: z
-        .union([z.array(z.string().max(300)), z.enum([""])])
+        .union([z.array(z.string().max(300)), z.literal("")])
         .optional(),
       gender: z.string().optional(),
       id_number: z.string().max(5000).optional(),
@@ -12596,7 +12590,7 @@ export const s_PostAccountsRequestBody = z.object({
       last_name_kanji: z.string().max(5000).optional(),
       maiden_name: z.string().max(5000).optional(),
       metadata: z
-        .union([z.record(z.string(), z.string()), z.enum([""])])
+        .union([z.record(z.string(), z.string()), z.literal("")])
         .optional(),
       phone: z.string().optional(),
       political_exposure: z.enum(["existing", "none"]).optional(),
@@ -12616,7 +12610,7 @@ export const s_PostAccountsRequestBody = z.object({
           executive: PermissiveBoolean.optional(),
           owner: PermissiveBoolean.optional(),
           percent_ownership: z
-            .union([z.coerce.number(), z.enum([""])])
+            .union([z.coerce.number(), z.literal("")])
             .optional(),
           title: z.string().max(5000).optional(),
         })
@@ -12641,7 +12635,7 @@ export const s_PostAccountsRequestBody = z.object({
     })
     .optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   settings: z
     .object({
@@ -12663,7 +12657,7 @@ export const s_PostAccountsRequestBody = z.object({
               date: z.coerce.number().optional(),
               ip: z.string().optional(),
               user_agent: z
-                .union([z.string().max(5000), z.enum([""])])
+                .union([z.string().max(5000), z.literal("")])
                 .optional(),
             })
             .optional(),
@@ -12679,10 +12673,10 @@ export const s_PostAccountsRequestBody = z.object({
             .optional(),
           statement_descriptor_prefix: z.string().max(10).optional(),
           statement_descriptor_prefix_kana: z
-            .union([z.string().max(10), z.enum([""])])
+            .union([z.string().max(10), z.literal("")])
             .optional(),
           statement_descriptor_prefix_kanji: z
-            .union([z.string().max(10), z.enum([""])])
+            .union([z.string().max(10), z.literal("")])
             .optional(),
         })
         .optional(),
@@ -12706,7 +12700,7 @@ export const s_PostAccountsRequestBody = z.object({
           schedule: z
             .object({
               delay_days: z
-                .union([z.enum(["minimum"]), z.coerce.number()])
+                .union([z.literal("minimum"), z.coerce.number()])
                 .optional(),
               interval: z
                 .enum(["daily", "manual", "monthly", "weekly"])
@@ -12749,7 +12743,7 @@ export const s_PostAccountsRequestBody = z.object({
               date: z.coerce.number().optional(),
               ip: z.string().optional(),
               user_agent: z
-                .union([z.string().max(5000), z.enum([""])])
+                .union([z.string().max(5000), z.literal("")])
                 .optional(),
             })
             .optional(),
@@ -12809,7 +12803,7 @@ export const s_PostAccountsAccountRequestBody = z.object({
         .optional(),
       support_email: z.string().optional(),
       support_phone: z.string().max(5000).optional(),
-      support_url: z.union([z.string(), z.enum([""])]).optional(),
+      support_url: z.union([z.string(), z.literal("")]).optional(),
       url: z.string().optional(),
     })
     .optional(),
@@ -13064,7 +13058,7 @@ export const s_PostAccountsAccountRequestBody = z.object({
             month: z.coerce.number(),
             year: z.coerce.number(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       registration_number: z.string().max(5000).optional(),
@@ -13149,7 +13143,7 @@ export const s_PostAccountsAccountRequestBody = z.object({
   groups: z
     .object({
       payments_pricing: z
-        .union([z.string().max(5000), z.enum([""])])
+        .union([z.string().max(5000), z.literal("")])
         .optional(),
     })
     .optional(),
@@ -13194,7 +13188,7 @@ export const s_PostAccountsAccountRequestBody = z.object({
             month: z.coerce.number(),
             year: z.coerce.number(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       email: z.string().optional(),
@@ -13202,7 +13196,7 @@ export const s_PostAccountsAccountRequestBody = z.object({
       first_name_kana: z.string().max(5000).optional(),
       first_name_kanji: z.string().max(5000).optional(),
       full_name_aliases: z
-        .union([z.array(z.string().max(300)), z.enum([""])])
+        .union([z.array(z.string().max(300)), z.literal("")])
         .optional(),
       gender: z.string().optional(),
       id_number: z.string().max(5000).optional(),
@@ -13212,7 +13206,7 @@ export const s_PostAccountsAccountRequestBody = z.object({
       last_name_kanji: z.string().max(5000).optional(),
       maiden_name: z.string().max(5000).optional(),
       metadata: z
-        .union([z.record(z.string(), z.string()), z.enum([""])])
+        .union([z.record(z.string(), z.string()), z.literal("")])
         .optional(),
       phone: z.string().optional(),
       political_exposure: z.enum(["existing", "none"]).optional(),
@@ -13232,7 +13226,7 @@ export const s_PostAccountsAccountRequestBody = z.object({
           executive: PermissiveBoolean.optional(),
           owner: PermissiveBoolean.optional(),
           percent_ownership: z
-            .union([z.coerce.number(), z.enum([""])])
+            .union([z.coerce.number(), z.literal("")])
             .optional(),
           title: z.string().max(5000).optional(),
         })
@@ -13257,7 +13251,7 @@ export const s_PostAccountsAccountRequestBody = z.object({
     })
     .optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   settings: z
     .object({
@@ -13279,7 +13273,7 @@ export const s_PostAccountsAccountRequestBody = z.object({
               date: z.coerce.number().optional(),
               ip: z.string().optional(),
               user_agent: z
-                .union([z.string().max(5000), z.enum([""])])
+                .union([z.string().max(5000), z.literal("")])
                 .optional(),
             })
             .optional(),
@@ -13295,17 +13289,17 @@ export const s_PostAccountsAccountRequestBody = z.object({
             .optional(),
           statement_descriptor_prefix: z.string().max(10).optional(),
           statement_descriptor_prefix_kana: z
-            .union([z.string().max(10), z.enum([""])])
+            .union([z.string().max(10), z.literal("")])
             .optional(),
           statement_descriptor_prefix_kanji: z
-            .union([z.string().max(10), z.enum([""])])
+            .union([z.string().max(10), z.literal("")])
             .optional(),
         })
         .optional(),
       invoices: z
         .object({
           default_account_tax_ids: z
-            .union([z.array(z.string().max(5000)), z.enum([""])])
+            .union([z.array(z.string().max(5000)), z.literal("")])
             .optional(),
           hosted_payment_method_save: z
             .enum(["always", "never", "offer"])
@@ -13325,7 +13319,7 @@ export const s_PostAccountsAccountRequestBody = z.object({
           schedule: z
             .object({
               delay_days: z
-                .union([z.enum(["minimum"]), z.coerce.number()])
+                .union([z.literal("minimum"), z.coerce.number()])
                 .optional(),
               interval: z
                 .enum(["daily", "manual", "monthly", "weekly"])
@@ -13368,7 +13362,7 @@ export const s_PostAccountsAccountRequestBody = z.object({
               date: z.coerce.number().optional(),
               ip: z.string().optional(),
               user_agent: z
-                .union([z.string().max(5000), z.enum([""])])
+                .union([z.string().max(5000), z.literal("")])
                 .optional(),
             })
             .optional(),
@@ -13405,7 +13399,7 @@ export const s_PostAccountsAccountBankAccountsRequestBody = z.object({
               .optional(),
           })
           .optional(),
-        object: z.enum(["bank_account"]).optional(),
+        object: z.literal("bank_account").optional(),
         routing_number: z.string().max(5000).optional(),
       }),
       z.string().max(5000),
@@ -13444,7 +13438,7 @@ export const s_PostAccountsAccountBankAccountsIdRequestBody = z.object({
   exp_year: z.string().max(5000).optional(),
   expand: z.array(z.string().max(5000)).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   name: z.string().max(5000).optional(),
 })
@@ -13453,7 +13447,7 @@ export const s_capability: z.ZodType<t_capability> = z.object({
   account: z.union([z.string().max(5000), z.lazy(() => s_account)]),
   future_requirements: s_account_capability_future_requirements.optional(),
   id: z.string().max(5000),
-  object: z.enum(["capability"]),
+  object: z.literal("capability"),
   requested: PermissiveBoolean,
   requested_at: z.coerce.number().nullable().optional(),
   requirements: s_account_capability_requirements.optional(),
@@ -13490,7 +13484,7 @@ export const s_bank_account: z.ZodType<t_bank_account> = z.object({
   id: z.string().max(5000),
   last4: z.string().max(5000),
   metadata: z.record(z.string(), z.string().max(500)).nullable().optional(),
-  object: z.enum(["bank_account"]),
+  object: z.literal("bank_account"),
   requirements: s_external_account_requirements.nullable().optional(),
   routing_number: z.string().max(5000).nullable().optional(),
   status: z.string().max(5000),
@@ -13537,7 +13531,7 @@ export const s_card: z.ZodType<t_card> = z.object({
   metadata: z.record(z.string(), z.string().max(500)).nullable().optional(),
   name: z.string().max(5000).nullable().optional(),
   networks: s_token_card_networks.optional(),
-  object: z.enum(["card"]),
+  object: z.literal("card"),
   regulated_status: z.enum(["regulated", "unregulated"]).nullable().optional(),
   status: z.string().max(5000).nullable().optional(),
   tokenization_method: z.string().max(5000).nullable().optional(),
@@ -13562,7 +13556,7 @@ export const s_PostAccountsAccountExternalAccountsRequestBody = z.object({
               .optional(),
           })
           .optional(),
-        object: z.enum(["bank_account"]).optional(),
+        object: z.literal("bank_account").optional(),
         routing_number: z.string().max(5000).optional(),
       }),
       z.string().max(5000),
@@ -13596,7 +13590,7 @@ export const s_PostAccountsAccountExternalAccountsIdRequestBody = z.object({
   exp_year: z.string().max(5000).optional(),
   expand: z.array(z.string().max(5000)).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   name: z.string().max(5000).optional(),
 })
@@ -13629,7 +13623,7 @@ export const s_person: z.ZodType<t_person> = z.object({
   maiden_name: z.string().max(5000).nullable().optional(),
   metadata: z.record(z.string(), z.string().max(500)).optional(),
   nationality: z.string().max(5000).nullable().optional(),
-  object: z.enum(["person"]),
+  object: z.literal("person"),
   phone: z.string().max(5000).nullable().optional(),
   political_exposure: z.enum(["existing", "none"]).optional(),
   registered_address: s_address.optional(),
@@ -13647,7 +13641,7 @@ export const s_PostAccountsAccountPeopleRequestBody = z.object({
         .object({
           date: z.coerce.number().optional(),
           ip: z.string().optional(),
-          user_agent: z.union([z.string().max(5000), z.enum([""])]).optional(),
+          user_agent: z.union([z.string().max(5000), z.literal("")]).optional(),
         })
         .optional(),
     })
@@ -13691,7 +13685,7 @@ export const s_PostAccountsAccountPeopleRequestBody = z.object({
         month: z.coerce.number(),
         year: z.coerce.number(),
       }),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   documents: z
@@ -13699,21 +13693,21 @@ export const s_PostAccountsAccountPeopleRequestBody = z.object({
       company_authorization: z
         .object({
           files: z
-            .array(z.union([z.string().max(500), z.enum([""])]))
+            .array(z.union([z.string().max(500), z.literal("")]))
             .optional(),
         })
         .optional(),
       passport: z
         .object({
           files: z
-            .array(z.union([z.string().max(500), z.enum([""])]))
+            .array(z.union([z.string().max(500), z.literal("")]))
             .optional(),
         })
         .optional(),
       visa: z
         .object({
           files: z
-            .array(z.union([z.string().max(500), z.enum([""])]))
+            .array(z.union([z.string().max(500), z.literal("")]))
             .optional(),
         })
         .optional(),
@@ -13725,7 +13719,7 @@ export const s_PostAccountsAccountPeopleRequestBody = z.object({
   first_name_kana: z.string().max(5000).optional(),
   first_name_kanji: z.string().max(5000).optional(),
   full_name_aliases: z
-    .union([z.array(z.string().max(5000)), z.enum([""])])
+    .union([z.array(z.string().max(5000)), z.literal("")])
     .optional(),
   gender: z.string().optional(),
   id_number: z.string().max(5000).optional(),
@@ -13735,7 +13729,7 @@ export const s_PostAccountsAccountPeopleRequestBody = z.object({
   last_name_kanji: z.string().max(5000).optional(),
   maiden_name: z.string().max(5000).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   nationality: z.string().max(5000).optional(),
   person_token: z.string().max(5000).optional(),
@@ -13758,7 +13752,7 @@ export const s_PostAccountsAccountPeopleRequestBody = z.object({
       executive: PermissiveBoolean.optional(),
       legal_guardian: PermissiveBoolean.optional(),
       owner: PermissiveBoolean.optional(),
-      percent_ownership: z.union([z.coerce.number(), z.enum([""])]).optional(),
+      percent_ownership: z.union([z.coerce.number(), z.literal("")]).optional(),
       representative: PermissiveBoolean.optional(),
       title: z.string().max(5000).optional(),
     })
@@ -13847,7 +13841,7 @@ export const s_PostAccountsAccountPeoplePersonRequestBody = z.object({
         .object({
           date: z.coerce.number().optional(),
           ip: z.string().optional(),
-          user_agent: z.union([z.string().max(5000), z.enum([""])]).optional(),
+          user_agent: z.union([z.string().max(5000), z.literal("")]).optional(),
         })
         .optional(),
     })
@@ -13891,7 +13885,7 @@ export const s_PostAccountsAccountPeoplePersonRequestBody = z.object({
         month: z.coerce.number(),
         year: z.coerce.number(),
       }),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   documents: z
@@ -13899,21 +13893,21 @@ export const s_PostAccountsAccountPeoplePersonRequestBody = z.object({
       company_authorization: z
         .object({
           files: z
-            .array(z.union([z.string().max(500), z.enum([""])]))
+            .array(z.union([z.string().max(500), z.literal("")]))
             .optional(),
         })
         .optional(),
       passport: z
         .object({
           files: z
-            .array(z.union([z.string().max(500), z.enum([""])]))
+            .array(z.union([z.string().max(500), z.literal("")]))
             .optional(),
         })
         .optional(),
       visa: z
         .object({
           files: z
-            .array(z.union([z.string().max(500), z.enum([""])]))
+            .array(z.union([z.string().max(500), z.literal("")]))
             .optional(),
         })
         .optional(),
@@ -13925,7 +13919,7 @@ export const s_PostAccountsAccountPeoplePersonRequestBody = z.object({
   first_name_kana: z.string().max(5000).optional(),
   first_name_kanji: z.string().max(5000).optional(),
   full_name_aliases: z
-    .union([z.array(z.string().max(5000)), z.enum([""])])
+    .union([z.array(z.string().max(5000)), z.literal("")])
     .optional(),
   gender: z.string().optional(),
   id_number: z.string().max(5000).optional(),
@@ -13935,7 +13929,7 @@ export const s_PostAccountsAccountPeoplePersonRequestBody = z.object({
   last_name_kanji: z.string().max(5000).optional(),
   maiden_name: z.string().max(5000).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   nationality: z.string().max(5000).optional(),
   person_token: z.string().max(5000).optional(),
@@ -13958,7 +13952,7 @@ export const s_PostAccountsAccountPeoplePersonRequestBody = z.object({
       executive: PermissiveBoolean.optional(),
       legal_guardian: PermissiveBoolean.optional(),
       owner: PermissiveBoolean.optional(),
-      percent_ownership: z.union([z.coerce.number(), z.enum([""])]).optional(),
+      percent_ownership: z.union([z.coerce.number(), z.literal("")]).optional(),
       representative: PermissiveBoolean.optional(),
       title: z.string().max(5000).optional(),
     })
@@ -14047,7 +14041,7 @@ export const s_PostAccountsAccountPersonsRequestBody = z.object({
         .object({
           date: z.coerce.number().optional(),
           ip: z.string().optional(),
-          user_agent: z.union([z.string().max(5000), z.enum([""])]).optional(),
+          user_agent: z.union([z.string().max(5000), z.literal("")]).optional(),
         })
         .optional(),
     })
@@ -14091,7 +14085,7 @@ export const s_PostAccountsAccountPersonsRequestBody = z.object({
         month: z.coerce.number(),
         year: z.coerce.number(),
       }),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   documents: z
@@ -14099,21 +14093,21 @@ export const s_PostAccountsAccountPersonsRequestBody = z.object({
       company_authorization: z
         .object({
           files: z
-            .array(z.union([z.string().max(500), z.enum([""])]))
+            .array(z.union([z.string().max(500), z.literal("")]))
             .optional(),
         })
         .optional(),
       passport: z
         .object({
           files: z
-            .array(z.union([z.string().max(500), z.enum([""])]))
+            .array(z.union([z.string().max(500), z.literal("")]))
             .optional(),
         })
         .optional(),
       visa: z
         .object({
           files: z
-            .array(z.union([z.string().max(500), z.enum([""])]))
+            .array(z.union([z.string().max(500), z.literal("")]))
             .optional(),
         })
         .optional(),
@@ -14125,7 +14119,7 @@ export const s_PostAccountsAccountPersonsRequestBody = z.object({
   first_name_kana: z.string().max(5000).optional(),
   first_name_kanji: z.string().max(5000).optional(),
   full_name_aliases: z
-    .union([z.array(z.string().max(5000)), z.enum([""])])
+    .union([z.array(z.string().max(5000)), z.literal("")])
     .optional(),
   gender: z.string().optional(),
   id_number: z.string().max(5000).optional(),
@@ -14135,7 +14129,7 @@ export const s_PostAccountsAccountPersonsRequestBody = z.object({
   last_name_kanji: z.string().max(5000).optional(),
   maiden_name: z.string().max(5000).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   nationality: z.string().max(5000).optional(),
   person_token: z.string().max(5000).optional(),
@@ -14158,7 +14152,7 @@ export const s_PostAccountsAccountPersonsRequestBody = z.object({
       executive: PermissiveBoolean.optional(),
       legal_guardian: PermissiveBoolean.optional(),
       owner: PermissiveBoolean.optional(),
-      percent_ownership: z.union([z.coerce.number(), z.enum([""])]).optional(),
+      percent_ownership: z.union([z.coerce.number(), z.literal("")]).optional(),
       representative: PermissiveBoolean.optional(),
       title: z.string().max(5000).optional(),
     })
@@ -14247,7 +14241,7 @@ export const s_PostAccountsAccountPersonsPersonRequestBody = z.object({
         .object({
           date: z.coerce.number().optional(),
           ip: z.string().optional(),
-          user_agent: z.union([z.string().max(5000), z.enum([""])]).optional(),
+          user_agent: z.union([z.string().max(5000), z.literal("")]).optional(),
         })
         .optional(),
     })
@@ -14291,7 +14285,7 @@ export const s_PostAccountsAccountPersonsPersonRequestBody = z.object({
         month: z.coerce.number(),
         year: z.coerce.number(),
       }),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   documents: z
@@ -14299,21 +14293,21 @@ export const s_PostAccountsAccountPersonsPersonRequestBody = z.object({
       company_authorization: z
         .object({
           files: z
-            .array(z.union([z.string().max(500), z.enum([""])]))
+            .array(z.union([z.string().max(500), z.literal("")]))
             .optional(),
         })
         .optional(),
       passport: z
         .object({
           files: z
-            .array(z.union([z.string().max(500), z.enum([""])]))
+            .array(z.union([z.string().max(500), z.literal("")]))
             .optional(),
         })
         .optional(),
       visa: z
         .object({
           files: z
-            .array(z.union([z.string().max(500), z.enum([""])]))
+            .array(z.union([z.string().max(500), z.literal("")]))
             .optional(),
         })
         .optional(),
@@ -14325,7 +14319,7 @@ export const s_PostAccountsAccountPersonsPersonRequestBody = z.object({
   first_name_kana: z.string().max(5000).optional(),
   first_name_kanji: z.string().max(5000).optional(),
   full_name_aliases: z
-    .union([z.array(z.string().max(5000)), z.enum([""])])
+    .union([z.array(z.string().max(5000)), z.literal("")])
     .optional(),
   gender: z.string().optional(),
   id_number: z.string().max(5000).optional(),
@@ -14335,7 +14329,7 @@ export const s_PostAccountsAccountPersonsPersonRequestBody = z.object({
   last_name_kanji: z.string().max(5000).optional(),
   maiden_name: z.string().max(5000).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   nationality: z.string().max(5000).optional(),
   person_token: z.string().max(5000).optional(),
@@ -14358,7 +14352,7 @@ export const s_PostAccountsAccountPersonsPersonRequestBody = z.object({
       executive: PermissiveBoolean.optional(),
       legal_guardian: PermissiveBoolean.optional(),
       owner: PermissiveBoolean.optional(),
-      percent_ownership: z.union([z.coerce.number(), z.enum([""])]).optional(),
+      percent_ownership: z.union([z.coerce.number(), z.literal("")]).optional(),
       representative: PermissiveBoolean.optional(),
       title: z.string().max(5000).optional(),
     })
@@ -14465,7 +14459,7 @@ export const s_application_fee: z.ZodType<t_application_fee> = z.object({
   fee_source: s_platform_earning_fee_source.nullable().optional(),
   id: z.string().max(5000),
   livemode: PermissiveBoolean,
-  object: z.enum(["application_fee"]),
+  object: z.literal("application_fee"),
   originating_transaction: z
     .union([z.string().max(5000), z.lazy(() => s_charge)])
     .nullable()
@@ -14474,7 +14468,7 @@ export const s_application_fee: z.ZodType<t_application_fee> = z.object({
   refunds: z.object({
     data: z.array(z.lazy(() => s_fee_refund)),
     has_more: PermissiveBoolean,
-    object: z.enum(["list"]),
+    object: z.literal("list"),
     url: z.string().max(5000),
   }),
 })
@@ -14490,13 +14484,13 @@ export const s_fee_refund: z.ZodType<t_fee_refund> = z.object({
   fee: z.union([z.string().max(5000), z.lazy(() => s_application_fee)]),
   id: z.string().max(5000),
   metadata: z.record(z.string(), z.string().max(500)).nullable().optional(),
-  object: z.enum(["fee_refund"]),
+  object: z.literal("fee_refund"),
 })
 
 export const s_PostApplicationFeesFeeRefundsIdRequestBody = z.object({
   expand: z.array(z.string().max(5000)).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
 })
 
@@ -14547,7 +14541,7 @@ export const s_balance_transaction: z.ZodType<t_balance_transaction> = z.object(
     fee_details: z.array(s_fee),
     id: z.string().max(5000),
     net: z.coerce.number(),
-    object: z.enum(["balance_transaction"]),
+    object: z.literal("balance_transaction"),
     reporting_category: z.string().max(5000),
     source: z
       .union([
@@ -14622,10 +14616,10 @@ export const s_balance_transaction: z.ZodType<t_balance_transaction> = z.object(
 )
 
 export const s_billing_alert: z.ZodType<t_billing_alert> = z.object({
-  alert_type: z.enum(["usage_threshold"]),
+  alert_type: z.literal("usage_threshold"),
   id: z.string().max(5000),
   livemode: PermissiveBoolean,
-  object: z.enum(["billing.alert"]),
+  object: z.literal("billing.alert"),
   status: z.enum(["active", "archived", "inactive"]).nullable().optional(),
   title: z.string().max(5000),
   usage_threshold: z
@@ -14635,7 +14629,7 @@ export const s_billing_alert: z.ZodType<t_billing_alert> = z.object({
 })
 
 export const s_PostBillingAlertsRequestBody = z.object({
-  alert_type: z.enum(["usage_threshold"]),
+  alert_type: z.literal("usage_threshold"),
   expand: z.array(z.string().max(5000)).optional(),
   title: z.string().max(256),
   usage_threshold: z
@@ -14644,13 +14638,13 @@ export const s_PostBillingAlertsRequestBody = z.object({
         .array(
           z.object({
             customer: z.string().max(5000).optional(),
-            type: z.enum(["customer"]),
+            type: z.literal("customer"),
           }),
         )
         .optional(),
       gte: z.coerce.number(),
       meter: z.string().max(5000),
-      recurrence: z.enum(["one_time"]),
+      recurrence: z.literal("one_time"),
     })
     .optional(),
 })
@@ -14676,7 +14670,7 @@ export const s_billing_credit_balance_summary: z.ZodType<t_billing_credit_balanc
       s_deleted_customer,
     ]),
     livemode: PermissiveBoolean,
-    object: z.enum(["billing.credit_balance_summary"]),
+    object: z.literal("billing.credit_balance_summary"),
   })
 
 export const s_billing_credit_balance_transaction: z.ZodType<t_billing_credit_balance_transaction> =
@@ -14697,7 +14691,7 @@ export const s_billing_credit_balance_transaction: z.ZodType<t_billing_credit_ba
     effective_at: z.coerce.number(),
     id: z.string().max(5000),
     livemode: PermissiveBoolean,
-    object: z.enum(["billing.credit_balance_transaction"]),
+    object: z.literal("billing.credit_balance_transaction"),
     test_clock: z
       .union([z.string().max(5000), s_test_helpers_test_clock])
       .nullable()
@@ -14722,7 +14716,7 @@ export const s_billing_credit_grant: z.ZodType<t_billing_credit_grant> =
     livemode: PermissiveBoolean,
     metadata: z.record(z.string(), z.string().max(500)),
     name: z.string().max(5000).nullable().optional(),
-    object: z.enum(["billing.credit_grant"]),
+    object: z.literal("billing.credit_grant"),
     priority: z.coerce.number().nullable().optional(),
     test_clock: z
       .union([z.string().max(5000), s_test_helpers_test_clock])
@@ -14737,11 +14731,11 @@ export const s_PostBillingCreditGrantsRequestBody = z.object({
     monetary: z
       .object({currency: z.string(), value: z.coerce.number()})
       .optional(),
-    type: z.enum(["monetary"]),
+    type: z.literal("monetary"),
   }),
   applicability_config: z.object({
     scope: z.object({
-      price_type: z.enum(["metered"]).optional(),
+      price_type: z.literal("metered").optional(),
       prices: z.array(z.object({id: z.string().max(5000)})).optional(),
     }),
   }),
@@ -14757,7 +14751,7 @@ export const s_PostBillingCreditGrantsRequestBody = z.object({
 
 export const s_PostBillingCreditGrantsIdRequestBody = z.object({
   expand: z.array(z.string().max(5000)).optional(),
-  expires_at: z.union([z.coerce.number(), z.enum([""])]).optional(),
+  expires_at: z.union([z.coerce.number(), z.literal("")]).optional(),
   metadata: z.record(z.string(), z.string()).optional(),
 })
 
@@ -14773,7 +14767,7 @@ export const s_PostBillingMeterEventAdjustmentsRequestBody = z.object({
   cancel: z.object({identifier: z.string().max(100).optional()}).optional(),
   event_name: z.string().max(100),
   expand: z.array(z.string().max(5000)).optional(),
-  type: z.enum(["cancel"]),
+  type: z.literal("cancel"),
 })
 
 export const s_PostBillingMeterEventsRequestBody = z.object({
@@ -14786,7 +14780,7 @@ export const s_PostBillingMeterEventsRequestBody = z.object({
 
 export const s_PostBillingMetersRequestBody = z.object({
   customer_mapping: z
-    .object({event_payload_key: z.string().max(100), type: z.enum(["by_id"])})
+    .object({event_payload_key: z.string().max(100), type: z.literal("by_id")})
     .optional(),
   default_aggregation: z.object({formula: z.enum(["count", "last", "sum"])}),
   display_name: z.string().max(250),
@@ -14812,12 +14806,12 @@ export const s_PostBillingMetersIdReactivateRequestBody = z.object({
 export const s_PostBillingPortalConfigurationsRequestBody = z.object({
   business_profile: z
     .object({
-      headline: z.union([z.string().max(60), z.enum([""])]).optional(),
+      headline: z.union([z.string().max(60), z.literal("")]).optional(),
       privacy_policy_url: z.string().optional(),
       terms_of_service_url: z.string().optional(),
     })
     .optional(),
-  default_return_url: z.union([z.string(), z.enum([""])]).optional(),
+  default_return_url: z.union([z.string(), z.literal("")]).optional(),
   expand: z.array(z.string().max(5000)).optional(),
   features: z.object({
     customer_update: z
@@ -14834,7 +14828,7 @@ export const s_PostBillingPortalConfigurationsRequestBody = z.object({
                 "tax_id",
               ]),
             ),
-            z.enum([""]),
+            z.literal(""),
           ])
           .optional(),
         enabled: PermissiveBoolean,
@@ -14860,7 +14854,7 @@ export const s_PostBillingPortalConfigurationsRequestBody = z.object({
                   "unused",
                 ]),
               ),
-              z.enum([""]),
+              z.literal(""),
             ]),
           })
           .optional(),
@@ -14876,7 +14870,7 @@ export const s_PostBillingPortalConfigurationsRequestBody = z.object({
         default_allowed_updates: z
           .union([
             z.array(z.enum(["price", "promotion_code", "quantity"])),
-            z.enum([""]),
+            z.literal(""),
           ])
           .optional(),
         enabled: PermissiveBoolean,
@@ -14895,7 +14889,7 @@ export const s_PostBillingPortalConfigurationsRequestBody = z.object({
                 product: z.string().max(5000),
               }),
             ),
-            z.enum([""]),
+            z.literal(""),
           ])
           .optional(),
         proration_behavior: z
@@ -14927,12 +14921,12 @@ export const s_PostBillingPortalConfigurationsConfigurationRequestBody =
     active: PermissiveBoolean.optional(),
     business_profile: z
       .object({
-        headline: z.union([z.string().max(60), z.enum([""])]).optional(),
-        privacy_policy_url: z.union([z.string(), z.enum([""])]).optional(),
-        terms_of_service_url: z.union([z.string(), z.enum([""])]).optional(),
+        headline: z.union([z.string().max(60), z.literal("")]).optional(),
+        privacy_policy_url: z.union([z.string(), z.literal("")]).optional(),
+        terms_of_service_url: z.union([z.string(), z.literal("")]).optional(),
       })
       .optional(),
-    default_return_url: z.union([z.string(), z.enum([""])]).optional(),
+    default_return_url: z.union([z.string(), z.literal("")]).optional(),
     expand: z.array(z.string().max(5000)).optional(),
     features: z
       .object({
@@ -14950,7 +14944,7 @@ export const s_PostBillingPortalConfigurationsConfigurationRequestBody =
                     "tax_id",
                   ]),
                 ),
-                z.enum([""]),
+                z.literal(""),
               ])
               .optional(),
             enabled: PermissiveBoolean.optional(),
@@ -14979,7 +14973,7 @@ export const s_PostBillingPortalConfigurationsConfigurationRequestBody =
                         "unused",
                       ]),
                     ),
-                    z.enum([""]),
+                    z.literal(""),
                   ])
                   .optional(),
               })
@@ -14996,7 +14990,7 @@ export const s_PostBillingPortalConfigurationsConfigurationRequestBody =
             default_allowed_updates: z
               .union([
                 z.array(z.enum(["price", "promotion_code", "quantity"])),
-                z.enum([""]),
+                z.literal(""),
               ])
               .optional(),
             enabled: PermissiveBoolean.optional(),
@@ -15015,7 +15009,7 @@ export const s_PostBillingPortalConfigurationsConfigurationRequestBody =
                     product: z.string().max(5000),
                   }),
                 ),
-                z.enum([""]),
+                z.literal(""),
               ])
               .optional(),
             proration_behavior: z
@@ -15033,7 +15027,7 @@ export const s_PostBillingPortalConfigurationsConfigurationRequestBody =
                         ]),
                       }),
                     ),
-                    z.enum([""]),
+                    z.literal(""),
                   ])
                   .optional(),
               })
@@ -15044,7 +15038,7 @@ export const s_PostBillingPortalConfigurationsConfigurationRequestBody =
       .optional(),
     login_page: z.object({enabled: PermissiveBoolean}).optional(),
     metadata: z
-      .union([z.record(z.string(), z.string()), z.enum([""])])
+      .union([z.record(z.string(), z.string()), z.literal("")])
       .optional(),
   })
 
@@ -15068,7 +15062,7 @@ export const s_PostBillingPortalSessionsRequestBody = z.object({
           retention: z
             .object({
               coupon_offer: z.object({coupon: z.string().max(5000)}),
-              type: z.enum(["coupon_offer"]),
+              type: z.literal("coupon_offer"),
             })
             .optional(),
           subscription: z.string().max(5000),
@@ -15198,7 +15192,7 @@ export const s_charge: z.ZodType<t_charge> = z.object({
   id: z.string().max(5000),
   livemode: PermissiveBoolean,
   metadata: z.record(z.string(), z.string().max(500)),
-  object: z.enum(["charge"]),
+  object: z.literal("charge"),
   on_behalf_of: z
     .union([z.string().max(5000), z.lazy(() => s_account)])
     .nullable()
@@ -15225,7 +15219,7 @@ export const s_charge: z.ZodType<t_charge> = z.object({
     .object({
       data: z.array(z.lazy(() => s_refund)),
       has_more: PermissiveBoolean,
-      object: z.enum(["list"]),
+      object: z.literal("list"),
       url: z.string().max(5000),
     })
     .nullable()
@@ -15272,7 +15266,7 @@ export const s_PostChargesRequestBody = z.object({
         metadata: z.record(z.string(), z.string()).optional(),
         name: z.string().max(5000).optional(),
         number: z.string().max(5000),
-        object: z.enum(["card"]).optional(),
+        object: z.literal("card").optional(),
       }),
       z.string().max(5000),
     ])
@@ -15291,7 +15285,7 @@ export const s_PostChargesRequestBody = z.object({
     .optional(),
   expand: z.array(z.string().max(5000)).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   on_behalf_of: z.string().max(5000).optional(),
   radar_options: z
@@ -15334,7 +15328,7 @@ export const s_PostChargesChargeRequestBody = z.object({
     .object({user_report: z.enum(["", "fraudulent", "safe"])})
     .optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   receipt_email: z.string().max(5000).optional(),
   shipping: z
@@ -15383,7 +15377,7 @@ export const s_dispute: z.ZodType<t_dispute> = z.object({
   is_charge_refundable: PermissiveBoolean,
   livemode: PermissiveBoolean,
   metadata: z.record(z.string(), z.string().max(500)),
-  object: z.enum(["dispute"]),
+  object: z.literal("dispute"),
   payment_intent: z
     .union([z.string().max(5000), z.lazy(() => s_payment_intent)])
     .nullable()
@@ -15425,45 +15419,45 @@ export const s_PostChargesChargeDisputeRequestBody = z.object({
                 disputed_transaction: z
                   .object({
                     customer_account_id: z
-                      .union([z.string().max(5000), z.enum([""])])
+                      .union([z.string().max(5000), z.literal("")])
                       .optional(),
                     customer_device_fingerprint: z
-                      .union([z.string().max(5000), z.enum([""])])
+                      .union([z.string().max(5000), z.literal("")])
                       .optional(),
                     customer_device_id: z
-                      .union([z.string().max(5000), z.enum([""])])
+                      .union([z.string().max(5000), z.literal("")])
                       .optional(),
                     customer_email_address: z
-                      .union([z.string().max(5000), z.enum([""])])
+                      .union([z.string().max(5000), z.literal("")])
                       .optional(),
                     customer_purchase_ip: z
-                      .union([z.string().max(5000), z.enum([""])])
+                      .union([z.string().max(5000), z.literal("")])
                       .optional(),
                     merchandise_or_services: z
                       .enum(["merchandise", "services"])
                       .optional(),
                     product_description: z
-                      .union([z.string().max(5000), z.enum([""])])
+                      .union([z.string().max(5000), z.literal("")])
                       .optional(),
                     shipping_address: z
                       .object({
                         city: z
-                          .union([z.string().max(5000), z.enum([""])])
+                          .union([z.string().max(5000), z.literal("")])
                           .optional(),
                         country: z
-                          .union([z.string().max(5000), z.enum([""])])
+                          .union([z.string().max(5000), z.literal("")])
                           .optional(),
                         line1: z
-                          .union([z.string().max(5000), z.enum([""])])
+                          .union([z.string().max(5000), z.literal("")])
                           .optional(),
                         line2: z
-                          .union([z.string().max(5000), z.enum([""])])
+                          .union([z.string().max(5000), z.literal("")])
                           .optional(),
                         postal_code: z
-                          .union([z.string().max(5000), z.enum([""])])
+                          .union([z.string().max(5000), z.literal("")])
                           .optional(),
                         state: z
-                          .union([z.string().max(5000), z.enum([""])])
+                          .union([z.string().max(5000), z.literal("")])
                           .optional(),
                       })
                       .optional(),
@@ -15474,42 +15468,42 @@ export const s_PostChargesChargeDisputeRequestBody = z.object({
                     z.object({
                       charge: z.string().max(5000),
                       customer_account_id: z
-                        .union([z.string().max(5000), z.enum([""])])
+                        .union([z.string().max(5000), z.literal("")])
                         .optional(),
                       customer_device_fingerprint: z
-                        .union([z.string().max(5000), z.enum([""])])
+                        .union([z.string().max(5000), z.literal("")])
                         .optional(),
                       customer_device_id: z
-                        .union([z.string().max(5000), z.enum([""])])
+                        .union([z.string().max(5000), z.literal("")])
                         .optional(),
                       customer_email_address: z
-                        .union([z.string().max(5000), z.enum([""])])
+                        .union([z.string().max(5000), z.literal("")])
                         .optional(),
                       customer_purchase_ip: z
-                        .union([z.string().max(5000), z.enum([""])])
+                        .union([z.string().max(5000), z.literal("")])
                         .optional(),
                       product_description: z
-                        .union([z.string().max(5000), z.enum([""])])
+                        .union([z.string().max(5000), z.literal("")])
                         .optional(),
                       shipping_address: z
                         .object({
                           city: z
-                            .union([z.string().max(5000), z.enum([""])])
+                            .union([z.string().max(5000), z.literal("")])
                             .optional(),
                           country: z
-                            .union([z.string().max(5000), z.enum([""])])
+                            .union([z.string().max(5000), z.literal("")])
                             .optional(),
                           line1: z
-                            .union([z.string().max(5000), z.enum([""])])
+                            .union([z.string().max(5000), z.literal("")])
                             .optional(),
                           line2: z
-                            .union([z.string().max(5000), z.enum([""])])
+                            .union([z.string().max(5000), z.literal("")])
                             .optional(),
                           postal_code: z
-                            .union([z.string().max(5000), z.enum([""])])
+                            .union([z.string().max(5000), z.literal("")])
                             .optional(),
                           state: z
-                            .union([z.string().max(5000), z.enum([""])])
+                            .union([z.string().max(5000), z.literal("")])
                             .optional(),
                         })
                         .optional(),
@@ -15522,7 +15516,7 @@ export const s_PostChargesChargeDisputeRequestBody = z.object({
               .object({fee_acknowledged: PermissiveBoolean.optional()})
               .optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       product_description: z.string().max(20000).optional(),
@@ -15543,7 +15537,7 @@ export const s_PostChargesChargeDisputeRequestBody = z.object({
     .optional(),
   expand: z.array(z.string().max(5000)).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   submit: PermissiveBoolean.optional(),
 })
@@ -15557,7 +15551,7 @@ export const s_PostChargesChargeRefundRequestBody = z.object({
   expand: z.array(z.string().max(5000)).optional(),
   instructions_email: z.string().optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   payment_intent: z.string().max(5000).optional(),
   reason: z
@@ -15589,7 +15583,7 @@ export const s_refund: z.ZodType<t_refund> = z.object({
   instructions_email: z.string().max(5000).optional(),
   metadata: z.record(z.string(), z.string().max(500)).nullable().optional(),
   next_action: s_refund_next_action.optional(),
-  object: z.enum(["refund"]),
+  object: z.literal("refund"),
   payment_intent: z
     .union([z.string().max(5000), z.lazy(() => s_payment_intent)])
     .nullable()
@@ -15627,9 +15621,9 @@ export const s_PostChargesChargeRefundsRequestBody = z.object({
   expand: z.array(z.string().max(5000)).optional(),
   instructions_email: z.string().optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
-  origin: z.enum(["customer_balance"]).optional(),
+  origin: z.literal("customer_balance").optional(),
   payment_intent: z.string().max(5000).optional(),
   reason: z
     .enum(["duplicate", "fraudulent", "requested_by_customer"])
@@ -15641,7 +15635,7 @@ export const s_PostChargesChargeRefundsRequestBody = z.object({
 export const s_PostChargesChargeRefundsRefundRequestBody = z.object({
   expand: z.array(z.string().max(5000)).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
 })
 
@@ -15704,7 +15698,7 @@ export const s_checkout_session: z.ZodType<t_checkout_session> = z.object({
     .object({
       data: z.array(z.lazy(() => s_item)),
       has_more: PermissiveBoolean,
-      object: z.enum(["list"]),
+      object: z.literal("list"),
       url: z.string().max(5000),
     })
     .optional(),
@@ -15757,7 +15751,7 @@ export const s_checkout_session: z.ZodType<t_checkout_session> = z.object({
     .optional(),
   metadata: z.record(z.string(), z.string().max(500)).nullable().optional(),
   mode: z.enum(["payment", "setup", "subscription"]),
-  object: z.enum(["checkout.session"]),
+  object: z.literal("checkout.session"),
   optional_items: z
     .array(s_payment_pages_checkout_session_optional_item)
     .nullable()
@@ -15885,7 +15879,10 @@ export const s_PostCheckoutSessionsRequestBody = z.object({
           })
           .optional(),
         key: z.string().max(200),
-        label: z.object({custom: z.string().max(50), type: z.enum(["custom"])}),
+        label: z.object({
+          custom: z.string().max(50),
+          type: z.literal("custom"),
+        }),
         numeric: z
           .object({
             default_value: z.string().max(255).optional(),
@@ -15908,16 +15905,16 @@ export const s_PostCheckoutSessionsRequestBody = z.object({
   custom_text: z
     .object({
       after_submit: z
-        .union([z.object({message: z.string().max(1200)}), z.enum([""])])
+        .union([z.object({message: z.string().max(1200)}), z.literal("")])
         .optional(),
       shipping_address: z
-        .union([z.object({message: z.string().max(1200)}), z.enum([""])])
+        .union([z.object({message: z.string().max(1200)}), z.literal("")])
         .optional(),
       submit: z
-        .union([z.object({message: z.string().max(1200)}), z.enum([""])])
+        .union([z.object({message: z.string().max(1200)}), z.literal("")])
         .optional(),
       terms_of_service_acceptance: z
-        .union([z.object({message: z.string().max(1200)}), z.enum([""])])
+        .union([z.object({message: z.string().max(1200)}), z.literal("")])
         .optional(),
     })
     .optional(),
@@ -15947,7 +15944,7 @@ export const s_PostCheckoutSessionsRequestBody = z.object({
       invoice_data: z
         .object({
           account_tax_ids: z
-            .union([z.array(z.string().max(5000)), z.enum([""])])
+            .union([z.array(z.string().max(5000)), z.literal("")])
             .optional(),
           custom_fields: z
             .union([
@@ -15957,7 +15954,7 @@ export const s_PostCheckoutSessionsRequestBody = z.object({
                   value: z.string().max(140),
                 }),
               ),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
           description: z.string().max(1500).optional(),
@@ -15977,7 +15974,7 @@ export const s_PostCheckoutSessionsRequestBody = z.object({
                   .optional(),
                 template: z.string().max(5000).optional(),
               }),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
         })
@@ -16140,7 +16137,7 @@ export const s_PostCheckoutSessionsRequestBody = z.object({
           mandate_options: z
             .object({
               custom_mandate_url: z
-                .union([z.string(), z.enum([""])])
+                .union([z.string(), z.literal("")])
                 .optional(),
               default_for: z
                 .array(z.enum(["invoice", "subscription"]))
@@ -16162,13 +16159,13 @@ export const s_PostCheckoutSessionsRequestBody = z.object({
         })
         .optional(),
       affirm: z
-        .object({setup_future_usage: z.enum(["none"]).optional()})
+        .object({setup_future_usage: z.literal("none").optional()})
         .optional(),
       afterpay_clearpay: z
-        .object({setup_future_usage: z.enum(["none"]).optional()})
+        .object({setup_future_usage: z.literal("none").optional()})
         .optional(),
       alipay: z
-        .object({setup_future_usage: z.enum(["none"]).optional()})
+        .object({setup_future_usage: z.literal("none").optional()})
         .optional(),
       amazon_pay: z
         .object({
@@ -16177,7 +16174,7 @@ export const s_PostCheckoutSessionsRequestBody = z.object({
         .optional(),
       au_becs_debit: z
         .object({
-          setup_future_usage: z.enum(["none"]).optional(),
+          setup_future_usage: z.literal("none").optional(),
           target_date: z.string().max(5000).optional(),
         })
         .optional(),
@@ -16186,7 +16183,7 @@ export const s_PostCheckoutSessionsRequestBody = z.object({
           mandate_options: z
             .object({
               reference_prefix: z
-                .union([z.string().max(12), z.enum([""])])
+                .union([z.string().max(12), z.literal("")])
                 .optional(),
             })
             .optional(),
@@ -16197,7 +16194,7 @@ export const s_PostCheckoutSessionsRequestBody = z.object({
         })
         .optional(),
       bancontact: z
-        .object({setup_future_usage: z.enum(["none"]).optional()})
+        .object({setup_future_usage: z.literal("none").optional()})
         .optional(),
       boleto: z
         .object({
@@ -16278,34 +16275,34 @@ export const s_PostCheckoutSessionsRequestBody = z.object({
               ]),
             })
             .optional(),
-          funding_type: z.enum(["bank_transfer"]).optional(),
-          setup_future_usage: z.enum(["none"]).optional(),
+          funding_type: z.literal("bank_transfer").optional(),
+          setup_future_usage: z.literal("none").optional(),
         })
         .optional(),
       eps: z
-        .object({setup_future_usage: z.enum(["none"]).optional()})
+        .object({setup_future_usage: z.literal("none").optional()})
         .optional(),
       fpx: z
-        .object({setup_future_usage: z.enum(["none"]).optional()})
+        .object({setup_future_usage: z.literal("none").optional()})
         .optional(),
       giropay: z
-        .object({setup_future_usage: z.enum(["none"]).optional()})
+        .object({setup_future_usage: z.literal("none").optional()})
         .optional(),
       grabpay: z
-        .object({setup_future_usage: z.enum(["none"]).optional()})
+        .object({setup_future_usage: z.literal("none").optional()})
         .optional(),
       ideal: z
-        .object({setup_future_usage: z.enum(["none"]).optional()})
+        .object({setup_future_usage: z.literal("none").optional()})
         .optional(),
       kakao_pay: z
         .object({
-          capture_method: z.enum(["manual"]).optional(),
+          capture_method: z.literal("manual").optional(),
           setup_future_usage: z.enum(["none", "off_session"]).optional(),
         })
         .optional(),
       klarna: z
         .object({
-          setup_future_usage: z.enum(["none"]).optional(),
+          setup_future_usage: z.literal("none").optional(),
           subscriptions: z
             .union([
               z.array(
@@ -16320,7 +16317,7 @@ export const s_PostCheckoutSessionsRequestBody = z.object({
                   reference: z.string().max(255),
                 }),
               ),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
         })
@@ -16328,12 +16325,12 @@ export const s_PostCheckoutSessionsRequestBody = z.object({
       konbini: z
         .object({
           expires_after_days: z.coerce.number().optional(),
-          setup_future_usage: z.enum(["none"]).optional(),
+          setup_future_usage: z.literal("none").optional(),
         })
         .optional(),
       kr_card: z
         .object({
-          capture_method: z.enum(["manual"]).optional(),
+          capture_method: z.literal("manual").optional(),
           setup_future_usage: z.enum(["none", "off_session"]).optional(),
         })
         .optional(),
@@ -16343,35 +16340,35 @@ export const s_PostCheckoutSessionsRequestBody = z.object({
         })
         .optional(),
       mobilepay: z
-        .object({setup_future_usage: z.enum(["none"]).optional()})
+        .object({setup_future_usage: z.literal("none").optional()})
         .optional(),
       multibanco: z
-        .object({setup_future_usage: z.enum(["none"]).optional()})
+        .object({setup_future_usage: z.literal("none").optional()})
         .optional(),
       naver_pay: z
         .object({
-          capture_method: z.enum(["manual"]).optional(),
+          capture_method: z.literal("manual").optional(),
           setup_future_usage: z.enum(["none", "off_session"]).optional(),
         })
         .optional(),
       oxxo: z
         .object({
           expires_after_days: z.coerce.number().optional(),
-          setup_future_usage: z.enum(["none"]).optional(),
+          setup_future_usage: z.literal("none").optional(),
         })
         .optional(),
       p24: z
         .object({
-          setup_future_usage: z.enum(["none"]).optional(),
+          setup_future_usage: z.literal("none").optional(),
           tos_shown_and_accepted: PermissiveBoolean.optional(),
         })
         .optional(),
       pay_by_bank: z.record(z.string(), z.unknown()).optional(),
       payco: z
-        .object({capture_method: z.enum(["manual"]).optional()})
+        .object({capture_method: z.literal("manual").optional()})
         .optional(),
       paynow: z
-        .object({setup_future_usage: z.enum(["none"]).optional()})
+        .object({setup_future_usage: z.literal("none").optional()})
         .optional(),
       paypal: z
         .object({
@@ -16409,7 +16406,7 @@ export const s_PostCheckoutSessionsRequestBody = z.object({
       pix: z
         .object({
           expires_after_seconds: z.coerce.number().optional(),
-          setup_future_usage: z.enum(["none"]).optional(),
+          setup_future_usage: z.literal("none").optional(),
         })
         .optional(),
       revolut_pay: z
@@ -16418,14 +16415,14 @@ export const s_PostCheckoutSessionsRequestBody = z.object({
         })
         .optional(),
       samsung_pay: z
-        .object({capture_method: z.enum(["manual"]).optional()})
+        .object({capture_method: z.literal("manual").optional()})
         .optional(),
       sepa_debit: z
         .object({
           mandate_options: z
             .object({
               reference_prefix: z
-                .union([z.string().max(12), z.enum([""])])
+                .union([z.string().max(12), z.literal("")])
                 .optional(),
             })
             .optional(),
@@ -16436,7 +16433,7 @@ export const s_PostCheckoutSessionsRequestBody = z.object({
         })
         .optional(),
       sofort: z
-        .object({setup_future_usage: z.enum(["none"]).optional()})
+        .object({setup_future_usage: z.literal("none").optional()})
         .optional(),
       swish: z.object({reference: z.string().max(5000).optional()}).optional(),
       us_bank_account: z
@@ -16469,7 +16466,7 @@ export const s_PostCheckoutSessionsRequestBody = z.object({
         .object({
           app_id: z.string().max(5000).optional(),
           client: z.enum(["android", "ios", "web"]),
-          setup_future_usage: z.enum(["none"]).optional(),
+          setup_future_usage: z.literal("none").optional(),
         })
         .optional(),
     })
@@ -16857,7 +16854,7 @@ export const s_PostCheckoutSessionsRequestBody = z.object({
               .enum(["exclusive", "inclusive", "unspecified"])
               .optional(),
             tax_code: z.string().optional(),
-            type: z.enum(["fixed_amount"]).optional(),
+            type: z.literal("fixed_amount").optional(),
           })
           .optional(),
       }),
@@ -16946,7 +16943,7 @@ export const s_PostCheckoutSessionsSessionRequestBody = z.object({
     .optional(),
   expand: z.array(z.string().max(5000)).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   shipping_options: z
     .union([
@@ -17006,12 +17003,12 @@ export const s_PostCheckoutSessionsSessionRequestBody = z.object({
                 .enum(["exclusive", "inclusive", "unspecified"])
                 .optional(),
               tax_code: z.string().optional(),
-              type: z.enum(["fixed_amount"]).optional(),
+              type: z.literal("fixed_amount").optional(),
             })
             .optional(),
         }),
       ),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
 })
@@ -17029,7 +17026,7 @@ export const s_item: z.ZodType<t_item> = z.object({
   description: z.string().max(5000).nullable().optional(),
   discounts: z.array(z.lazy(() => s_line_items_discount_amount)).optional(),
   id: z.string().max(5000),
-  object: z.enum(["item"]),
+  object: z.literal("item"),
   price: z
     .lazy(() => s_price)
     .nullable()
@@ -17051,8 +17048,8 @@ export const s_PostClimateOrdersRequestBody = z.object({
 export const s_PostClimateOrdersOrderRequestBody = z.object({
   beneficiary: z
     .union([
-      z.object({public_name: z.union([z.string().max(5000), z.enum([""])])}),
-      z.enum([""]),
+      z.object({public_name: z.union([z.string().max(5000), z.literal("")])}),
+      z.literal(""),
     ])
     .optional(),
   expand: z.array(z.string().max(5000)).optional(),
@@ -17071,7 +17068,7 @@ export const s_confirmation_token: z.ZodType<t_confirmation_token> = z.object({
   mandate_data: s_confirmation_tokens_resource_mandate_data
     .nullable()
     .optional(),
-  object: z.enum(["confirmation_token"]),
+  object: z.literal("confirmation_token"),
   payment_intent: z.string().max(5000).nullable().optional(),
   payment_method_options: s_confirmation_tokens_resource_payment_method_options
     .nullable()
@@ -17105,7 +17102,7 @@ export const s_PostCouponsRequestBody = z.object({
   id: z.string().max(5000).optional(),
   max_redemptions: z.coerce.number().optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   name: z.string().max(40).optional(),
   percent_off: z.coerce.number().optional(),
@@ -17118,7 +17115,7 @@ export const s_PostCouponsCouponRequestBody = z.object({
     .optional(),
   expand: z.array(z.string().max(5000)).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   name: z.string().max(40).optional(),
 })
@@ -17145,14 +17142,14 @@ export const s_credit_note: z.ZodType<t_credit_note> = z.object({
   lines: z.object({
     data: z.array(z.lazy(() => s_credit_note_line_item)),
     has_more: PermissiveBoolean,
-    object: z.enum(["list"]),
+    object: z.literal("list"),
     url: z.string().max(5000),
   }),
   livemode: PermissiveBoolean,
   memo: z.string().max(5000).nullable().optional(),
   metadata: z.record(z.string(), z.string().max(500)).nullable().optional(),
   number: z.string().max(5000),
-  object: z.enum(["credit_note"]),
+  object: z.literal("credit_note"),
   out_of_band_amount: z.coerce.number().nullable().optional(),
   pdf: z.string().max(5000),
   post_payment_amount: z.coerce.number(),
@@ -17202,11 +17199,11 @@ export const s_PostCreditNotesRequestBody = z.object({
                 taxable_amount: z.coerce.number(),
               }),
             ),
-            z.enum([""]),
+            z.literal(""),
           ])
           .optional(),
         tax_rates: z
-          .union([z.array(z.string().max(5000)), z.enum([""])])
+          .union([z.array(z.string().max(5000)), z.literal("")])
           .optional(),
         type: z.enum(["custom_line_item", "invoice_line_item"]),
         unit_amount: z.coerce.number().optional(),
@@ -17245,7 +17242,7 @@ export const s_credit_note_line_item: z.ZodType<t_credit_note_line_item> =
     id: z.string().max(5000),
     invoice_line_item: z.string().max(5000).optional(),
     livemode: PermissiveBoolean,
-    object: z.enum(["credit_note_line_item"]),
+    object: z.literal("credit_note_line_item"),
     pretax_credit_amounts: z.array(
       z.lazy(() => s_credit_notes_pretax_credit_amount),
     ),
@@ -17307,7 +17304,7 @@ export const s_customer_session: z.ZodType<t_customer_session> = z.object({
   customer: z.union([z.string().max(5000), z.lazy(() => s_customer)]),
   expires_at: z.coerce.number(),
   livemode: PermissiveBoolean,
-  object: z.enum(["customer_session"]),
+  object: z.literal("customer_session"),
 })
 
 export const s_customer: z.ZodType<t_customer> = z.object({
@@ -17340,7 +17337,7 @@ export const s_customer: z.ZodType<t_customer> = z.object({
   metadata: z.record(z.string(), z.string().max(500)).optional(),
   name: z.string().max(5000).nullable().optional(),
   next_invoice_sequence: z.coerce.number().optional(),
-  object: z.enum(["customer"]),
+  object: z.literal("customer"),
   phone: z.string().max(5000).nullable().optional(),
   preferred_locales: z.array(z.string().max(5000)).nullable().optional(),
   shipping: s_shipping.nullable().optional(),
@@ -17350,7 +17347,7 @@ export const s_customer: z.ZodType<t_customer> = z.object({
         z.union([z.lazy(() => s_bank_account), z.lazy(() => s_card), s_source]),
       ),
       has_more: PermissiveBoolean,
-      object: z.enum(["list"]),
+      object: z.literal("list"),
       url: z.string().max(5000),
     })
     .optional(),
@@ -17358,7 +17355,7 @@ export const s_customer: z.ZodType<t_customer> = z.object({
     .object({
       data: z.array(z.lazy(() => s_subscription)),
       has_more: PermissiveBoolean,
-      object: z.enum(["list"]),
+      object: z.literal("list"),
       url: z.string().max(5000),
     })
     .optional(),
@@ -17368,7 +17365,7 @@ export const s_customer: z.ZodType<t_customer> = z.object({
     .object({
       data: z.array(z.lazy(() => s_tax_id)),
       has_more: PermissiveBoolean,
-      object: z.enum(["list"]),
+      object: z.literal("list"),
       url: z.string().max(5000),
     })
     .optional(),
@@ -17389,7 +17386,7 @@ export const s_PostCustomersRequestBody = z.object({
         postal_code: z.string().max(5000).optional(),
         state: z.string().max(5000).optional(),
       }),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   balance: z.coerce.number().optional(),
@@ -17415,7 +17412,7 @@ export const s_PostCustomersRequestBody = z.object({
           z.array(
             z.object({name: z.string().max(40), value: z.string().max(140)}),
           ),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       default_payment_method: z.string().max(5000).optional(),
@@ -17428,13 +17425,13 @@ export const s_PostCustomersRequestBody = z.object({
               .optional(),
             template: z.string().max(5000).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
     })
     .optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   name: z.string().max(256).optional(),
   next_invoice_sequence: z.coerce.number().optional(),
@@ -17455,13 +17452,13 @@ export const s_PostCustomersRequestBody = z.object({
         name: z.string().max(5000),
         phone: z.string().max(5000).optional(),
       }),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   source: z.string().max(5000).optional(),
   tax: z
     .object({
-      ip_address: z.union([z.string(), z.enum([""])]).optional(),
+      ip_address: z.union([z.string(), z.literal("")]).optional(),
       validate_location: z.enum(["deferred", "immediately"]).optional(),
     })
     .optional(),
@@ -17599,7 +17596,7 @@ export const s_PostCustomersCustomerRequestBody = z.object({
         postal_code: z.string().max(5000).optional(),
         state: z.string().max(5000).optional(),
       }),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   balance: z.coerce.number().optional(),
@@ -17611,7 +17608,7 @@ export const s_PostCustomersCustomerRequestBody = z.object({
         account_number: z.string().max(5000),
         country: z.string().max(5000),
         currency: z.string().optional(),
-        object: z.enum(["bank_account"]).optional(),
+        object: z.literal("bank_account").optional(),
         routing_number: z.string().max(5000).optional(),
       }),
       z.string().max(5000),
@@ -17632,7 +17629,7 @@ export const s_PostCustomersCustomerRequestBody = z.object({
         metadata: z.record(z.string(), z.string()).optional(),
         name: z.string().max(5000).optional(),
         number: z.string().max(5000),
-        object: z.enum(["card"]).optional(),
+        object: z.literal("card").optional(),
       }),
       z.string().max(5000),
     ])
@@ -17663,7 +17660,7 @@ export const s_PostCustomersCustomerRequestBody = z.object({
           z.array(
             z.object({name: z.string().max(40), value: z.string().max(140)}),
           ),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       default_payment_method: z.string().max(5000).optional(),
@@ -17676,13 +17673,13 @@ export const s_PostCustomersCustomerRequestBody = z.object({
               .optional(),
             template: z.string().max(5000).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
     })
     .optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   name: z.string().max(256).optional(),
   next_invoice_sequence: z.coerce.number().optional(),
@@ -17702,13 +17699,13 @@ export const s_PostCustomersCustomerRequestBody = z.object({
         name: z.string().max(5000),
         phone: z.string().max(5000).optional(),
       }),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   source: z.string().max(5000).optional(),
   tax: z
     .object({
-      ip_address: z.union([z.string(), z.enum([""])]).optional(),
+      ip_address: z.union([z.string(), z.literal("")]).optional(),
       validate_location: z.enum(["auto", "deferred", "immediately"]).optional(),
     })
     .optional(),
@@ -17738,7 +17735,7 @@ export const s_customer_balance_transaction: z.ZodType<t_customer_balance_transa
       .optional(),
     livemode: PermissiveBoolean,
     metadata: z.record(z.string(), z.string().max(500)).nullable().optional(),
-    object: z.enum(["customer_balance_transaction"]),
+    object: z.literal("customer_balance_transaction"),
     type: z.enum([
       "adjustment",
       "applied_to_invoice",
@@ -17761,7 +17758,7 @@ export const s_PostCustomersCustomerBalanceTransactionsRequestBody = z.object({
   description: z.string().max(350).optional(),
   expand: z.array(z.string().max(5000)).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
 })
 
@@ -17770,7 +17767,7 @@ export const s_PostCustomersCustomerBalanceTransactionsTransactionRequestBody =
     description: z.string().max(350).optional(),
     expand: z.array(z.string().max(5000)).optional(),
     metadata: z
-      .union([z.record(z.string(), z.string()), z.enum([""])])
+      .union([z.record(z.string(), z.string()), z.literal("")])
       .optional(),
   })
 
@@ -17784,7 +17781,7 @@ export const s_PostCustomersCustomerBankAccountsRequestBody = z.object({
         account_number: z.string().max(5000),
         country: z.string().max(5000),
         currency: z.string().optional(),
-        object: z.enum(["bank_account"]).optional(),
+        object: z.literal("bank_account").optional(),
         routing_number: z.string().max(5000).optional(),
       }),
       z.string().max(5000),
@@ -17805,7 +17802,7 @@ export const s_PostCustomersCustomerBankAccountsRequestBody = z.object({
         metadata: z.record(z.string(), z.string()).optional(),
         name: z.string().max(5000).optional(),
         number: z.string().max(5000),
-        object: z.enum(["card"]).optional(),
+        object: z.literal("card").optional(),
       }),
       z.string().max(5000),
     ])
@@ -17839,7 +17836,7 @@ export const s_PostCustomersCustomerBankAccountsIdRequestBody = z.object({
   exp_year: z.string().max(5000).optional(),
   expand: z.array(z.string().max(5000)).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   name: z.string().max(5000).optional(),
   owner: z
@@ -17876,7 +17873,7 @@ export const s_PostCustomersCustomerCardsRequestBody = z.object({
         account_number: z.string().max(5000),
         country: z.string().max(5000),
         currency: z.string().optional(),
-        object: z.enum(["bank_account"]).optional(),
+        object: z.literal("bank_account").optional(),
         routing_number: z.string().max(5000).optional(),
       }),
       z.string().max(5000),
@@ -17897,7 +17894,7 @@ export const s_PostCustomersCustomerCardsRequestBody = z.object({
         metadata: z.record(z.string(), z.string()).optional(),
         name: z.string().max(5000).optional(),
         number: z.string().max(5000),
-        object: z.enum(["card"]).optional(),
+        object: z.literal("card").optional(),
       }),
       z.string().max(5000),
     ])
@@ -17924,7 +17921,7 @@ export const s_PostCustomersCustomerCardsIdRequestBody = z.object({
   exp_year: z.string().max(5000).optional(),
   expand: z.array(z.string().max(5000)).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   name: z.string().max(5000).optional(),
   owner: z
@@ -17974,7 +17971,7 @@ export const s_customer_cash_balance_transaction: z.ZodType<t_customer_cash_bala
     id: z.string().max(5000),
     livemode: PermissiveBoolean,
     net_amount: z.coerce.number(),
-    object: z.enum(["customer_cash_balance_transaction"]),
+    object: z.literal("customer_cash_balance_transaction"),
     refunded_from_payment: z.lazy(() =>
       s_customer_balance_resource_cash_balance_transaction_resource_refunded_from_payment_transaction.optional(),
     ),
@@ -18008,7 +18005,7 @@ export const s_deleted_discount: z.ZodType<t_deleted_discount> = z.object({
   id: z.string().max(5000),
   invoice: z.string().max(5000).nullable().optional(),
   invoice_item: z.string().max(5000).nullable().optional(),
-  object: z.enum(["discount"]),
+  object: z.literal("discount"),
   promotion_code: z
     .union([z.string().max(5000), z.lazy(() => s_promotion_code)])
     .nullable()
@@ -18029,7 +18026,7 @@ export const s_discount: z.ZodType<t_discount> = z.object({
   id: z.string().max(5000),
   invoice: z.string().max(5000).nullable().optional(),
   invoice_item: z.string().max(5000).nullable().optional(),
-  object: z.enum(["discount"]),
+  object: z.literal("discount"),
   promotion_code: z
     .union([z.string().max(5000), z.lazy(() => s_promotion_code)])
     .nullable()
@@ -18055,7 +18052,7 @@ export const s_PostCustomersCustomerFundingInstructionsRequestBody = z.object({
   }),
   currency: z.string(),
   expand: z.array(z.string().max(5000)).optional(),
-  funding_type: z.enum(["bank_transfer"]),
+  funding_type: z.literal("bank_transfer"),
 })
 
 export const s_payment_method: z.ZodType<t_payment_method> = z.object({
@@ -18101,7 +18098,7 @@ export const s_payment_method: z.ZodType<t_payment_method> = z.object({
   multibanco: s_payment_method_multibanco.optional(),
   naver_pay: s_payment_method_naver_pay.optional(),
   nz_bank_account: s_payment_method_nz_bank_account.optional(),
-  object: z.enum(["payment_method"]),
+  object: z.literal("payment_method"),
   oxxo: s_payment_method_oxxo.optional(),
   p24: s_payment_method_p24.optional(),
   pay_by_bank: s_payment_method_pay_by_bank.optional(),
@@ -18185,7 +18182,7 @@ export const s_PostCustomersCustomerSourcesRequestBody = z.object({
         account_number: z.string().max(5000),
         country: z.string().max(5000),
         currency: z.string().optional(),
-        object: z.enum(["bank_account"]).optional(),
+        object: z.literal("bank_account").optional(),
         routing_number: z.string().max(5000).optional(),
       }),
       z.string().max(5000),
@@ -18206,7 +18203,7 @@ export const s_PostCustomersCustomerSourcesRequestBody = z.object({
         metadata: z.record(z.string(), z.string()).optional(),
         name: z.string().max(5000).optional(),
         number: z.string().max(5000),
-        object: z.enum(["card"]).optional(),
+        object: z.literal("card").optional(),
       }),
       z.string().max(5000),
     ])
@@ -18233,7 +18230,7 @@ export const s_PostCustomersCustomerSourcesIdRequestBody = z.object({
   exp_year: z.string().max(5000).optional(),
   expand: z.array(z.string().max(5000)).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   name: z.string().max(5000).optional(),
   owner: z
@@ -18309,7 +18306,7 @@ export const s_subscription: z.ZodType<t_subscription> = z.object({
   items: z.object({
     data: z.array(z.lazy(() => s_subscription_item)),
     has_more: PermissiveBoolean,
-    object: z.enum(["list"]),
+    object: z.literal("list"),
     url: z.string().max(5000),
   }),
   latest_invoice: z
@@ -18319,7 +18316,7 @@ export const s_subscription: z.ZodType<t_subscription> = z.object({
   livemode: PermissiveBoolean,
   metadata: z.record(z.string(), z.string().max(500)),
   next_pending_invoice_item_invoice: z.coerce.number().nullable().optional(),
-  object: z.enum(["subscription"]),
+  object: z.literal("subscription"),
   on_behalf_of: z
     .union([z.string().max(5000), z.lazy(() => s_account)])
     .nullable()
@@ -18398,13 +18395,13 @@ export const s_PostCustomersCustomerSubscriptionsRequestBody = z.object({
           .optional(),
         quantity: z.coerce.number().optional(),
         tax_rates: z
-          .union([z.array(z.string().max(5000)), z.enum([""])])
+          .union([z.array(z.string().max(5000)), z.literal("")])
           .optional(),
       }),
     )
     .optional(),
   application_fee_percent: z
-    .union([z.coerce.number(), z.enum([""])])
+    .union([z.coerce.number(), z.literal("")])
     .optional(),
   automatic_tax: z
     .object({
@@ -18425,7 +18422,7 @@ export const s_PostCustomersCustomerSubscriptionsRequestBody = z.object({
         amount_gte: z.coerce.number().optional(),
         reset_billing_cycle_anchor: PermissiveBoolean.optional(),
       }),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   cancel_at: z
@@ -18440,7 +18437,7 @@ export const s_PostCustomersCustomerSubscriptionsRequestBody = z.object({
   default_payment_method: z.string().max(5000).optional(),
   default_source: z.string().max(5000).optional(),
   default_tax_rates: z
-    .union([z.array(z.string().max(5000)), z.enum([""])])
+    .union([z.array(z.string().max(5000)), z.literal("")])
     .optional(),
   discounts: z
     .union([
@@ -18451,14 +18448,14 @@ export const s_PostCustomersCustomerSubscriptionsRequestBody = z.object({
           promotion_code: z.string().max(5000).optional(),
         }),
       ),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   expand: z.array(z.string().max(5000)).optional(),
   invoice_settings: z
     .object({
       account_tax_ids: z
-        .union([z.array(z.string().max(5000)), z.enum([""])])
+        .union([z.array(z.string().max(5000)), z.literal("")])
         .optional(),
       issuer: z
         .object({
@@ -18472,7 +18469,7 @@ export const s_PostCustomersCustomerSubscriptionsRequestBody = z.object({
     .array(
       z.object({
         billing_thresholds: z
-          .union([z.object({usage_gte: z.coerce.number()}), z.enum([""])])
+          .union([z.object({usage_gte: z.coerce.number()}), z.literal("")])
           .optional(),
         discounts: z
           .union([
@@ -18483,7 +18480,7 @@ export const s_PostCustomersCustomerSubscriptionsRequestBody = z.object({
                 promotion_code: z.string().max(5000).optional(),
               }),
             ),
-            z.enum([""]),
+            z.literal(""),
           ])
           .optional(),
         metadata: z.record(z.string(), z.string()).optional(),
@@ -18505,13 +18502,13 @@ export const s_PostCustomersCustomerSubscriptionsRequestBody = z.object({
           .optional(),
         quantity: z.coerce.number().optional(),
         tax_rates: z
-          .union([z.array(z.string().max(5000)), z.enum([""])])
+          .union([z.array(z.string().max(5000)), z.literal("")])
           .optional(),
       }),
     )
     .optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   off_session: PermissiveBoolean.optional(),
   payment_behavior: z
@@ -18540,7 +18537,7 @@ export const s_PostCustomersCustomerSubscriptionsRequestBody = z.object({
                   .enum(["automatic", "instant", "microdeposits"])
                   .optional(),
               }),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
           bancontact: z
@@ -18548,7 +18545,7 @@ export const s_PostCustomersCustomerSubscriptionsRequestBody = z.object({
               z.object({
                 preferred_language: z.enum(["de", "en", "fr", "nl"]).optional(),
               }),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
           card: z
@@ -18582,7 +18579,7 @@ export const s_PostCustomersCustomerSubscriptionsRequestBody = z.object({
                   .enum(["any", "automatic", "challenge"])
                   .optional(),
               }),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
           customer_balance: z
@@ -18598,14 +18595,14 @@ export const s_PostCustomersCustomerSubscriptionsRequestBody = z.object({
                   .optional(),
                 funding_type: z.string().optional(),
               }),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
           konbini: z
-            .union([z.record(z.string(), z.unknown()), z.enum([""])])
+            .union([z.record(z.string(), z.unknown()), z.literal("")])
             .optional(),
           sepa_debit: z
-            .union([z.record(z.string(), z.unknown()), z.enum([""])])
+            .union([z.record(z.string(), z.unknown()), z.literal("")])
             .optional(),
           us_bank_account: z
             .union([
@@ -18638,7 +18635,7 @@ export const s_PostCustomersCustomerSubscriptionsRequestBody = z.object({
                   .enum(["automatic", "instant", "microdeposits"])
                   .optional(),
               }),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
         })
@@ -18688,7 +18685,7 @@ export const s_PostCustomersCustomerSubscriptionsRequestBody = z.object({
               "wechat_pay",
             ]),
           ),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       save_default_payment_method: z
@@ -18702,7 +18699,7 @@ export const s_PostCustomersCustomerSubscriptionsRequestBody = z.object({
         interval: z.enum(["day", "month", "week", "year"]),
         interval_count: z.coerce.number().optional(),
       }),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   proration_behavior: z
@@ -18714,7 +18711,7 @@ export const s_PostCustomersCustomerSubscriptionsRequestBody = z.object({
       destination: z.string(),
     })
     .optional(),
-  trial_end: z.union([z.enum(["now"]), z.coerce.number()]).optional(),
+  trial_end: z.union([z.literal("now"), z.coerce.number()]).optional(),
   trial_from_plan: PermissiveBoolean.optional(),
   trial_period_days: z.coerce.number().optional(),
   trial_settings: z
@@ -18761,13 +18758,13 @@ export const s_PostCustomersCustomerSubscriptionsSubscriptionExposedIdRequestBod
             .optional(),
           quantity: z.coerce.number().optional(),
           tax_rates: z
-            .union([z.array(z.string().max(5000)), z.enum([""])])
+            .union([z.array(z.string().max(5000)), z.literal("")])
             .optional(),
         }),
       )
       .optional(),
     application_fee_percent: z
-      .union([z.coerce.number(), z.enum([""])])
+      .union([z.coerce.number(), z.literal("")])
       .optional(),
     automatic_tax: z
       .object({
@@ -18787,20 +18784,20 @@ export const s_PostCustomersCustomerSubscriptionsSubscriptionExposedIdRequestBod
           amount_gte: z.coerce.number().optional(),
           reset_billing_cycle_anchor: PermissiveBoolean.optional(),
         }),
-        z.enum([""]),
+        z.literal(""),
       ])
       .optional(),
     cancel_at: z
       .union([
         z.coerce.number(),
-        z.enum([""]),
+        z.literal(""),
         z.enum(["max_period_end", "min_period_end"]),
       ])
       .optional(),
     cancel_at_period_end: PermissiveBoolean.optional(),
     cancellation_details: z
       .object({
-        comment: z.union([z.string().max(5000), z.enum([""])]).optional(),
+        comment: z.union([z.string().max(5000), z.literal("")]).optional(),
         feedback: z
           .enum([
             "",
@@ -18821,9 +18818,9 @@ export const s_PostCustomersCustomerSubscriptionsSubscriptionExposedIdRequestBod
       .optional(),
     days_until_due: z.coerce.number().optional(),
     default_payment_method: z.string().max(5000).optional(),
-    default_source: z.union([z.string().max(5000), z.enum([""])]).optional(),
+    default_source: z.union([z.string().max(5000), z.literal("")]).optional(),
     default_tax_rates: z
-      .union([z.array(z.string().max(5000)), z.enum([""])])
+      .union([z.array(z.string().max(5000)), z.literal("")])
       .optional(),
     discounts: z
       .union([
@@ -18834,14 +18831,14 @@ export const s_PostCustomersCustomerSubscriptionsSubscriptionExposedIdRequestBod
             promotion_code: z.string().max(5000).optional(),
           }),
         ),
-        z.enum([""]),
+        z.literal(""),
       ])
       .optional(),
     expand: z.array(z.string().max(5000)).optional(),
     invoice_settings: z
       .object({
         account_tax_ids: z
-          .union([z.array(z.string().max(5000)), z.enum([""])])
+          .union([z.array(z.string().max(5000)), z.literal("")])
           .optional(),
         issuer: z
           .object({
@@ -18855,7 +18852,7 @@ export const s_PostCustomersCustomerSubscriptionsSubscriptionExposedIdRequestBod
       .array(
         z.object({
           billing_thresholds: z
-            .union([z.object({usage_gte: z.coerce.number()}), z.enum([""])])
+            .union([z.object({usage_gte: z.coerce.number()}), z.literal("")])
             .optional(),
           clear_usage: PermissiveBoolean.optional(),
           deleted: PermissiveBoolean.optional(),
@@ -18868,12 +18865,12 @@ export const s_PostCustomersCustomerSubscriptionsSubscriptionExposedIdRequestBod
                   promotion_code: z.string().max(5000).optional(),
                 }),
               ),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
           id: z.string().max(5000).optional(),
           metadata: z
-            .union([z.record(z.string(), z.string()), z.enum([""])])
+            .union([z.record(z.string(), z.string()), z.literal("")])
             .optional(),
           price: z.string().max(5000).optional(),
           price_data: z
@@ -18893,13 +18890,13 @@ export const s_PostCustomersCustomerSubscriptionsSubscriptionExposedIdRequestBod
             .optional(),
           quantity: z.coerce.number().optional(),
           tax_rates: z
-            .union([z.array(z.string().max(5000)), z.enum([""])])
+            .union([z.array(z.string().max(5000)), z.literal("")])
             .optional(),
         }),
       )
       .optional(),
     metadata: z
-      .union([z.record(z.string(), z.string()), z.enum([""])])
+      .union([z.record(z.string(), z.string()), z.literal("")])
       .optional(),
     off_session: PermissiveBoolean.optional(),
     pause_collection: z
@@ -18908,7 +18905,7 @@ export const s_PostCustomersCustomerSubscriptionsSubscriptionExposedIdRequestBod
           behavior: z.enum(["keep_as_draft", "mark_uncollectible", "void"]),
           resumes_at: z.coerce.number().optional(),
         }),
-        z.enum([""]),
+        z.literal(""),
       ])
       .optional(),
     payment_behavior: z
@@ -18937,7 +18934,7 @@ export const s_PostCustomersCustomerSubscriptionsSubscriptionExposedIdRequestBod
                     .enum(["automatic", "instant", "microdeposits"])
                     .optional(),
                 }),
-                z.enum([""]),
+                z.literal(""),
               ])
               .optional(),
             bancontact: z
@@ -18947,7 +18944,7 @@ export const s_PostCustomersCustomerSubscriptionsSubscriptionExposedIdRequestBod
                     .enum(["de", "en", "fr", "nl"])
                     .optional(),
                 }),
-                z.enum([""]),
+                z.literal(""),
               ])
               .optional(),
             card: z
@@ -18981,7 +18978,7 @@ export const s_PostCustomersCustomerSubscriptionsSubscriptionExposedIdRequestBod
                     .enum(["any", "automatic", "challenge"])
                     .optional(),
                 }),
-                z.enum([""]),
+                z.literal(""),
               ])
               .optional(),
             customer_balance: z
@@ -18997,14 +18994,14 @@ export const s_PostCustomersCustomerSubscriptionsSubscriptionExposedIdRequestBod
                     .optional(),
                   funding_type: z.string().optional(),
                 }),
-                z.enum([""]),
+                z.literal(""),
               ])
               .optional(),
             konbini: z
-              .union([z.record(z.string(), z.unknown()), z.enum([""])])
+              .union([z.record(z.string(), z.unknown()), z.literal("")])
               .optional(),
             sepa_debit: z
-              .union([z.record(z.string(), z.unknown()), z.enum([""])])
+              .union([z.record(z.string(), z.unknown()), z.literal("")])
               .optional(),
             us_bank_account: z
               .union([
@@ -19039,7 +19036,7 @@ export const s_PostCustomersCustomerSubscriptionsSubscriptionExposedIdRequestBod
                     .enum(["automatic", "instant", "microdeposits"])
                     .optional(),
                 }),
-                z.enum([""]),
+                z.literal(""),
               ])
               .optional(),
           })
@@ -19089,7 +19086,7 @@ export const s_PostCustomersCustomerSubscriptionsSubscriptionExposedIdRequestBod
                 "wechat_pay",
               ]),
             ),
-            z.enum([""]),
+            z.literal(""),
           ])
           .optional(),
         save_default_payment_method: z
@@ -19103,7 +19100,7 @@ export const s_PostCustomersCustomerSubscriptionsSubscriptionExposedIdRequestBod
           interval: z.enum(["day", "month", "week", "year"]),
           interval_count: z.coerce.number().optional(),
         }),
-        z.enum([""]),
+        z.literal(""),
       ])
       .optional(),
     proration_behavior: z
@@ -19116,10 +19113,10 @@ export const s_PostCustomersCustomerSubscriptionsSubscriptionExposedIdRequestBod
           amount_percent: z.coerce.number().optional(),
           destination: z.string(),
         }),
-        z.enum([""]),
+        z.literal(""),
       ])
       .optional(),
-    trial_end: z.union([z.enum(["now"]), z.coerce.number()]).optional(),
+    trial_end: z.union([z.literal("now"), z.coerce.number()]).optional(),
     trial_from_plan: PermissiveBoolean.optional(),
     trial_settings: z
       .object({
@@ -19139,7 +19136,7 @@ export const s_tax_id: z.ZodType<t_tax_id> = z.object({
     .optional(),
   id: z.string().max(5000),
   livemode: PermissiveBoolean,
-  object: z.enum(["tax_id"]),
+  object: z.literal("tax_id"),
   owner: z
     .lazy(() => s_tax_i_ds_owner)
     .nullable()
@@ -19402,45 +19399,45 @@ export const s_PostDisputesDisputeRequestBody = z.object({
                 disputed_transaction: z
                   .object({
                     customer_account_id: z
-                      .union([z.string().max(5000), z.enum([""])])
+                      .union([z.string().max(5000), z.literal("")])
                       .optional(),
                     customer_device_fingerprint: z
-                      .union([z.string().max(5000), z.enum([""])])
+                      .union([z.string().max(5000), z.literal("")])
                       .optional(),
                     customer_device_id: z
-                      .union([z.string().max(5000), z.enum([""])])
+                      .union([z.string().max(5000), z.literal("")])
                       .optional(),
                     customer_email_address: z
-                      .union([z.string().max(5000), z.enum([""])])
+                      .union([z.string().max(5000), z.literal("")])
                       .optional(),
                     customer_purchase_ip: z
-                      .union([z.string().max(5000), z.enum([""])])
+                      .union([z.string().max(5000), z.literal("")])
                       .optional(),
                     merchandise_or_services: z
                       .enum(["merchandise", "services"])
                       .optional(),
                     product_description: z
-                      .union([z.string().max(5000), z.enum([""])])
+                      .union([z.string().max(5000), z.literal("")])
                       .optional(),
                     shipping_address: z
                       .object({
                         city: z
-                          .union([z.string().max(5000), z.enum([""])])
+                          .union([z.string().max(5000), z.literal("")])
                           .optional(),
                         country: z
-                          .union([z.string().max(5000), z.enum([""])])
+                          .union([z.string().max(5000), z.literal("")])
                           .optional(),
                         line1: z
-                          .union([z.string().max(5000), z.enum([""])])
+                          .union([z.string().max(5000), z.literal("")])
                           .optional(),
                         line2: z
-                          .union([z.string().max(5000), z.enum([""])])
+                          .union([z.string().max(5000), z.literal("")])
                           .optional(),
                         postal_code: z
-                          .union([z.string().max(5000), z.enum([""])])
+                          .union([z.string().max(5000), z.literal("")])
                           .optional(),
                         state: z
-                          .union([z.string().max(5000), z.enum([""])])
+                          .union([z.string().max(5000), z.literal("")])
                           .optional(),
                       })
                       .optional(),
@@ -19451,42 +19448,42 @@ export const s_PostDisputesDisputeRequestBody = z.object({
                     z.object({
                       charge: z.string().max(5000),
                       customer_account_id: z
-                        .union([z.string().max(5000), z.enum([""])])
+                        .union([z.string().max(5000), z.literal("")])
                         .optional(),
                       customer_device_fingerprint: z
-                        .union([z.string().max(5000), z.enum([""])])
+                        .union([z.string().max(5000), z.literal("")])
                         .optional(),
                       customer_device_id: z
-                        .union([z.string().max(5000), z.enum([""])])
+                        .union([z.string().max(5000), z.literal("")])
                         .optional(),
                       customer_email_address: z
-                        .union([z.string().max(5000), z.enum([""])])
+                        .union([z.string().max(5000), z.literal("")])
                         .optional(),
                       customer_purchase_ip: z
-                        .union([z.string().max(5000), z.enum([""])])
+                        .union([z.string().max(5000), z.literal("")])
                         .optional(),
                       product_description: z
-                        .union([z.string().max(5000), z.enum([""])])
+                        .union([z.string().max(5000), z.literal("")])
                         .optional(),
                       shipping_address: z
                         .object({
                           city: z
-                            .union([z.string().max(5000), z.enum([""])])
+                            .union([z.string().max(5000), z.literal("")])
                             .optional(),
                           country: z
-                            .union([z.string().max(5000), z.enum([""])])
+                            .union([z.string().max(5000), z.literal("")])
                             .optional(),
                           line1: z
-                            .union([z.string().max(5000), z.enum([""])])
+                            .union([z.string().max(5000), z.literal("")])
                             .optional(),
                           line2: z
-                            .union([z.string().max(5000), z.enum([""])])
+                            .union([z.string().max(5000), z.literal("")])
                             .optional(),
                           postal_code: z
-                            .union([z.string().max(5000), z.enum([""])])
+                            .union([z.string().max(5000), z.literal("")])
                             .optional(),
                           state: z
-                            .union([z.string().max(5000), z.enum([""])])
+                            .union([z.string().max(5000), z.literal("")])
                             .optional(),
                         })
                         .optional(),
@@ -19499,7 +19496,7 @@ export const s_PostDisputesDisputeRequestBody = z.object({
               .object({fee_acknowledged: PermissiveBoolean.optional()})
               .optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       product_description: z.string().max(20000).optional(),
@@ -19520,7 +19517,7 @@ export const s_PostDisputesDisputeRequestBody = z.object({
     .optional(),
   expand: z.array(z.string().max(5000)).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   submit: PermissiveBoolean.optional(),
 })
@@ -19540,7 +19537,7 @@ export const s_PostEntitlementsFeaturesIdRequestBody = z.object({
   active: PermissiveBoolean.optional(),
   expand: z.array(z.string().max(5000)).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   name: z.string().max(80).optional(),
 })
@@ -19579,7 +19576,7 @@ export const s_PostExternalAccountsIdRequestBody = z.object({
   exp_year: z.string().max(5000).optional(),
   expand: z.array(z.string().max(5000)).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   name: z.string().max(5000).optional(),
 })
@@ -19592,7 +19589,7 @@ export const s_file_link: z.ZodType<t_file_link> = z.object({
   id: z.string().max(5000),
   livemode: PermissiveBoolean,
   metadata: z.record(z.string(), z.string().max(500)),
-  object: z.enum(["file_link"]),
+  object: z.literal("file_link"),
   url: z.string().max(5000).nullable().optional(),
 })
 
@@ -19601,17 +19598,17 @@ export const s_PostFileLinksRequestBody = z.object({
   expires_at: z.coerce.number().optional(),
   file: z.string().max(5000),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
 })
 
 export const s_PostFileLinksLinkRequestBody = z.object({
   expand: z.array(z.string().max(5000)).optional(),
   expires_at: z
-    .union([z.enum(["now"]), z.coerce.number(), z.enum([""])])
+    .union([z.literal("now"), z.coerce.number(), z.literal("")])
     .optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
 })
 
@@ -19624,12 +19621,12 @@ export const s_file: z.ZodType<t_file> = z.object({
     .object({
       data: z.array(z.lazy(() => s_file_link)),
       has_more: PermissiveBoolean,
-      object: z.enum(["list"]),
+      object: z.literal("list"),
       url: z.string().max(5000).regex(new RegExp("^/v1/file_links")),
     })
     .nullable()
     .optional(),
-  object: z.enum(["file"]),
+  object: z.literal("file"),
   purpose: z.enum([
     "account_requirement",
     "additional_verification",
@@ -19672,7 +19669,7 @@ export const s_financial_connections_account: z.ZodType<t_financial_connections_
     institution_name: z.string().max(5000),
     last4: z.string().max(5000).nullable().optional(),
     livemode: PermissiveBoolean,
-    object: z.enum(["financial_connections.account"]),
+    object: z.literal("financial_connections.account"),
     ownership: z
       .union([z.string().max(5000), s_financial_connections_account_ownership])
       .nullable()
@@ -19695,10 +19692,7 @@ export const s_financial_connections_account: z.ZodType<t_financial_connections_
       "other",
       "savings",
     ]),
-    subscriptions: z
-      .array(z.enum(["transactions"]))
-      .nullable()
-      .optional(),
+    subscriptions: z.array(z.literal("transactions")).nullable().optional(),
     supported_payment_method_types: z.array(
       z.enum(["link", "us_bank_account"]),
     ),
@@ -19719,13 +19713,13 @@ export const s_PostFinancialConnectionsAccountsAccountRefreshRequestBody =
 export const s_PostFinancialConnectionsAccountsAccountSubscribeRequestBody =
   z.object({
     expand: z.array(z.string().max(5000)).optional(),
-    features: z.array(z.enum(["transactions"])),
+    features: z.array(z.literal("transactions")),
   })
 
 export const s_PostFinancialConnectionsAccountsAccountUnsubscribeRequestBody =
   z.object({
     expand: z.array(z.string().max(5000)).optional(),
-    features: z.array(z.enum(["transactions"])),
+    features: z.array(z.literal("transactions")),
   })
 
 export const s_PostFinancialConnectionsSessionsRequestBody = z.object({
@@ -19769,7 +19763,7 @@ export const s_financial_connections_session: z.ZodType<t_financial_connections_
     accounts: z.object({
       data: z.array(z.lazy(() => s_financial_connections_account)),
       has_more: PermissiveBoolean,
-      object: z.enum(["list"]),
+      object: z.literal("list"),
       url: z
         .string()
         .max(5000)
@@ -19780,7 +19774,7 @@ export const s_financial_connections_session: z.ZodType<t_financial_connections_
       s_bank_connections_resource_link_account_session_filters.optional(),
     id: z.string().max(5000),
     livemode: PermissiveBoolean,
-    object: z.enum(["financial_connections.session"]),
+    object: z.literal("financial_connections.session"),
     permissions: z.array(
       z.enum(["balances", "ownership", "payment_method", "transactions"]),
     ),
@@ -19833,7 +19827,7 @@ export const s_PostIdentityVerificationSessionsRequestBody = z.object({
             require_live_capture: PermissiveBoolean.optional(),
             require_matching_selfie: PermissiveBoolean.optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
     })
@@ -19865,7 +19859,7 @@ export const s_PostIdentityVerificationSessionsSessionRequestBody = z.object({
             require_live_capture: PermissiveBoolean.optional(),
             require_matching_selfie: PermissiveBoolean.optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
     })
@@ -19895,7 +19889,7 @@ export const s_invoice_payment: z.ZodType<t_invoice_payment> = z.object({
   ]),
   is_default: PermissiveBoolean,
   livemode: PermissiveBoolean,
-  object: z.enum(["invoice_payment"]),
+  object: z.literal("invoice_payment"),
   payment: z.lazy(() => s_invoices_payments_invoice_payment_associated_payment),
   status: z.string().max(5000),
   status_transitions: s_invoices_payments_invoice_payment_status_transitions,
@@ -19929,7 +19923,7 @@ export const s_invoiceitem: z.ZodType<t_invoiceitem> = z.object({
     .optional(),
   livemode: PermissiveBoolean,
   metadata: z.record(z.string(), z.string().max(500)).nullable().optional(),
-  object: z.enum(["invoiceitem"]),
+  object: z.literal("invoiceitem"),
   parent: s_billing_bill_resource_invoice_item_parents_invoice_item_parent
     .nullable()
     .optional(),
@@ -19961,13 +19955,13 @@ export const s_PostInvoiceitemsRequestBody = z.object({
           promotion_code: z.string().max(5000).optional(),
         }),
       ),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   expand: z.array(z.string().max(5000)).optional(),
   invoice: z.string().max(5000).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   period: z
     .object({end: z.coerce.number(), start: z.coerce.number()})
@@ -19987,7 +19981,7 @@ export const s_PostInvoiceitemsRequestBody = z.object({
   quantity: z.coerce.number().optional(),
   subscription: z.string().max(5000).optional(),
   tax_behavior: z.enum(["exclusive", "inclusive", "unspecified"]).optional(),
-  tax_code: z.union([z.string(), z.enum([""])]).optional(),
+  tax_code: z.union([z.string(), z.literal("")]).optional(),
   tax_rates: z.array(z.string().max(5000)).optional(),
   unit_amount_decimal: z.string().optional(),
 })
@@ -20005,12 +19999,12 @@ export const s_PostInvoiceitemsInvoiceitemRequestBody = z.object({
           promotion_code: z.string().max(5000).optional(),
         }),
       ),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   expand: z.array(z.string().max(5000)).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   period: z
     .object({end: z.coerce.number(), start: z.coerce.number()})
@@ -20029,8 +20023,8 @@ export const s_PostInvoiceitemsInvoiceitemRequestBody = z.object({
   pricing: z.object({price: z.string().max(5000).optional()}).optional(),
   quantity: z.coerce.number().optional(),
   tax_behavior: z.enum(["exclusive", "inclusive", "unspecified"]).optional(),
-  tax_code: z.union([z.string(), z.enum([""])]).optional(),
-  tax_rates: z.union([z.array(z.string().max(5000)), z.enum([""])]).optional(),
+  tax_code: z.union([z.string(), z.literal("")]).optional(),
+  tax_rates: z.union([z.array(z.string().max(5000)), z.literal("")]).optional(),
   unit_amount_decimal: z.string().optional(),
 })
 
@@ -20141,14 +20135,14 @@ export const s_invoice: z.ZodType<t_invoice> = z.object({
   lines: z.object({
     data: z.array(z.lazy(() => s_line_item)),
     has_more: PermissiveBoolean,
-    object: z.enum(["list"]),
+    object: z.literal("list"),
     url: z.string().max(5000),
   }),
   livemode: PermissiveBoolean,
   metadata: z.record(z.string(), z.string().max(500)).nullable().optional(),
   next_payment_attempt: z.coerce.number().nullable().optional(),
   number: z.string().max(5000).nullable().optional(),
-  object: z.enum(["invoice"]),
+  object: z.literal("invoice"),
   on_behalf_of: z
     .union([z.string().max(5000), z.lazy(() => s_account)])
     .nullable()
@@ -20162,7 +20156,7 @@ export const s_invoice: z.ZodType<t_invoice> = z.object({
     .object({
       data: z.array(z.lazy(() => s_invoice_payment)),
       has_more: PermissiveBoolean,
-      object: z.enum(["list"]),
+      object: z.literal("list"),
       url: z.string().max(5000),
     })
     .optional(),
@@ -20207,7 +20201,7 @@ export const s_invoice: z.ZodType<t_invoice> = z.object({
 
 export const s_PostInvoicesRequestBody = z.object({
   account_tax_ids: z
-    .union([z.array(z.string().max(5000)), z.enum([""])])
+    .union([z.array(z.string().max(5000)), z.literal("")])
     .optional(),
   application_fee_amount: z.coerce.number().optional(),
   auto_advance: PermissiveBoolean.optional(),
@@ -20230,7 +20224,7 @@ export const s_PostInvoicesRequestBody = z.object({
   custom_fields: z
     .union([
       z.array(z.object({name: z.string().max(40), value: z.string().max(140)})),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   customer: z.string().max(5000).optional(),
@@ -20248,7 +20242,7 @@ export const s_PostInvoicesRequestBody = z.object({
           promotion_code: z.string().max(5000).optional(),
         }),
       ),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   due_date: z.coerce.number().optional(),
@@ -20256,19 +20250,21 @@ export const s_PostInvoicesRequestBody = z.object({
   expand: z.array(z.string().max(5000)).optional(),
   footer: z.string().max(5000).optional(),
   from_invoice: z
-    .object({action: z.enum(["revision"]), invoice: z.string().max(5000)})
+    .object({action: z.literal("revision"), invoice: z.string().max(5000)})
     .optional(),
   issuer: z
     .object({account: z.string().optional(), type: z.enum(["account", "self"])})
     .optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   number: z.string().max(26).optional(),
   on_behalf_of: z.string().optional(),
   payment_settings: z
     .object({
-      default_mandate: z.union([z.string().max(5000), z.enum([""])]).optional(),
+      default_mandate: z
+        .union([z.string().max(5000), z.literal("")])
+        .optional(),
       payment_method_options: z
         .object({
           acss_debit: z
@@ -20285,7 +20281,7 @@ export const s_PostInvoicesRequestBody = z.object({
                   .enum(["automatic", "instant", "microdeposits"])
                   .optional(),
               }),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
           bancontact: z
@@ -20293,7 +20289,7 @@ export const s_PostInvoicesRequestBody = z.object({
               z.object({
                 preferred_language: z.enum(["de", "en", "fr", "nl"]).optional(),
               }),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
           card: z
@@ -20306,10 +20302,10 @@ export const s_PostInvoicesRequestBody = z.object({
                       .union([
                         z.object({
                           count: z.coerce.number().optional(),
-                          interval: z.enum(["month"]).optional(),
+                          interval: z.literal("month").optional(),
                           type: z.enum(["bonus", "fixed_count", "revolving"]),
                         }),
-                        z.enum([""]),
+                        z.literal(""),
                       ])
                       .optional(),
                   })
@@ -20318,7 +20314,7 @@ export const s_PostInvoicesRequestBody = z.object({
                   .enum(["any", "automatic", "challenge"])
                   .optional(),
               }),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
           customer_balance: z
@@ -20334,14 +20330,14 @@ export const s_PostInvoicesRequestBody = z.object({
                   .optional(),
                 funding_type: z.string().optional(),
               }),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
           konbini: z
-            .union([z.record(z.string(), z.unknown()), z.enum([""])])
+            .union([z.record(z.string(), z.unknown()), z.literal("")])
             .optional(),
           sepa_debit: z
-            .union([z.record(z.string(), z.unknown()), z.enum([""])])
+            .union([z.record(z.string(), z.unknown()), z.literal("")])
             .optional(),
           us_bank_account: z
             .union([
@@ -20374,7 +20370,7 @@ export const s_PostInvoicesRequestBody = z.object({
                   .enum(["automatic", "instant", "microdeposits"])
                   .optional(),
               }),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
         })
@@ -20424,7 +20420,7 @@ export const s_PostInvoicesRequestBody = z.object({
               "wechat_pay",
             ]),
           ),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
     })
@@ -20439,7 +20435,7 @@ export const s_PostInvoicesRequestBody = z.object({
         .object({page_size: z.enum(["a4", "auto", "letter"]).optional()})
         .optional(),
       template: z.string().max(5000).optional(),
-      template_version: z.union([z.coerce.number(), z.enum([""])]).optional(),
+      template_version: z.union([z.coerce.number(), z.literal("")]).optional(),
     })
     .optional(),
   shipping_cost: z
@@ -20498,7 +20494,7 @@ export const s_PostInvoicesRequestBody = z.object({
             .enum(["exclusive", "inclusive", "unspecified"])
             .optional(),
           tax_code: z.string().optional(),
-          type: z.enum(["fixed_amount"]).optional(),
+          type: z.literal("fixed_amount").optional(),
         })
         .optional(),
     })
@@ -20514,7 +20510,7 @@ export const s_PostInvoicesRequestBody = z.object({
         state: z.string().max(5000).optional(),
       }),
       name: z.string().max(5000),
-      phone: z.union([z.string().max(5000), z.enum([""])]).optional(),
+      phone: z.union([z.string().max(5000), z.literal("")]).optional(),
     })
     .optional(),
   statement_descriptor: z.string().max(22).optional(),
@@ -20550,7 +20546,7 @@ export const s_PostInvoicesCreatePreviewRequestBody = z.object({
             postal_code: z.string().max(5000).optional(),
             state: z.string().max(5000).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       shipping: z
@@ -20567,11 +20563,11 @@ export const s_PostInvoicesCreatePreviewRequestBody = z.object({
             name: z.string().max(5000),
             phone: z.string().max(5000).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       tax: z
-        .object({ip_address: z.union([z.string(), z.enum([""])]).optional()})
+        .object({ip_address: z.union([z.string(), z.literal("")]).optional()})
         .optional(),
       tax_exempt: z.enum(["", "exempt", "none", "reverse"]).optional(),
       tax_ids: z
@@ -20704,7 +20700,7 @@ export const s_PostInvoicesCreatePreviewRequestBody = z.object({
           promotion_code: z.string().max(5000).optional(),
         }),
       ),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   expand: z.array(z.string().max(5000)).optional(),
@@ -20724,12 +20720,12 @@ export const s_PostInvoicesCreatePreviewRequestBody = z.object({
                 promotion_code: z.string().max(5000).optional(),
               }),
             ),
-            z.enum([""]),
+            z.literal(""),
           ])
           .optional(),
         invoiceitem: z.string().max(5000).optional(),
         metadata: z
-          .union([z.record(z.string(), z.string()), z.enum([""])])
+          .union([z.record(z.string(), z.string()), z.literal("")])
           .optional(),
         period: z
           .object({end: z.coerce.number(), start: z.coerce.number()})
@@ -20750,9 +20746,9 @@ export const s_PostInvoicesCreatePreviewRequestBody = z.object({
         tax_behavior: z
           .enum(["exclusive", "inclusive", "unspecified"])
           .optional(),
-        tax_code: z.union([z.string(), z.enum([""])]).optional(),
+        tax_code: z.union([z.string(), z.literal("")]).optional(),
         tax_rates: z
-          .union([z.array(z.string().max(5000)), z.enum([""])])
+          .union([z.array(z.string().max(5000)), z.literal("")])
           .optional(),
         unit_amount: z.coerce.number().optional(),
         unit_amount_decimal: z.string().optional(),
@@ -20762,7 +20758,7 @@ export const s_PostInvoicesCreatePreviewRequestBody = z.object({
   issuer: z
     .object({account: z.string().optional(), type: z.enum(["account", "self"])})
     .optional(),
-  on_behalf_of: z.union([z.string(), z.enum([""])]).optional(),
+  on_behalf_of: z.union([z.string(), z.literal("")]).optional(),
   preview_mode: z.enum(["next", "recurring"]).optional(),
   schedule: z.string().max(5000).optional(),
   schedule_details: z
@@ -20800,7 +20796,7 @@ export const s_PostInvoicesCreatePreviewRequestBody = z.object({
                     .optional(),
                   quantity: z.coerce.number().optional(),
                   tax_rates: z
-                    .union([z.array(z.string().max(5000)), z.enum([""])])
+                    .union([z.array(z.string().max(5000)), z.literal("")])
                     .optional(),
                 }),
               )
@@ -20826,7 +20822,7 @@ export const s_PostInvoicesCreatePreviewRequestBody = z.object({
                   amount_gte: z.coerce.number().optional(),
                   reset_billing_cycle_anchor: PermissiveBoolean.optional(),
                 }),
-                z.enum([""]),
+                z.literal(""),
               ])
               .optional(),
             collection_method: z
@@ -20834,10 +20830,10 @@ export const s_PostInvoicesCreatePreviewRequestBody = z.object({
               .optional(),
             default_payment_method: z.string().max(5000).optional(),
             default_tax_rates: z
-              .union([z.array(z.string().max(5000)), z.enum([""])])
+              .union([z.array(z.string().max(5000)), z.literal("")])
               .optional(),
             description: z
-              .union([z.string().max(500), z.enum([""])])
+              .union([z.string().max(500), z.literal("")])
               .optional(),
             discounts: z
               .union([
@@ -20848,7 +20844,7 @@ export const s_PostInvoicesCreatePreviewRequestBody = z.object({
                     promotion_code: z.string().max(5000).optional(),
                   }),
                 ),
-                z.enum([""]),
+                z.literal(""),
               ])
               .optional(),
             duration: z
@@ -20857,11 +20853,11 @@ export const s_PostInvoicesCreatePreviewRequestBody = z.object({
                 interval_count: z.coerce.number().optional(),
               })
               .optional(),
-            end_date: z.union([z.coerce.number(), z.enum(["now"])]).optional(),
+            end_date: z.union([z.coerce.number(), z.literal("now")]).optional(),
             invoice_settings: z
               .object({
                 account_tax_ids: z
-                  .union([z.array(z.string().max(5000)), z.enum([""])])
+                  .union([z.array(z.string().max(5000)), z.literal("")])
                   .optional(),
                 days_until_due: z.coerce.number().optional(),
                 issuer: z
@@ -20877,7 +20873,7 @@ export const s_PostInvoicesCreatePreviewRequestBody = z.object({
                 billing_thresholds: z
                   .union([
                     z.object({usage_gte: z.coerce.number()}),
-                    z.enum([""]),
+                    z.literal(""),
                   ])
                   .optional(),
                 discounts: z
@@ -20889,7 +20885,7 @@ export const s_PostInvoicesCreatePreviewRequestBody = z.object({
                         promotion_code: z.string().max(5000).optional(),
                       }),
                     ),
-                    z.enum([""]),
+                    z.literal(""),
                   ])
                   .optional(),
                 metadata: z.record(z.string(), z.string()).optional(),
@@ -20911,7 +20907,7 @@ export const s_PostInvoicesCreatePreviewRequestBody = z.object({
                   .optional(),
                 quantity: z.coerce.number().optional(),
                 tax_rates: z
-                  .union([z.array(z.string().max(5000)), z.enum([""])])
+                  .union([z.array(z.string().max(5000)), z.literal("")])
                   .optional(),
               }),
             ),
@@ -20922,7 +20918,7 @@ export const s_PostInvoicesCreatePreviewRequestBody = z.object({
               .enum(["always_invoice", "create_prorations", "none"])
               .optional(),
             start_date: z
-              .union([z.coerce.number(), z.enum(["now"])])
+              .union([z.coerce.number(), z.literal("now")])
               .optional(),
             transfer_data: z
               .object({
@@ -20931,7 +20927,9 @@ export const s_PostInvoicesCreatePreviewRequestBody = z.object({
               })
               .optional(),
             trial: PermissiveBoolean.optional(),
-            trial_end: z.union([z.coerce.number(), z.enum(["now"])]).optional(),
+            trial_end: z
+              .union([z.coerce.number(), z.literal("now")])
+              .optional(),
           }),
         )
         .optional(),
@@ -20952,20 +20950,20 @@ export const s_PostInvoicesCreatePreviewRequestBody = z.object({
       cancel_at: z
         .union([
           z.coerce.number(),
-          z.enum([""]),
+          z.literal(""),
           z.enum(["max_period_end", "min_period_end"]),
         ])
         .optional(),
       cancel_at_period_end: PermissiveBoolean.optional(),
       cancel_now: PermissiveBoolean.optional(),
       default_tax_rates: z
-        .union([z.array(z.string().max(5000)), z.enum([""])])
+        .union([z.array(z.string().max(5000)), z.literal("")])
         .optional(),
       items: z
         .array(
           z.object({
             billing_thresholds: z
-              .union([z.object({usage_gte: z.coerce.number()}), z.enum([""])])
+              .union([z.object({usage_gte: z.coerce.number()}), z.literal("")])
               .optional(),
             clear_usage: PermissiveBoolean.optional(),
             deleted: PermissiveBoolean.optional(),
@@ -20978,12 +20976,12 @@ export const s_PostInvoicesCreatePreviewRequestBody = z.object({
                     promotion_code: z.string().max(5000).optional(),
                   }),
                 ),
-                z.enum([""]),
+                z.literal(""),
               ])
               .optional(),
             id: z.string().max(5000).optional(),
             metadata: z
-              .union([z.record(z.string(), z.string()), z.enum([""])])
+              .union([z.record(z.string(), z.string()), z.literal("")])
               .optional(),
             price: z.string().max(5000).optional(),
             price_data: z
@@ -21003,7 +21001,7 @@ export const s_PostInvoicesCreatePreviewRequestBody = z.object({
               .optional(),
             quantity: z.coerce.number().optional(),
             tax_rates: z
-              .union([z.array(z.string().max(5000)), z.enum([""])])
+              .union([z.array(z.string().max(5000)), z.literal("")])
               .optional(),
           }),
         )
@@ -21012,16 +21010,16 @@ export const s_PostInvoicesCreatePreviewRequestBody = z.object({
         .enum(["always_invoice", "create_prorations", "none"])
         .optional(),
       proration_date: z.coerce.number().optional(),
-      resume_at: z.enum(["now"]).optional(),
+      resume_at: z.literal("now").optional(),
       start_date: z.coerce.number().optional(),
-      trial_end: z.union([z.enum(["now"]), z.coerce.number()]).optional(),
+      trial_end: z.union([z.literal("now"), z.coerce.number()]).optional(),
     })
     .optional(),
 })
 
 export const s_PostInvoicesInvoiceRequestBody = z.object({
   account_tax_ids: z
-    .union([z.array(z.string().max(5000)), z.enum([""])])
+    .union([z.array(z.string().max(5000)), z.literal("")])
     .optional(),
   application_fee_amount: z.coerce.number().optional(),
   auto_advance: PermissiveBoolean.optional(),
@@ -21043,14 +21041,14 @@ export const s_PostInvoicesInvoiceRequestBody = z.object({
   custom_fields: z
     .union([
       z.array(z.object({name: z.string().max(40), value: z.string().max(140)})),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   days_until_due: z.coerce.number().optional(),
   default_payment_method: z.string().max(5000).optional(),
-  default_source: z.union([z.string().max(5000), z.enum([""])]).optional(),
+  default_source: z.union([z.string().max(5000), z.literal("")]).optional(),
   default_tax_rates: z
-    .union([z.array(z.string().max(5000)), z.enum([""])])
+    .union([z.array(z.string().max(5000)), z.literal("")])
     .optional(),
   description: z.string().max(1500).optional(),
   discounts: z
@@ -21062,24 +21060,26 @@ export const s_PostInvoicesInvoiceRequestBody = z.object({
           promotion_code: z.string().max(5000).optional(),
         }),
       ),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   due_date: z.coerce.number().optional(),
-  effective_at: z.union([z.coerce.number(), z.enum([""])]).optional(),
+  effective_at: z.union([z.coerce.number(), z.literal("")]).optional(),
   expand: z.array(z.string().max(5000)).optional(),
   footer: z.string().max(5000).optional(),
   issuer: z
     .object({account: z.string().optional(), type: z.enum(["account", "self"])})
     .optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
-  number: z.union([z.string().max(26), z.enum([""])]).optional(),
-  on_behalf_of: z.union([z.string(), z.enum([""])]).optional(),
+  number: z.union([z.string().max(26), z.literal("")]).optional(),
+  on_behalf_of: z.union([z.string(), z.literal("")]).optional(),
   payment_settings: z
     .object({
-      default_mandate: z.union([z.string().max(5000), z.enum([""])]).optional(),
+      default_mandate: z
+        .union([z.string().max(5000), z.literal("")])
+        .optional(),
       payment_method_options: z
         .object({
           acss_debit: z
@@ -21096,7 +21096,7 @@ export const s_PostInvoicesInvoiceRequestBody = z.object({
                   .enum(["automatic", "instant", "microdeposits"])
                   .optional(),
               }),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
           bancontact: z
@@ -21104,7 +21104,7 @@ export const s_PostInvoicesInvoiceRequestBody = z.object({
               z.object({
                 preferred_language: z.enum(["de", "en", "fr", "nl"]).optional(),
               }),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
           card: z
@@ -21117,10 +21117,10 @@ export const s_PostInvoicesInvoiceRequestBody = z.object({
                       .union([
                         z.object({
                           count: z.coerce.number().optional(),
-                          interval: z.enum(["month"]).optional(),
+                          interval: z.literal("month").optional(),
                           type: z.enum(["bonus", "fixed_count", "revolving"]),
                         }),
-                        z.enum([""]),
+                        z.literal(""),
                       ])
                       .optional(),
                   })
@@ -21129,7 +21129,7 @@ export const s_PostInvoicesInvoiceRequestBody = z.object({
                   .enum(["any", "automatic", "challenge"])
                   .optional(),
               }),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
           customer_balance: z
@@ -21145,14 +21145,14 @@ export const s_PostInvoicesInvoiceRequestBody = z.object({
                   .optional(),
                 funding_type: z.string().optional(),
               }),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
           konbini: z
-            .union([z.record(z.string(), z.unknown()), z.enum([""])])
+            .union([z.record(z.string(), z.unknown()), z.literal("")])
             .optional(),
           sepa_debit: z
-            .union([z.record(z.string(), z.unknown()), z.enum([""])])
+            .union([z.record(z.string(), z.unknown()), z.literal("")])
             .optional(),
           us_bank_account: z
             .union([
@@ -21185,7 +21185,7 @@ export const s_PostInvoicesInvoiceRequestBody = z.object({
                   .enum(["automatic", "instant", "microdeposits"])
                   .optional(),
               }),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
         })
@@ -21235,7 +21235,7 @@ export const s_PostInvoicesInvoiceRequestBody = z.object({
               "wechat_pay",
             ]),
           ),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
     })
@@ -21249,7 +21249,7 @@ export const s_PostInvoicesInvoiceRequestBody = z.object({
         .object({page_size: z.enum(["a4", "auto", "letter"]).optional()})
         .optional(),
       template: z.string().max(5000).optional(),
-      template_version: z.union([z.coerce.number(), z.enum([""])]).optional(),
+      template_version: z.union([z.coerce.number(), z.literal("")]).optional(),
     })
     .optional(),
   shipping_cost: z
@@ -21309,11 +21309,11 @@ export const s_PostInvoicesInvoiceRequestBody = z.object({
               .enum(["exclusive", "inclusive", "unspecified"])
               .optional(),
             tax_code: z.string().optional(),
-            type: z.enum(["fixed_amount"]).optional(),
+            type: z.literal("fixed_amount").optional(),
           })
           .optional(),
       }),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   shipping_details: z
@@ -21328,16 +21328,16 @@ export const s_PostInvoicesInvoiceRequestBody = z.object({
           state: z.string().max(5000).optional(),
         }),
         name: z.string().max(5000),
-        phone: z.union([z.string().max(5000), z.enum([""])]).optional(),
+        phone: z.union([z.string().max(5000), z.literal("")]).optional(),
       }),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   statement_descriptor: z.string().max(22).optional(),
   transfer_data: z
     .union([
       z.object({amount: z.coerce.number().optional(), destination: z.string()}),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
 })
@@ -21345,7 +21345,7 @@ export const s_PostInvoicesInvoiceRequestBody = z.object({
 export const s_PostInvoicesInvoiceAddLinesRequestBody = z.object({
   expand: z.array(z.string().max(5000)).optional(),
   invoice_metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   lines: z.array(
     z.object({
@@ -21361,12 +21361,12 @@ export const s_PostInvoicesInvoiceAddLinesRequestBody = z.object({
               promotion_code: z.string().max(5000).optional(),
             }),
           ),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       invoice_item: z.string().max(5000).optional(),
       metadata: z
-        .union([z.record(z.string(), z.string()), z.enum([""])])
+        .union([z.record(z.string(), z.string()), z.literal("")])
         .optional(),
       period: z
         .object({end: z.coerce.number(), start: z.coerce.number()})
@@ -21457,11 +21457,11 @@ export const s_PostInvoicesInvoiceAddLinesRequestBody = z.object({
               taxable_amount: z.coerce.number(),
             }),
           ),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       tax_rates: z
-        .union([z.array(z.string().max(5000)), z.enum([""])])
+        .union([z.array(z.string().max(5000)), z.literal("")])
         .optional(),
     }),
   ),
@@ -21491,7 +21491,7 @@ export const s_line_item: z.ZodType<t_line_item> = z.object({
   invoice: z.string().max(5000).nullable().optional(),
   livemode: PermissiveBoolean,
   metadata: z.record(z.string(), z.string().max(500)),
-  object: z.enum(["line_item"]),
+  object: z.literal("line_item"),
   parent:
     s_billing_bill_resource_invoicing_lines_parents_invoice_line_item_parent
       .nullable()
@@ -21528,12 +21528,12 @@ export const s_PostInvoicesInvoiceLinesLineItemIdRequestBody = z.object({
           promotion_code: z.string().max(5000).optional(),
         }),
       ),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   expand: z.array(z.string().max(5000)).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   period: z
     .object({end: z.coerce.number(), start: z.coerce.number()})
@@ -21624,10 +21624,10 @@ export const s_PostInvoicesInvoiceLinesLineItemIdRequestBody = z.object({
           taxable_amount: z.coerce.number(),
         }),
       ),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
-  tax_rates: z.union([z.array(z.string().max(5000)), z.enum([""])]).optional(),
+  tax_rates: z.union([z.array(z.string().max(5000)), z.literal("")]).optional(),
 })
 
 export const s_PostInvoicesInvoiceMarkUncollectibleRequestBody = z.object({
@@ -21637,7 +21637,7 @@ export const s_PostInvoicesInvoiceMarkUncollectibleRequestBody = z.object({
 export const s_PostInvoicesInvoicePayRequestBody = z.object({
   expand: z.array(z.string().max(5000)).optional(),
   forgive: PermissiveBoolean.optional(),
-  mandate: z.union([z.string().max(5000), z.enum([""])]).optional(),
+  mandate: z.union([z.string().max(5000), z.literal("")]).optional(),
   off_session: PermissiveBoolean.optional(),
   paid_out_of_band: PermissiveBoolean.optional(),
   payment_method: z.string().max(5000).optional(),
@@ -21647,7 +21647,7 @@ export const s_PostInvoicesInvoicePayRequestBody = z.object({
 export const s_PostInvoicesInvoiceRemoveLinesRequestBody = z.object({
   expand: z.array(z.string().max(5000)).optional(),
   invoice_metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   lines: z.array(
     z.object({
@@ -21664,7 +21664,7 @@ export const s_PostInvoicesInvoiceSendRequestBody = z.object({
 export const s_PostInvoicesInvoiceUpdateLinesRequestBody = z.object({
   expand: z.array(z.string().max(5000)).optional(),
   invoice_metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   lines: z.array(
     z.object({
@@ -21680,12 +21680,12 @@ export const s_PostInvoicesInvoiceUpdateLinesRequestBody = z.object({
               promotion_code: z.string().max(5000).optional(),
             }),
           ),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       id: z.string().max(5000),
       metadata: z
-        .union([z.record(z.string(), z.string()), z.enum([""])])
+        .union([z.record(z.string(), z.string()), z.literal("")])
         .optional(),
       period: z
         .object({end: z.coerce.number(), start: z.coerce.number()})
@@ -21776,11 +21776,11 @@ export const s_PostInvoicesInvoiceUpdateLinesRequestBody = z.object({
               taxable_amount: z.coerce.number(),
             }),
           ),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       tax_rates: z
-        .union([z.array(z.string().max(5000)), z.enum([""])])
+        .union([z.array(z.string().max(5000)), z.literal("")])
         .optional(),
     }),
   ),
@@ -21825,7 +21825,7 @@ export const s_issuing_authorization: z.ZodType<t_issuing_authorization> =
     merchant_data: s_issuing_authorization_merchant_data,
     metadata: z.record(z.string(), z.string().max(500)),
     network_data: s_issuing_authorization_network_data.nullable().optional(),
-    object: z.enum(["issuing.authorization"]),
+    object: z.literal("issuing.authorization"),
     pending_request: s_issuing_authorization_pending_request
       .nullable()
       .optional(),
@@ -21845,7 +21845,7 @@ export const s_issuing_authorization: z.ZodType<t_issuing_authorization> =
 export const s_PostIssuingAuthorizationsAuthorizationRequestBody = z.object({
   expand: z.array(z.string().max(5000)).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
 })
 
@@ -21854,7 +21854,7 @@ export const s_PostIssuingAuthorizationsAuthorizationApproveRequestBody =
     amount: z.coerce.number().optional(),
     expand: z.array(z.string().max(5000)).optional(),
     metadata: z
-      .union([z.record(z.string(), z.string()), z.enum([""])])
+      .union([z.record(z.string(), z.string()), z.literal("")])
       .optional(),
   })
 
@@ -21862,7 +21862,7 @@ export const s_PostIssuingAuthorizationsAuthorizationDeclineRequestBody =
   z.object({
     expand: z.array(z.string().max(5000)).optional(),
     metadata: z
-      .union([z.record(z.string(), z.string()), z.enum([""])])
+      .union([z.record(z.string(), z.string()), z.literal("")])
       .optional(),
   })
 
@@ -21879,7 +21879,7 @@ export const s_issuing_cardholder: z.ZodType<t_issuing_cardholder> = z.object({
   livemode: PermissiveBoolean,
   metadata: z.record(z.string(), z.string().max(500)),
   name: z.string().max(5000),
-  object: z.enum(["issuing.cardholder"]),
+  object: z.literal("issuing.cardholder"),
   phone_number: z.string().max(5000).nullable().optional(),
   preferred_locales: z
     .array(z.enum(["de", "en", "es", "fr", "it"]))
@@ -21916,7 +21916,7 @@ export const s_PostIssuingCardholdersRequestBody = z.object({
               date: z.coerce.number().optional(),
               ip: z.string().optional(),
               user_agent: z
-                .union([z.string().max(5000), z.enum([""])])
+                .union([z.string().max(5000), z.literal("")])
                 .optional(),
             })
             .optional(),
@@ -22901,7 +22901,7 @@ export const s_PostIssuingCardholdersCardholderRequestBody = z.object({
               date: z.coerce.number().optional(),
               ip: z.string().optional(),
               user_agent: z
-                .union([z.string().max(5000), z.enum([""])])
+                .union([z.string().max(5000), z.literal("")])
                 .optional(),
             })
             .optional(),
@@ -23877,7 +23877,7 @@ export const s_issuing_card: z.ZodType<t_issuing_card> = z.object({
   livemode: PermissiveBoolean,
   metadata: z.record(z.string(), z.string().max(500)),
   number: z.string().max(5000).optional(),
-  object: z.enum(["issuing.card"]),
+  object: z.literal("issuing.card"),
   personalization_design: z
     .union([
       z.string().max(5000),
@@ -23916,7 +23916,7 @@ export const s_PostIssuingCardsRequestBody = z.object({
   replacement_reason: z
     .enum(["damaged", "expired", "lost", "stolen"])
     .optional(),
-  second_line: z.union([z.string().max(5000), z.enum([""])]).optional(),
+  second_line: z.union([z.string().max(5000), z.literal("")]).optional(),
   shipping: z
     .object({
       address: z.object({
@@ -24878,7 +24878,7 @@ export const s_PostIssuingCardsCardRequestBody = z.object({
   cancellation_reason: z.enum(["lost", "stolen"]).optional(),
   expand: z.array(z.string().max(5000)).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   personalization_design: z.string().max(5000).optional(),
   pin: z.object({encrypted_number: z.string().max(5000).optional()}).optional(),
@@ -25874,7 +25874,7 @@ export const s_issuing_dispute: z.ZodType<t_issuing_dispute> = z.object({
     ])
     .optional(),
   metadata: z.record(z.string(), z.string().max(500)),
-  object: z.enum(["issuing.dispute"]),
+  object: z.literal("issuing.dispute"),
   status: z.enum(["expired", "lost", "submitted", "unsubmitted", "won"]),
   transaction: z.union([
     z.string().max(5000),
@@ -25891,128 +25891,128 @@ export const s_PostIssuingDisputesRequestBody = z.object({
         .union([
           z.object({
             additional_documentation: z
-              .union([z.string(), z.enum([""])])
+              .union([z.string(), z.literal("")])
               .optional(),
-            canceled_at: z.union([z.coerce.number(), z.enum([""])]).optional(),
+            canceled_at: z.union([z.coerce.number(), z.literal("")]).optional(),
             cancellation_policy_provided: z
-              .union([PermissiveBoolean, z.enum([""])])
+              .union([PermissiveBoolean, z.literal("")])
               .optional(),
             cancellation_reason: z
-              .union([z.string().max(2500), z.enum([""])])
+              .union([z.string().max(2500), z.literal("")])
               .optional(),
-            expected_at: z.union([z.coerce.number(), z.enum([""])]).optional(),
+            expected_at: z.union([z.coerce.number(), z.literal("")]).optional(),
             explanation: z
-              .union([z.string().max(2500), z.enum([""])])
+              .union([z.string().max(2500), z.literal("")])
               .optional(),
             product_description: z
-              .union([z.string().max(2500), z.enum([""])])
+              .union([z.string().max(2500), z.literal("")])
               .optional(),
             product_type: z.enum(["", "merchandise", "service"]).optional(),
             return_status: z
               .enum(["", "merchant_rejected", "successful"])
               .optional(),
-            returned_at: z.union([z.coerce.number(), z.enum([""])]).optional(),
+            returned_at: z.union([z.coerce.number(), z.literal("")]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       duplicate: z
         .union([
           z.object({
             additional_documentation: z
-              .union([z.string(), z.enum([""])])
+              .union([z.string(), z.literal("")])
               .optional(),
-            card_statement: z.union([z.string(), z.enum([""])]).optional(),
-            cash_receipt: z.union([z.string(), z.enum([""])]).optional(),
-            check_image: z.union([z.string(), z.enum([""])]).optional(),
+            card_statement: z.union([z.string(), z.literal("")]).optional(),
+            cash_receipt: z.union([z.string(), z.literal("")]).optional(),
+            check_image: z.union([z.string(), z.literal("")]).optional(),
             explanation: z
-              .union([z.string().max(2500), z.enum([""])])
+              .union([z.string().max(2500), z.literal("")])
               .optional(),
             original_transaction: z.string().max(5000).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       fraudulent: z
         .union([
           z.object({
             additional_documentation: z
-              .union([z.string(), z.enum([""])])
+              .union([z.string(), z.literal("")])
               .optional(),
             explanation: z
-              .union([z.string().max(2500), z.enum([""])])
+              .union([z.string().max(2500), z.literal("")])
               .optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       merchandise_not_as_described: z
         .union([
           z.object({
             additional_documentation: z
-              .union([z.string(), z.enum([""])])
+              .union([z.string(), z.literal("")])
               .optional(),
             explanation: z
-              .union([z.string().max(2500), z.enum([""])])
+              .union([z.string().max(2500), z.literal("")])
               .optional(),
-            received_at: z.union([z.coerce.number(), z.enum([""])]).optional(),
+            received_at: z.union([z.coerce.number(), z.literal("")]).optional(),
             return_description: z
-              .union([z.string().max(2500), z.enum([""])])
+              .union([z.string().max(2500), z.literal("")])
               .optional(),
             return_status: z
               .enum(["", "merchant_rejected", "successful"])
               .optional(),
-            returned_at: z.union([z.coerce.number(), z.enum([""])]).optional(),
+            returned_at: z.union([z.coerce.number(), z.literal("")]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       no_valid_authorization: z
         .union([
           z.object({
             additional_documentation: z
-              .union([z.string(), z.enum([""])])
+              .union([z.string(), z.literal("")])
               .optional(),
             explanation: z
-              .union([z.string().max(2500), z.enum([""])])
+              .union([z.string().max(2500), z.literal("")])
               .optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       not_received: z
         .union([
           z.object({
             additional_documentation: z
-              .union([z.string(), z.enum([""])])
+              .union([z.string(), z.literal("")])
               .optional(),
-            expected_at: z.union([z.coerce.number(), z.enum([""])]).optional(),
+            expected_at: z.union([z.coerce.number(), z.literal("")]).optional(),
             explanation: z
-              .union([z.string().max(2500), z.enum([""])])
+              .union([z.string().max(2500), z.literal("")])
               .optional(),
             product_description: z
-              .union([z.string().max(2500), z.enum([""])])
+              .union([z.string().max(2500), z.literal("")])
               .optional(),
             product_type: z.enum(["", "merchandise", "service"]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       other: z
         .union([
           z.object({
             additional_documentation: z
-              .union([z.string(), z.enum([""])])
+              .union([z.string(), z.literal("")])
               .optional(),
             explanation: z
-              .union([z.string().max(2500), z.enum([""])])
+              .union([z.string().max(2500), z.literal("")])
               .optional(),
             product_description: z
-              .union([z.string().max(2500), z.enum([""])])
+              .union([z.string().max(2500), z.literal("")])
               .optional(),
             product_type: z.enum(["", "merchandise", "service"]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       reason: z
@@ -26031,18 +26031,18 @@ export const s_PostIssuingDisputesRequestBody = z.object({
         .union([
           z.object({
             additional_documentation: z
-              .union([z.string(), z.enum([""])])
+              .union([z.string(), z.literal("")])
               .optional(),
-            canceled_at: z.union([z.coerce.number(), z.enum([""])]).optional(),
+            canceled_at: z.union([z.coerce.number(), z.literal("")]).optional(),
             cancellation_reason: z
-              .union([z.string().max(2500), z.enum([""])])
+              .union([z.string().max(2500), z.literal("")])
               .optional(),
             explanation: z
-              .union([z.string().max(2500), z.enum([""])])
+              .union([z.string().max(2500), z.literal("")])
               .optional(),
-            received_at: z.union([z.coerce.number(), z.enum([""])]).optional(),
+            received_at: z.union([z.coerce.number(), z.literal("")]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
     })
@@ -26061,128 +26061,128 @@ export const s_PostIssuingDisputesDisputeRequestBody = z.object({
         .union([
           z.object({
             additional_documentation: z
-              .union([z.string(), z.enum([""])])
+              .union([z.string(), z.literal("")])
               .optional(),
-            canceled_at: z.union([z.coerce.number(), z.enum([""])]).optional(),
+            canceled_at: z.union([z.coerce.number(), z.literal("")]).optional(),
             cancellation_policy_provided: z
-              .union([PermissiveBoolean, z.enum([""])])
+              .union([PermissiveBoolean, z.literal("")])
               .optional(),
             cancellation_reason: z
-              .union([z.string().max(2500), z.enum([""])])
+              .union([z.string().max(2500), z.literal("")])
               .optional(),
-            expected_at: z.union([z.coerce.number(), z.enum([""])]).optional(),
+            expected_at: z.union([z.coerce.number(), z.literal("")]).optional(),
             explanation: z
-              .union([z.string().max(2500), z.enum([""])])
+              .union([z.string().max(2500), z.literal("")])
               .optional(),
             product_description: z
-              .union([z.string().max(2500), z.enum([""])])
+              .union([z.string().max(2500), z.literal("")])
               .optional(),
             product_type: z.enum(["", "merchandise", "service"]).optional(),
             return_status: z
               .enum(["", "merchant_rejected", "successful"])
               .optional(),
-            returned_at: z.union([z.coerce.number(), z.enum([""])]).optional(),
+            returned_at: z.union([z.coerce.number(), z.literal("")]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       duplicate: z
         .union([
           z.object({
             additional_documentation: z
-              .union([z.string(), z.enum([""])])
+              .union([z.string(), z.literal("")])
               .optional(),
-            card_statement: z.union([z.string(), z.enum([""])]).optional(),
-            cash_receipt: z.union([z.string(), z.enum([""])]).optional(),
-            check_image: z.union([z.string(), z.enum([""])]).optional(),
+            card_statement: z.union([z.string(), z.literal("")]).optional(),
+            cash_receipt: z.union([z.string(), z.literal("")]).optional(),
+            check_image: z.union([z.string(), z.literal("")]).optional(),
             explanation: z
-              .union([z.string().max(2500), z.enum([""])])
+              .union([z.string().max(2500), z.literal("")])
               .optional(),
             original_transaction: z.string().max(5000).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       fraudulent: z
         .union([
           z.object({
             additional_documentation: z
-              .union([z.string(), z.enum([""])])
+              .union([z.string(), z.literal("")])
               .optional(),
             explanation: z
-              .union([z.string().max(2500), z.enum([""])])
+              .union([z.string().max(2500), z.literal("")])
               .optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       merchandise_not_as_described: z
         .union([
           z.object({
             additional_documentation: z
-              .union([z.string(), z.enum([""])])
+              .union([z.string(), z.literal("")])
               .optional(),
             explanation: z
-              .union([z.string().max(2500), z.enum([""])])
+              .union([z.string().max(2500), z.literal("")])
               .optional(),
-            received_at: z.union([z.coerce.number(), z.enum([""])]).optional(),
+            received_at: z.union([z.coerce.number(), z.literal("")]).optional(),
             return_description: z
-              .union([z.string().max(2500), z.enum([""])])
+              .union([z.string().max(2500), z.literal("")])
               .optional(),
             return_status: z
               .enum(["", "merchant_rejected", "successful"])
               .optional(),
-            returned_at: z.union([z.coerce.number(), z.enum([""])]).optional(),
+            returned_at: z.union([z.coerce.number(), z.literal("")]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       no_valid_authorization: z
         .union([
           z.object({
             additional_documentation: z
-              .union([z.string(), z.enum([""])])
+              .union([z.string(), z.literal("")])
               .optional(),
             explanation: z
-              .union([z.string().max(2500), z.enum([""])])
+              .union([z.string().max(2500), z.literal("")])
               .optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       not_received: z
         .union([
           z.object({
             additional_documentation: z
-              .union([z.string(), z.enum([""])])
+              .union([z.string(), z.literal("")])
               .optional(),
-            expected_at: z.union([z.coerce.number(), z.enum([""])]).optional(),
+            expected_at: z.union([z.coerce.number(), z.literal("")]).optional(),
             explanation: z
-              .union([z.string().max(2500), z.enum([""])])
+              .union([z.string().max(2500), z.literal("")])
               .optional(),
             product_description: z
-              .union([z.string().max(2500), z.enum([""])])
+              .union([z.string().max(2500), z.literal("")])
               .optional(),
             product_type: z.enum(["", "merchandise", "service"]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       other: z
         .union([
           z.object({
             additional_documentation: z
-              .union([z.string(), z.enum([""])])
+              .union([z.string(), z.literal("")])
               .optional(),
             explanation: z
-              .union([z.string().max(2500), z.enum([""])])
+              .union([z.string().max(2500), z.literal("")])
               .optional(),
             product_description: z
-              .union([z.string().max(2500), z.enum([""])])
+              .union([z.string().max(2500), z.literal("")])
               .optional(),
             product_type: z.enum(["", "merchandise", "service"]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       reason: z
@@ -26201,32 +26201,32 @@ export const s_PostIssuingDisputesDisputeRequestBody = z.object({
         .union([
           z.object({
             additional_documentation: z
-              .union([z.string(), z.enum([""])])
+              .union([z.string(), z.literal("")])
               .optional(),
-            canceled_at: z.union([z.coerce.number(), z.enum([""])]).optional(),
+            canceled_at: z.union([z.coerce.number(), z.literal("")]).optional(),
             cancellation_reason: z
-              .union([z.string().max(2500), z.enum([""])])
+              .union([z.string().max(2500), z.literal("")])
               .optional(),
             explanation: z
-              .union([z.string().max(2500), z.enum([""])])
+              .union([z.string().max(2500), z.literal("")])
               .optional(),
-            received_at: z.union([z.coerce.number(), z.enum([""])]).optional(),
+            received_at: z.union([z.coerce.number(), z.literal("")]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
     })
     .optional(),
   expand: z.array(z.string().max(5000)).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
 })
 
 export const s_PostIssuingDisputesDisputeSubmitRequestBody = z.object({
   expand: z.array(z.string().max(5000)).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
 })
 
@@ -26245,7 +26245,7 @@ export const s_issuing_personalization_design: z.ZodType<t_issuing_personalizati
     lookup_key: z.string().max(5000).nullable().optional(),
     metadata: z.record(z.string(), z.string().max(500)),
     name: z.string().max(5000).nullable().optional(),
-    object: z.enum(["issuing.personalization_design"]),
+    object: z.literal("issuing.personalization_design"),
     physical_bundle: z.union([z.string().max(5000), s_issuing_physical_bundle]),
     preferences: s_issuing_personalization_design_preferences,
     rejection_reasons: s_issuing_personalization_design_rejection_reasons,
@@ -26256,10 +26256,10 @@ export const s_PostIssuingPersonalizationDesignsRequestBody = z.object({
   card_logo: z.string().optional(),
   carrier_text: z
     .object({
-      footer_body: z.union([z.string().max(200), z.enum([""])]).optional(),
-      footer_title: z.union([z.string().max(30), z.enum([""])]).optional(),
-      header_body: z.union([z.string().max(200), z.enum([""])]).optional(),
-      header_title: z.union([z.string().max(30), z.enum([""])]).optional(),
+      footer_body: z.union([z.string().max(200), z.literal("")]).optional(),
+      footer_title: z.union([z.string().max(30), z.literal("")]).optional(),
+      header_body: z.union([z.string().max(200), z.literal("")]).optional(),
+      header_title: z.union([z.string().max(30), z.literal("")]).optional(),
     })
     .optional(),
   expand: z.array(z.string().max(5000)).optional(),
@@ -26273,22 +26273,22 @@ export const s_PostIssuingPersonalizationDesignsRequestBody = z.object({
 
 export const s_PostIssuingPersonalizationDesignsPersonalizationDesignRequestBody =
   z.object({
-    card_logo: z.union([z.string(), z.enum([""])]).optional(),
+    card_logo: z.union([z.string(), z.literal("")]).optional(),
     carrier_text: z
       .union([
         z.object({
-          footer_body: z.union([z.string().max(200), z.enum([""])]).optional(),
-          footer_title: z.union([z.string().max(30), z.enum([""])]).optional(),
-          header_body: z.union([z.string().max(200), z.enum([""])]).optional(),
-          header_title: z.union([z.string().max(30), z.enum([""])]).optional(),
+          footer_body: z.union([z.string().max(200), z.literal("")]).optional(),
+          footer_title: z.union([z.string().max(30), z.literal("")]).optional(),
+          header_body: z.union([z.string().max(200), z.literal("")]).optional(),
+          header_title: z.union([z.string().max(30), z.literal("")]).optional(),
         }),
-        z.enum([""]),
+        z.literal(""),
       ])
       .optional(),
     expand: z.array(z.string().max(5000)).optional(),
-    lookup_key: z.union([z.string().max(200), z.enum([""])]).optional(),
+    lookup_key: z.union([z.string().max(200), z.literal("")]).optional(),
     metadata: z.record(z.string(), z.string()).optional(),
-    name: z.union([z.string().max(200), z.enum([""])]).optional(),
+    name: z.union([z.string().max(200), z.literal("")]).optional(),
     physical_bundle: z.string().max(5000).optional(),
     preferences: z.object({is_default: PermissiveBoolean}).optional(),
     transfer_lookup_key: PermissiveBoolean.optional(),
@@ -26309,7 +26309,7 @@ export const s_issuing_token: z.ZodType<t_issuing_token> = z.object({
   network: z.enum(["mastercard", "visa"]),
   network_data: s_issuing_network_token_network_data.optional(),
   network_updated_at: z.coerce.number(),
-  object: z.enum(["issuing.token"]),
+  object: z.literal("issuing.token"),
   status: z.enum(["active", "deleted", "requested", "suspended"]),
   wallet_provider: z
     .enum(["apple_pay", "google_pay", "samsung_pay"])
@@ -26351,7 +26351,7 @@ export const s_issuing_transaction: z.ZodType<t_issuing_transaction> = z.object(
     merchant_data: s_issuing_authorization_merchant_data,
     metadata: z.record(z.string(), z.string().max(500)),
     network_data: s_issuing_transaction_network_data.nullable().optional(),
-    object: z.enum(["issuing.transaction"]),
+    object: z.literal("issuing.transaction"),
     purchase_details: s_issuing_transaction_purchase_details
       .nullable()
       .optional(),
@@ -26371,7 +26371,7 @@ export const s_issuing_transaction: z.ZodType<t_issuing_transaction> = z.object(
 export const s_PostIssuingTransactionsTransactionRequestBody = z.object({
   expand: z.array(z.string().max(5000)).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
 })
 
@@ -26421,7 +26421,7 @@ export const s_mandate: z.ZodType<t_mandate> = z.object({
   id: z.string().max(5000),
   livemode: PermissiveBoolean,
   multi_use: s_mandate_multi_use.optional(),
-  object: z.enum(["mandate"]),
+  object: z.literal("mandate"),
   on_behalf_of: z.string().max(5000).optional(),
   payment_method: z.union([
     z.string().max(5000),
@@ -26488,7 +26488,7 @@ export const s_payment_intent: z.ZodType<t_payment_intent> = z.object({
   livemode: PermissiveBoolean,
   metadata: z.record(z.string(), z.string().max(500)).optional(),
   next_action: s_payment_intent_next_action.nullable().optional(),
-  object: z.enum(["payment_intent"]),
+  object: z.literal("payment_intent"),
   on_behalf_of: z
     .union([z.string().max(5000), z.lazy(() => s_account)])
     .nullable()
@@ -26567,7 +26567,7 @@ export const s_PostPaymentIntentsRequestBody = z.object({
           type: z.enum(["offline", "online"]),
         }),
       }),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   metadata: z.record(z.string(), z.string()).optional(),
@@ -26618,12 +26618,12 @@ export const s_PostPaymentIntentsRequestBody = z.object({
                 postal_code: z.string().max(5000).optional(),
                 state: z.string().max(5000).optional(),
               }),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
-          email: z.union([z.string(), z.enum([""])]).optional(),
-          name: z.union([z.string().max(5000), z.enum([""])]).optional(),
-          phone: z.union([z.string().max(5000), z.enum([""])]).optional(),
+          email: z.union([z.string(), z.literal("")]).optional(),
+          name: z.union([z.string().max(5000), z.literal("")]).optional(),
+          phone: z.union([z.string().max(5000), z.literal("")]).optional(),
           tax_id: z.string().max(5000).optional(),
         })
         .optional(),
@@ -26878,7 +26878,7 @@ export const s_PostPaymentIntentsRequestBody = z.object({
             mandate_options: z
               .object({
                 custom_mandate_url: z
-                  .union([z.string(), z.enum([""])])
+                  .union([z.string(), z.literal("")])
                   .optional(),
                 interval_description: z.string().max(500).optional(),
                 payment_schedule: z
@@ -26895,7 +26895,7 @@ export const s_PostPaymentIntentsRequestBody = z.object({
               .enum(["automatic", "instant", "microdeposits"])
               .optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       affirm: z
@@ -26903,9 +26903,9 @@ export const s_PostPaymentIntentsRequestBody = z.object({
           z.object({
             capture_method: z.enum(["", "manual"]).optional(),
             preferred_locale: z.string().max(30).optional(),
-            setup_future_usage: z.enum(["none"]).optional(),
+            setup_future_usage: z.literal("none").optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       afterpay_clearpay: z
@@ -26913,9 +26913,9 @@ export const s_PostPaymentIntentsRequestBody = z.object({
           z.object({
             capture_method: z.enum(["", "manual"]).optional(),
             reference: z.string().max(128).optional(),
-            setup_future_usage: z.enum(["none"]).optional(),
+            setup_future_usage: z.literal("none").optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       alipay: z
@@ -26923,13 +26923,13 @@ export const s_PostPaymentIntentsRequestBody = z.object({
           z.object({
             setup_future_usage: z.enum(["", "none", "off_session"]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       alma: z
         .union([
           z.object({capture_method: z.enum(["", "manual"]).optional()}),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       amazon_pay: z
@@ -26938,7 +26938,7 @@ export const s_PostPaymentIntentsRequestBody = z.object({
             capture_method: z.enum(["", "manual"]).optional(),
             setup_future_usage: z.enum(["", "none", "off_session"]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       au_becs_debit: z
@@ -26949,7 +26949,7 @@ export const s_PostPaymentIntentsRequestBody = z.object({
               .optional(),
             target_date: z.string().max(5000).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       bacs_debit: z
@@ -26958,7 +26958,7 @@ export const s_PostPaymentIntentsRequestBody = z.object({
             mandate_options: z
               .object({
                 reference_prefix: z
-                  .union([z.string().max(12), z.enum([""])])
+                  .union([z.string().max(12), z.literal("")])
                   .optional(),
               })
               .optional(),
@@ -26967,7 +26967,7 @@ export const s_PostPaymentIntentsRequestBody = z.object({
               .optional(),
             target_date: z.string().max(5000).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       bancontact: z
@@ -26976,13 +26976,13 @@ export const s_PostPaymentIntentsRequestBody = z.object({
             preferred_language: z.enum(["de", "en", "fr", "nl"]).optional(),
             setup_future_usage: z.enum(["", "none", "off_session"]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       billie: z
         .union([
           z.object({capture_method: z.enum(["", "manual"]).optional()}),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       blik: z
@@ -26991,7 +26991,7 @@ export const s_PostPaymentIntentsRequestBody = z.object({
             code: z.string().max(5000).optional(),
             setup_future_usage: z.enum(["", "none"]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       boleto: z
@@ -27002,7 +27002,7 @@ export const s_PostPaymentIntentsRequestBody = z.object({
               .enum(["", "none", "off_session", "on_session"])
               .optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       card: z
@@ -27017,10 +27017,10 @@ export const s_PostPaymentIntentsRequestBody = z.object({
                   .union([
                     z.object({
                       count: z.coerce.number().optional(),
-                      interval: z.enum(["month"]).optional(),
+                      interval: z.literal("month").optional(),
                       type: z.enum(["bonus", "fixed_count", "revolving"]),
                     }),
-                    z.enum([""]),
+                    z.literal(""),
                   ])
                   .optional(),
               })
@@ -27035,7 +27035,7 @@ export const s_PostPaymentIntentsRequestBody = z.object({
                 interval_count: z.coerce.number().optional(),
                 reference: z.string().max(80),
                 start_date: z.coerce.number(),
-                supported_types: z.array(z.enum(["india"])).optional(),
+                supported_types: z.array(z.literal("india")).optional(),
               })
               .optional(),
             network: z
@@ -27071,10 +27071,10 @@ export const s_PostPaymentIntentsRequestBody = z.object({
               .enum(["", "none", "off_session", "on_session"])
               .optional(),
             statement_descriptor_suffix_kana: z
-              .union([z.string().max(22), z.enum([""])])
+              .union([z.string().max(22), z.literal("")])
               .optional(),
             statement_descriptor_suffix_kanji: z
-              .union([z.string().max(17), z.enum([""])])
+              .union([z.string().max(17), z.literal("")])
               .optional(),
             three_d_secure: z
               .object({
@@ -27103,7 +27103,7 @@ export const s_PostPaymentIntentsRequestBody = z.object({
               })
               .optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       card_present: z
@@ -27120,7 +27120,7 @@ export const s_PostPaymentIntentsRequestBody = z.object({
               })
               .optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       cashapp: z
@@ -27131,13 +27131,13 @@ export const s_PostPaymentIntentsRequestBody = z.object({
               .enum(["", "none", "off_session", "on_session"])
               .optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       crypto: z
         .union([
-          z.object({setup_future_usage: z.enum(["none"]).optional()}),
-          z.enum([""]),
+          z.object({setup_future_usage: z.literal("none").optional()}),
+          z.literal(""),
         ])
         .optional(),
       customer_balance: z
@@ -27170,34 +27170,34 @@ export const s_PostPaymentIntentsRequestBody = z.object({
                 ]),
               })
               .optional(),
-            funding_type: z.enum(["bank_transfer"]).optional(),
-            setup_future_usage: z.enum(["none"]).optional(),
+            funding_type: z.literal("bank_transfer").optional(),
+            setup_future_usage: z.literal("none").optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       eps: z
         .union([
-          z.object({setup_future_usage: z.enum(["none"]).optional()}),
-          z.enum([""]),
+          z.object({setup_future_usage: z.literal("none").optional()}),
+          z.literal(""),
         ])
         .optional(),
       fpx: z
         .union([
-          z.object({setup_future_usage: z.enum(["none"]).optional()}),
-          z.enum([""]),
+          z.object({setup_future_usage: z.literal("none").optional()}),
+          z.literal(""),
         ])
         .optional(),
       giropay: z
         .union([
-          z.object({setup_future_usage: z.enum(["none"]).optional()}),
-          z.enum([""]),
+          z.object({setup_future_usage: z.literal("none").optional()}),
+          z.literal(""),
         ])
         .optional(),
       grabpay: z
         .union([
-          z.object({setup_future_usage: z.enum(["none"]).optional()}),
-          z.enum([""]),
+          z.object({setup_future_usage: z.literal("none").optional()}),
+          z.literal(""),
         ])
         .optional(),
       ideal: z
@@ -27205,11 +27205,11 @@ export const s_PostPaymentIntentsRequestBody = z.object({
           z.object({
             setup_future_usage: z.enum(["", "none", "off_session"]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       interac_present: z
-        .union([z.record(z.string(), z.unknown()), z.enum([""])])
+        .union([z.record(z.string(), z.unknown()), z.literal("")])
         .optional(),
       kakao_pay: z
         .union([
@@ -27217,7 +27217,7 @@ export const s_PostPaymentIntentsRequestBody = z.object({
             capture_method: z.enum(["", "manual"]).optional(),
             setup_future_usage: z.enum(["", "none", "off_session"]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       klarna: z
@@ -27304,29 +27304,29 @@ export const s_PostPaymentIntentsRequestBody = z.object({
                     reference: z.string().max(255),
                   }),
                 ),
-                z.enum([""]),
+                z.literal(""),
               ])
               .optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       konbini: z
         .union([
           z.object({
             confirmation_number: z
-              .union([z.string().max(11), z.enum([""])])
+              .union([z.string().max(11), z.literal("")])
               .optional(),
             expires_after_days: z
-              .union([z.coerce.number(), z.enum([""])])
+              .union([z.coerce.number(), z.literal("")])
               .optional(),
-            expires_at: z.union([z.coerce.number(), z.enum([""])]).optional(),
+            expires_at: z.union([z.coerce.number(), z.literal("")]).optional(),
             product_description: z
-              .union([z.string().max(22), z.enum([""])])
+              .union([z.string().max(22), z.literal("")])
               .optional(),
-            setup_future_usage: z.enum(["none"]).optional(),
+            setup_future_usage: z.literal("none").optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       kr_card: z
@@ -27335,7 +27335,7 @@ export const s_PostPaymentIntentsRequestBody = z.object({
             capture_method: z.enum(["", "manual"]).optional(),
             setup_future_usage: z.enum(["", "none", "off_session"]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       link: z
@@ -27344,22 +27344,22 @@ export const s_PostPaymentIntentsRequestBody = z.object({
             capture_method: z.enum(["", "manual"]).optional(),
             setup_future_usage: z.enum(["", "none", "off_session"]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       mobilepay: z
         .union([
           z.object({
             capture_method: z.enum(["", "manual"]).optional(),
-            setup_future_usage: z.enum(["none"]).optional(),
+            setup_future_usage: z.literal("none").optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       multibanco: z
         .union([
-          z.object({setup_future_usage: z.enum(["none"]).optional()}),
-          z.enum([""]),
+          z.object({setup_future_usage: z.literal("none").optional()}),
+          z.literal(""),
         ])
         .optional(),
       naver_pay: z
@@ -27368,7 +27368,7 @@ export const s_PostPaymentIntentsRequestBody = z.object({
             capture_method: z.enum(["", "manual"]).optional(),
             setup_future_usage: z.enum(["", "none", "off_session"]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       nz_bank_account: z
@@ -27379,40 +27379,40 @@ export const s_PostPaymentIntentsRequestBody = z.object({
               .optional(),
             target_date: z.string().max(5000).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       oxxo: z
         .union([
           z.object({
             expires_after_days: z.coerce.number().optional(),
-            setup_future_usage: z.enum(["none"]).optional(),
+            setup_future_usage: z.literal("none").optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       p24: z
         .union([
           z.object({
-            setup_future_usage: z.enum(["none"]).optional(),
+            setup_future_usage: z.literal("none").optional(),
             tos_shown_and_accepted: PermissiveBoolean.optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       pay_by_bank: z
-        .union([z.record(z.string(), z.unknown()), z.enum([""])])
+        .union([z.record(z.string(), z.unknown()), z.literal("")])
         .optional(),
       payco: z
         .union([
           z.object({capture_method: z.enum(["", "manual"]).optional()}),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       paynow: z
         .union([
-          z.object({setup_future_usage: z.enum(["none"]).optional()}),
-          z.enum([""]),
+          z.object({setup_future_usage: z.literal("none").optional()}),
+          z.literal(""),
         ])
         .optional(),
       paypal: z
@@ -27448,7 +27448,7 @@ export const s_PostPaymentIntentsRequestBody = z.object({
             risk_correlation_id: z.string().max(32).optional(),
             setup_future_usage: z.enum(["", "none", "off_session"]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       pix: z
@@ -27456,15 +27456,15 @@ export const s_PostPaymentIntentsRequestBody = z.object({
           z.object({
             expires_after_seconds: z.coerce.number().optional(),
             expires_at: z.coerce.number().optional(),
-            setup_future_usage: z.enum(["none"]).optional(),
+            setup_future_usage: z.literal("none").optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       promptpay: z
         .union([
-          z.object({setup_future_usage: z.enum(["none"]).optional()}),
-          z.enum([""]),
+          z.object({setup_future_usage: z.literal("none").optional()}),
+          z.literal(""),
         ])
         .optional(),
       revolut_pay: z
@@ -27473,19 +27473,19 @@ export const s_PostPaymentIntentsRequestBody = z.object({
             capture_method: z.enum(["", "manual"]).optional(),
             setup_future_usage: z.enum(["", "none", "off_session"]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       samsung_pay: z
         .union([
           z.object({capture_method: z.enum(["", "manual"]).optional()}),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       satispay: z
         .union([
           z.object({capture_method: z.enum(["", "manual"]).optional()}),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       sepa_debit: z
@@ -27494,7 +27494,7 @@ export const s_PostPaymentIntentsRequestBody = z.object({
             mandate_options: z
               .object({
                 reference_prefix: z
-                  .union([z.string().max(12), z.enum([""])])
+                  .union([z.string().max(12), z.literal("")])
                   .optional(),
               })
               .optional(),
@@ -27503,7 +27503,7 @@ export const s_PostPaymentIntentsRequestBody = z.object({
               .optional(),
             target_date: z.string().max(5000).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       sofort: z
@@ -27514,22 +27514,24 @@ export const s_PostPaymentIntentsRequestBody = z.object({
               .optional(),
             setup_future_usage: z.enum(["", "none", "off_session"]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       swish: z
         .union([
           z.object({
-            reference: z.union([z.string().max(5000), z.enum([""])]).optional(),
-            setup_future_usage: z.enum(["none"]).optional(),
+            reference: z
+              .union([z.string().max(5000), z.literal("")])
+              .optional(),
+            setup_future_usage: z.literal("none").optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       twint: z
         .union([
-          z.object({setup_future_usage: z.enum(["none"]).optional()}),
-          z.enum([""]),
+          z.object({setup_future_usage: z.literal("none").optional()}),
+          z.literal(""),
         ])
         .optional(),
       us_bank_account: z
@@ -27581,7 +27583,7 @@ export const s_PostPaymentIntentsRequestBody = z.object({
               .enum(["automatic", "instant", "microdeposits"])
               .optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       wechat_pay: z
@@ -27589,15 +27591,15 @@ export const s_PostPaymentIntentsRequestBody = z.object({
           z.object({
             app_id: z.string().max(5000).optional(),
             client: z.enum(["android", "ios", "web"]).optional(),
-            setup_future_usage: z.enum(["none"]).optional(),
+            setup_future_usage: z.literal("none").optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       zip: z
         .union([
-          z.object({setup_future_usage: z.enum(["none"]).optional()}),
-          z.enum([""]),
+          z.object({setup_future_usage: z.literal("none").optional()}),
+          z.literal(""),
         ])
         .optional(),
     })
@@ -27636,14 +27638,16 @@ export const s_PostPaymentIntentsRequestBody = z.object({
 
 export const s_PostPaymentIntentsIntentRequestBody = z.object({
   amount: z.coerce.number().optional(),
-  application_fee_amount: z.union([z.coerce.number(), z.enum([""])]).optional(),
+  application_fee_amount: z
+    .union([z.coerce.number(), z.literal("")])
+    .optional(),
   capture_method: z.enum(["automatic", "automatic_async", "manual"]).optional(),
   currency: z.string().optional(),
   customer: z.string().max(5000).optional(),
   description: z.string().max(1000).optional(),
   expand: z.array(z.string().max(5000)).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   payment_method: z.string().max(5000).optional(),
   payment_method_configuration: z.string().max(100).optional(),
@@ -27688,12 +27692,12 @@ export const s_PostPaymentIntentsIntentRequestBody = z.object({
                 postal_code: z.string().max(5000).optional(),
                 state: z.string().max(5000).optional(),
               }),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
-          email: z.union([z.string(), z.enum([""])]).optional(),
-          name: z.union([z.string().max(5000), z.enum([""])]).optional(),
-          phone: z.union([z.string().max(5000), z.enum([""])]).optional(),
+          email: z.union([z.string(), z.literal("")]).optional(),
+          name: z.union([z.string().max(5000), z.literal("")]).optional(),
+          phone: z.union([z.string().max(5000), z.literal("")]).optional(),
           tax_id: z.string().max(5000).optional(),
         })
         .optional(),
@@ -27948,7 +27952,7 @@ export const s_PostPaymentIntentsIntentRequestBody = z.object({
             mandate_options: z
               .object({
                 custom_mandate_url: z
-                  .union([z.string(), z.enum([""])])
+                  .union([z.string(), z.literal("")])
                   .optional(),
                 interval_description: z.string().max(500).optional(),
                 payment_schedule: z
@@ -27965,7 +27969,7 @@ export const s_PostPaymentIntentsIntentRequestBody = z.object({
               .enum(["automatic", "instant", "microdeposits"])
               .optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       affirm: z
@@ -27973,9 +27977,9 @@ export const s_PostPaymentIntentsIntentRequestBody = z.object({
           z.object({
             capture_method: z.enum(["", "manual"]).optional(),
             preferred_locale: z.string().max(30).optional(),
-            setup_future_usage: z.enum(["none"]).optional(),
+            setup_future_usage: z.literal("none").optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       afterpay_clearpay: z
@@ -27983,9 +27987,9 @@ export const s_PostPaymentIntentsIntentRequestBody = z.object({
           z.object({
             capture_method: z.enum(["", "manual"]).optional(),
             reference: z.string().max(128).optional(),
-            setup_future_usage: z.enum(["none"]).optional(),
+            setup_future_usage: z.literal("none").optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       alipay: z
@@ -27993,13 +27997,13 @@ export const s_PostPaymentIntentsIntentRequestBody = z.object({
           z.object({
             setup_future_usage: z.enum(["", "none", "off_session"]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       alma: z
         .union([
           z.object({capture_method: z.enum(["", "manual"]).optional()}),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       amazon_pay: z
@@ -28008,7 +28012,7 @@ export const s_PostPaymentIntentsIntentRequestBody = z.object({
             capture_method: z.enum(["", "manual"]).optional(),
             setup_future_usage: z.enum(["", "none", "off_session"]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       au_becs_debit: z
@@ -28019,7 +28023,7 @@ export const s_PostPaymentIntentsIntentRequestBody = z.object({
               .optional(),
             target_date: z.string().max(5000).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       bacs_debit: z
@@ -28028,7 +28032,7 @@ export const s_PostPaymentIntentsIntentRequestBody = z.object({
             mandate_options: z
               .object({
                 reference_prefix: z
-                  .union([z.string().max(12), z.enum([""])])
+                  .union([z.string().max(12), z.literal("")])
                   .optional(),
               })
               .optional(),
@@ -28037,7 +28041,7 @@ export const s_PostPaymentIntentsIntentRequestBody = z.object({
               .optional(),
             target_date: z.string().max(5000).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       bancontact: z
@@ -28046,13 +28050,13 @@ export const s_PostPaymentIntentsIntentRequestBody = z.object({
             preferred_language: z.enum(["de", "en", "fr", "nl"]).optional(),
             setup_future_usage: z.enum(["", "none", "off_session"]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       billie: z
         .union([
           z.object({capture_method: z.enum(["", "manual"]).optional()}),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       blik: z
@@ -28061,7 +28065,7 @@ export const s_PostPaymentIntentsIntentRequestBody = z.object({
             code: z.string().max(5000).optional(),
             setup_future_usage: z.enum(["", "none"]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       boleto: z
@@ -28072,7 +28076,7 @@ export const s_PostPaymentIntentsIntentRequestBody = z.object({
               .enum(["", "none", "off_session", "on_session"])
               .optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       card: z
@@ -28087,10 +28091,10 @@ export const s_PostPaymentIntentsIntentRequestBody = z.object({
                   .union([
                     z.object({
                       count: z.coerce.number().optional(),
-                      interval: z.enum(["month"]).optional(),
+                      interval: z.literal("month").optional(),
                       type: z.enum(["bonus", "fixed_count", "revolving"]),
                     }),
-                    z.enum([""]),
+                    z.literal(""),
                   ])
                   .optional(),
               })
@@ -28105,7 +28109,7 @@ export const s_PostPaymentIntentsIntentRequestBody = z.object({
                 interval_count: z.coerce.number().optional(),
                 reference: z.string().max(80),
                 start_date: z.coerce.number(),
-                supported_types: z.array(z.enum(["india"])).optional(),
+                supported_types: z.array(z.literal("india")).optional(),
               })
               .optional(),
             network: z
@@ -28141,10 +28145,10 @@ export const s_PostPaymentIntentsIntentRequestBody = z.object({
               .enum(["", "none", "off_session", "on_session"])
               .optional(),
             statement_descriptor_suffix_kana: z
-              .union([z.string().max(22), z.enum([""])])
+              .union([z.string().max(22), z.literal("")])
               .optional(),
             statement_descriptor_suffix_kanji: z
-              .union([z.string().max(17), z.enum([""])])
+              .union([z.string().max(17), z.literal("")])
               .optional(),
             three_d_secure: z
               .object({
@@ -28173,7 +28177,7 @@ export const s_PostPaymentIntentsIntentRequestBody = z.object({
               })
               .optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       card_present: z
@@ -28190,7 +28194,7 @@ export const s_PostPaymentIntentsIntentRequestBody = z.object({
               })
               .optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       cashapp: z
@@ -28201,13 +28205,13 @@ export const s_PostPaymentIntentsIntentRequestBody = z.object({
               .enum(["", "none", "off_session", "on_session"])
               .optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       crypto: z
         .union([
-          z.object({setup_future_usage: z.enum(["none"]).optional()}),
-          z.enum([""]),
+          z.object({setup_future_usage: z.literal("none").optional()}),
+          z.literal(""),
         ])
         .optional(),
       customer_balance: z
@@ -28240,34 +28244,34 @@ export const s_PostPaymentIntentsIntentRequestBody = z.object({
                 ]),
               })
               .optional(),
-            funding_type: z.enum(["bank_transfer"]).optional(),
-            setup_future_usage: z.enum(["none"]).optional(),
+            funding_type: z.literal("bank_transfer").optional(),
+            setup_future_usage: z.literal("none").optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       eps: z
         .union([
-          z.object({setup_future_usage: z.enum(["none"]).optional()}),
-          z.enum([""]),
+          z.object({setup_future_usage: z.literal("none").optional()}),
+          z.literal(""),
         ])
         .optional(),
       fpx: z
         .union([
-          z.object({setup_future_usage: z.enum(["none"]).optional()}),
-          z.enum([""]),
+          z.object({setup_future_usage: z.literal("none").optional()}),
+          z.literal(""),
         ])
         .optional(),
       giropay: z
         .union([
-          z.object({setup_future_usage: z.enum(["none"]).optional()}),
-          z.enum([""]),
+          z.object({setup_future_usage: z.literal("none").optional()}),
+          z.literal(""),
         ])
         .optional(),
       grabpay: z
         .union([
-          z.object({setup_future_usage: z.enum(["none"]).optional()}),
-          z.enum([""]),
+          z.object({setup_future_usage: z.literal("none").optional()}),
+          z.literal(""),
         ])
         .optional(),
       ideal: z
@@ -28275,11 +28279,11 @@ export const s_PostPaymentIntentsIntentRequestBody = z.object({
           z.object({
             setup_future_usage: z.enum(["", "none", "off_session"]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       interac_present: z
-        .union([z.record(z.string(), z.unknown()), z.enum([""])])
+        .union([z.record(z.string(), z.unknown()), z.literal("")])
         .optional(),
       kakao_pay: z
         .union([
@@ -28287,7 +28291,7 @@ export const s_PostPaymentIntentsIntentRequestBody = z.object({
             capture_method: z.enum(["", "manual"]).optional(),
             setup_future_usage: z.enum(["", "none", "off_session"]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       klarna: z
@@ -28374,29 +28378,29 @@ export const s_PostPaymentIntentsIntentRequestBody = z.object({
                     reference: z.string().max(255),
                   }),
                 ),
-                z.enum([""]),
+                z.literal(""),
               ])
               .optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       konbini: z
         .union([
           z.object({
             confirmation_number: z
-              .union([z.string().max(11), z.enum([""])])
+              .union([z.string().max(11), z.literal("")])
               .optional(),
             expires_after_days: z
-              .union([z.coerce.number(), z.enum([""])])
+              .union([z.coerce.number(), z.literal("")])
               .optional(),
-            expires_at: z.union([z.coerce.number(), z.enum([""])]).optional(),
+            expires_at: z.union([z.coerce.number(), z.literal("")]).optional(),
             product_description: z
-              .union([z.string().max(22), z.enum([""])])
+              .union([z.string().max(22), z.literal("")])
               .optional(),
-            setup_future_usage: z.enum(["none"]).optional(),
+            setup_future_usage: z.literal("none").optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       kr_card: z
@@ -28405,7 +28409,7 @@ export const s_PostPaymentIntentsIntentRequestBody = z.object({
             capture_method: z.enum(["", "manual"]).optional(),
             setup_future_usage: z.enum(["", "none", "off_session"]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       link: z
@@ -28414,22 +28418,22 @@ export const s_PostPaymentIntentsIntentRequestBody = z.object({
             capture_method: z.enum(["", "manual"]).optional(),
             setup_future_usage: z.enum(["", "none", "off_session"]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       mobilepay: z
         .union([
           z.object({
             capture_method: z.enum(["", "manual"]).optional(),
-            setup_future_usage: z.enum(["none"]).optional(),
+            setup_future_usage: z.literal("none").optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       multibanco: z
         .union([
-          z.object({setup_future_usage: z.enum(["none"]).optional()}),
-          z.enum([""]),
+          z.object({setup_future_usage: z.literal("none").optional()}),
+          z.literal(""),
         ])
         .optional(),
       naver_pay: z
@@ -28438,7 +28442,7 @@ export const s_PostPaymentIntentsIntentRequestBody = z.object({
             capture_method: z.enum(["", "manual"]).optional(),
             setup_future_usage: z.enum(["", "none", "off_session"]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       nz_bank_account: z
@@ -28449,40 +28453,40 @@ export const s_PostPaymentIntentsIntentRequestBody = z.object({
               .optional(),
             target_date: z.string().max(5000).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       oxxo: z
         .union([
           z.object({
             expires_after_days: z.coerce.number().optional(),
-            setup_future_usage: z.enum(["none"]).optional(),
+            setup_future_usage: z.literal("none").optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       p24: z
         .union([
           z.object({
-            setup_future_usage: z.enum(["none"]).optional(),
+            setup_future_usage: z.literal("none").optional(),
             tos_shown_and_accepted: PermissiveBoolean.optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       pay_by_bank: z
-        .union([z.record(z.string(), z.unknown()), z.enum([""])])
+        .union([z.record(z.string(), z.unknown()), z.literal("")])
         .optional(),
       payco: z
         .union([
           z.object({capture_method: z.enum(["", "manual"]).optional()}),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       paynow: z
         .union([
-          z.object({setup_future_usage: z.enum(["none"]).optional()}),
-          z.enum([""]),
+          z.object({setup_future_usage: z.literal("none").optional()}),
+          z.literal(""),
         ])
         .optional(),
       paypal: z
@@ -28518,7 +28522,7 @@ export const s_PostPaymentIntentsIntentRequestBody = z.object({
             risk_correlation_id: z.string().max(32).optional(),
             setup_future_usage: z.enum(["", "none", "off_session"]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       pix: z
@@ -28526,15 +28530,15 @@ export const s_PostPaymentIntentsIntentRequestBody = z.object({
           z.object({
             expires_after_seconds: z.coerce.number().optional(),
             expires_at: z.coerce.number().optional(),
-            setup_future_usage: z.enum(["none"]).optional(),
+            setup_future_usage: z.literal("none").optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       promptpay: z
         .union([
-          z.object({setup_future_usage: z.enum(["none"]).optional()}),
-          z.enum([""]),
+          z.object({setup_future_usage: z.literal("none").optional()}),
+          z.literal(""),
         ])
         .optional(),
       revolut_pay: z
@@ -28543,19 +28547,19 @@ export const s_PostPaymentIntentsIntentRequestBody = z.object({
             capture_method: z.enum(["", "manual"]).optional(),
             setup_future_usage: z.enum(["", "none", "off_session"]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       samsung_pay: z
         .union([
           z.object({capture_method: z.enum(["", "manual"]).optional()}),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       satispay: z
         .union([
           z.object({capture_method: z.enum(["", "manual"]).optional()}),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       sepa_debit: z
@@ -28564,7 +28568,7 @@ export const s_PostPaymentIntentsIntentRequestBody = z.object({
             mandate_options: z
               .object({
                 reference_prefix: z
-                  .union([z.string().max(12), z.enum([""])])
+                  .union([z.string().max(12), z.literal("")])
                   .optional(),
               })
               .optional(),
@@ -28573,7 +28577,7 @@ export const s_PostPaymentIntentsIntentRequestBody = z.object({
               .optional(),
             target_date: z.string().max(5000).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       sofort: z
@@ -28584,22 +28588,24 @@ export const s_PostPaymentIntentsIntentRequestBody = z.object({
               .optional(),
             setup_future_usage: z.enum(["", "none", "off_session"]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       swish: z
         .union([
           z.object({
-            reference: z.union([z.string().max(5000), z.enum([""])]).optional(),
-            setup_future_usage: z.enum(["none"]).optional(),
+            reference: z
+              .union([z.string().max(5000), z.literal("")])
+              .optional(),
+            setup_future_usage: z.literal("none").optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       twint: z
         .union([
-          z.object({setup_future_usage: z.enum(["none"]).optional()}),
-          z.enum([""]),
+          z.object({setup_future_usage: z.literal("none").optional()}),
+          z.literal(""),
         ])
         .optional(),
       us_bank_account: z
@@ -28651,7 +28657,7 @@ export const s_PostPaymentIntentsIntentRequestBody = z.object({
               .enum(["automatic", "instant", "microdeposits"])
               .optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       wechat_pay: z
@@ -28659,21 +28665,21 @@ export const s_PostPaymentIntentsIntentRequestBody = z.object({
           z.object({
             app_id: z.string().max(5000).optional(),
             client: z.enum(["android", "ios", "web"]).optional(),
-            setup_future_usage: z.enum(["none"]).optional(),
+            setup_future_usage: z.literal("none").optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       zip: z
         .union([
-          z.object({setup_future_usage: z.enum(["none"]).optional()}),
-          z.enum([""]),
+          z.object({setup_future_usage: z.literal("none").optional()}),
+          z.literal(""),
         ])
         .optional(),
     })
     .optional(),
   payment_method_types: z.array(z.string().max(5000)).optional(),
-  receipt_email: z.union([z.string(), z.enum([""])]).optional(),
+  receipt_email: z.union([z.string(), z.literal("")]).optional(),
   setup_future_usage: z.enum(["", "off_session", "on_session"]).optional(),
   shipping: z
     .union([
@@ -28691,7 +28697,7 @@ export const s_PostPaymentIntentsIntentRequestBody = z.object({
         phone: z.string().max(5000).optional(),
         tracking_number: z.string().max(5000).optional(),
       }),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   statement_descriptor: z.string().max(22).optional(),
@@ -28720,7 +28726,7 @@ export const s_PostPaymentIntentsIntentCaptureRequestBody = z.object({
   expand: z.array(z.string().max(5000)).optional(),
   final_capture: PermissiveBoolean.optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   statement_descriptor: z.string().max(22).optional(),
   statement_descriptor_suffix: z.string().max(22).optional(),
@@ -28746,14 +28752,14 @@ export const s_PostPaymentIntentsIntentConfirmRequestBody = z.object({
           type: z.enum(["offline", "online"]),
         }),
       }),
-      z.enum([""]),
+      z.literal(""),
       z.object({
         customer_acceptance: z.object({
           online: z.object({
             ip_address: z.string().optional(),
             user_agent: z.string().max(5000).optional(),
           }),
-          type: z.enum(["online"]),
+          type: z.literal("online"),
         }),
       }),
     ])
@@ -28803,12 +28809,12 @@ export const s_PostPaymentIntentsIntentConfirmRequestBody = z.object({
                 postal_code: z.string().max(5000).optional(),
                 state: z.string().max(5000).optional(),
               }),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
-          email: z.union([z.string(), z.enum([""])]).optional(),
-          name: z.union([z.string().max(5000), z.enum([""])]).optional(),
-          phone: z.union([z.string().max(5000), z.enum([""])]).optional(),
+          email: z.union([z.string(), z.literal("")]).optional(),
+          name: z.union([z.string().max(5000), z.literal("")]).optional(),
+          phone: z.union([z.string().max(5000), z.literal("")]).optional(),
           tax_id: z.string().max(5000).optional(),
         })
         .optional(),
@@ -29063,7 +29069,7 @@ export const s_PostPaymentIntentsIntentConfirmRequestBody = z.object({
             mandate_options: z
               .object({
                 custom_mandate_url: z
-                  .union([z.string(), z.enum([""])])
+                  .union([z.string(), z.literal("")])
                   .optional(),
                 interval_description: z.string().max(500).optional(),
                 payment_schedule: z
@@ -29080,7 +29086,7 @@ export const s_PostPaymentIntentsIntentConfirmRequestBody = z.object({
               .enum(["automatic", "instant", "microdeposits"])
               .optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       affirm: z
@@ -29088,9 +29094,9 @@ export const s_PostPaymentIntentsIntentConfirmRequestBody = z.object({
           z.object({
             capture_method: z.enum(["", "manual"]).optional(),
             preferred_locale: z.string().max(30).optional(),
-            setup_future_usage: z.enum(["none"]).optional(),
+            setup_future_usage: z.literal("none").optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       afterpay_clearpay: z
@@ -29098,9 +29104,9 @@ export const s_PostPaymentIntentsIntentConfirmRequestBody = z.object({
           z.object({
             capture_method: z.enum(["", "manual"]).optional(),
             reference: z.string().max(128).optional(),
-            setup_future_usage: z.enum(["none"]).optional(),
+            setup_future_usage: z.literal("none").optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       alipay: z
@@ -29108,13 +29114,13 @@ export const s_PostPaymentIntentsIntentConfirmRequestBody = z.object({
           z.object({
             setup_future_usage: z.enum(["", "none", "off_session"]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       alma: z
         .union([
           z.object({capture_method: z.enum(["", "manual"]).optional()}),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       amazon_pay: z
@@ -29123,7 +29129,7 @@ export const s_PostPaymentIntentsIntentConfirmRequestBody = z.object({
             capture_method: z.enum(["", "manual"]).optional(),
             setup_future_usage: z.enum(["", "none", "off_session"]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       au_becs_debit: z
@@ -29134,7 +29140,7 @@ export const s_PostPaymentIntentsIntentConfirmRequestBody = z.object({
               .optional(),
             target_date: z.string().max(5000).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       bacs_debit: z
@@ -29143,7 +29149,7 @@ export const s_PostPaymentIntentsIntentConfirmRequestBody = z.object({
             mandate_options: z
               .object({
                 reference_prefix: z
-                  .union([z.string().max(12), z.enum([""])])
+                  .union([z.string().max(12), z.literal("")])
                   .optional(),
               })
               .optional(),
@@ -29152,7 +29158,7 @@ export const s_PostPaymentIntentsIntentConfirmRequestBody = z.object({
               .optional(),
             target_date: z.string().max(5000).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       bancontact: z
@@ -29161,13 +29167,13 @@ export const s_PostPaymentIntentsIntentConfirmRequestBody = z.object({
             preferred_language: z.enum(["de", "en", "fr", "nl"]).optional(),
             setup_future_usage: z.enum(["", "none", "off_session"]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       billie: z
         .union([
           z.object({capture_method: z.enum(["", "manual"]).optional()}),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       blik: z
@@ -29176,7 +29182,7 @@ export const s_PostPaymentIntentsIntentConfirmRequestBody = z.object({
             code: z.string().max(5000).optional(),
             setup_future_usage: z.enum(["", "none"]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       boleto: z
@@ -29187,7 +29193,7 @@ export const s_PostPaymentIntentsIntentConfirmRequestBody = z.object({
               .enum(["", "none", "off_session", "on_session"])
               .optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       card: z
@@ -29202,10 +29208,10 @@ export const s_PostPaymentIntentsIntentConfirmRequestBody = z.object({
                   .union([
                     z.object({
                       count: z.coerce.number().optional(),
-                      interval: z.enum(["month"]).optional(),
+                      interval: z.literal("month").optional(),
                       type: z.enum(["bonus", "fixed_count", "revolving"]),
                     }),
-                    z.enum([""]),
+                    z.literal(""),
                   ])
                   .optional(),
               })
@@ -29220,7 +29226,7 @@ export const s_PostPaymentIntentsIntentConfirmRequestBody = z.object({
                 interval_count: z.coerce.number().optional(),
                 reference: z.string().max(80),
                 start_date: z.coerce.number(),
-                supported_types: z.array(z.enum(["india"])).optional(),
+                supported_types: z.array(z.literal("india")).optional(),
               })
               .optional(),
             network: z
@@ -29256,10 +29262,10 @@ export const s_PostPaymentIntentsIntentConfirmRequestBody = z.object({
               .enum(["", "none", "off_session", "on_session"])
               .optional(),
             statement_descriptor_suffix_kana: z
-              .union([z.string().max(22), z.enum([""])])
+              .union([z.string().max(22), z.literal("")])
               .optional(),
             statement_descriptor_suffix_kanji: z
-              .union([z.string().max(17), z.enum([""])])
+              .union([z.string().max(17), z.literal("")])
               .optional(),
             three_d_secure: z
               .object({
@@ -29288,7 +29294,7 @@ export const s_PostPaymentIntentsIntentConfirmRequestBody = z.object({
               })
               .optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       card_present: z
@@ -29305,7 +29311,7 @@ export const s_PostPaymentIntentsIntentConfirmRequestBody = z.object({
               })
               .optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       cashapp: z
@@ -29316,13 +29322,13 @@ export const s_PostPaymentIntentsIntentConfirmRequestBody = z.object({
               .enum(["", "none", "off_session", "on_session"])
               .optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       crypto: z
         .union([
-          z.object({setup_future_usage: z.enum(["none"]).optional()}),
-          z.enum([""]),
+          z.object({setup_future_usage: z.literal("none").optional()}),
+          z.literal(""),
         ])
         .optional(),
       customer_balance: z
@@ -29355,34 +29361,34 @@ export const s_PostPaymentIntentsIntentConfirmRequestBody = z.object({
                 ]),
               })
               .optional(),
-            funding_type: z.enum(["bank_transfer"]).optional(),
-            setup_future_usage: z.enum(["none"]).optional(),
+            funding_type: z.literal("bank_transfer").optional(),
+            setup_future_usage: z.literal("none").optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       eps: z
         .union([
-          z.object({setup_future_usage: z.enum(["none"]).optional()}),
-          z.enum([""]),
+          z.object({setup_future_usage: z.literal("none").optional()}),
+          z.literal(""),
         ])
         .optional(),
       fpx: z
         .union([
-          z.object({setup_future_usage: z.enum(["none"]).optional()}),
-          z.enum([""]),
+          z.object({setup_future_usage: z.literal("none").optional()}),
+          z.literal(""),
         ])
         .optional(),
       giropay: z
         .union([
-          z.object({setup_future_usage: z.enum(["none"]).optional()}),
-          z.enum([""]),
+          z.object({setup_future_usage: z.literal("none").optional()}),
+          z.literal(""),
         ])
         .optional(),
       grabpay: z
         .union([
-          z.object({setup_future_usage: z.enum(["none"]).optional()}),
-          z.enum([""]),
+          z.object({setup_future_usage: z.literal("none").optional()}),
+          z.literal(""),
         ])
         .optional(),
       ideal: z
@@ -29390,11 +29396,11 @@ export const s_PostPaymentIntentsIntentConfirmRequestBody = z.object({
           z.object({
             setup_future_usage: z.enum(["", "none", "off_session"]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       interac_present: z
-        .union([z.record(z.string(), z.unknown()), z.enum([""])])
+        .union([z.record(z.string(), z.unknown()), z.literal("")])
         .optional(),
       kakao_pay: z
         .union([
@@ -29402,7 +29408,7 @@ export const s_PostPaymentIntentsIntentConfirmRequestBody = z.object({
             capture_method: z.enum(["", "manual"]).optional(),
             setup_future_usage: z.enum(["", "none", "off_session"]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       klarna: z
@@ -29489,29 +29495,29 @@ export const s_PostPaymentIntentsIntentConfirmRequestBody = z.object({
                     reference: z.string().max(255),
                   }),
                 ),
-                z.enum([""]),
+                z.literal(""),
               ])
               .optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       konbini: z
         .union([
           z.object({
             confirmation_number: z
-              .union([z.string().max(11), z.enum([""])])
+              .union([z.string().max(11), z.literal("")])
               .optional(),
             expires_after_days: z
-              .union([z.coerce.number(), z.enum([""])])
+              .union([z.coerce.number(), z.literal("")])
               .optional(),
-            expires_at: z.union([z.coerce.number(), z.enum([""])]).optional(),
+            expires_at: z.union([z.coerce.number(), z.literal("")]).optional(),
             product_description: z
-              .union([z.string().max(22), z.enum([""])])
+              .union([z.string().max(22), z.literal("")])
               .optional(),
-            setup_future_usage: z.enum(["none"]).optional(),
+            setup_future_usage: z.literal("none").optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       kr_card: z
@@ -29520,7 +29526,7 @@ export const s_PostPaymentIntentsIntentConfirmRequestBody = z.object({
             capture_method: z.enum(["", "manual"]).optional(),
             setup_future_usage: z.enum(["", "none", "off_session"]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       link: z
@@ -29529,22 +29535,22 @@ export const s_PostPaymentIntentsIntentConfirmRequestBody = z.object({
             capture_method: z.enum(["", "manual"]).optional(),
             setup_future_usage: z.enum(["", "none", "off_session"]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       mobilepay: z
         .union([
           z.object({
             capture_method: z.enum(["", "manual"]).optional(),
-            setup_future_usage: z.enum(["none"]).optional(),
+            setup_future_usage: z.literal("none").optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       multibanco: z
         .union([
-          z.object({setup_future_usage: z.enum(["none"]).optional()}),
-          z.enum([""]),
+          z.object({setup_future_usage: z.literal("none").optional()}),
+          z.literal(""),
         ])
         .optional(),
       naver_pay: z
@@ -29553,7 +29559,7 @@ export const s_PostPaymentIntentsIntentConfirmRequestBody = z.object({
             capture_method: z.enum(["", "manual"]).optional(),
             setup_future_usage: z.enum(["", "none", "off_session"]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       nz_bank_account: z
@@ -29564,40 +29570,40 @@ export const s_PostPaymentIntentsIntentConfirmRequestBody = z.object({
               .optional(),
             target_date: z.string().max(5000).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       oxxo: z
         .union([
           z.object({
             expires_after_days: z.coerce.number().optional(),
-            setup_future_usage: z.enum(["none"]).optional(),
+            setup_future_usage: z.literal("none").optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       p24: z
         .union([
           z.object({
-            setup_future_usage: z.enum(["none"]).optional(),
+            setup_future_usage: z.literal("none").optional(),
             tos_shown_and_accepted: PermissiveBoolean.optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       pay_by_bank: z
-        .union([z.record(z.string(), z.unknown()), z.enum([""])])
+        .union([z.record(z.string(), z.unknown()), z.literal("")])
         .optional(),
       payco: z
         .union([
           z.object({capture_method: z.enum(["", "manual"]).optional()}),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       paynow: z
         .union([
-          z.object({setup_future_usage: z.enum(["none"]).optional()}),
-          z.enum([""]),
+          z.object({setup_future_usage: z.literal("none").optional()}),
+          z.literal(""),
         ])
         .optional(),
       paypal: z
@@ -29633,7 +29639,7 @@ export const s_PostPaymentIntentsIntentConfirmRequestBody = z.object({
             risk_correlation_id: z.string().max(32).optional(),
             setup_future_usage: z.enum(["", "none", "off_session"]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       pix: z
@@ -29641,15 +29647,15 @@ export const s_PostPaymentIntentsIntentConfirmRequestBody = z.object({
           z.object({
             expires_after_seconds: z.coerce.number().optional(),
             expires_at: z.coerce.number().optional(),
-            setup_future_usage: z.enum(["none"]).optional(),
+            setup_future_usage: z.literal("none").optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       promptpay: z
         .union([
-          z.object({setup_future_usage: z.enum(["none"]).optional()}),
-          z.enum([""]),
+          z.object({setup_future_usage: z.literal("none").optional()}),
+          z.literal(""),
         ])
         .optional(),
       revolut_pay: z
@@ -29658,19 +29664,19 @@ export const s_PostPaymentIntentsIntentConfirmRequestBody = z.object({
             capture_method: z.enum(["", "manual"]).optional(),
             setup_future_usage: z.enum(["", "none", "off_session"]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       samsung_pay: z
         .union([
           z.object({capture_method: z.enum(["", "manual"]).optional()}),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       satispay: z
         .union([
           z.object({capture_method: z.enum(["", "manual"]).optional()}),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       sepa_debit: z
@@ -29679,7 +29685,7 @@ export const s_PostPaymentIntentsIntentConfirmRequestBody = z.object({
             mandate_options: z
               .object({
                 reference_prefix: z
-                  .union([z.string().max(12), z.enum([""])])
+                  .union([z.string().max(12), z.literal("")])
                   .optional(),
               })
               .optional(),
@@ -29688,7 +29694,7 @@ export const s_PostPaymentIntentsIntentConfirmRequestBody = z.object({
               .optional(),
             target_date: z.string().max(5000).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       sofort: z
@@ -29699,22 +29705,24 @@ export const s_PostPaymentIntentsIntentConfirmRequestBody = z.object({
               .optional(),
             setup_future_usage: z.enum(["", "none", "off_session"]).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       swish: z
         .union([
           z.object({
-            reference: z.union([z.string().max(5000), z.enum([""])]).optional(),
-            setup_future_usage: z.enum(["none"]).optional(),
+            reference: z
+              .union([z.string().max(5000), z.literal("")])
+              .optional(),
+            setup_future_usage: z.literal("none").optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       twint: z
         .union([
-          z.object({setup_future_usage: z.enum(["none"]).optional()}),
-          z.enum([""]),
+          z.object({setup_future_usage: z.literal("none").optional()}),
+          z.literal(""),
         ])
         .optional(),
       us_bank_account: z
@@ -29766,7 +29774,7 @@ export const s_PostPaymentIntentsIntentConfirmRequestBody = z.object({
               .enum(["automatic", "instant", "microdeposits"])
               .optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       wechat_pay: z
@@ -29774,15 +29782,15 @@ export const s_PostPaymentIntentsIntentConfirmRequestBody = z.object({
           z.object({
             app_id: z.string().max(5000).optional(),
             client: z.enum(["android", "ios", "web"]).optional(),
-            setup_future_usage: z.enum(["none"]).optional(),
+            setup_future_usage: z.literal("none").optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       zip: z
         .union([
-          z.object({setup_future_usage: z.enum(["none"]).optional()}),
-          z.enum([""]),
+          z.object({setup_future_usage: z.literal("none").optional()}),
+          z.literal(""),
         ])
         .optional(),
     })
@@ -29791,7 +29799,7 @@ export const s_PostPaymentIntentsIntentConfirmRequestBody = z.object({
   radar_options: z
     .object({session: z.string().max(5000).optional()})
     .optional(),
-  receipt_email: z.union([z.string(), z.enum([""])]).optional(),
+  receipt_email: z.union([z.string(), z.literal("")]).optional(),
   return_url: z.string().optional(),
   setup_future_usage: z.enum(["", "off_session", "on_session"]).optional(),
   shipping: z
@@ -29810,7 +29818,7 @@ export const s_PostPaymentIntentsIntentConfirmRequestBody = z.object({
         phone: z.string().max(5000).optional(),
         tracking_number: z.string().max(5000).optional(),
       }),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   use_stripe_sdk: PermissiveBoolean.optional(),
@@ -29864,13 +29872,13 @@ export const s_payment_link: z.ZodType<t_payment_link> = z.object({
     .object({
       data: z.array(z.lazy(() => s_item)),
       has_more: PermissiveBoolean,
-      object: z.enum(["list"]),
+      object: z.literal("list"),
       url: z.string().max(5000),
     })
     .optional(),
   livemode: PermissiveBoolean,
   metadata: z.record(z.string(), z.string().max(500)),
-  object: z.enum(["payment_link"]),
+  object: z.literal("payment_link"),
   on_behalf_of: z
     .union([z.string().max(5000), z.lazy(() => s_account)])
     .nullable()
@@ -29995,7 +30003,10 @@ export const s_PostPaymentLinksRequestBody = z.object({
           })
           .optional(),
         key: z.string().max(200),
-        label: z.object({custom: z.string().max(50), type: z.enum(["custom"])}),
+        label: z.object({
+          custom: z.string().max(50),
+          type: z.literal("custom"),
+        }),
         numeric: z
           .object({
             default_value: z.string().max(255).optional(),
@@ -30018,16 +30029,16 @@ export const s_PostPaymentLinksRequestBody = z.object({
   custom_text: z
     .object({
       after_submit: z
-        .union([z.object({message: z.string().max(1200)}), z.enum([""])])
+        .union([z.object({message: z.string().max(1200)}), z.literal("")])
         .optional(),
       shipping_address: z
-        .union([z.object({message: z.string().max(1200)}), z.enum([""])])
+        .union([z.object({message: z.string().max(1200)}), z.literal("")])
         .optional(),
       submit: z
-        .union([z.object({message: z.string().max(1200)}), z.enum([""])])
+        .union([z.object({message: z.string().max(1200)}), z.literal("")])
         .optional(),
       terms_of_service_acceptance: z
-        .union([z.object({message: z.string().max(1200)}), z.enum([""])])
+        .union([z.object({message: z.string().max(1200)}), z.literal("")])
         .optional(),
     })
     .optional(),
@@ -30040,7 +30051,7 @@ export const s_PostPaymentLinksRequestBody = z.object({
       invoice_data: z
         .object({
           account_tax_ids: z
-            .union([z.array(z.string().max(5000)), z.enum([""])])
+            .union([z.array(z.string().max(5000)), z.literal("")])
             .optional(),
           custom_fields: z
             .union([
@@ -30050,7 +30061,7 @@ export const s_PostPaymentLinksRequestBody = z.object({
                   value: z.string().max(140),
                 }),
               ),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
           description: z.string().max(1500).optional(),
@@ -30062,7 +30073,7 @@ export const s_PostPaymentLinksRequestBody = z.object({
             })
             .optional(),
           metadata: z
-            .union([z.record(z.string(), z.string()), z.enum([""])])
+            .union([z.record(z.string(), z.string()), z.literal("")])
             .optional(),
           rendering_options: z
             .union([
@@ -30072,7 +30083,7 @@ export const s_PostPaymentLinksRequestBody = z.object({
                   .optional(),
                 template: z.string().max(5000).optional(),
               }),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
         })
@@ -30529,7 +30540,7 @@ export const s_PostPaymentLinksPaymentLinkRequestBody = z.object({
           key: z.string().max(200),
           label: z.object({
             custom: z.string().max(50),
-            type: z.enum(["custom"]),
+            type: z.literal("custom"),
           }),
           numeric: z
             .object({
@@ -30549,35 +30560,35 @@ export const s_PostPaymentLinksPaymentLinkRequestBody = z.object({
           type: z.enum(["dropdown", "numeric", "text"]),
         }),
       ),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   custom_text: z
     .object({
       after_submit: z
-        .union([z.object({message: z.string().max(1200)}), z.enum([""])])
+        .union([z.object({message: z.string().max(1200)}), z.literal("")])
         .optional(),
       shipping_address: z
-        .union([z.object({message: z.string().max(1200)}), z.enum([""])])
+        .union([z.object({message: z.string().max(1200)}), z.literal("")])
         .optional(),
       submit: z
-        .union([z.object({message: z.string().max(1200)}), z.enum([""])])
+        .union([z.object({message: z.string().max(1200)}), z.literal("")])
         .optional(),
       terms_of_service_acceptance: z
-        .union([z.object({message: z.string().max(1200)}), z.enum([""])])
+        .union([z.object({message: z.string().max(1200)}), z.literal("")])
         .optional(),
     })
     .optional(),
   customer_creation: z.enum(["always", "if_required"]).optional(),
   expand: z.array(z.string().max(5000)).optional(),
-  inactive_message: z.union([z.string().max(500), z.enum([""])]).optional(),
+  inactive_message: z.union([z.string().max(500), z.literal("")]).optional(),
   invoice_creation: z
     .object({
       enabled: PermissiveBoolean,
       invoice_data: z
         .object({
           account_tax_ids: z
-            .union([z.array(z.string().max(5000)), z.enum([""])])
+            .union([z.array(z.string().max(5000)), z.literal("")])
             .optional(),
           custom_fields: z
             .union([
@@ -30587,7 +30598,7 @@ export const s_PostPaymentLinksPaymentLinkRequestBody = z.object({
                   value: z.string().max(140),
                 }),
               ),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
           description: z.string().max(1500).optional(),
@@ -30599,7 +30610,7 @@ export const s_PostPaymentLinksPaymentLinkRequestBody = z.object({
             })
             .optional(),
           metadata: z
-            .union([z.record(z.string(), z.string()), z.enum([""])])
+            .union([z.record(z.string(), z.string()), z.literal("")])
             .optional(),
           rendering_options: z
             .union([
@@ -30609,7 +30620,7 @@ export const s_PostPaymentLinksPaymentLinkRequestBody = z.object({
                   .optional(),
                 template: z.string().max(5000).optional(),
               }),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
         })
@@ -30634,17 +30645,17 @@ export const s_PostPaymentLinksPaymentLinkRequestBody = z.object({
   metadata: z.record(z.string(), z.string()).optional(),
   payment_intent_data: z
     .object({
-      description: z.union([z.string().max(1000), z.enum([""])]).optional(),
+      description: z.union([z.string().max(1000), z.literal("")]).optional(),
       metadata: z
-        .union([z.record(z.string(), z.string()), z.enum([""])])
+        .union([z.record(z.string(), z.string()), z.literal("")])
         .optional(),
       statement_descriptor: z
-        .union([z.string().max(22), z.enum([""])])
+        .union([z.string().max(22), z.literal("")])
         .optional(),
       statement_descriptor_suffix: z
-        .union([z.string().max(22), z.enum([""])])
+        .union([z.string().max(22), z.literal("")])
         .optional(),
-      transfer_group: z.union([z.string().max(5000), z.enum([""])]).optional(),
+      transfer_group: z.union([z.string().max(5000), z.literal("")]).optional(),
     })
     .optional(),
   payment_method_collection: z.enum(["always", "if_required"]).optional(),
@@ -30691,14 +30702,14 @@ export const s_PostPaymentLinksPaymentLinkRequestBody = z.object({
           "zip",
         ]),
       ),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   phone_number_collection: z.object({enabled: PermissiveBoolean}).optional(),
   restrictions: z
     .union([
       z.object({completed_sessions: z.object({limit: z.coerce.number()})}),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   shipping_address_collection: z
@@ -30947,7 +30958,7 @@ export const s_PostPaymentLinksPaymentLinkRequestBody = z.object({
           ]),
         ),
       }),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   submit_type: z
@@ -30966,9 +30977,9 @@ export const s_PostPaymentLinksPaymentLinkRequestBody = z.object({
         })
         .optional(),
       metadata: z
-        .union([z.record(z.string(), z.string()), z.enum([""])])
+        .union([z.record(z.string(), z.string()), z.literal("")])
         .optional(),
-      trial_period_days: z.union([z.coerce.number(), z.enum([""])]).optional(),
+      trial_period_days: z.union([z.coerce.number(), z.literal("")]).optional(),
       trial_settings: z
         .union([
           z.object({
@@ -30980,7 +30991,7 @@ export const s_PostPaymentLinksPaymentLinkRequestBody = z.object({
               ]),
             }),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
     })
@@ -31789,12 +31800,12 @@ export const s_PostPaymentMethodsRequestBody = z.object({
             postal_code: z.string().max(5000).optional(),
             state: z.string().max(5000).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
-      email: z.union([z.string(), z.enum([""])]).optional(),
-      name: z.union([z.string().max(5000), z.enum([""])]).optional(),
-      phone: z.union([z.string().max(5000), z.enum([""])]).optional(),
+      email: z.union([z.string(), z.literal("")]).optional(),
+      name: z.union([z.string().max(5000), z.literal("")]).optional(),
+      phone: z.union([z.string().max(5000), z.literal("")]).optional(),
       tax_id: z.string().max(5000).optional(),
     })
     .optional(),
@@ -32079,12 +32090,12 @@ export const s_PostPaymentMethodsPaymentMethodRequestBody = z.object({
             postal_code: z.string().max(5000).optional(),
             state: z.string().max(5000).optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
-      email: z.union([z.string(), z.enum([""])]).optional(),
-      name: z.union([z.string().max(5000), z.enum([""])]).optional(),
-      phone: z.union([z.string().max(5000), z.enum([""])]).optional(),
+      email: z.union([z.string(), z.literal("")]).optional(),
+      name: z.union([z.string().max(5000), z.literal("")]).optional(),
+      phone: z.union([z.string().max(5000), z.literal("")]).optional(),
       tax_id: z.string().max(5000).optional(),
     })
     .optional(),
@@ -32104,7 +32115,7 @@ export const s_PostPaymentMethodsPaymentMethodRequestBody = z.object({
   expand: z.array(z.string().max(5000)).optional(),
   link: z.record(z.string(), z.unknown()).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   pay_by_bank: z.record(z.string(), z.unknown()).optional(),
   us_bank_account: z
@@ -32160,7 +32171,7 @@ export const s_payout: z.ZodType<t_payout> = z.object({
   livemode: PermissiveBoolean,
   metadata: z.record(z.string(), z.string().max(500)).nullable().optional(),
   method: z.string().max(5000),
-  object: z.enum(["payout"]),
+  object: z.literal("payout"),
   original_payout: z
     .union([z.string().max(5000), z.lazy(() => s_payout)])
     .nullable()
@@ -32192,7 +32203,7 @@ export const s_PostPayoutsRequestBody = z.object({
 export const s_PostPayoutsPayoutRequestBody = z.object({
   expand: z.array(z.string().max(5000)).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
 })
 
@@ -32219,7 +32230,7 @@ export const s_plan: z.ZodType<t_plan> = z.object({
   metadata: z.record(z.string(), z.string().max(500)).nullable().optional(),
   meter: z.string().max(5000).nullable().optional(),
   nickname: z.string().max(5000).nullable().optional(),
-  object: z.enum(["plan"]),
+  object: z.literal("plan"),
   product: z
     .union([z.string().max(5000), z.lazy(() => s_product), s_deleted_product])
     .nullable()
@@ -32242,7 +32253,7 @@ export const s_PostPlansRequestBody = z.object({
   interval: z.enum(["day", "month", "week", "year"]),
   interval_count: z.coerce.number().optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   meter: z.string().max(5000).optional(),
   nickname: z.string().max(5000).optional(),
@@ -32267,7 +32278,7 @@ export const s_PostPlansRequestBody = z.object({
         flat_amount_decimal: z.string().optional(),
         unit_amount: z.coerce.number().optional(),
         unit_amount_decimal: z.string().optional(),
-        up_to: z.union([z.enum(["inf"]), z.coerce.number()]),
+        up_to: z.union([z.literal("inf"), z.coerce.number()]),
       }),
     )
     .optional(),
@@ -32283,7 +32294,7 @@ export const s_PostPlansPlanRequestBody = z.object({
   active: PermissiveBoolean.optional(),
   expand: z.array(z.string().max(5000)).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   nickname: z.string().max(5000).optional(),
   product: z.string().max(5000).optional(),
@@ -32302,7 +32313,7 @@ export const s_price: z.ZodType<t_price> = z.object({
   lookup_key: z.string().max(5000).nullable().optional(),
   metadata: z.record(z.string(), z.string().max(500)),
   nickname: z.string().max(5000).nullable().optional(),
-  object: z.enum(["price"]),
+  object: z.literal("price"),
   product: z.union([
     z.string().max(5000),
     z.lazy(() => s_product),
@@ -32347,7 +32358,7 @@ export const s_PostPricesRequestBody = z.object({
               flat_amount_decimal: z.string().optional(),
               unit_amount: z.coerce.number().optional(),
               unit_amount_decimal: z.string().optional(),
-              up_to: z.union([z.enum(["inf"]), z.coerce.number()]),
+              up_to: z.union([z.literal("inf"), z.coerce.number()]),
             }),
           )
           .optional(),
@@ -32396,7 +32407,7 @@ export const s_PostPricesRequestBody = z.object({
         flat_amount_decimal: z.string().optional(),
         unit_amount: z.coerce.number().optional(),
         unit_amount_decimal: z.string().optional(),
-        up_to: z.union([z.enum(["inf"]), z.coerce.number()]),
+        up_to: z.union([z.literal("inf"), z.coerce.number()]),
       }),
     )
     .optional(),
@@ -32434,7 +32445,7 @@ export const s_PostPricesPriceRequestBody = z.object({
                 flat_amount_decimal: z.string().optional(),
                 unit_amount: z.coerce.number().optional(),
                 unit_amount_decimal: z.string().optional(),
-                up_to: z.union([z.enum(["inf"]), z.coerce.number()]),
+                up_to: z.union([z.literal("inf"), z.coerce.number()]),
               }),
             )
             .optional(),
@@ -32442,13 +32453,13 @@ export const s_PostPricesPriceRequestBody = z.object({
           unit_amount_decimal: z.string().optional(),
         }),
       ),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   expand: z.array(z.string().max(5000)).optional(),
   lookup_key: z.string().max(200).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   nickname: z.string().max(5000).optional(),
   tax_behavior: z.enum(["exclusive", "inclusive", "unspecified"]).optional(),
@@ -32469,7 +32480,7 @@ export const s_product: z.ZodType<t_product> = z.object({
   marketing_features: z.array(s_product_marketing_feature),
   metadata: z.record(z.string(), z.string().max(500)),
   name: z.string().max(5000),
-  object: z.enum(["product"]),
+  object: z.literal("product"),
   package_dimensions: s_package_dimensions.nullable().optional(),
   shippable: PermissiveBoolean.nullable().optional(),
   statement_descriptor: z.string().max(5000).nullable().optional(),
@@ -32509,7 +32520,7 @@ export const s_PostProductsRequestBody = z.object({
                   flat_amount_decimal: z.string().optional(),
                   unit_amount: z.coerce.number().optional(),
                   unit_amount_decimal: z.string().optional(),
-                  up_to: z.union([z.enum(["inf"]), z.coerce.number()]),
+                  up_to: z.union([z.literal("inf"), z.coerce.number()]),
                 }),
               )
               .optional(),
@@ -32567,14 +32578,14 @@ export const s_PostProductsRequestBody = z.object({
 export const s_PostProductsIdRequestBody = z.object({
   active: PermissiveBoolean.optional(),
   default_price: z.string().max(5000).optional(),
-  description: z.union([z.string().max(40000), z.enum([""])]).optional(),
+  description: z.union([z.string().max(40000), z.literal("")]).optional(),
   expand: z.array(z.string().max(5000)).optional(),
-  images: z.union([z.array(z.string()), z.enum([""])]).optional(),
+  images: z.union([z.array(z.string()), z.literal("")]).optional(),
   marketing_features: z
-    .union([z.array(z.object({name: z.string().max(5000)})), z.enum([""])])
+    .union([z.array(z.object({name: z.string().max(5000)})), z.literal("")])
     .optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   name: z.string().max(5000).optional(),
   package_dimensions: z
@@ -32585,14 +32596,14 @@ export const s_PostProductsIdRequestBody = z.object({
         weight: z.coerce.number(),
         width: z.coerce.number(),
       }),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   shippable: PermissiveBoolean.optional(),
   statement_descriptor: z.string().max(22).optional(),
-  tax_code: z.union([z.string(), z.enum([""])]).optional(),
-  unit_label: z.union([z.string().max(12), z.enum([""])]).optional(),
-  url: z.union([z.string(), z.enum([""])]).optional(),
+  tax_code: z.union([z.string(), z.literal("")]).optional(),
+  unit_label: z.union([z.string().max(12), z.literal("")]).optional(),
+  url: z.union([z.string(), z.literal("")]).optional(),
 })
 
 export const s_PostProductsProductFeaturesRequestBody = z.object({
@@ -32614,7 +32625,7 @@ export const s_promotion_code: z.ZodType<t_promotion_code> = z.object({
   livemode: PermissiveBoolean,
   max_redemptions: z.coerce.number().nullable().optional(),
   metadata: z.record(z.string(), z.string().max(500)).nullable().optional(),
-  object: z.enum(["promotion_code"]),
+  object: z.literal("promotion_code"),
   restrictions: s_promotion_codes_resource_restrictions,
   times_redeemed: z.coerce.number(),
 })
@@ -32647,7 +32658,7 @@ export const s_PostPromotionCodesPromotionCodeRequestBody = z.object({
   active: PermissiveBoolean.optional(),
   expand: z.array(z.string().max(5000)).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   restrictions: z
     .object({
@@ -32701,14 +32712,14 @@ export const s_quote: z.ZodType<t_quote> = z.object({
     .object({
       data: z.array(z.lazy(() => s_item)),
       has_more: PermissiveBoolean,
-      object: z.enum(["list"]),
+      object: z.literal("list"),
       url: z.string().max(5000),
     })
     .optional(),
   livemode: PermissiveBoolean,
   metadata: z.record(z.string(), z.string().max(500)),
   number: z.string().max(5000).nullable().optional(),
-  object: z.enum(["quote"]),
+  object: z.literal("quote"),
   on_behalf_of: z
     .union([z.string().max(5000), z.lazy(() => s_account)])
     .nullable()
@@ -32736,9 +32747,11 @@ export const s_quote: z.ZodType<t_quote> = z.object({
 })
 
 export const s_PostQuotesRequestBody = z.object({
-  application_fee_amount: z.union([z.coerce.number(), z.enum([""])]).optional(),
+  application_fee_amount: z
+    .union([z.coerce.number(), z.literal("")])
+    .optional(),
   application_fee_percent: z
-    .union([z.coerce.number(), z.enum([""])])
+    .union([z.coerce.number(), z.literal("")])
     .optional(),
   automatic_tax: z
     .object({
@@ -32756,9 +32769,9 @@ export const s_PostQuotesRequestBody = z.object({
     .optional(),
   customer: z.string().max(5000).optional(),
   default_tax_rates: z
-    .union([z.array(z.string().max(5000)), z.enum([""])])
+    .union([z.array(z.string().max(5000)), z.literal("")])
     .optional(),
-  description: z.union([z.string().max(500), z.enum([""])]).optional(),
+  description: z.union([z.string().max(500), z.literal("")]).optional(),
   discounts: z
     .union([
       z.array(
@@ -32768,19 +32781,19 @@ export const s_PostQuotesRequestBody = z.object({
           promotion_code: z.string().max(5000).optional(),
         }),
       ),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   expand: z.array(z.string().max(5000)).optional(),
   expires_at: z.coerce.number().optional(),
-  footer: z.union([z.string().max(500), z.enum([""])]).optional(),
+  footer: z.union([z.string().max(500), z.literal("")]).optional(),
   from_quote: z
     .object({
       is_revision: PermissiveBoolean.optional(),
       quote: z.string().max(5000),
     })
     .optional(),
-  header: z.union([z.string().max(50), z.enum([""])]).optional(),
+  header: z.union([z.string().max(50), z.literal("")]).optional(),
   invoice_settings: z
     .object({
       days_until_due: z.coerce.number().optional(),
@@ -32804,7 +32817,7 @@ export const s_PostQuotesRequestBody = z.object({
                 promotion_code: z.string().max(5000).optional(),
               }),
             ),
-            z.enum([""]),
+            z.literal(""),
           ])
           .optional(),
         price: z.string().max(5000).optional(),
@@ -32827,13 +32840,13 @@ export const s_PostQuotesRequestBody = z.object({
           .optional(),
         quantity: z.coerce.number().optional(),
         tax_rates: z
-          .union([z.array(z.string().max(5000)), z.enum([""])])
+          .union([z.array(z.string().max(5000)), z.literal("")])
           .optional(),
       }),
     )
     .optional(),
   metadata: z.record(z.string(), z.string()).optional(),
-  on_behalf_of: z.union([z.string(), z.enum([""])]).optional(),
+  on_behalf_of: z.union([z.string(), z.literal("")]).optional(),
   subscription_data: z
     .object({
       billing_mode: z
@@ -32842,13 +32855,13 @@ export const s_PostQuotesRequestBody = z.object({
       description: z.string().max(500).optional(),
       effective_date: z
         .union([
-          z.enum(["current_period_end"]),
+          z.literal("current_period_end"),
           z.coerce.number(),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       metadata: z.record(z.string(), z.string()).optional(),
-      trial_period_days: z.union([z.coerce.number(), z.enum([""])]).optional(),
+      trial_period_days: z.union([z.coerce.number(), z.literal("")]).optional(),
     })
     .optional(),
   test_clock: z.string().max(5000).optional(),
@@ -32859,15 +32872,17 @@ export const s_PostQuotesRequestBody = z.object({
         amount_percent: z.coerce.number().optional(),
         destination: z.string(),
       }),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
 })
 
 export const s_PostQuotesQuoteRequestBody = z.object({
-  application_fee_amount: z.union([z.coerce.number(), z.enum([""])]).optional(),
+  application_fee_amount: z
+    .union([z.coerce.number(), z.literal("")])
+    .optional(),
   application_fee_percent: z
-    .union([z.coerce.number(), z.enum([""])])
+    .union([z.coerce.number(), z.literal("")])
     .optional(),
   automatic_tax: z
     .object({
@@ -32885,9 +32900,9 @@ export const s_PostQuotesQuoteRequestBody = z.object({
     .optional(),
   customer: z.string().max(5000).optional(),
   default_tax_rates: z
-    .union([z.array(z.string().max(5000)), z.enum([""])])
+    .union([z.array(z.string().max(5000)), z.literal("")])
     .optional(),
-  description: z.union([z.string().max(500), z.enum([""])]).optional(),
+  description: z.union([z.string().max(500), z.literal("")]).optional(),
   discounts: z
     .union([
       z.array(
@@ -32897,13 +32912,13 @@ export const s_PostQuotesQuoteRequestBody = z.object({
           promotion_code: z.string().max(5000).optional(),
         }),
       ),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   expand: z.array(z.string().max(5000)).optional(),
   expires_at: z.coerce.number().optional(),
-  footer: z.union([z.string().max(500), z.enum([""])]).optional(),
-  header: z.union([z.string().max(50), z.enum([""])]).optional(),
+  footer: z.union([z.string().max(500), z.literal("")]).optional(),
+  header: z.union([z.string().max(50), z.literal("")]).optional(),
   invoice_settings: z
     .object({
       days_until_due: z.coerce.number().optional(),
@@ -32927,7 +32942,7 @@ export const s_PostQuotesQuoteRequestBody = z.object({
                 promotion_code: z.string().max(5000).optional(),
               }),
             ),
-            z.enum([""]),
+            z.literal(""),
           ])
           .optional(),
         id: z.string().max(5000).optional(),
@@ -32951,25 +32966,25 @@ export const s_PostQuotesQuoteRequestBody = z.object({
           .optional(),
         quantity: z.coerce.number().optional(),
         tax_rates: z
-          .union([z.array(z.string().max(5000)), z.enum([""])])
+          .union([z.array(z.string().max(5000)), z.literal("")])
           .optional(),
       }),
     )
     .optional(),
   metadata: z.record(z.string(), z.string()).optional(),
-  on_behalf_of: z.union([z.string(), z.enum([""])]).optional(),
+  on_behalf_of: z.union([z.string(), z.literal("")]).optional(),
   subscription_data: z
     .object({
-      description: z.union([z.string().max(500), z.enum([""])]).optional(),
+      description: z.union([z.string().max(500), z.literal("")]).optional(),
       effective_date: z
         .union([
-          z.enum(["current_period_end"]),
+          z.literal("current_period_end"),
           z.coerce.number(),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       metadata: z.record(z.string(), z.string()).optional(),
-      trial_period_days: z.union([z.coerce.number(), z.enum([""])]).optional(),
+      trial_period_days: z.union([z.coerce.number(), z.literal("")]).optional(),
     })
     .optional(),
   transfer_data: z
@@ -32979,7 +32994,7 @@ export const s_PostQuotesQuoteRequestBody = z.object({
         amount_percent: z.coerce.number().optional(),
         destination: z.string(),
       }),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
 })
@@ -33005,7 +33020,7 @@ export const s_radar_early_fraud_warning: z.ZodType<t_radar_early_fraud_warning>
     fraud_type: z.string().max(5000),
     id: z.string().max(5000),
     livemode: PermissiveBoolean,
-    object: z.enum(["radar.early_fraud_warning"]),
+    object: z.literal("radar.early_fraud_warning"),
     payment_intent: z
       .union([z.string().max(5000), z.lazy(() => s_payment_intent)])
       .optional(),
@@ -33053,9 +33068,9 @@ export const s_PostRefundsRequestBody = z.object({
   expand: z.array(z.string().max(5000)).optional(),
   instructions_email: z.string().optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
-  origin: z.enum(["customer_balance"]).optional(),
+  origin: z.literal("customer_balance").optional(),
   payment_intent: z.string().max(5000).optional(),
   reason: z
     .enum(["duplicate", "fraudulent", "requested_by_customer"])
@@ -33067,7 +33082,7 @@ export const s_PostRefundsRequestBody = z.object({
 export const s_PostRefundsRefundRequestBody = z.object({
   expand: z.array(z.string().max(5000)).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
 })
 
@@ -33081,7 +33096,7 @@ export const s_reporting_report_run: z.ZodType<t_reporting_report_run> =
     error: z.string().max(5000).nullable().optional(),
     id: z.string().max(5000),
     livemode: PermissiveBoolean,
-    object: z.enum(["reporting.report_run"]),
+    object: z.literal("reporting.report_run"),
     parameters: s_financial_reporting_finance_report_run_run_parameters,
     report_type: z.string().max(5000),
     result: z
@@ -33773,7 +33788,7 @@ export const s_review: z.ZodType<t_review> = z.object({
   ip_address: z.string().max(5000).nullable().optional(),
   ip_address_location: s_radar_review_resource_location.nullable().optional(),
   livemode: PermissiveBoolean,
-  object: z.enum(["review"]),
+  object: z.literal("review"),
   open: PermissiveBoolean,
   opened_reason: z.enum(["manual", "rule"]),
   payment_intent: z
@@ -33804,7 +33819,7 @@ export const s_setup_attempt: z.ZodType<t_setup_attempt> = z.object({
     .optional(),
   id: z.string().max(5000),
   livemode: PermissiveBoolean,
-  object: z.enum(["setup_attempt"]),
+  object: z.literal("setup_attempt"),
   on_behalf_of: z
     .union([z.string().max(5000), z.lazy(() => s_account)])
     .nullable()
@@ -33864,7 +33879,7 @@ export const s_setup_intent: z.ZodType<t_setup_intent> = z.object({
     .optional(),
   metadata: z.record(z.string(), z.string().max(500)).nullable().optional(),
   next_action: s_setup_intent_next_action.nullable().optional(),
-  object: z.enum(["setup_intent"]),
+  object: z.literal("setup_intent"),
   on_behalf_of: z
     .union([z.string().max(5000), z.lazy(() => s_account)])
     .nullable()
@@ -33922,7 +33937,7 @@ export const s_PostSetupIntentsRequestBody = z.object({
           type: z.enum(["offline", "online"]),
         }),
       }),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   metadata: z.record(z.string(), z.string()).optional(),
@@ -33970,12 +33985,12 @@ export const s_PostSetupIntentsRequestBody = z.object({
                 postal_code: z.string().max(5000).optional(),
                 state: z.string().max(5000).optional(),
               }),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
-          email: z.union([z.string(), z.enum([""])]).optional(),
-          name: z.union([z.string().max(5000), z.enum([""])]).optional(),
-          phone: z.union([z.string().max(5000), z.enum([""])]).optional(),
+          email: z.union([z.string(), z.literal("")]).optional(),
+          name: z.union([z.string().max(5000), z.literal("")]).optional(),
+          phone: z.union([z.string().max(5000), z.literal("")]).optional(),
           tax_id: z.string().max(5000).optional(),
         })
         .optional(),
@@ -34230,7 +34245,7 @@ export const s_PostSetupIntentsRequestBody = z.object({
           mandate_options: z
             .object({
               custom_mandate_url: z
-                .union([z.string(), z.enum([""])])
+                .union([z.string(), z.literal("")])
                 .optional(),
               default_for: z
                 .array(z.enum(["invoice", "subscription"]))
@@ -34253,7 +34268,7 @@ export const s_PostSetupIntentsRequestBody = z.object({
           mandate_options: z
             .object({
               reference_prefix: z
-                .union([z.string().max(12), z.enum([""])])
+                .union([z.string().max(12), z.literal("")])
                 .optional(),
             })
             .optional(),
@@ -34272,7 +34287,7 @@ export const s_PostSetupIntentsRequestBody = z.object({
               interval_count: z.coerce.number().optional(),
               reference: z.string().max(80),
               start_date: z.coerce.number(),
-              supported_types: z.array(z.enum(["india"])).optional(),
+              supported_types: z.array(z.literal("india")).optional(),
             })
             .optional(),
           network: z
@@ -34401,7 +34416,7 @@ export const s_PostSetupIntentsRequestBody = z.object({
                   reference: z.string().max(255),
                 }),
               ),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
         })
@@ -34415,7 +34430,7 @@ export const s_PostSetupIntentsRequestBody = z.object({
           mandate_options: z
             .object({
               reference_prefix: z
-                .union([z.string().max(12), z.enum([""])])
+                .union([z.string().max(12), z.literal("")])
                 .optional(),
             })
             .optional(),
@@ -34481,7 +34496,7 @@ export const s_PostSetupIntentsIntentRequestBody = z.object({
   expand: z.array(z.string().max(5000)).optional(),
   flow_directions: z.array(z.enum(["inbound", "outbound"])).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   payment_method: z.string().max(5000).optional(),
   payment_method_configuration: z.string().max(100).optional(),
@@ -34526,12 +34541,12 @@ export const s_PostSetupIntentsIntentRequestBody = z.object({
                 postal_code: z.string().max(5000).optional(),
                 state: z.string().max(5000).optional(),
               }),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
-          email: z.union([z.string(), z.enum([""])]).optional(),
-          name: z.union([z.string().max(5000), z.enum([""])]).optional(),
-          phone: z.union([z.string().max(5000), z.enum([""])]).optional(),
+          email: z.union([z.string(), z.literal("")]).optional(),
+          name: z.union([z.string().max(5000), z.literal("")]).optional(),
+          phone: z.union([z.string().max(5000), z.literal("")]).optional(),
           tax_id: z.string().max(5000).optional(),
         })
         .optional(),
@@ -34786,7 +34801,7 @@ export const s_PostSetupIntentsIntentRequestBody = z.object({
           mandate_options: z
             .object({
               custom_mandate_url: z
-                .union([z.string(), z.enum([""])])
+                .union([z.string(), z.literal("")])
                 .optional(),
               default_for: z
                 .array(z.enum(["invoice", "subscription"]))
@@ -34809,7 +34824,7 @@ export const s_PostSetupIntentsIntentRequestBody = z.object({
           mandate_options: z
             .object({
               reference_prefix: z
-                .union([z.string().max(12), z.enum([""])])
+                .union([z.string().max(12), z.literal("")])
                 .optional(),
             })
             .optional(),
@@ -34828,7 +34843,7 @@ export const s_PostSetupIntentsIntentRequestBody = z.object({
               interval_count: z.coerce.number().optional(),
               reference: z.string().max(80),
               start_date: z.coerce.number(),
-              supported_types: z.array(z.enum(["india"])).optional(),
+              supported_types: z.array(z.literal("india")).optional(),
             })
             .optional(),
           network: z
@@ -34957,7 +34972,7 @@ export const s_PostSetupIntentsIntentRequestBody = z.object({
                   reference: z.string().max(255),
                 }),
               ),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
         })
@@ -34971,7 +34986,7 @@ export const s_PostSetupIntentsIntentRequestBody = z.object({
           mandate_options: z
             .object({
               reference_prefix: z
-                .union([z.string().max(12), z.enum([""])])
+                .union([z.string().max(12), z.literal("")])
                 .optional(),
             })
             .optional(),
@@ -35047,14 +35062,14 @@ export const s_PostSetupIntentsIntentConfirmRequestBody = z.object({
           type: z.enum(["offline", "online"]),
         }),
       }),
-      z.enum([""]),
+      z.literal(""),
       z.object({
         customer_acceptance: z.object({
           online: z.object({
             ip_address: z.string().optional(),
             user_agent: z.string().max(5000).optional(),
           }),
-          type: z.enum(["online"]),
+          type: z.literal("online"),
         }),
       }),
     ])
@@ -35101,12 +35116,12 @@ export const s_PostSetupIntentsIntentConfirmRequestBody = z.object({
                 postal_code: z.string().max(5000).optional(),
                 state: z.string().max(5000).optional(),
               }),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
-          email: z.union([z.string(), z.enum([""])]).optional(),
-          name: z.union([z.string().max(5000), z.enum([""])]).optional(),
-          phone: z.union([z.string().max(5000), z.enum([""])]).optional(),
+          email: z.union([z.string(), z.literal("")]).optional(),
+          name: z.union([z.string().max(5000), z.literal("")]).optional(),
+          phone: z.union([z.string().max(5000), z.literal("")]).optional(),
           tax_id: z.string().max(5000).optional(),
         })
         .optional(),
@@ -35361,7 +35376,7 @@ export const s_PostSetupIntentsIntentConfirmRequestBody = z.object({
           mandate_options: z
             .object({
               custom_mandate_url: z
-                .union([z.string(), z.enum([""])])
+                .union([z.string(), z.literal("")])
                 .optional(),
               default_for: z
                 .array(z.enum(["invoice", "subscription"]))
@@ -35384,7 +35399,7 @@ export const s_PostSetupIntentsIntentConfirmRequestBody = z.object({
           mandate_options: z
             .object({
               reference_prefix: z
-                .union([z.string().max(12), z.enum([""])])
+                .union([z.string().max(12), z.literal("")])
                 .optional(),
             })
             .optional(),
@@ -35403,7 +35418,7 @@ export const s_PostSetupIntentsIntentConfirmRequestBody = z.object({
               interval_count: z.coerce.number().optional(),
               reference: z.string().max(80),
               start_date: z.coerce.number(),
-              supported_types: z.array(z.enum(["india"])).optional(),
+              supported_types: z.array(z.literal("india")).optional(),
             })
             .optional(),
           network: z
@@ -35532,7 +35547,7 @@ export const s_PostSetupIntentsIntentConfirmRequestBody = z.object({
                   reference: z.string().max(255),
                 }),
               ),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
         })
@@ -35546,7 +35561,7 @@ export const s_PostSetupIntentsIntentConfirmRequestBody = z.object({
           mandate_options: z
             .object({
               reference_prefix: z
-                .union([z.string().max(12), z.enum([""])])
+                .union([z.string().max(12), z.literal("")])
                 .optional(),
             })
             .optional(),
@@ -35646,7 +35661,7 @@ export const s_PostShippingRatesRequestBody = z.object({
   metadata: z.record(z.string(), z.string()).optional(),
   tax_behavior: z.enum(["exclusive", "inclusive", "unspecified"]).optional(),
   tax_code: z.string().optional(),
-  type: z.enum(["fixed_amount"]).optional(),
+  type: z.literal("fixed_amount").optional(),
 })
 
 export const s_PostShippingRatesShippingRateTokenRequestBody = z.object({
@@ -35668,7 +35683,7 @@ export const s_PostShippingRatesShippingRateTokenRequestBody = z.object({
     })
     .optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   tax_behavior: z.enum(["exclusive", "inclusive", "unspecified"]).optional(),
 })
@@ -35690,7 +35705,7 @@ export const s_scheduled_query_run: z.ZodType<t_scheduled_query_run> = z.object(
       .optional(),
     id: z.string().max(5000),
     livemode: PermissiveBoolean,
-    object: z.enum(["scheduled_query_run"]),
+    object: z.literal("scheduled_query_run"),
     result_available_until: z.coerce.number(),
     sql: z.string().max(100000),
     status: z.string().max(5000),
@@ -35725,7 +35740,7 @@ export const s_PostSourcesRequestBody = z.object({
           user_agent: z.string().max(5000).optional(),
         })
         .optional(),
-      amount: z.union([z.coerce.number(), z.enum([""])]).optional(),
+      amount: z.union([z.coerce.number(), z.literal("")]).optional(),
       currency: z.string().optional(),
       interval: z.enum(["one_time", "scheduled", "variable"]).optional(),
       notification_method: z
@@ -35818,7 +35833,7 @@ export const s_PostSourcesSourceRequestBody = z.object({
           user_agent: z.string().max(5000).optional(),
         })
         .optional(),
-      amount: z.union([z.coerce.number(), z.enum([""])]).optional(),
+      amount: z.union([z.coerce.number(), z.literal("")]).optional(),
       currency: z.string().optional(),
       interval: z.enum(["one_time", "scheduled", "variable"]).optional(),
       notification_method: z
@@ -35827,7 +35842,7 @@ export const s_PostSourcesSourceRequestBody = z.object({
     })
     .optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   owner: z
     .object({
@@ -35895,7 +35910,7 @@ export const s_subscription_item: z.ZodType<t_subscription_item> = z.object({
   discounts: z.array(z.union([z.string().max(5000), z.lazy(() => s_discount)])),
   id: z.string().max(5000),
   metadata: z.record(z.string(), z.string().max(500)),
-  object: z.enum(["subscription_item"]),
+  object: z.literal("subscription_item"),
   price: z.lazy(() => s_price),
   quantity: z.coerce.number().optional(),
   subscription: z.string().max(5000),
@@ -35904,7 +35919,7 @@ export const s_subscription_item: z.ZodType<t_subscription_item> = z.object({
 
 export const s_PostSubscriptionItemsRequestBody = z.object({
   billing_thresholds: z
-    .union([z.object({usage_gte: z.coerce.number()}), z.enum([""])])
+    .union([z.object({usage_gte: z.coerce.number()}), z.literal("")])
     .optional(),
   discounts: z
     .union([
@@ -35915,7 +35930,7 @@ export const s_PostSubscriptionItemsRequestBody = z.object({
           promotion_code: z.string().max(5000).optional(),
         }),
       ),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   expand: z.array(z.string().max(5000)).optional(),
@@ -35950,7 +35965,7 @@ export const s_PostSubscriptionItemsRequestBody = z.object({
   proration_date: z.coerce.number().optional(),
   quantity: z.coerce.number().optional(),
   subscription: z.string().max(5000),
-  tax_rates: z.union([z.array(z.string().max(5000)), z.enum([""])]).optional(),
+  tax_rates: z.union([z.array(z.string().max(5000)), z.literal("")]).optional(),
 })
 
 export const s_DeleteSubscriptionItemsItemRequestBody = z.object({
@@ -35963,7 +35978,7 @@ export const s_DeleteSubscriptionItemsItemRequestBody = z.object({
 
 export const s_PostSubscriptionItemsItemRequestBody = z.object({
   billing_thresholds: z
-    .union([z.object({usage_gte: z.coerce.number()}), z.enum([""])])
+    .union([z.object({usage_gte: z.coerce.number()}), z.literal("")])
     .optional(),
   discounts: z
     .union([
@@ -35974,12 +35989,12 @@ export const s_PostSubscriptionItemsItemRequestBody = z.object({
           promotion_code: z.string().max(5000).optional(),
         }),
       ),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   expand: z.array(z.string().max(5000)).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   off_session: PermissiveBoolean.optional(),
   payment_behavior: z
@@ -36011,7 +36026,7 @@ export const s_PostSubscriptionItemsItemRequestBody = z.object({
     .optional(),
   proration_date: z.coerce.number().optional(),
   quantity: z.coerce.number().optional(),
-  tax_rates: z.union([z.array(z.string().max(5000)), z.enum([""])]).optional(),
+  tax_rates: z.union([z.array(z.string().max(5000)), z.literal("")]).optional(),
 })
 
 export const s_subscription_schedule: z.ZodType<t_subscription_schedule> =
@@ -36037,7 +36052,7 @@ export const s_subscription_schedule: z.ZodType<t_subscription_schedule> =
     id: z.string().max(5000),
     livemode: PermissiveBoolean,
     metadata: z.record(z.string(), z.string().max(500)).nullable().optional(),
-    object: z.enum(["subscription_schedule"]),
+    object: z.literal("subscription_schedule"),
     phases: z.array(z.lazy(() => s_subscription_schedule_phase_configuration)),
     released_at: z.coerce.number().nullable().optional(),
     released_subscription: z.string().max(5000).nullable().optional(),
@@ -36082,18 +36097,18 @@ export const s_PostSubscriptionSchedulesRequestBody = z.object({
             amount_gte: z.coerce.number().optional(),
             reset_billing_cycle_anchor: PermissiveBoolean.optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       collection_method: z
         .enum(["charge_automatically", "send_invoice"])
         .optional(),
       default_payment_method: z.string().max(5000).optional(),
-      description: z.union([z.string().max(500), z.enum([""])]).optional(),
+      description: z.union([z.string().max(500), z.literal("")]).optional(),
       invoice_settings: z
         .object({
           account_tax_ids: z
-            .union([z.array(z.string().max(5000)), z.enum([""])])
+            .union([z.array(z.string().max(5000)), z.literal("")])
             .optional(),
           days_until_due: z.coerce.number().optional(),
           issuer: z
@@ -36104,14 +36119,14 @@ export const s_PostSubscriptionSchedulesRequestBody = z.object({
             .optional(),
         })
         .optional(),
-      on_behalf_of: z.union([z.string(), z.enum([""])]).optional(),
+      on_behalf_of: z.union([z.string(), z.literal("")]).optional(),
       transfer_data: z
         .union([
           z.object({
             amount_percent: z.coerce.number().optional(),
             destination: z.string(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
     })
@@ -36120,7 +36135,7 @@ export const s_PostSubscriptionSchedulesRequestBody = z.object({
   expand: z.array(z.string().max(5000)).optional(),
   from_subscription: z.string().max(5000).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   phases: z
     .array(
@@ -36151,7 +36166,7 @@ export const s_PostSubscriptionSchedulesRequestBody = z.object({
                 .optional(),
               quantity: z.coerce.number().optional(),
               tax_rates: z
-                .union([z.array(z.string().max(5000)), z.enum([""])])
+                .union([z.array(z.string().max(5000)), z.literal("")])
                 .optional(),
             }),
           )
@@ -36175,7 +36190,7 @@ export const s_PostSubscriptionSchedulesRequestBody = z.object({
               amount_gte: z.coerce.number().optional(),
               reset_billing_cycle_anchor: PermissiveBoolean.optional(),
             }),
-            z.enum([""]),
+            z.literal(""),
           ])
           .optional(),
         collection_method: z
@@ -36184,9 +36199,9 @@ export const s_PostSubscriptionSchedulesRequestBody = z.object({
         currency: z.string().optional(),
         default_payment_method: z.string().max(5000).optional(),
         default_tax_rates: z
-          .union([z.array(z.string().max(5000)), z.enum([""])])
+          .union([z.array(z.string().max(5000)), z.literal("")])
           .optional(),
-        description: z.union([z.string().max(500), z.enum([""])]).optional(),
+        description: z.union([z.string().max(500), z.literal("")]).optional(),
         discounts: z
           .union([
             z.array(
@@ -36196,7 +36211,7 @@ export const s_PostSubscriptionSchedulesRequestBody = z.object({
                 promotion_code: z.string().max(5000).optional(),
               }),
             ),
-            z.enum([""]),
+            z.literal(""),
           ])
           .optional(),
         duration: z
@@ -36209,7 +36224,7 @@ export const s_PostSubscriptionSchedulesRequestBody = z.object({
         invoice_settings: z
           .object({
             account_tax_ids: z
-              .union([z.array(z.string().max(5000)), z.enum([""])])
+              .union([z.array(z.string().max(5000)), z.literal("")])
               .optional(),
             days_until_due: z.coerce.number().optional(),
             issuer: z
@@ -36223,7 +36238,7 @@ export const s_PostSubscriptionSchedulesRequestBody = z.object({
         items: z.array(
           z.object({
             billing_thresholds: z
-              .union([z.object({usage_gte: z.coerce.number()}), z.enum([""])])
+              .union([z.object({usage_gte: z.coerce.number()}), z.literal("")])
               .optional(),
             discounts: z
               .union([
@@ -36234,7 +36249,7 @@ export const s_PostSubscriptionSchedulesRequestBody = z.object({
                     promotion_code: z.string().max(5000).optional(),
                   }),
                 ),
-                z.enum([""]),
+                z.literal(""),
               ])
               .optional(),
             metadata: z.record(z.string(), z.string()).optional(),
@@ -36256,7 +36271,7 @@ export const s_PostSubscriptionSchedulesRequestBody = z.object({
               .optional(),
             quantity: z.coerce.number().optional(),
             tax_rates: z
-              .union([z.array(z.string().max(5000)), z.enum([""])])
+              .union([z.array(z.string().max(5000)), z.literal("")])
               .optional(),
           }),
         ),
@@ -36277,7 +36292,7 @@ export const s_PostSubscriptionSchedulesRequestBody = z.object({
       }),
     )
     .optional(),
-  start_date: z.union([z.coerce.number(), z.enum(["now"])]).optional(),
+  start_date: z.union([z.coerce.number(), z.literal("now")]).optional(),
 })
 
 export const s_PostSubscriptionSchedulesScheduleRequestBody = z.object({
@@ -36302,18 +36317,18 @@ export const s_PostSubscriptionSchedulesScheduleRequestBody = z.object({
             amount_gte: z.coerce.number().optional(),
             reset_billing_cycle_anchor: PermissiveBoolean.optional(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       collection_method: z
         .enum(["charge_automatically", "send_invoice"])
         .optional(),
       default_payment_method: z.string().max(5000).optional(),
-      description: z.union([z.string().max(500), z.enum([""])]).optional(),
+      description: z.union([z.string().max(500), z.literal("")]).optional(),
       invoice_settings: z
         .object({
           account_tax_ids: z
-            .union([z.array(z.string().max(5000)), z.enum([""])])
+            .union([z.array(z.string().max(5000)), z.literal("")])
             .optional(),
           days_until_due: z.coerce.number().optional(),
           issuer: z
@@ -36324,14 +36339,14 @@ export const s_PostSubscriptionSchedulesScheduleRequestBody = z.object({
             .optional(),
         })
         .optional(),
-      on_behalf_of: z.union([z.string(), z.enum([""])]).optional(),
+      on_behalf_of: z.union([z.string(), z.literal("")]).optional(),
       transfer_data: z
         .union([
           z.object({
             amount_percent: z.coerce.number().optional(),
             destination: z.string(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
     })
@@ -36339,7 +36354,7 @@ export const s_PostSubscriptionSchedulesScheduleRequestBody = z.object({
   end_behavior: z.enum(["cancel", "none", "release", "renew"]).optional(),
   expand: z.array(z.string().max(5000)).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   phases: z
     .array(
@@ -36370,7 +36385,7 @@ export const s_PostSubscriptionSchedulesScheduleRequestBody = z.object({
                 .optional(),
               quantity: z.coerce.number().optional(),
               tax_rates: z
-                .union([z.array(z.string().max(5000)), z.enum([""])])
+                .union([z.array(z.string().max(5000)), z.literal("")])
                 .optional(),
             }),
           )
@@ -36394,7 +36409,7 @@ export const s_PostSubscriptionSchedulesScheduleRequestBody = z.object({
               amount_gte: z.coerce.number().optional(),
               reset_billing_cycle_anchor: PermissiveBoolean.optional(),
             }),
-            z.enum([""]),
+            z.literal(""),
           ])
           .optional(),
         collection_method: z
@@ -36402,9 +36417,9 @@ export const s_PostSubscriptionSchedulesScheduleRequestBody = z.object({
           .optional(),
         default_payment_method: z.string().max(5000).optional(),
         default_tax_rates: z
-          .union([z.array(z.string().max(5000)), z.enum([""])])
+          .union([z.array(z.string().max(5000)), z.literal("")])
           .optional(),
-        description: z.union([z.string().max(500), z.enum([""])]).optional(),
+        description: z.union([z.string().max(500), z.literal("")]).optional(),
         discounts: z
           .union([
             z.array(
@@ -36414,7 +36429,7 @@ export const s_PostSubscriptionSchedulesScheduleRequestBody = z.object({
                 promotion_code: z.string().max(5000).optional(),
               }),
             ),
-            z.enum([""]),
+            z.literal(""),
           ])
           .optional(),
         duration: z
@@ -36423,11 +36438,11 @@ export const s_PostSubscriptionSchedulesScheduleRequestBody = z.object({
             interval_count: z.coerce.number().optional(),
           })
           .optional(),
-        end_date: z.union([z.coerce.number(), z.enum(["now"])]).optional(),
+        end_date: z.union([z.coerce.number(), z.literal("now")]).optional(),
         invoice_settings: z
           .object({
             account_tax_ids: z
-              .union([z.array(z.string().max(5000)), z.enum([""])])
+              .union([z.array(z.string().max(5000)), z.literal("")])
               .optional(),
             days_until_due: z.coerce.number().optional(),
             issuer: z
@@ -36441,7 +36456,7 @@ export const s_PostSubscriptionSchedulesScheduleRequestBody = z.object({
         items: z.array(
           z.object({
             billing_thresholds: z
-              .union([z.object({usage_gte: z.coerce.number()}), z.enum([""])])
+              .union([z.object({usage_gte: z.coerce.number()}), z.literal("")])
               .optional(),
             discounts: z
               .union([
@@ -36452,7 +36467,7 @@ export const s_PostSubscriptionSchedulesScheduleRequestBody = z.object({
                     promotion_code: z.string().max(5000).optional(),
                   }),
                 ),
-                z.enum([""]),
+                z.literal(""),
               ])
               .optional(),
             metadata: z.record(z.string(), z.string()).optional(),
@@ -36474,7 +36489,7 @@ export const s_PostSubscriptionSchedulesScheduleRequestBody = z.object({
               .optional(),
             quantity: z.coerce.number().optional(),
             tax_rates: z
-              .union([z.array(z.string().max(5000)), z.enum([""])])
+              .union([z.array(z.string().max(5000)), z.literal("")])
               .optional(),
           }),
         ),
@@ -36484,7 +36499,7 @@ export const s_PostSubscriptionSchedulesScheduleRequestBody = z.object({
         proration_behavior: z
           .enum(["always_invoice", "create_prorations", "none"])
           .optional(),
-        start_date: z.union([z.coerce.number(), z.enum(["now"])]).optional(),
+        start_date: z.union([z.coerce.number(), z.literal("now")]).optional(),
         transfer_data: z
           .object({
             amount_percent: z.coerce.number().optional(),
@@ -36492,7 +36507,7 @@ export const s_PostSubscriptionSchedulesScheduleRequestBody = z.object({
           })
           .optional(),
         trial: PermissiveBoolean.optional(),
-        trial_end: z.union([z.coerce.number(), z.enum(["now"])]).optional(),
+        trial_end: z.union([z.coerce.number(), z.literal("now")]).optional(),
       }),
     )
     .optional(),
@@ -36539,13 +36554,13 @@ export const s_PostSubscriptionsRequestBody = z.object({
           .optional(),
         quantity: z.coerce.number().optional(),
         tax_rates: z
-          .union([z.array(z.string().max(5000)), z.enum([""])])
+          .union([z.array(z.string().max(5000)), z.literal("")])
           .optional(),
       }),
     )
     .optional(),
   application_fee_percent: z
-    .union([z.coerce.number(), z.enum([""])])
+    .union([z.coerce.number(), z.literal("")])
     .optional(),
   automatic_tax: z
     .object({
@@ -36576,7 +36591,7 @@ export const s_PostSubscriptionsRequestBody = z.object({
         amount_gte: z.coerce.number().optional(),
         reset_billing_cycle_anchor: PermissiveBoolean.optional(),
       }),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   cancel_at: z
@@ -36592,7 +36607,7 @@ export const s_PostSubscriptionsRequestBody = z.object({
   default_payment_method: z.string().max(5000).optional(),
   default_source: z.string().max(5000).optional(),
   default_tax_rates: z
-    .union([z.array(z.string().max(5000)), z.enum([""])])
+    .union([z.array(z.string().max(5000)), z.literal("")])
     .optional(),
   description: z.string().max(500).optional(),
   discounts: z
@@ -36604,14 +36619,14 @@ export const s_PostSubscriptionsRequestBody = z.object({
           promotion_code: z.string().max(5000).optional(),
         }),
       ),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   expand: z.array(z.string().max(5000)).optional(),
   invoice_settings: z
     .object({
       account_tax_ids: z
-        .union([z.array(z.string().max(5000)), z.enum([""])])
+        .union([z.array(z.string().max(5000)), z.literal("")])
         .optional(),
       issuer: z
         .object({
@@ -36625,7 +36640,7 @@ export const s_PostSubscriptionsRequestBody = z.object({
     .array(
       z.object({
         billing_thresholds: z
-          .union([z.object({usage_gte: z.coerce.number()}), z.enum([""])])
+          .union([z.object({usage_gte: z.coerce.number()}), z.literal("")])
           .optional(),
         discounts: z
           .union([
@@ -36636,7 +36651,7 @@ export const s_PostSubscriptionsRequestBody = z.object({
                 promotion_code: z.string().max(5000).optional(),
               }),
             ),
-            z.enum([""]),
+            z.literal(""),
           ])
           .optional(),
         metadata: z.record(z.string(), z.string()).optional(),
@@ -36658,16 +36673,16 @@ export const s_PostSubscriptionsRequestBody = z.object({
           .optional(),
         quantity: z.coerce.number().optional(),
         tax_rates: z
-          .union([z.array(z.string().max(5000)), z.enum([""])])
+          .union([z.array(z.string().max(5000)), z.literal("")])
           .optional(),
       }),
     )
     .optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   off_session: PermissiveBoolean.optional(),
-  on_behalf_of: z.union([z.string(), z.enum([""])]).optional(),
+  on_behalf_of: z.union([z.string(), z.literal("")]).optional(),
   payment_behavior: z
     .enum([
       "allow_incomplete",
@@ -36694,7 +36709,7 @@ export const s_PostSubscriptionsRequestBody = z.object({
                   .enum(["automatic", "instant", "microdeposits"])
                   .optional(),
               }),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
           bancontact: z
@@ -36702,7 +36717,7 @@ export const s_PostSubscriptionsRequestBody = z.object({
               z.object({
                 preferred_language: z.enum(["de", "en", "fr", "nl"]).optional(),
               }),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
           card: z
@@ -36736,7 +36751,7 @@ export const s_PostSubscriptionsRequestBody = z.object({
                   .enum(["any", "automatic", "challenge"])
                   .optional(),
               }),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
           customer_balance: z
@@ -36752,14 +36767,14 @@ export const s_PostSubscriptionsRequestBody = z.object({
                   .optional(),
                 funding_type: z.string().optional(),
               }),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
           konbini: z
-            .union([z.record(z.string(), z.unknown()), z.enum([""])])
+            .union([z.record(z.string(), z.unknown()), z.literal("")])
             .optional(),
           sepa_debit: z
-            .union([z.record(z.string(), z.unknown()), z.enum([""])])
+            .union([z.record(z.string(), z.unknown()), z.literal("")])
             .optional(),
           us_bank_account: z
             .union([
@@ -36792,7 +36807,7 @@ export const s_PostSubscriptionsRequestBody = z.object({
                   .enum(["automatic", "instant", "microdeposits"])
                   .optional(),
               }),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
         })
@@ -36842,7 +36857,7 @@ export const s_PostSubscriptionsRequestBody = z.object({
               "wechat_pay",
             ]),
           ),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       save_default_payment_method: z
@@ -36856,7 +36871,7 @@ export const s_PostSubscriptionsRequestBody = z.object({
         interval: z.enum(["day", "month", "week", "year"]),
         interval_count: z.coerce.number().optional(),
       }),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   proration_behavior: z
@@ -36868,7 +36883,7 @@ export const s_PostSubscriptionsRequestBody = z.object({
       destination: z.string(),
     })
     .optional(),
-  trial_end: z.union([z.enum(["now"]), z.coerce.number()]).optional(),
+  trial_end: z.union([z.literal("now"), z.coerce.number()]).optional(),
   trial_from_plan: PermissiveBoolean.optional(),
   trial_period_days: z.coerce.number().optional(),
   trial_settings: z
@@ -36883,7 +36898,7 @@ export const s_PostSubscriptionsRequestBody = z.object({
 export const s_DeleteSubscriptionsSubscriptionExposedIdRequestBody = z.object({
   cancellation_details: z
     .object({
-      comment: z.union([z.string().max(5000), z.enum([""])]).optional(),
+      comment: z.union([z.string().max(5000), z.literal("")]).optional(),
       feedback: z
         .enum([
           "",
@@ -36931,13 +36946,13 @@ export const s_PostSubscriptionsSubscriptionExposedIdRequestBody = z.object({
           .optional(),
         quantity: z.coerce.number().optional(),
         tax_rates: z
-          .union([z.array(z.string().max(5000)), z.enum([""])])
+          .union([z.array(z.string().max(5000)), z.literal("")])
           .optional(),
       }),
     )
     .optional(),
   application_fee_percent: z
-    .union([z.coerce.number(), z.enum([""])])
+    .union([z.coerce.number(), z.literal("")])
     .optional(),
   automatic_tax: z
     .object({
@@ -36957,20 +36972,20 @@ export const s_PostSubscriptionsSubscriptionExposedIdRequestBody = z.object({
         amount_gte: z.coerce.number().optional(),
         reset_billing_cycle_anchor: PermissiveBoolean.optional(),
       }),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   cancel_at: z
     .union([
       z.coerce.number(),
-      z.enum([""]),
+      z.literal(""),
       z.enum(["max_period_end", "min_period_end"]),
     ])
     .optional(),
   cancel_at_period_end: PermissiveBoolean.optional(),
   cancellation_details: z
     .object({
-      comment: z.union([z.string().max(5000), z.enum([""])]).optional(),
+      comment: z.union([z.string().max(5000), z.literal("")]).optional(),
       feedback: z
         .enum([
           "",
@@ -36991,11 +37006,11 @@ export const s_PostSubscriptionsSubscriptionExposedIdRequestBody = z.object({
     .optional(),
   days_until_due: z.coerce.number().optional(),
   default_payment_method: z.string().max(5000).optional(),
-  default_source: z.union([z.string().max(5000), z.enum([""])]).optional(),
+  default_source: z.union([z.string().max(5000), z.literal("")]).optional(),
   default_tax_rates: z
-    .union([z.array(z.string().max(5000)), z.enum([""])])
+    .union([z.array(z.string().max(5000)), z.literal("")])
     .optional(),
-  description: z.union([z.string().max(500), z.enum([""])]).optional(),
+  description: z.union([z.string().max(500), z.literal("")]).optional(),
   discounts: z
     .union([
       z.array(
@@ -37005,14 +37020,14 @@ export const s_PostSubscriptionsSubscriptionExposedIdRequestBody = z.object({
           promotion_code: z.string().max(5000).optional(),
         }),
       ),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   expand: z.array(z.string().max(5000)).optional(),
   invoice_settings: z
     .object({
       account_tax_ids: z
-        .union([z.array(z.string().max(5000)), z.enum([""])])
+        .union([z.array(z.string().max(5000)), z.literal("")])
         .optional(),
       issuer: z
         .object({
@@ -37026,7 +37041,7 @@ export const s_PostSubscriptionsSubscriptionExposedIdRequestBody = z.object({
     .array(
       z.object({
         billing_thresholds: z
-          .union([z.object({usage_gte: z.coerce.number()}), z.enum([""])])
+          .union([z.object({usage_gte: z.coerce.number()}), z.literal("")])
           .optional(),
         clear_usage: PermissiveBoolean.optional(),
         deleted: PermissiveBoolean.optional(),
@@ -37039,12 +37054,12 @@ export const s_PostSubscriptionsSubscriptionExposedIdRequestBody = z.object({
                 promotion_code: z.string().max(5000).optional(),
               }),
             ),
-            z.enum([""]),
+            z.literal(""),
           ])
           .optional(),
         id: z.string().max(5000).optional(),
         metadata: z
-          .union([z.record(z.string(), z.string()), z.enum([""])])
+          .union([z.record(z.string(), z.string()), z.literal("")])
           .optional(),
         price: z.string().max(5000).optional(),
         price_data: z
@@ -37064,23 +37079,23 @@ export const s_PostSubscriptionsSubscriptionExposedIdRequestBody = z.object({
           .optional(),
         quantity: z.coerce.number().optional(),
         tax_rates: z
-          .union([z.array(z.string().max(5000)), z.enum([""])])
+          .union([z.array(z.string().max(5000)), z.literal("")])
           .optional(),
       }),
     )
     .optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   off_session: PermissiveBoolean.optional(),
-  on_behalf_of: z.union([z.string(), z.enum([""])]).optional(),
+  on_behalf_of: z.union([z.string(), z.literal("")]).optional(),
   pause_collection: z
     .union([
       z.object({
         behavior: z.enum(["keep_as_draft", "mark_uncollectible", "void"]),
         resumes_at: z.coerce.number().optional(),
       }),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   payment_behavior: z
@@ -37109,7 +37124,7 @@ export const s_PostSubscriptionsSubscriptionExposedIdRequestBody = z.object({
                   .enum(["automatic", "instant", "microdeposits"])
                   .optional(),
               }),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
           bancontact: z
@@ -37117,7 +37132,7 @@ export const s_PostSubscriptionsSubscriptionExposedIdRequestBody = z.object({
               z.object({
                 preferred_language: z.enum(["de", "en", "fr", "nl"]).optional(),
               }),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
           card: z
@@ -37151,7 +37166,7 @@ export const s_PostSubscriptionsSubscriptionExposedIdRequestBody = z.object({
                   .enum(["any", "automatic", "challenge"])
                   .optional(),
               }),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
           customer_balance: z
@@ -37167,14 +37182,14 @@ export const s_PostSubscriptionsSubscriptionExposedIdRequestBody = z.object({
                   .optional(),
                 funding_type: z.string().optional(),
               }),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
           konbini: z
-            .union([z.record(z.string(), z.unknown()), z.enum([""])])
+            .union([z.record(z.string(), z.unknown()), z.literal("")])
             .optional(),
           sepa_debit: z
-            .union([z.record(z.string(), z.unknown()), z.enum([""])])
+            .union([z.record(z.string(), z.unknown()), z.literal("")])
             .optional(),
           us_bank_account: z
             .union([
@@ -37207,7 +37222,7 @@ export const s_PostSubscriptionsSubscriptionExposedIdRequestBody = z.object({
                   .enum(["automatic", "instant", "microdeposits"])
                   .optional(),
               }),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
         })
@@ -37257,7 +37272,7 @@ export const s_PostSubscriptionsSubscriptionExposedIdRequestBody = z.object({
               "wechat_pay",
             ]),
           ),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       save_default_payment_method: z
@@ -37271,7 +37286,7 @@ export const s_PostSubscriptionsSubscriptionExposedIdRequestBody = z.object({
         interval: z.enum(["day", "month", "week", "year"]),
         interval_count: z.coerce.number().optional(),
       }),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   proration_behavior: z
@@ -37284,10 +37299,10 @@ export const s_PostSubscriptionsSubscriptionExposedIdRequestBody = z.object({
         amount_percent: z.coerce.number().optional(),
         destination: z.string(),
       }),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
-  trial_end: z.union([z.enum(["now"]), z.coerce.number()]).optional(),
+  trial_end: z.union([z.literal("now"), z.coerce.number()]).optional(),
   trial_from_plan: PermissiveBoolean.optional(),
   trial_settings: z
     .object({
@@ -37299,7 +37314,7 @@ export const s_PostSubscriptionsSubscriptionExposedIdRequestBody = z.object({
 })
 
 export const s_PostSubscriptionsSubscriptionMigrateRequestBody = z.object({
-  billing_mode: z.object({type: z.enum(["flexible"])}),
+  billing_mode: z.object({type: z.literal("flexible")}),
   expand: z.array(z.string().max(5000)).optional(),
 })
 
@@ -37319,12 +37334,14 @@ export const s_PostTaxCalculationsRequestBody = z.object({
     .object({
       address: z
         .object({
-          city: z.union([z.string().max(5000), z.enum([""])]).optional(),
+          city: z.union([z.string().max(5000), z.literal("")]).optional(),
           country: z.string().max(5000),
-          line1: z.union([z.string().max(5000), z.enum([""])]).optional(),
-          line2: z.union([z.string().max(5000), z.enum([""])]).optional(),
-          postal_code: z.union([z.string().max(5000), z.enum([""])]).optional(),
-          state: z.union([z.string().max(5000), z.enum([""])]).optional(),
+          line1: z.union([z.string().max(5000), z.literal("")]).optional(),
+          line2: z.union([z.string().max(5000), z.literal("")]).optional(),
+          postal_code: z
+            .union([z.string().max(5000), z.literal("")])
+            .optional(),
+          state: z.union([z.string().max(5000), z.literal("")]).optional(),
         })
         .optional(),
       address_source: z.enum(["billing", "shipping"]).optional(),
@@ -37468,12 +37485,12 @@ export const s_PostTaxCalculationsRequestBody = z.object({
   ship_from_details: z
     .object({
       address: z.object({
-        city: z.union([z.string().max(5000), z.enum([""])]).optional(),
+        city: z.union([z.string().max(5000), z.literal("")]).optional(),
         country: z.string().max(5000),
-        line1: z.union([z.string().max(5000), z.enum([""])]).optional(),
-        line2: z.union([z.string().max(5000), z.enum([""])]).optional(),
-        postal_code: z.union([z.string().max(5000), z.enum([""])]).optional(),
-        state: z.union([z.string().max(5000), z.enum([""])]).optional(),
+        line1: z.union([z.string().max(5000), z.literal("")]).optional(),
+        line2: z.union([z.string().max(5000), z.literal("")]).optional(),
+        postal_code: z.union([z.string().max(5000), z.literal("")]).optional(),
+        state: z.union([z.string().max(5000), z.literal("")]).optional(),
       }),
     })
     .optional(),
@@ -37489,7 +37506,7 @@ export const s_PostTaxCalculationsRequestBody = z.object({
 })
 
 export const s_PostTaxRegistrationsRequestBody = z.object({
-  active_from: z.union([z.enum(["now"]), z.coerce.number()]),
+  active_from: z.union([z.literal("now"), z.coerce.number()]),
   country: z.string().max(5000),
   country_options: z.object({
     ae: z
@@ -37501,7 +37518,7 @@ export const s_PostTaxRegistrationsRequestBody = z.object({
               .optional(),
           })
           .optional(),
-        type: z.enum(["standard"]),
+        type: z.literal("standard"),
       })
       .optional(),
     al: z
@@ -37513,10 +37530,10 @@ export const s_PostTaxRegistrationsRequestBody = z.object({
               .optional(),
           })
           .optional(),
-        type: z.enum(["standard"]),
+        type: z.literal("standard"),
       })
       .optional(),
-    am: z.object({type: z.enum(["simplified"])}).optional(),
+    am: z.object({type: z.literal("simplified")}).optional(),
     ao: z
       .object({
         standard: z
@@ -37526,7 +37543,7 @@ export const s_PostTaxRegistrationsRequestBody = z.object({
               .optional(),
           })
           .optional(),
-        type: z.enum(["standard"]),
+        type: z.literal("standard"),
       })
       .optional(),
     at: z
@@ -37552,7 +37569,7 @@ export const s_PostTaxRegistrationsRequestBody = z.object({
               .optional(),
           })
           .optional(),
-        type: z.enum(["standard"]),
+        type: z.literal("standard"),
       })
       .optional(),
     aw: z
@@ -37564,10 +37581,10 @@ export const s_PostTaxRegistrationsRequestBody = z.object({
               .optional(),
           })
           .optional(),
-        type: z.enum(["standard"]),
+        type: z.literal("standard"),
       })
       .optional(),
-    az: z.object({type: z.enum(["simplified"])}).optional(),
+    az: z.object({type: z.literal("simplified")}).optional(),
     ba: z
       .object({
         standard: z
@@ -37577,7 +37594,7 @@ export const s_PostTaxRegistrationsRequestBody = z.object({
               .optional(),
           })
           .optional(),
-        type: z.enum(["standard"]),
+        type: z.literal("standard"),
       })
       .optional(),
     bb: z
@@ -37589,7 +37606,7 @@ export const s_PostTaxRegistrationsRequestBody = z.object({
               .optional(),
           })
           .optional(),
-        type: z.enum(["standard"]),
+        type: z.literal("standard"),
       })
       .optional(),
     bd: z
@@ -37601,7 +37618,7 @@ export const s_PostTaxRegistrationsRequestBody = z.object({
               .optional(),
           })
           .optional(),
-        type: z.enum(["standard"]),
+        type: z.literal("standard"),
       })
       .optional(),
     be: z
@@ -37627,7 +37644,7 @@ export const s_PostTaxRegistrationsRequestBody = z.object({
               .optional(),
           })
           .optional(),
-        type: z.enum(["standard"]),
+        type: z.literal("standard"),
       })
       .optional(),
     bg: z
@@ -37653,10 +37670,10 @@ export const s_PostTaxRegistrationsRequestBody = z.object({
               .optional(),
           })
           .optional(),
-        type: z.enum(["standard"]),
+        type: z.literal("standard"),
       })
       .optional(),
-    bj: z.object({type: z.enum(["simplified"])}).optional(),
+    bj: z.object({type: z.literal("simplified")}).optional(),
     bs: z
       .object({
         standard: z
@@ -37666,10 +37683,10 @@ export const s_PostTaxRegistrationsRequestBody = z.object({
               .optional(),
           })
           .optional(),
-        type: z.enum(["standard"]),
+        type: z.literal("standard"),
       })
       .optional(),
-    by: z.object({type: z.enum(["simplified"])}).optional(),
+    by: z.object({type: z.literal("simplified")}).optional(),
     ca: z
       .object({
         province_standard: z
@@ -37687,7 +37704,7 @@ export const s_PostTaxRegistrationsRequestBody = z.object({
               .optional(),
           })
           .optional(),
-        type: z.enum(["standard"]),
+        type: z.literal("standard"),
       })
       .optional(),
     ch: z
@@ -37699,14 +37716,14 @@ export const s_PostTaxRegistrationsRequestBody = z.object({
               .optional(),
           })
           .optional(),
-        type: z.enum(["standard"]),
+        type: z.literal("standard"),
       })
       .optional(),
-    cl: z.object({type: z.enum(["simplified"])}).optional(),
-    cm: z.object({type: z.enum(["simplified"])}).optional(),
-    co: z.object({type: z.enum(["simplified"])}).optional(),
-    cr: z.object({type: z.enum(["simplified"])}).optional(),
-    cv: z.object({type: z.enum(["simplified"])}).optional(),
+    cl: z.object({type: z.literal("simplified")}).optional(),
+    cm: z.object({type: z.literal("simplified")}).optional(),
+    co: z.object({type: z.literal("simplified")}).optional(),
+    cr: z.object({type: z.literal("simplified")}).optional(),
+    cv: z.object({type: z.literal("simplified")}).optional(),
     cy: z
       .object({
         standard: z
@@ -37763,7 +37780,7 @@ export const s_PostTaxRegistrationsRequestBody = z.object({
         type: z.enum(["ioss", "oss_non_union", "oss_union", "standard"]),
       })
       .optional(),
-    ec: z.object({type: z.enum(["simplified"])}).optional(),
+    ec: z.object({type: z.literal("simplified")}).optional(),
     ee: z
       .object({
         standard: z
@@ -37778,7 +37795,7 @@ export const s_PostTaxRegistrationsRequestBody = z.object({
         type: z.enum(["ioss", "oss_non_union", "oss_union", "standard"]),
       })
       .optional(),
-    eg: z.object({type: z.enum(["simplified"])}).optional(),
+    eg: z.object({type: z.literal("simplified")}).optional(),
     es: z
       .object({
         standard: z
@@ -37802,7 +37819,7 @@ export const s_PostTaxRegistrationsRequestBody = z.object({
               .optional(),
           })
           .optional(),
-        type: z.enum(["standard"]),
+        type: z.literal("standard"),
       })
       .optional(),
     fi: z
@@ -37842,10 +37859,10 @@ export const s_PostTaxRegistrationsRequestBody = z.object({
               .optional(),
           })
           .optional(),
-        type: z.enum(["standard"]),
+        type: z.literal("standard"),
       })
       .optional(),
-    ge: z.object({type: z.enum(["simplified"])}).optional(),
+    ge: z.object({type: z.literal("simplified")}).optional(),
     gn: z
       .object({
         standard: z
@@ -37855,7 +37872,7 @@ export const s_PostTaxRegistrationsRequestBody = z.object({
               .optional(),
           })
           .optional(),
-        type: z.enum(["standard"]),
+        type: z.literal("standard"),
       })
       .optional(),
     gr: z
@@ -37900,7 +37917,7 @@ export const s_PostTaxRegistrationsRequestBody = z.object({
         type: z.enum(["ioss", "oss_non_union", "oss_union", "standard"]),
       })
       .optional(),
-    id: z.object({type: z.enum(["simplified"])}).optional(),
+    id: z.object({type: z.literal("simplified")}).optional(),
     ie: z
       .object({
         standard: z
@@ -37915,7 +37932,7 @@ export const s_PostTaxRegistrationsRequestBody = z.object({
         type: z.enum(["ioss", "oss_non_union", "oss_union", "standard"]),
       })
       .optional(),
-    in: z.object({type: z.enum(["simplified"])}).optional(),
+    in: z.object({type: z.literal("simplified")}).optional(),
     is: z
       .object({
         standard: z
@@ -37925,7 +37942,7 @@ export const s_PostTaxRegistrationsRequestBody = z.object({
               .optional(),
           })
           .optional(),
-        type: z.enum(["standard"]),
+        type: z.literal("standard"),
       })
       .optional(),
     it: z
@@ -37951,15 +37968,15 @@ export const s_PostTaxRegistrationsRequestBody = z.object({
               .optional(),
           })
           .optional(),
-        type: z.enum(["standard"]),
+        type: z.literal("standard"),
       })
       .optional(),
-    ke: z.object({type: z.enum(["simplified"])}).optional(),
-    kg: z.object({type: z.enum(["simplified"])}).optional(),
-    kh: z.object({type: z.enum(["simplified"])}).optional(),
-    kr: z.object({type: z.enum(["simplified"])}).optional(),
-    kz: z.object({type: z.enum(["simplified"])}).optional(),
-    la: z.object({type: z.enum(["simplified"])}).optional(),
+    ke: z.object({type: z.literal("simplified")}).optional(),
+    kg: z.object({type: z.literal("simplified")}).optional(),
+    kh: z.object({type: z.literal("simplified")}).optional(),
+    kr: z.object({type: z.literal("simplified")}).optional(),
+    kz: z.object({type: z.literal("simplified")}).optional(),
+    la: z.object({type: z.literal("simplified")}).optional(),
     lt: z
       .object({
         standard: z
@@ -38002,8 +38019,8 @@ export const s_PostTaxRegistrationsRequestBody = z.object({
         type: z.enum(["ioss", "oss_non_union", "oss_union", "standard"]),
       })
       .optional(),
-    ma: z.object({type: z.enum(["simplified"])}).optional(),
-    md: z.object({type: z.enum(["simplified"])}).optional(),
+    ma: z.object({type: z.literal("simplified")}).optional(),
+    md: z.object({type: z.literal("simplified")}).optional(),
     me: z
       .object({
         standard: z
@@ -38013,7 +38030,7 @@ export const s_PostTaxRegistrationsRequestBody = z.object({
               .optional(),
           })
           .optional(),
-        type: z.enum(["standard"]),
+        type: z.literal("standard"),
       })
       .optional(),
     mk: z
@@ -38025,7 +38042,7 @@ export const s_PostTaxRegistrationsRequestBody = z.object({
               .optional(),
           })
           .optional(),
-        type: z.enum(["standard"]),
+        type: z.literal("standard"),
       })
       .optional(),
     mr: z
@@ -38037,7 +38054,7 @@ export const s_PostTaxRegistrationsRequestBody = z.object({
               .optional(),
           })
           .optional(),
-        type: z.enum(["standard"]),
+        type: z.literal("standard"),
       })
       .optional(),
     mt: z
@@ -38054,9 +38071,9 @@ export const s_PostTaxRegistrationsRequestBody = z.object({
         type: z.enum(["ioss", "oss_non_union", "oss_union", "standard"]),
       })
       .optional(),
-    mx: z.object({type: z.enum(["simplified"])}).optional(),
-    my: z.object({type: z.enum(["simplified"])}).optional(),
-    ng: z.object({type: z.enum(["simplified"])}).optional(),
+    mx: z.object({type: z.literal("simplified")}).optional(),
+    my: z.object({type: z.literal("simplified")}).optional(),
+    ng: z.object({type: z.literal("simplified")}).optional(),
     nl: z
       .object({
         standard: z
@@ -38080,10 +38097,10 @@ export const s_PostTaxRegistrationsRequestBody = z.object({
               .optional(),
           })
           .optional(),
-        type: z.enum(["standard"]),
+        type: z.literal("standard"),
       })
       .optional(),
-    np: z.object({type: z.enum(["simplified"])}).optional(),
+    np: z.object({type: z.literal("simplified")}).optional(),
     nz: z
       .object({
         standard: z
@@ -38093,7 +38110,7 @@ export const s_PostTaxRegistrationsRequestBody = z.object({
               .optional(),
           })
           .optional(),
-        type: z.enum(["standard"]),
+        type: z.literal("standard"),
       })
       .optional(),
     om: z
@@ -38105,11 +38122,11 @@ export const s_PostTaxRegistrationsRequestBody = z.object({
               .optional(),
           })
           .optional(),
-        type: z.enum(["standard"]),
+        type: z.literal("standard"),
       })
       .optional(),
-    pe: z.object({type: z.enum(["simplified"])}).optional(),
-    ph: z.object({type: z.enum(["simplified"])}).optional(),
+    pe: z.object({type: z.literal("simplified")}).optional(),
+    ph: z.object({type: z.literal("simplified")}).optional(),
     pl: z
       .object({
         standard: z
@@ -38161,11 +38178,11 @@ export const s_PostTaxRegistrationsRequestBody = z.object({
               .optional(),
           })
           .optional(),
-        type: z.enum(["standard"]),
+        type: z.literal("standard"),
       })
       .optional(),
-    ru: z.object({type: z.enum(["simplified"])}).optional(),
-    sa: z.object({type: z.enum(["simplified"])}).optional(),
+    ru: z.object({type: z.literal("simplified")}).optional(),
+    sa: z.object({type: z.literal("simplified")}).optional(),
     se: z
       .object({
         standard: z
@@ -38189,7 +38206,7 @@ export const s_PostTaxRegistrationsRequestBody = z.object({
               .optional(),
           })
           .optional(),
-        type: z.enum(["standard"]),
+        type: z.literal("standard"),
       })
       .optional(),
     si: z
@@ -38220,7 +38237,7 @@ export const s_PostTaxRegistrationsRequestBody = z.object({
         type: z.enum(["ioss", "oss_non_union", "oss_union", "standard"]),
       })
       .optional(),
-    sn: z.object({type: z.enum(["simplified"])}).optional(),
+    sn: z.object({type: z.literal("simplified")}).optional(),
     sr: z
       .object({
         standard: z
@@ -38230,15 +38247,15 @@ export const s_PostTaxRegistrationsRequestBody = z.object({
               .optional(),
           })
           .optional(),
-        type: z.enum(["standard"]),
+        type: z.literal("standard"),
       })
       .optional(),
-    th: z.object({type: z.enum(["simplified"])}).optional(),
-    tj: z.object({type: z.enum(["simplified"])}).optional(),
-    tr: z.object({type: z.enum(["simplified"])}).optional(),
-    tz: z.object({type: z.enum(["simplified"])}).optional(),
-    ua: z.object({type: z.enum(["simplified"])}).optional(),
-    ug: z.object({type: z.enum(["simplified"])}).optional(),
+    th: z.object({type: z.literal("simplified")}).optional(),
+    tj: z.object({type: z.literal("simplified")}).optional(),
+    tr: z.object({type: z.literal("simplified")}).optional(),
+    tz: z.object({type: z.literal("simplified")}).optional(),
+    ua: z.object({type: z.literal("simplified")}).optional(),
+    ug: z.object({type: z.literal("simplified")}).optional(),
     us: z
       .object({
         local_amusement_tax: z
@@ -38280,11 +38297,11 @@ export const s_PostTaxRegistrationsRequestBody = z.object({
               .optional(),
           })
           .optional(),
-        type: z.enum(["standard"]),
+        type: z.literal("standard"),
       })
       .optional(),
-    uz: z.object({type: z.enum(["simplified"])}).optional(),
-    vn: z.object({type: z.enum(["simplified"])}).optional(),
+    uz: z.object({type: z.literal("simplified")}).optional(),
+    vn: z.object({type: z.literal("simplified")}).optional(),
     za: z
       .object({
         standard: z
@@ -38294,10 +38311,10 @@ export const s_PostTaxRegistrationsRequestBody = z.object({
               .optional(),
           })
           .optional(),
-        type: z.enum(["standard"]),
+        type: z.literal("standard"),
       })
       .optional(),
-    zm: z.object({type: z.enum(["simplified"])}).optional(),
+    zm: z.object({type: z.literal("simplified")}).optional(),
     zw: z
       .object({
         standard: z
@@ -38307,7 +38324,7 @@ export const s_PostTaxRegistrationsRequestBody = z.object({
               .optional(),
           })
           .optional(),
-        type: z.enum(["standard"]),
+        type: z.literal("standard"),
       })
       .optional(),
   }),
@@ -38316,10 +38333,10 @@ export const s_PostTaxRegistrationsRequestBody = z.object({
 })
 
 export const s_PostTaxRegistrationsIdRequestBody = z.object({
-  active_from: z.union([z.enum(["now"]), z.coerce.number()]).optional(),
+  active_from: z.union([z.literal("now"), z.coerce.number()]).optional(),
   expand: z.array(z.string().max(5000)).optional(),
   expires_at: z
-    .union([z.enum(["now"]), z.coerce.number(), z.enum([""])])
+    .union([z.literal("now"), z.coerce.number(), z.literal("")])
     .optional(),
 })
 
@@ -38542,7 +38559,7 @@ export const s_PostTaxRatesTaxRateRequestBody = z.object({
   expand: z.array(z.string().max(5000)).optional(),
   jurisdiction: z.string().max(50).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   state: z.string().max(5000).optional(),
   tax_type: z
@@ -38574,7 +38591,7 @@ export const s_terminal_configuration: z.ZodType<t_terminal_configuration> =
     is_account_default: PermissiveBoolean.nullable().optional(),
     livemode: PermissiveBoolean,
     name: z.string().max(5000).nullable().optional(),
-    object: z.enum(["terminal.configuration"]),
+    object: z.literal("terminal.configuration"),
     offline:
       s_terminal_configuration_configuration_resource_offline_config.optional(),
     reboot_window:
@@ -38591,18 +38608,18 @@ export const s_terminal_configuration: z.ZodType<t_terminal_configuration> =
 
 export const s_PostTerminalConfigurationsRequestBody = z.object({
   bbpos_wisepos_e: z
-    .object({splashscreen: z.union([z.string(), z.enum([""])]).optional()})
+    .object({splashscreen: z.union([z.string(), z.literal("")]).optional()})
     .optional(),
   expand: z.array(z.string().max(5000)).optional(),
   name: z.string().max(100).optional(),
   offline: z
-    .union([z.object({enabled: PermissiveBoolean}), z.enum([""])])
+    .union([z.object({enabled: PermissiveBoolean}), z.literal("")])
     .optional(),
   reboot_window: z
     .object({end_hour: z.coerce.number(), start_hour: z.coerce.number()})
     .optional(),
   stripe_s700: z
-    .object({splashscreen: z.union([z.string(), z.enum([""])]).optional()})
+    .object({splashscreen: z.union([z.string(), z.literal("")]).optional()})
     .optional(),
   tipping: z
     .union([
@@ -38748,11 +38765,11 @@ export const s_PostTerminalConfigurationsRequestBody = z.object({
           })
           .optional(),
       }),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   verifone_p400: z
-    .object({splashscreen: z.union([z.string(), z.enum([""])]).optional()})
+    .object({splashscreen: z.union([z.string(), z.literal("")]).optional()})
     .optional(),
   wifi: z
     .union([
@@ -38783,7 +38800,7 @@ export const s_PostTerminalConfigurationsRequestBody = z.object({
           "personal_psk",
         ]),
       }),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
 })
@@ -38791,25 +38808,25 @@ export const s_PostTerminalConfigurationsRequestBody = z.object({
 export const s_PostTerminalConfigurationsConfigurationRequestBody = z.object({
   bbpos_wisepos_e: z
     .union([
-      z.object({splashscreen: z.union([z.string(), z.enum([""])]).optional()}),
-      z.enum([""]),
+      z.object({splashscreen: z.union([z.string(), z.literal("")]).optional()}),
+      z.literal(""),
     ])
     .optional(),
   expand: z.array(z.string().max(5000)).optional(),
   name: z.string().max(100).optional(),
   offline: z
-    .union([z.object({enabled: PermissiveBoolean}), z.enum([""])])
+    .union([z.object({enabled: PermissiveBoolean}), z.literal("")])
     .optional(),
   reboot_window: z
     .union([
       z.object({end_hour: z.coerce.number(), start_hour: z.coerce.number()}),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   stripe_s700: z
     .union([
-      z.object({splashscreen: z.union([z.string(), z.enum([""])]).optional()}),
-      z.enum([""]),
+      z.object({splashscreen: z.union([z.string(), z.literal("")]).optional()}),
+      z.literal(""),
     ])
     .optional(),
   tipping: z
@@ -38956,13 +38973,13 @@ export const s_PostTerminalConfigurationsConfigurationRequestBody = z.object({
           })
           .optional(),
       }),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
   verifone_p400: z
     .union([
-      z.object({splashscreen: z.union([z.string(), z.enum([""])]).optional()}),
-      z.enum([""]),
+      z.object({splashscreen: z.union([z.string(), z.literal("")]).optional()}),
+      z.literal(""),
     ])
     .optional(),
   wifi: z
@@ -38994,7 +39011,7 @@ export const s_PostTerminalConfigurationsConfigurationRequestBody = z.object({
           "personal_psk",
         ]),
       }),
-      z.enum([""]),
+      z.literal(""),
     ])
     .optional(),
 })
@@ -39017,7 +39034,7 @@ export const s_PostTerminalLocationsRequestBody = z.object({
   display_name: z.string().max(1000),
   expand: z.array(z.string().max(5000)).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
 })
 
@@ -39033,12 +39050,12 @@ export const s_PostTerminalLocationsLocationRequestBody = z.object({
     })
     .optional(),
   configuration_overrides: z
-    .union([z.string().max(1000), z.enum([""])])
+    .union([z.string().max(1000), z.literal("")])
     .optional(),
-  display_name: z.union([z.string().max(1000), z.enum([""])]).optional(),
+  display_name: z.union([z.string().max(1000), z.literal("")]).optional(),
   expand: z.array(z.string().max(5000)).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
 })
 
@@ -39068,7 +39085,7 @@ export const s_terminal_reader: z.ZodType<t_terminal_reader> = z.object({
     .nullable()
     .optional(),
   metadata: z.record(z.string(), z.string().max(500)),
-  object: z.enum(["terminal.reader"]),
+  object: z.literal("terminal.reader"),
   serial_number: z.string().max(5000),
   status: z.enum(["offline", "online"]).nullable().optional(),
 })
@@ -39078,16 +39095,16 @@ export const s_PostTerminalReadersRequestBody = z.object({
   label: z.string().max(5000).optional(),
   location: z.string().max(5000).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   registration_code: z.string().max(5000),
 })
 
 export const s_PostTerminalReadersReaderRequestBody = z.object({
   expand: z.array(z.string().max(5000)).optional(),
-  label: z.union([z.string().max(5000), z.enum([""])]).optional(),
+  label: z.union([z.string().max(5000), z.literal("")]).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
 })
 
@@ -39222,7 +39239,7 @@ export const s_PostTerminalReadersReaderSetReaderDisplayRequestBody = z.object({
     })
     .optional(),
   expand: z.array(z.string().max(5000)).optional(),
-  type: z.enum(["cart"]),
+  type: z.literal("cart"),
 })
 
 export const s_PostTestHelpersConfirmationTokensRequestBody = z.object({
@@ -39269,12 +39286,12 @@ export const s_PostTestHelpersConfirmationTokensRequestBody = z.object({
                 postal_code: z.string().max(5000).optional(),
                 state: z.string().max(5000).optional(),
               }),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
-          email: z.union([z.string(), z.enum([""])]).optional(),
-          name: z.union([z.string().max(5000), z.enum([""])]).optional(),
-          phone: z.union([z.string().max(5000), z.enum([""])]).optional(),
+          email: z.union([z.string(), z.literal("")]).optional(),
+          name: z.union([z.string().max(5000), z.literal("")]).optional(),
+          phone: z.union([z.string().max(5000), z.literal("")]).optional(),
           tax_id: z.string().max(5000).optional(),
         })
         .optional(),
@@ -39529,7 +39546,7 @@ export const s_PostTestHelpersConfirmationTokensRequestBody = z.object({
             .object({
               plan: z.object({
                 count: z.coerce.number().optional(),
-                interval: z.enum(["month"]).optional(),
+                interval: z.literal("month").optional(),
                 type: z.enum(["bonus", "fixed_count", "revolving"]),
               }),
             })
@@ -39551,7 +39568,7 @@ export const s_PostTestHelpersConfirmationTokensRequestBody = z.object({
         state: z.string().max(5000).optional(),
       }),
       name: z.string().max(5000),
-      phone: z.union([z.string().max(5000), z.enum([""])]).optional(),
+      phone: z.union([z.string().max(5000), z.literal("")]).optional(),
     })
     .optional(),
 })
@@ -41215,7 +41232,7 @@ export const s_treasury_inbound_transfer: z.ZodType<t_treasury_inbound_transfer>
       s_treasury_inbound_transfers_resource_inbound_transfer_resource_linked_flows,
     livemode: PermissiveBoolean,
     metadata: z.record(z.string(), z.string().max(500)),
-    object: z.enum(["treasury.inbound_transfer"]),
+    object: z.literal("treasury.inbound_transfer"),
     origin_payment_method: z.string().max(5000).nullable().optional(),
     origin_payment_method_details: z
       .lazy(() => s_inbound_transfers)
@@ -41276,7 +41293,7 @@ export const s_treasury_outbound_payment: z.ZodType<t_treasury_outbound_payment>
     id: z.string().max(5000),
     livemode: PermissiveBoolean,
     metadata: z.record(z.string(), z.string().max(500)),
-    object: z.enum(["treasury.outbound_payment"]),
+    object: z.literal("treasury.outbound_payment"),
     returned_details: z
       .lazy(() => s_treasury_outbound_payments_resource_returned_status)
       .nullable()
@@ -41357,7 +41374,7 @@ export const s_treasury_outbound_transfer: z.ZodType<t_treasury_outbound_transfe
     id: z.string().max(5000),
     livemode: PermissiveBoolean,
     metadata: z.record(z.string(), z.string().max(500)),
-    object: z.enum(["treasury.outbound_transfer"]),
+    object: z.literal("treasury.outbound_transfer"),
     returned_details: z
       .lazy(() => s_treasury_outbound_transfers_resource_returned_details)
       .nullable()
@@ -41413,7 +41430,7 @@ export const s_PostTestHelpersTreasuryReceivedCreditsRequestBody = z.object({
   financial_account: z.string(),
   initiating_payment_method_details: z
     .object({
-      type: z.enum(["us_bank_account"]),
+      type: z.literal("us_bank_account"),
       us_bank_account: z
         .object({
           account_holder_name: z.string().max(5000).optional(),
@@ -41451,7 +41468,7 @@ export const s_treasury_received_credit: z.ZodType<t_treasury_received_credit> =
     ),
     livemode: PermissiveBoolean,
     network: z.enum(["ach", "card", "stripe", "us_domestic_wire"]),
-    object: z.enum(["treasury.received_credit"]),
+    object: z.literal("treasury.received_credit"),
     reversal_details: s_treasury_received_credits_resource_reversal_details
       .nullable()
       .optional(),
@@ -41470,7 +41487,7 @@ export const s_PostTestHelpersTreasuryReceivedDebitsRequestBody = z.object({
   financial_account: z.string(),
   initiating_payment_method_details: z
     .object({
-      type: z.enum(["us_bank_account"]),
+      type: z.literal("us_bank_account"),
       us_bank_account: z
         .object({
           account_holder_name: z.string().max(5000).optional(),
@@ -41480,7 +41497,7 @@ export const s_PostTestHelpersTreasuryReceivedDebitsRequestBody = z.object({
         .optional(),
     })
     .optional(),
-  network: z.enum(["ach"]),
+  network: z.literal("ach"),
 })
 
 export const s_treasury_received_debit: z.ZodType<t_treasury_received_debit> =
@@ -41507,7 +41524,7 @@ export const s_treasury_received_debit: z.ZodType<t_treasury_received_debit> =
     linked_flows: s_treasury_received_debits_resource_linked_flows,
     livemode: PermissiveBoolean,
     network: z.enum(["ach", "card", "stripe"]),
-    object: z.enum(["treasury.received_debit"]),
+    object: z.literal("treasury.received_debit"),
     reversal_details: s_treasury_received_debits_resource_reversal_details
       .nullable()
       .optional(),
@@ -41596,7 +41613,7 @@ export const s_PostTokensRequestBody = z.object({
                 month: z.coerce.number(),
                 year: z.coerce.number(),
               }),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
           registration_number: z.string().max(5000).optional(),
@@ -41684,7 +41701,7 @@ export const s_PostTokensRequestBody = z.object({
                 month: z.coerce.number(),
                 year: z.coerce.number(),
               }),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
           email: z.string().optional(),
@@ -41692,7 +41709,7 @@ export const s_PostTokensRequestBody = z.object({
           first_name_kana: z.string().max(5000).optional(),
           first_name_kanji: z.string().max(5000).optional(),
           full_name_aliases: z
-            .union([z.array(z.string().max(300)), z.enum([""])])
+            .union([z.array(z.string().max(300)), z.literal("")])
             .optional(),
           gender: z.string().optional(),
           id_number: z.string().max(5000).optional(),
@@ -41702,7 +41719,7 @@ export const s_PostTokensRequestBody = z.object({
           last_name_kanji: z.string().max(5000).optional(),
           maiden_name: z.string().max(5000).optional(),
           metadata: z
-            .union([z.record(z.string(), z.string()), z.enum([""])])
+            .union([z.record(z.string(), z.string()), z.literal("")])
             .optional(),
           phone: z.string().optional(),
           political_exposure: z.enum(["existing", "none"]).optional(),
@@ -41722,7 +41739,7 @@ export const s_PostTokensRequestBody = z.object({
               executive: PermissiveBoolean.optional(),
               owner: PermissiveBoolean.optional(),
               percent_ownership: z
-                .union([z.coerce.number(), z.enum([""])])
+                .union([z.coerce.number(), z.literal("")])
                 .optional(),
               title: z.string().max(5000).optional(),
             })
@@ -41799,7 +41816,7 @@ export const s_PostTokensRequestBody = z.object({
               date: z.coerce.number().optional(),
               ip: z.string().optional(),
               user_agent: z
-                .union([z.string().max(5000), z.enum([""])])
+                .union([z.string().max(5000), z.literal("")])
                 .optional(),
             })
             .optional(),
@@ -41844,7 +41861,7 @@ export const s_PostTokensRequestBody = z.object({
             month: z.coerce.number(),
             year: z.coerce.number(),
           }),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
       documents: z
@@ -41852,21 +41869,21 @@ export const s_PostTokensRequestBody = z.object({
           company_authorization: z
             .object({
               files: z
-                .array(z.union([z.string().max(500), z.enum([""])]))
+                .array(z.union([z.string().max(500), z.literal("")]))
                 .optional(),
             })
             .optional(),
           passport: z
             .object({
               files: z
-                .array(z.union([z.string().max(500), z.enum([""])]))
+                .array(z.union([z.string().max(500), z.literal("")]))
                 .optional(),
             })
             .optional(),
           visa: z
             .object({
               files: z
-                .array(z.union([z.string().max(500), z.enum([""])]))
+                .array(z.union([z.string().max(500), z.literal("")]))
                 .optional(),
             })
             .optional(),
@@ -41877,7 +41894,7 @@ export const s_PostTokensRequestBody = z.object({
       first_name_kana: z.string().max(5000).optional(),
       first_name_kanji: z.string().max(5000).optional(),
       full_name_aliases: z
-        .union([z.array(z.string().max(5000)), z.enum([""])])
+        .union([z.array(z.string().max(5000)), z.literal("")])
         .optional(),
       gender: z.string().optional(),
       id_number: z.string().max(5000).optional(),
@@ -41887,7 +41904,7 @@ export const s_PostTokensRequestBody = z.object({
       last_name_kanji: z.string().max(5000).optional(),
       maiden_name: z.string().max(5000).optional(),
       metadata: z
-        .union([z.record(z.string(), z.string()), z.enum([""])])
+        .union([z.record(z.string(), z.string()), z.literal("")])
         .optional(),
       nationality: z.string().max(5000).optional(),
       phone: z.string().optional(),
@@ -41910,7 +41927,7 @@ export const s_PostTokensRequestBody = z.object({
           legal_guardian: PermissiveBoolean.optional(),
           owner: PermissiveBoolean.optional(),
           percent_ownership: z
-            .union([z.coerce.number(), z.enum([""])])
+            .union([z.coerce.number(), z.literal("")])
             .optional(),
           representative: PermissiveBoolean.optional(),
           title: z.string().max(5000).optional(),
@@ -42003,7 +42020,7 @@ export const s_token: z.ZodType<t_token> = z.object({
   created: z.coerce.number(),
   id: z.string().max(5000),
   livemode: PermissiveBoolean,
-  object: z.enum(["token"]),
+  object: z.literal("token"),
   type: z.string().max(5000),
   used: PermissiveBoolean,
 })
@@ -42023,7 +42040,7 @@ export const s_topup: z.ZodType<t_topup> = z.object({
   id: z.string().max(5000),
   livemode: PermissiveBoolean,
   metadata: z.record(z.string(), z.string().max(500)),
-  object: z.enum(["topup"]),
+  object: z.literal("topup"),
   source: s_source.nullable().optional(),
   statement_descriptor: z.string().max(5000).nullable().optional(),
   status: z.enum(["canceled", "failed", "pending", "reversed", "succeeded"]),
@@ -42036,7 +42053,7 @@ export const s_PostTopupsRequestBody = z.object({
   description: z.string().max(5000).optional(),
   expand: z.array(z.string().max(5000)).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   source: z.string().max(5000).optional(),
   statement_descriptor: z.string().max(15).optional(),
@@ -42047,7 +42064,7 @@ export const s_PostTopupsTopupRequestBody = z.object({
   description: z.string().max(5000).optional(),
   expand: z.array(z.string().max(5000)).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
 })
 
@@ -42075,11 +42092,11 @@ export const s_transfer: z.ZodType<t_transfer> = z.object({
   id: z.string().max(5000),
   livemode: PermissiveBoolean,
   metadata: z.record(z.string(), z.string().max(500)),
-  object: z.enum(["transfer"]),
+  object: z.literal("transfer"),
   reversals: z.object({
     data: z.array(z.lazy(() => s_transfer_reversal)),
     has_more: PermissiveBoolean,
-    object: z.enum(["list"]),
+    object: z.literal("list"),
     url: z.string().max(5000),
   }),
   reversed: PermissiveBoolean,
@@ -42117,7 +42134,7 @@ export const s_transfer_reversal: z.ZodType<t_transfer_reversal> = z.object({
     .optional(),
   id: z.string().max(5000),
   metadata: z.record(z.string(), z.string().max(500)).nullable().optional(),
-  object: z.enum(["transfer_reversal"]),
+  object: z.literal("transfer_reversal"),
   source_refund: z
     .union([z.string().max(5000), z.lazy(() => s_refund)])
     .nullable()
@@ -42130,7 +42147,7 @@ export const s_PostTransfersIdReversalsRequestBody = z.object({
   description: z.string().max(5000).optional(),
   expand: z.array(z.string().max(5000)).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   refund_application_fee: PermissiveBoolean.optional(),
 })
@@ -42139,14 +42156,14 @@ export const s_PostTransfersTransferRequestBody = z.object({
   description: z.string().max(5000).optional(),
   expand: z.array(z.string().max(5000)).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
 })
 
 export const s_PostTransfersTransferReversalsIdRequestBody = z.object({
   expand: z.array(z.string().max(5000)).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
 })
 
@@ -42161,7 +42178,7 @@ export const s_treasury_credit_reversal: z.ZodType<t_treasury_credit_reversal> =
     livemode: PermissiveBoolean,
     metadata: z.record(z.string(), z.string().max(500)),
     network: z.enum(["ach", "stripe"]),
-    object: z.enum(["treasury.credit_reversal"]),
+    object: z.literal("treasury.credit_reversal"),
     received_credit: z.string().max(5000),
     status: z.enum(["canceled", "posted", "processing"]),
     status_transitions: s_treasury_received_credits_resource_status_transitions,
@@ -42192,7 +42209,7 @@ export const s_treasury_debit_reversal: z.ZodType<t_treasury_debit_reversal> =
     livemode: PermissiveBoolean,
     metadata: z.record(z.string(), z.string().max(500)),
     network: z.enum(["ach", "card"]),
-    object: z.enum(["treasury.debit_reversal"]),
+    object: z.literal("treasury.debit_reversal"),
     received_debit: z.string().max(5000),
     status: z.enum(["failed", "processing", "succeeded"]),
     status_transitions: s_treasury_received_debits_resource_status_transitions,
@@ -42236,7 +42253,7 @@ export const s_PostTreasuryFinancialAccountsRequestBody = z.object({
     })
     .optional(),
   metadata: z.record(z.string(), z.string()).optional(),
-  nickname: z.union([z.string().max(5000), z.enum([""])]).optional(),
+  nickname: z.union([z.string().max(5000), z.literal("")]).optional(),
   platform_restrictions: z
     .object({
       inbound_flows: z.enum(["restricted", "unrestricted"]).optional(),
@@ -42286,7 +42303,7 @@ export const s_PostTreasuryFinancialAccountsFinancialAccountRequestBody =
       })
       .optional(),
     metadata: z.record(z.string(), z.string()).optional(),
-    nickname: z.union([z.string().max(5000), z.enum([""])]).optional(),
+    nickname: z.union([z.string().max(5000), z.literal("")]).optional(),
     platform_restrictions: z
       .object({
         inbound_flows: z.enum(["restricted", "unrestricted"]).optional(),
@@ -42367,12 +42384,12 @@ export const s_PostTreasuryOutboundPaymentsRequestBody = z.object({
                 postal_code: z.string().max(5000).optional(),
                 state: z.string().max(5000).optional(),
               }),
-              z.enum([""]),
+              z.literal(""),
             ])
             .optional(),
-          email: z.union([z.string(), z.enum([""])]).optional(),
-          name: z.union([z.string().max(5000), z.enum([""])]).optional(),
-          phone: z.union([z.string().max(5000), z.enum([""])]).optional(),
+          email: z.union([z.string(), z.literal("")]).optional(),
+          name: z.union([z.string().max(5000), z.literal("")]).optional(),
+          phone: z.union([z.string().max(5000), z.literal("")]).optional(),
         })
         .optional(),
       financial_account: z.string().optional(),
@@ -42394,7 +42411,7 @@ export const s_PostTreasuryOutboundPaymentsRequestBody = z.object({
       us_bank_account: z
         .union([
           z.object({network: z.enum(["ach", "us_domestic_wire"]).optional()}),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
     })
@@ -42420,7 +42437,7 @@ export const s_PostTreasuryOutboundTransfersRequestBody = z.object({
   destination_payment_method_data: z
     .object({
       financial_account: z.string().optional(),
-      type: z.enum(["financial_account"]),
+      type: z.literal("financial_account"),
     })
     .optional(),
   destination_payment_method_options: z
@@ -42428,7 +42445,7 @@ export const s_PostTreasuryOutboundTransfersRequestBody = z.object({
       us_bank_account: z
         .union([
           z.object({network: z.enum(["ach", "us_domestic_wire"]).optional()}),
-          z.enum([""]),
+          z.literal(""),
         ])
         .optional(),
     })
@@ -42467,7 +42484,7 @@ export const s_treasury_transaction_entry: z.ZodType<t_treasury_transaction_entr
     ]),
     id: z.string().max(5000),
     livemode: PermissiveBoolean,
-    object: z.enum(["treasury.transaction_entry"]),
+    object: z.literal("treasury.transaction_entry"),
     transaction: z.union([
       z.string().max(5000),
       z.lazy(() => s_treasury_transaction),
@@ -42507,7 +42524,7 @@ export const s_treasury_transaction: z.ZodType<t_treasury_transaction> =
       .object({
         data: z.array(z.lazy(() => s_treasury_transaction_entry)),
         has_more: PermissiveBoolean,
-        object: z.enum(["list"]),
+        object: z.literal("list"),
         url: z
           .string()
           .max(5000)
@@ -42534,7 +42551,7 @@ export const s_treasury_transaction: z.ZodType<t_treasury_transaction> =
     ]),
     id: z.string().max(5000),
     livemode: PermissiveBoolean,
-    object: z.enum(["treasury.transaction"]),
+    object: z.literal("treasury.transaction"),
     status: z.enum(["open", "posted", "void"]),
     status_transitions:
       s_treasury_transactions_resource_abstract_transaction_resource_status_transitions,
@@ -42660,7 +42677,7 @@ export const s_PostWebhookEndpointsRequestBody = z.object({
     ])
     .optional(),
   connect: PermissiveBoolean.optional(),
-  description: z.union([z.string().max(5000), z.enum([""])]).optional(),
+  description: z.union([z.string().max(5000), z.literal("")]).optional(),
   enabled_events: z.array(
     z.enum([
       "*",
@@ -42910,13 +42927,13 @@ export const s_PostWebhookEndpointsRequestBody = z.object({
   ),
   expand: z.array(z.string().max(5000)).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   url: z.string(),
 })
 
 export const s_PostWebhookEndpointsWebhookEndpointRequestBody = z.object({
-  description: z.union([z.string().max(5000), z.enum([""])]).optional(),
+  description: z.union([z.string().max(5000), z.literal("")]).optional(),
   disabled: PermissiveBoolean.optional(),
   enabled_events: z
     .array(
@@ -43169,7 +43186,7 @@ export const s_PostWebhookEndpointsWebhookEndpointRequestBody = z.object({
     .optional(),
   expand: z.array(z.string().max(5000)).optional(),
   metadata: z
-    .union([z.record(z.string(), z.string()), z.enum([""])])
+    .union([z.record(z.string(), z.string()), z.literal("")])
     .optional(),
   url: z.string().optional(),
 })
@@ -43295,7 +43312,7 @@ export const s_connect_collection_transfer: z.ZodType<t_connect_collection_trans
     destination: z.union([z.string().max(5000), z.lazy(() => s_account)]),
     id: z.string().max(5000),
     livemode: PermissiveBoolean,
-    object: z.enum(["connect_collection_transfer"]),
+    object: z.literal("connect_collection_transfer"),
   })
 
 export const s_thresholds_resource_usage_threshold_config: z.ZodType<t_thresholds_resource_usage_threshold_config> =
@@ -43306,7 +43323,7 @@ export const s_thresholds_resource_usage_threshold_config: z.ZodType<t_threshold
       .optional(),
     gte: z.coerce.number(),
     meter: z.union([z.string().max(5000), s_billing_meter]),
-    recurrence: z.enum(["one_time"]),
+    recurrence: z.literal("one_time"),
   })
 
 export const s_billing_credit_grants_resource_balance_credit: z.ZodType<t_billing_credit_grants_resource_balance_credit> =
@@ -43746,7 +43763,10 @@ export const s_payment_method_sepa_debit: z.ZodType<t_payment_method_sepa_debit>
 
 export const s_subscription_automatic_tax: z.ZodType<t_subscription_automatic_tax> =
   z.object({
-    disabled_reason: z.enum(["requires_location_inputs"]).nullable().optional(),
+    disabled_reason: z
+      .literal("requires_location_inputs")
+      .nullable()
+      .optional(),
     enabled: PermissiveBoolean,
     liability: z
       .lazy(() => s_connect_account_reference)
@@ -44177,7 +44197,7 @@ export const s_terminal_reader_reader_resource_reader_action: z.ZodType<t_termin
 
 export const s_inbound_transfers: z.ZodType<t_inbound_transfers> = z.object({
   billing_details: s_treasury_shared_resource_billing_details,
-  type: z.enum(["us_bank_account"]),
+  type: z.literal("us_bank_account"),
   us_bank_account: z.lazy(() =>
     s_inbound_transfers_payment_method_details_us_bank_account.optional(),
   ),
@@ -44332,7 +44352,7 @@ export const s_thresholds_resource_usage_alert_filter: z.ZodType<t_thresholds_re
       .union([z.string().max(5000), z.lazy(() => s_customer)])
       .nullable()
       .optional(),
-    type: z.enum(["customer"]),
+    type: z.literal("customer"),
   })
 
 export const s_billing_credit_grants_resource_balance_credits_application_invoice_voided: z.ZodType<t_billing_credit_grants_resource_balance_credits_application_invoice_voided> =
@@ -44695,7 +44715,7 @@ export const s_quotes_resource_upfront: z.ZodType<t_quotes_resource_upfront> =
       .object({
         data: z.array(z.lazy(() => s_item)),
         has_more: PermissiveBoolean,
-        object: z.enum(["list"]),
+        object: z.literal("list"),
         url: z.string().max(5000),
       })
       .optional(),
@@ -44816,7 +44836,10 @@ export const s_setup_attempt_payment_method_details_sofort: z.ZodType<t_setup_at
 
 export const s_subscription_schedules_resource_default_settings_automatic_tax: z.ZodType<t_subscription_schedules_resource_default_settings_automatic_tax> =
   z.object({
-    disabled_reason: z.enum(["requires_location_inputs"]).nullable().optional(),
+    disabled_reason: z
+      .literal("requires_location_inputs")
+      .nullable()
+      .optional(),
     enabled: PermissiveBoolean,
     liability: z
       .lazy(() => s_connect_account_reference)
@@ -44854,7 +44877,10 @@ export const s_subscription_schedule_add_invoice_item: z.ZodType<t_subscription_
 
 export const s_schedules_phase_automatic_tax: z.ZodType<t_schedules_phase_automatic_tax> =
   z.object({
-    disabled_reason: z.enum(["requires_location_inputs"]).nullable().optional(),
+    disabled_reason: z
+      .literal("requires_location_inputs")
+      .nullable()
+      .optional(),
     enabled: PermissiveBoolean,
     liability: z
       .lazy(() => s_connect_account_reference)
@@ -44980,7 +45006,7 @@ export const s_inbound_transfers_payment_method_details_us_bank_account: z.ZodTy
     mandate: z
       .union([z.string().max(5000), z.lazy(() => s_mandate)])
       .optional(),
-    network: z.enum(["ach"]),
+    network: z.literal("ach"),
     routing_number: z.string().max(5000).nullable().optional(),
   })
 

--- a/packages/documentation/src/app/guides/concepts/enums/page.mdx
+++ b/packages/documentation/src/app/guides/concepts/enums/page.mdx
@@ -64,9 +64,28 @@ enum:
 For server templates, we just generate the exact `enum` values, meaning that an error will be raised both
 if a client sends us an unknown value, or the server attempts to respond with one.
 
+If an enum has multiple values, it is generated as a `z.enum`:
+
 ```typescript
 export type t_Fruit = "Apple" | "Banana" | "Orange"
 export const s_Fruit = z.enum(["Apple", "Banana", "Orange"])
+```
+
+#### Optimization for single-element enums
+
+If an enum contains only a single element, it is automatically treated as `closed` (even if the global default is `open`) and is generated as a `z.literal`. This is more efficient and provides better type inference in some scenarios.
+
+```yaml
+type: string
+enum:
+  - Apple
+```
+
+Generates:
+
+```typescript
+export type t_Fruit = "Apple"
+export const s_Fruit = z.literal("Apple")
 ```
 
 ### Client code (open enum)
@@ -132,7 +151,21 @@ There are two ways you can customize this behavior
 
 Where `<value>` is either `open` or `closed`.
 
-Example:
+### Exceptions: single-element enums and booleans
+
+- **Single-element enums**: These default to `closed` to allow the use of `z.literal` (or equivalent) for better type narrowing and validation efficiency. You can still explicitly set `x-enum-extensibility: open` if you need an extensible single-value enum.
+- **Booleans**: The `x-enum-extensibility` extension is not supported for boolean types. Boolean enums are always treated according to their defined values.
+
+Example of overriding a single-element enum to be open:
+
+```yaml
+type: string
+x-enum-extensibility: open
+enum:
+  - Apple
+```
+
+Example of explicitly closing an enum:
 
 ```yaml
 type: string

--- a/packages/openapi-code-generator/src/core/logger.ts
+++ b/packages/openapi-code-generator/src/core/logger.ts
@@ -8,10 +8,26 @@ enum Color {
   Reset = "\x1b[0m",
 }
 
-const ConsoleSink = {
-  info: (it: string) => console.info(it),
-  warn: (it: string) => console.info(it),
-  error: (it: string) => console.info(it),
+const ConsoleSinkFactory = (level: "info" | "warn" | "error") => {
+  const levelNumber = level === "info" ? 0 : level === "warn" ? 1 : 2
+
+  return {
+    info: (it: string) => {
+      if (levelNumber <= 0) {
+        console.info(it)
+      }
+    },
+    warn: (it: string) => {
+      if (levelNumber <= 1) {
+        console.info(it)
+      }
+    },
+    error: (it: string) => {
+      if (levelNumber <= 2) {
+        console.info(it)
+      }
+    },
+  }
 }
 
 const shouldColor = (isTTY: boolean) => {
@@ -37,7 +53,7 @@ export class Logger {
   constructor(
     private readonly isTTY: boolean,
     private readonly format = defaultFormat,
-    private readonly sink = ConsoleSink,
+    private readonly sink = ConsoleSinkFactory("info"),
   ) {}
 
   readonly info = (message: string, meta?: LoggerMeta): void => {
@@ -122,4 +138,8 @@ function diff(start: bigint, end: bigint) {
   return Number((end - start) / BigInt(1000000))
 }
 
-export const logger = new Logger(process.stdout.isTTY)
+export const logger = new Logger(
+  process.stdout.isTTY,
+  defaultFormat,
+  ConsoleSinkFactory(process.env.NODE_ENV === "test" ? "warn" : "info"),
+)

--- a/packages/openapi-code-generator/src/core/normalization/schema-normalizer.spec.ts
+++ b/packages/openapi-code-generator/src/core/normalization/schema-normalizer.spec.ts
@@ -74,6 +74,33 @@ describe("core/input - SchemaNormalizer", () => {
         expect(actual).toStrictEqual(ir.string())
       })
 
+      it("defaults to closed for single element enums", () => {
+        const actual = schemaNormalizer.normalize({
+          type: "string",
+          enum: ["a"],
+        })
+        expect(actual).toStrictEqual(
+          ir.string({
+            enum: ["a"],
+            "x-enum-extensibility": "closed",
+          }),
+        )
+      })
+
+      it("respects explicit open extensibility for single element enums", () => {
+        const actual = schemaNormalizer.normalize({
+          type: "string",
+          enum: ["a"],
+          "x-enum-extensibility": "open",
+        })
+        expect(actual).toStrictEqual(
+          ir.string({
+            enum: ["a"],
+            "x-enum-extensibility": "open",
+          }),
+        )
+      })
+
       it("passes through string specific modifiers", () => {
         const actual = schemaNormalizer.normalize({
           type: "string",
@@ -416,7 +443,7 @@ describe("core/input - SchemaNormalizer", () => {
                   properties: {
                     type: ir.string({
                       enum: ["foo"],
-                      "x-enum-extensibility": "open",
+                      "x-enum-extensibility": "closed",
                     }),
                   },
                 }),
@@ -424,7 +451,7 @@ describe("core/input - SchemaNormalizer", () => {
                   properties: {
                     type: ir.string({
                       enum: ["bar"],
-                      "x-enum-extensibility": "open",
+                      "x-enum-extensibility": "closed",
                     }),
                   },
                 }),
@@ -457,7 +484,7 @@ describe("core/input - SchemaNormalizer", () => {
                   properties: {
                     type: ir.string({
                       enum: ["foo"],
-                      "x-enum-extensibility": "open",
+                      "x-enum-extensibility": "closed",
                     }),
                   },
                 }),
@@ -465,7 +492,7 @@ describe("core/input - SchemaNormalizer", () => {
                   properties: {
                     type: ir.string({
                       enum: ["bar"],
-                      "x-enum-extensibility": "open",
+                      "x-enum-extensibility": "closed",
                     }),
                   },
                 }),

--- a/packages/openapi-code-generator/src/core/normalization/schema-normalizer.ts
+++ b/packages/openapi-code-generator/src/core/normalization/schema-normalizer.ts
@@ -33,6 +33,16 @@ export class SchemaNormalizer {
     return schema && Reflect.get(schema, "isIRModel")
   }
 
+  private getEnumExtensibility(
+    schemaObject: {"x-enum-extensibility"?: "open" | "closed" | undefined},
+    enumValues: unknown[],
+  ) {
+    return (
+      schemaObject["x-enum-extensibility"] ??
+      (enumValues.length === 1 ? "closed" : this.config.enumExtensibility)
+    )
+  }
+
   private hasPropertiesOrComposition(schema: SchemaObject): boolean {
     return Boolean(
       schema.allOf?.length ||
@@ -292,8 +302,7 @@ export class SchemaNormalizer {
           ...calcMaximums(),
           ...calcMinimums(),
           "x-enum-extensibility": enumValues.length
-            ? (schemaObject["x-enum-extensibility"] ??
-              self.config.enumExtensibility)
+            ? this.getEnumExtensibility(schemaObject, enumValues)
             : undefined,
         } satisfies IRModelNumeric
       }
@@ -315,8 +324,7 @@ export class SchemaNormalizer {
           pattern: schemaObject.pattern,
 
           "x-enum-extensibility": enumValues.length
-            ? (schemaObject["x-enum-extensibility"] ??
-              self.config.enumExtensibility)
+            ? this.getEnumExtensibility(schemaObject, enumValues)
             : undefined,
         } satisfies IRModelString
       }

--- a/packages/openapi-code-generator/src/typescript/common/schema-builders/abstract-schema-builder.ts
+++ b/packages/openapi-code-generator/src/typescript/common/schema-builders/abstract-schema-builder.ts
@@ -375,6 +375,8 @@ export abstract class AbstractSchemaBuilder<
 
   protected abstract arrayItems(model: MaybeIRModel): string
 
+  protected abstract literal(value: string | number | boolean): string
+
   protected abstract number(model: IRModelNumeric): string
 
   protected abstract string(model: IRModelString): string

--- a/packages/openapi-code-generator/src/typescript/common/schema-builders/joi-schema-builder.ts
+++ b/packages/openapi-code-generator/src/typescript/common/schema-builders/joi-schema-builder.ts
@@ -250,10 +250,27 @@ export class JoiBuilder extends AbstractSchemaBuilder<
     return this.fromModel(model, false)
   }
 
+  protected literal(value: string | number | boolean): string {
+    return [
+      joi,
+      "any()",
+      `valid(${typeof value === "string" ? quotedStringLiteral(value) : value})`,
+    ]
+      .filter(isDefined)
+      .join(".")
+  }
+
   protected number(model: IRModelNumeric) {
     const result = [joi, "number()"].filter(isDefined).join(".")
 
     if (model.enum) {
+      if (
+        hasSingleElement(model.enum) &&
+        model["x-enum-extensibility"] !== "open"
+      ) {
+        return this.literal(model.enum[0])
+      }
+
       if (model["x-enum-extensibility"] === "open") {
         return result
       }
@@ -289,6 +306,13 @@ export class JoiBuilder extends AbstractSchemaBuilder<
     const result = [joi, "string()"].filter(isDefined).join(".")
 
     if (model.enum) {
+      if (
+        hasSingleElement(model.enum) &&
+        model["x-enum-extensibility"] !== "open"
+      ) {
+        return this.literal(model.enum[0])
+      }
+
       if (model["x-enum-extensibility"] === "open") {
         return result
       }
@@ -320,8 +344,8 @@ export class JoiBuilder extends AbstractSchemaBuilder<
   }
 
   protected boolean(model: IRModelBoolean) {
-    const truthy = "truthy(1, '1')"
-    const falsy = "falsy(0, '0')"
+    const truthy = 'truthy(1, "1")'
+    const falsy = 'falsy(0, "0")'
 
     if (model.enum) {
       return [

--- a/packages/openapi-code-generator/src/typescript/common/schema-builders/joi-schema-builder.unit.spec.ts
+++ b/packages/openapi-code-generator/src/typescript/common/schema-builders/joi-schema-builder.unit.spec.ts
@@ -85,6 +85,41 @@ describe("typescript/common/schema-builders/joi-schema-builder - unit tests", ()
       )
     })
 
+    it("supports single element closed numeric enums as literal", async () => {
+      const enumValues = [200]
+
+      const {code, execute} = await getActual(
+        ir.number({
+          enum: enumValues,
+          "x-enum-extensibility": "closed",
+        }),
+      )
+
+      expect(code).toMatchInlineSnapshot(
+        `"const x = joi.any().valid(200).required()"`,
+      )
+
+      await expect(execute(200)).resolves.toBe(200)
+
+      await expect(execute(404)).rejects.toThrow(/"value" must be \[200\]/)
+    })
+
+    it("supports single element open numeric enums as number", async () => {
+      const enumValues = [200]
+
+      const {code, execute} = await getActual(
+        ir.number({
+          enum: enumValues,
+          "x-enum-extensibility": "open",
+        }),
+      )
+
+      expect(code).toMatchInlineSnapshot(`"const x = joi.number().required()"`)
+
+      await expect(execute(200)).resolves.toBe(200)
+      await expect(execute(404)).resolves.toBe(404)
+    })
+
     it("supports inclusiveMinimum", async () => {
       const {code, execute} = await getActual(ir.number({inclusiveMinimum: 10}))
 
@@ -281,6 +316,41 @@ describe("typescript/common/schema-builders/joi-schema-builder - unit tests", ()
       await expect(execute("orange")).rejects.toThrow(
         '"value" must be one of [red, blue, green]',
       )
+    })
+
+    it("supports single element closed string enums as literal", async () => {
+      const enumValues = ["red"]
+
+      const {code, execute} = await getActual(
+        ir.string({
+          enum: enumValues,
+          "x-enum-extensibility": "closed",
+        }),
+      )
+
+      expect(code).toMatchInlineSnapshot(
+        `"const x = joi.any().valid("red").required()"`,
+      )
+
+      await expect(execute("red")).resolves.toBe("red")
+
+      await expect(execute("orange")).rejects.toThrow(/"value" must be \[red\]/)
+    })
+
+    it("supports single element open string enums as string", async () => {
+      const enumValues = ["red"]
+
+      const {code, execute} = await getActual(
+        ir.string({
+          enum: enumValues,
+          "x-enum-extensibility": "open",
+        }),
+      )
+
+      expect(code).toMatchInlineSnapshot(`"const x = joi.string().required()"`)
+
+      await expect(execute("red")).resolves.toBe("red")
+      await expect(execute("orange")).resolves.toBe("orange")
     })
 
     it("supports open string enums", async () => {
@@ -544,6 +614,8 @@ describe("typescript/common/schema-builders/joi-schema-builder - unit tests", ()
       )
 
       await expect(execute(true)).resolves.toBe(true)
+      await expect(execute("true")).resolves.toBe(true)
+      await expect(execute(1)).resolves.toBe(true)
       await expect(execute(false)).rejects.toThrow('"value" must be [true]')
     })
 
@@ -559,6 +631,8 @@ describe("typescript/common/schema-builders/joi-schema-builder - unit tests", ()
       )
 
       await expect(execute(false)).resolves.toBe(false)
+      await expect(execute("false")).resolves.toBe(false)
+      await expect(execute(0)).resolves.toBe(false)
       await expect(execute(true)).rejects.toThrow('"value" must be [false]')
     })
   })

--- a/packages/openapi-code-generator/src/typescript/common/schema-builders/zod-v3-schema-builder.ts
+++ b/packages/openapi-code-generator/src/typescript/common/schema-builders/zod-v3-schema-builder.ts
@@ -228,9 +228,25 @@ export class ZodV3Builder extends AbstractSchemaBuilder<
     return this.fromModel(model, true)
   }
 
+  protected literal(value: string | number | boolean): string {
+    return [
+      zod,
+      `literal(${typeof value === "string" ? quotedStringLiteral(value) : value})`,
+    ]
+      .filter(isDefined)
+      .join(".")
+  }
+
   protected number(model: IRModelNumeric) {
     if (model.enum) {
       // TODO: replace with enum after https://github.com/colinhacks/zod/issues/2686
+
+      if (
+        hasSingleElement(model.enum) &&
+        model["x-enum-extensibility"] !== "open"
+      ) {
+        return this.literal(model.enum[0])
+      }
 
       if (model["x-enum-extensibility"] === "open") {
         this.schemaBuilderImports.addSingle(
@@ -284,6 +300,13 @@ export class ZodV3Builder extends AbstractSchemaBuilder<
 
   protected string(model: IRModelString) {
     if (model.enum) {
+      if (
+        hasSingleElement(model.enum) &&
+        model["x-enum-extensibility"] !== "open"
+      ) {
+        return this.literal(model.enum[0])
+      }
+
       if (model["x-enum-extensibility"] === "open") {
         this.schemaBuilderImports.addSingle(
           "UnknownEnumStringValue",
@@ -338,7 +361,6 @@ export class ZodV3Builder extends AbstractSchemaBuilder<
     // todo: switch to stricter parsing when property is part of a request body/response
     // todo: might be nice to have an x-extension prop that lets the user define the
     //       true/false mapping in their schema.
-
     if (model.enum) {
       this.addStaticSchema("PermissiveBoolean")
 

--- a/packages/openapi-code-generator/src/typescript/common/schema-builders/zod-v3-schema-builder.unit.spec.ts
+++ b/packages/openapi-code-generator/src/typescript/common/schema-builders/zod-v3-schema-builder.unit.spec.ts
@@ -93,6 +93,44 @@ describe("typescript/common/schema-builders/zod-v3-schema-builder - unit tests",
       )
     })
 
+    it("supports single element closed numeric enums as literal", async () => {
+      const enumValues = [200]
+
+      const {code, execute} = await getActual(
+        ir.number({
+          enum: enumValues,
+          "x-enum-extensibility": "closed",
+        }),
+      )
+
+      expect(code).toMatchInlineSnapshot(`"const x = z.literal(200)"`)
+
+      await expect(execute(200)).resolves.toBe(200)
+
+      await expect(execute(404)).rejects.toThrow(/200/)
+    })
+
+    it("supports single element open numeric enums as number", async () => {
+      const enumValues = [200]
+
+      const {code, execute} = await getActual(
+        ir.number({
+          enum: enumValues,
+          "x-enum-extensibility": "open",
+        }),
+      )
+
+      expect(code).toMatchInlineSnapshot(`
+        "const x = z.union([
+          z.literal(200),
+          z.number().transform((it) => it as typeof it & UnknownEnumNumberValue),
+        ])"
+      `)
+
+      await expect(execute(200)).resolves.toBe(200)
+      await expect(execute(404)).resolves.toBe(404)
+    })
+
     it("supports inclusiveMinimum", async () => {
       const {code, execute} = await getActual(ir.number({inclusiveMinimum: 10}))
 
@@ -291,6 +329,44 @@ describe("typescript/common/schema-builders/zod-v3-schema-builder - unit tests",
       await expect(execute("orange")).rejects.toThrow(
         "Invalid enum value. Expected 'red' | 'blue' | 'green', received 'orange'",
       )
+    })
+
+    it("supports single element closed string enums as literal", async () => {
+      const enumValues = ["red"]
+
+      const {code, execute} = await getActual(
+        ir.string({
+          enum: enumValues,
+          "x-enum-extensibility": "closed",
+        }),
+      )
+
+      expect(code).toMatchInlineSnapshot(`"const x = z.literal("red")"`)
+
+      await expect(execute("red")).resolves.toBe("red")
+
+      await expect(execute("orange")).rejects.toThrow(/red/)
+    })
+
+    it("supports single element open string enums as enum", async () => {
+      const enumValues = ["red"]
+
+      const {code, execute} = await getActual(
+        ir.string({
+          enum: enumValues,
+          "x-enum-extensibility": "open",
+        }),
+      )
+
+      expect(code).toMatchInlineSnapshot(`
+        "const x = z.union([
+          z.enum(["red"]),
+          z.string().transform((it) => it as typeof it & UnknownEnumStringValue),
+        ])"
+      `)
+
+      await expect(execute("red")).resolves.toBe("red")
+      await expect(execute("orange")).resolves.toBe("orange")
     })
 
     it("supports open string enums", async () => {
@@ -587,24 +663,28 @@ describe("typescript/common/schema-builders/zod-v3-schema-builder - unit tests",
       const codeWithoutImport = inlineStaticSchemas(code)
 
       expect(codeWithoutImport).toMatchInlineSnapshot(`
-          "const PermissiveBoolean = z.preprocess((value) => {
-                    if(typeof value === "string" && (value === "true" || value === "false")) {
-                      return value === "true"
-                    } else if(typeof value === "number" && (value === 1 || value === 0)) {
-                      return value === 1
-                    }
-                    return value
-                  }, z.boolean())
-          const PermissiveLiteralTrue = z.preprocess((value) => {
-                    return PermissiveBoolean.parse(value)
-                  }, z.literal(true))
+        "const PermissiveBoolean = z.preprocess((value) => {
+                  if(typeof value === "string" && (value === "true" || value === "false")) {
+                    return value === "true"
+                  } else if(typeof value === "number" && (value === 1 || value === 0)) {
+                    return value === 1
+                  }
+                  return value
+                }, z.boolean())
+        const PermissiveLiteralTrue = z.preprocess((value) => {
+                  return PermissiveBoolean.parse(value)
+                }, z.literal(true))
 
-          const x = PermissiveLiteralTrue"
-        `)
+        const x = PermissiveLiteralTrue"
+      `)
 
       await expect(executeBooleanTest(codeWithoutImport, true)).resolves.toBe(
         true,
       )
+      await expect(executeBooleanTest(codeWithoutImport, "true")).resolves.toBe(
+        true,
+      )
+      await expect(executeBooleanTest(codeWithoutImport, 1)).resolves.toBe(true)
       await expect(
         executeBooleanTest(codeWithoutImport, false),
       ).rejects.toThrow("Invalid literal value, expected true")
@@ -616,22 +696,28 @@ describe("typescript/common/schema-builders/zod-v3-schema-builder - unit tests",
       const codeWithoutImport = inlineStaticSchemas(code)
 
       expect(codeWithoutImport).toMatchInlineSnapshot(`
-          "const PermissiveBoolean = z.preprocess((value) => {
-                    if(typeof value === "string" && (value === "true" || value === "false")) {
-                      return value === "true"
-                    } else if(typeof value === "number" && (value === 1 || value === 0)) {
-                      return value === 1
-                    }
-                    return value
-                  }, z.boolean())
-          const PermissiveLiteralFalse = z.preprocess((value) => {
-                    return PermissiveBoolean.parse(value)
-                  }, z.literal(false))
+        "const PermissiveBoolean = z.preprocess((value) => {
+                  if(typeof value === "string" && (value === "true" || value === "false")) {
+                    return value === "true"
+                  } else if(typeof value === "number" && (value === 1 || value === 0)) {
+                    return value === 1
+                  }
+                  return value
+                }, z.boolean())
+        const PermissiveLiteralFalse = z.preprocess((value) => {
+                  return PermissiveBoolean.parse(value)
+                }, z.literal(false))
 
-          const x = PermissiveLiteralFalse"
-        `)
+        const x = PermissiveLiteralFalse"
+      `)
 
       await expect(executeBooleanTest(codeWithoutImport, false)).resolves.toBe(
+        false,
+      )
+      await expect(
+        executeBooleanTest(codeWithoutImport, "false"),
+      ).resolves.toBe(false)
+      await expect(executeBooleanTest(codeWithoutImport, 0)).resolves.toBe(
         false,
       )
       await expect(executeBooleanTest(codeWithoutImport, true)).rejects.toThrow(

--- a/packages/openapi-code-generator/src/typescript/common/schema-builders/zod-v4-schema-builder.ts
+++ b/packages/openapi-code-generator/src/typescript/common/schema-builders/zod-v4-schema-builder.ts
@@ -231,8 +231,24 @@ export class ZodV4Builder extends AbstractSchemaBuilder<
     return this.fromModel(model, true)
   }
 
+  protected literal(value: string | number | boolean): string {
+    return [
+      zod,
+      `literal(${typeof value === "string" ? quotedStringLiteral(value) : value})`,
+    ]
+      .filter(isDefined)
+      .join(".")
+  }
+
   protected number(model: IRModelNumeric) {
     if (model.enum) {
+      if (
+        hasSingleElement(model.enum) &&
+        model["x-enum-extensibility"] !== "open"
+      ) {
+        return this.literal(model.enum[0])
+      }
+
       if (model["x-enum-extensibility"] === "open") {
         this.schemaBuilderImports.addSingle(
           "UnknownEnumNumberValue",
@@ -285,6 +301,13 @@ export class ZodV4Builder extends AbstractSchemaBuilder<
 
   protected string(model: IRModelString) {
     if (model.enum) {
+      if (
+        hasSingleElement(model.enum) &&
+        model["x-enum-extensibility"] !== "open"
+      ) {
+        return this.literal(model.enum[0])
+      }
+
       if (model["x-enum-extensibility"] === "open") {
         this.schemaBuilderImports.addSingle(
           "UnknownEnumStringValue",

--- a/packages/openapi-code-generator/src/typescript/common/schema-builders/zod-v4-schema-builder.unit.spec.ts
+++ b/packages/openapi-code-generator/src/typescript/common/schema-builders/zod-v4-schema-builder.unit.spec.ts
@@ -121,6 +121,44 @@ describe("typescript/common/schema-builders/zod-v4-schema-builder - unit tests",
       )
     })
 
+    it("supports single element closed numeric enums as literal", async () => {
+      const enumValues = [200]
+
+      const {code, execute} = await getActual(
+        ir.number({
+          enum: enumValues,
+          "x-enum-extensibility": "closed",
+        }),
+      )
+
+      expect(code).toMatchInlineSnapshot(`"const x = z.literal(200)"`)
+
+      await expect(execute(200)).resolves.toBe(200)
+
+      await expect(execute(404)).rejects.toThrow(/200/)
+    })
+
+    it("supports single element open numeric enums as number", async () => {
+      const enumValues = [200]
+
+      const {code, execute} = await getActual(
+        ir.number({
+          enum: enumValues,
+          "x-enum-extensibility": "open",
+        }),
+      )
+
+      expect(code).toMatchInlineSnapshot(`
+        "const x = z.union([
+          z.literal(200),
+          z.number().transform((it) => it as typeof it & UnknownEnumNumberValue),
+        ])"
+      `)
+
+      await expect(execute(200)).resolves.toBe(200)
+      await expect(execute(404)).resolves.toBe(404)
+    })
+
     it("supports inclusiveMinimum", async () => {
       const {code, execute} = await getActual(ir.number({inclusiveMinimum: 10}))
 
@@ -323,6 +361,44 @@ describe("typescript/common/schema-builders/zod-v4-schema-builder - unit tests",
       await expect(execute("orange")).rejects.toThrow(
         `Invalid option: expected one of \\"red\\"|\\"blue\\"|\\"green\\"`,
       )
+    })
+
+    it("supports single element closed string enums as literal", async () => {
+      const enumValues = ["red"]
+
+      const {code, execute} = await getActual(
+        ir.string({
+          enum: enumValues,
+          "x-enum-extensibility": "closed",
+        }),
+      )
+
+      expect(code).toMatchInlineSnapshot(`"const x = z.literal("red")"`)
+
+      await expect(execute("red")).resolves.toBe("red")
+
+      await expect(execute("orange")).rejects.toThrow(/red/)
+    })
+
+    it("supports single element open string enums as enum", async () => {
+      const enumValues = ["red"]
+
+      const {code, execute} = await getActual(
+        ir.string({
+          enum: enumValues,
+          "x-enum-extensibility": "open",
+        }),
+      )
+
+      expect(code).toMatchInlineSnapshot(`
+        "const x = z.union([
+          z.enum(["red"]),
+          z.string().transform((it) => it as typeof it & UnknownEnumStringValue),
+        ])"
+      `)
+
+      await expect(execute("red")).resolves.toBe("red")
+      await expect(execute("orange")).resolves.toBe("orange")
     })
 
     it("supports open string enums", async () => {
@@ -625,24 +701,28 @@ describe("typescript/common/schema-builders/zod-v4-schema-builder - unit tests",
       const codeWithoutImport = inlineStaticSchemas(code)
 
       expect(codeWithoutImport).toMatchInlineSnapshot(`
-          "const PermissiveBoolean = z.preprocess((value) => {
-                    if(typeof value === "string" && (value === "true" || value === "false")) {
-                      return value === "true"
-                    } else if(typeof value === "number" && (value === 1 || value === 0)) {
-                      return value === 1
-                    }
-                    return value
-                  }, z.boolean())
-          const PermissiveLiteralTrue = z.preprocess((value) => {
-                    return PermissiveBoolean.parse(value)
-                  }, z.literal(true))
+        "const PermissiveBoolean = z.preprocess((value) => {
+                  if(typeof value === "string" && (value === "true" || value === "false")) {
+                    return value === "true"
+                  } else if(typeof value === "number" && (value === 1 || value === 0)) {
+                    return value === 1
+                  }
+                  return value
+                }, z.boolean())
+        const PermissiveLiteralTrue = z.preprocess((value) => {
+                  return PermissiveBoolean.parse(value)
+                }, z.literal(true))
 
-          const x = PermissiveLiteralTrue"
-        `)
+        const x = PermissiveLiteralTrue"
+      `)
 
       await expect(executeBooleanTest(codeWithoutImport, true)).resolves.toBe(
         true,
       )
+      await expect(executeBooleanTest(codeWithoutImport, "true")).resolves.toBe(
+        true,
+      )
+      await expect(executeBooleanTest(codeWithoutImport, 1)).resolves.toBe(true)
       await expect(
         executeBooleanTest(codeWithoutImport, false),
       ).rejects.toThrow("Invalid input: expected true")
@@ -654,22 +734,28 @@ describe("typescript/common/schema-builders/zod-v4-schema-builder - unit tests",
       const codeWithoutImport = inlineStaticSchemas(code)
 
       expect(codeWithoutImport).toMatchInlineSnapshot(`
-          "const PermissiveBoolean = z.preprocess((value) => {
-                    if(typeof value === "string" && (value === "true" || value === "false")) {
-                      return value === "true"
-                    } else if(typeof value === "number" && (value === 1 || value === 0)) {
-                      return value === 1
-                    }
-                    return value
-                  }, z.boolean())
-          const PermissiveLiteralFalse = z.preprocess((value) => {
-                    return PermissiveBoolean.parse(value)
-                  }, z.literal(false))
+        "const PermissiveBoolean = z.preprocess((value) => {
+                  if(typeof value === "string" && (value === "true" || value === "false")) {
+                    return value === "true"
+                  } else if(typeof value === "number" && (value === 1 || value === 0)) {
+                    return value === 1
+                  }
+                  return value
+                }, z.boolean())
+        const PermissiveLiteralFalse = z.preprocess((value) => {
+                  return PermissiveBoolean.parse(value)
+                }, z.literal(false))
 
-          const x = PermissiveLiteralFalse"
-        `)
+        const x = PermissiveLiteralFalse"
+      `)
 
       await expect(executeBooleanTest(codeWithoutImport, false)).resolves.toBe(
+        false,
+      )
+      await expect(
+        executeBooleanTest(codeWithoutImport, "false"),
+      ).resolves.toBe(false)
+      await expect(executeBooleanTest(codeWithoutImport, 0)).resolves.toBe(
         false,
       )
       await expect(executeBooleanTest(codeWithoutImport, true)).rejects.toThrow(


### PR DESCRIPTION
treat enums with a single valid value as closed by default, and use `z.literal`.

this is often the case with discriminated unions, and the open by default behavior in clients isn't desirable in this scenario.

it's still possible to override this behavior, in situations where you do intend to later add more values to the enum.