### PR TITLE
fix: extranous runtime deps bundled

### DIFF
--- a/packages/documentation/next.config.mjs
+++ b/packages/documentation/next.config.mjs
@@ -12,7 +12,7 @@ const nextConfig = {
     resolveAlias: {
       "next-mdx-import-source-file": "./src/mdx-components.tsx",
       // todo: ajv validator uses `require` in esm context, causing `node:module` to be used
-      //       figure out a way to prevent this.
+      //       https://github.com/ajv-validator/ajv/issues/2598 should solve upstream
       "@nahkies/openapi-code-generator/web":
         "./node_modules/@nahkies/openapi-code-generator/dist/cjs/web.cjs",
     },

--- a/packages/documentation/next.config.mjs
+++ b/packages/documentation/next.config.mjs
@@ -11,6 +11,8 @@ const nextConfig = {
   turbopack: {
     resolveAlias: {
       "next-mdx-import-source-file": "./src/mdx-components.tsx",
+      // todo: ajv validator uses `require` in esm context, causing `node:module` to be used
+      //       figure out a way to prevent this.
       "@nahkies/openapi-code-generator/web":
         "./node_modules/@nahkies/openapi-code-generator/dist/cjs/web.cjs",
     },

--- a/packages/openapi-code-generator/src/typescript/server/server-operation-builder.ts
+++ b/packages/openapi-code-generator/src/typescript/server/server-operation-builder.ts
@@ -2,7 +2,7 @@ import type {
   QueryParameter,
   SchemaStructure,
 } from "@nahkies/typescript-common-runtime/query-parser"
-import type {SizeLimit} from "@nahkies/typescript-common-runtime/request-bodies"
+import type {SizeLimit} from "@nahkies/typescript-common-runtime/request-bodies/octet-stream"
 import type {Input} from "../../core/input.ts"
 import {logger} from "../../core/logger.ts"
 import type {IRModel, IROperation} from "../../core/openapi-types-normalized.ts"

--- a/packages/openapi-code-generator/tsdown.config.mts
+++ b/packages/openapi-code-generator/tsdown.config.mts
@@ -13,6 +13,10 @@ export default defineConfig({
   publint: true,
   attw: {profile: "node16"},
 
+  deps: {
+    onlyBundle: ["@nahkies/typescript-common-runtime"],
+  },
+
   format: {
     esm: {
       outDir: "./dist/esm",

--- a/packages/typescript-axios-runtime/src/main.spec.ts
+++ b/packages/typescript-axios-runtime/src/main.spec.ts
@@ -2,7 +2,7 @@
 // biome-ignore-all lint/suspicious/noExplicitAny: tests
 
 import {describe, expect, it} from "@jest/globals"
-import type {Encoding} from "@nahkies/typescript-common-runtime/request-bodies"
+import type {Encoding} from "@nahkies/typescript-common-runtime/request-bodies/url-search-params"
 import type {AxiosRequestConfig, RawAxiosRequestHeaders} from "axios"
 import {
   AbstractAxiosClient,

--- a/packages/typescript-axios-runtime/src/main.ts
+++ b/packages/typescript-axios-runtime/src/main.ts
@@ -1,7 +1,7 @@
 import {
   type Encoding,
   requestBodyToUrlSearchParams,
-} from "@nahkies/typescript-common-runtime/request-bodies"
+} from "@nahkies/typescript-common-runtime/request-bodies/url-search-params"
 import type {
   HeaderParams,
   QueryParams,

--- a/packages/typescript-axios-runtime/tsdown.config.mts
+++ b/packages/typescript-axios-runtime/tsdown.config.mts
@@ -13,6 +13,10 @@ export default defineConfig({
   publint: true,
   attw: {profile: "node16"},
 
+  deps: {
+    onlyBundle: ["@nahkies/typescript-common-runtime"],
+  },
+
   format: {
     esm: {
       outDir: "./dist/esm",

--- a/packages/typescript-common-runtime/package.json
+++ b/packages/typescript-common-runtime/package.json
@@ -59,14 +59,24 @@
         "default": "./dist/cjs/query-parser.cjs"
       }
     },
-    "./request-bodies": {
+    "./request-bodies/octet-stream": {
       "import": {
-        "types": "./dist/esm/request-bodies/index.d.mts",
-        "default": "./dist/esm/request-bodies/index.mjs"
+        "types": "./dist/esm/request-bodies/octet-stream.d.mts",
+        "default": "./dist/esm/request-bodies/octet-stream.mjs"
       },
       "require": {
-        "types": "./dist/cjs/request-bodies/index.d.cts",
-        "default": "./dist/cjs/request-bodies/index.cjs"
+        "types": "./dist/cjs/request-bodies/octet-stream.d.cts",
+        "default": "./dist/cjs/request-bodies/octet-stream.cjs"
+      }
+    },
+    "./request-bodies/url-search-params": {
+      "import": {
+        "types": "./dist/esm/request-bodies/url-search-params.d.mts",
+        "default": "./dist/esm/request-bodies/url-search-params.mjs"
+      },
+      "require": {
+        "types": "./dist/cjs/request-bodies/url-search-params.d.cts",
+        "default": "./dist/cjs/request-bodies/url-search-params.cjs"
       }
     }
   },

--- a/packages/typescript-common-runtime/src/request-bodies/index.ts
+++ b/packages/typescript-common-runtime/src/request-bodies/index.ts
@@ -1,9 +1,0 @@
-// todo: parseOctetStreamRequestBody is only for server side, and requestBodyToUrlSearchParams is only for client side.
-//       probably need to split this package to avoid polluting client dependency tress.
-export {parseOctetStreamRequestBody, type SizeLimit} from "./octet-stream.ts"
-
-export {
-  type Encoding,
-  requestBodyToUrlSearchParams,
-  type Style,
-} from "./url-search-params.ts"

--- a/packages/typescript-common-runtime/tsdown.config.mts
+++ b/packages/typescript-common-runtime/tsdown.config.mts
@@ -20,6 +20,8 @@ export default defineConfig({
   publint: true,
   attw: {profile: "node16"},
 
+  deps: {onlyBundle: []},
+
   format: {
     esm: {
       outDir: "./dist/esm",

--- a/packages/typescript-common-runtime/tsdown.config.mts
+++ b/packages/typescript-common-runtime/tsdown.config.mts
@@ -8,7 +8,8 @@ export default defineConfig({
     "./src/validation.ts",
     "./src/types.ts",
     "./src/query-parser.ts",
-    "./src/request-bodies/index.ts",
+    "./src/request-bodies/octet-stream.ts",
+    "./src/request-bodies/url-search-params.ts",
   ],
 
   target: "esnext",

--- a/packages/typescript-express-runtime/package.json
+++ b/packages/typescript-express-runtime/package.json
@@ -77,6 +77,7 @@
     "test": "jest"
   },
   "dependencies": {
+    "raw-body": "^3.0.2",
     "tslib": "^2.8.1"
   },
   "peerDependencies": {

--- a/packages/typescript-express-runtime/src/server.ts
+++ b/packages/typescript-express-runtime/src/server.ts
@@ -23,7 +23,7 @@ export {parseQueryParameters} from "@nahkies/typescript-common-runtime/query-par
 import {
   parseOctetStreamRequestBody,
   type SizeLimit,
-} from "@nahkies/typescript-common-runtime/request-bodies"
+} from "@nahkies/typescript-common-runtime/request-bodies/octet-stream"
 
 export {
   type Params,

--- a/packages/typescript-express-runtime/tsdown.config.mts
+++ b/packages/typescript-express-runtime/tsdown.config.mts
@@ -19,6 +19,10 @@ export default defineConfig({
   publint: true,
   attw: {profile: "node16"},
 
+  deps: {
+    onlyBundle: ["@nahkies/typescript-common-runtime"],
+  },
+
   format: {
     esm: {
       outDir: "./dist/esm",

--- a/packages/typescript-fetch-runtime/src/main.spec.ts
+++ b/packages/typescript-fetch-runtime/src/main.spec.ts
@@ -1,7 +1,7 @@
 // biome-ignore-all lint/suspicious/noExplicitAny: tests
 
 import {describe, expect, it} from "@jest/globals"
-import type {Encoding} from "@nahkies/typescript-common-runtime/request-bodies"
+import type {Encoding} from "@nahkies/typescript-common-runtime/request-bodies/url-search-params"
 import {
   AbstractFetchClient,
   type AbstractFetchClientConfig,

--- a/packages/typescript-fetch-runtime/src/main.ts
+++ b/packages/typescript-fetch-runtime/src/main.ts
@@ -1,7 +1,7 @@
 import {
   type Encoding,
   requestBodyToUrlSearchParams,
-} from "@nahkies/typescript-common-runtime/request-bodies"
+} from "@nahkies/typescript-common-runtime/request-bodies/url-search-params"
 import {isNonEmptyArray} from "@nahkies/typescript-common-runtime/types"
 import type {
   AbstractFetchClientConfig,

--- a/packages/typescript-fetch-runtime/tsdown.config.mts
+++ b/packages/typescript-fetch-runtime/tsdown.config.mts
@@ -18,6 +18,10 @@ export default defineConfig({
   publint: true,
   attw: {profile: "node16"},
 
+  deps: {
+    onlyBundle: ["@nahkies/typescript-common-runtime"],
+  },
+
   format: {
     esm: {
       outDir: "./dist/esm",

--- a/packages/typescript-koa-runtime/package.json
+++ b/packages/typescript-koa-runtime/package.json
@@ -76,6 +76,7 @@
     "test": "jest"
   },
   "dependencies": {
+    "raw-body": "^3.0.2",
     "tslib": "^2.8.1"
   },
   "peerDependencies": {

--- a/packages/typescript-koa-runtime/src/server.ts
+++ b/packages/typescript-koa-runtime/src/server.ts
@@ -2,8 +2,8 @@ import type {Server} from "node:http"
 import type {AddressInfo, ListenOptions} from "node:net"
 import Cors from "@koa/cors"
 import type Router from "@koa/router"
-import type {SizeLimit} from "@nahkies/typescript-common-runtime/request-bodies"
-import {parseOctetStreamRequestBody} from "@nahkies/typescript-common-runtime/request-bodies"
+import type {SizeLimit} from "@nahkies/typescript-common-runtime/request-bodies/octet-stream"
+import {parseOctetStreamRequestBody} from "@nahkies/typescript-common-runtime/request-bodies/octet-stream"
 import {
   type Res,
   SkipResponse,

--- a/packages/typescript-koa-runtime/tsdown.config.mts
+++ b/packages/typescript-koa-runtime/tsdown.config.mts
@@ -19,6 +19,10 @@ export default defineConfig({
   publint: true,
   attw: {profile: "node16"},
 
+  deps: {
+    onlyBundle: ["@nahkies/typescript-common-runtime"],
+  },
+
   format: {
     esm: {
       outDir: "./dist/esm",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -514,6 +514,9 @@ importers:
       express:
         specifier: ^5.1.0
         version: 5.2.1
+      raw-body:
+        specifier: ^3.0.2
+        version: 3.0.2
       tslib:
         specifier: ^2.8.1
         version: 2.8.1
@@ -579,6 +582,9 @@ importers:
 
   packages/typescript-koa-runtime:
     dependencies:
+      raw-body:
+        specifier: ^3.0.2
+        version: 3.0.2
       tslib:
         specifier: ^2.8.1
         version: 2.8.1


### PR DESCRIPTION
this fixes issues using the `typescript-fetch-runtime` in client side applications (eg: `nextjs`), caused by erroneous bundling of `raw-body` and it's dependencies.

it further updates the `tsdown` config to prevent this reoccurring in future - in general bundling dependencies like this is an anti-pattern, as it obscures the SBOM and may prevent security scanners from detecting CVE alerts against dependencies for example, amongst other potential issues with multiple versions of the same package effectively being used as runtime (in a non-obvious way)

now only the unpublished common runtime package from this repository is allowed to be bundled, as intended.