### PR TITLE
fix: use bin shim

### DIFF
--- a/packages/openapi-code-generator/bin/cli.mjs
+++ b/packages/openapi-code-generator/bin/cli.mjs
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+
+// shim to ensure the bin gets linked when the repo is clean.
+import "../dist/esm/cli.mjs"

--- a/packages/openapi-code-generator/package.json
+++ b/packages/openapi-code-generator/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/mnahkies/openapi-code-generator/issues"
   },
   "bin": {
-    "openapi-code-generator": "./dist/esm/cli.mjs"
+    "openapi-code-generator": "./bin/cli.mjs"
   },
   "main": "./dist/cjs/index.cjs",
   "module": "./dist/esm/index.mjs",
@@ -150,6 +150,7 @@
   },
   "files": [
     "src",
+    "bin",
     "dist",
     "README.md",
     "CHANGELOG.md",


### PR DESCRIPTION
avoids issues with `pnpm` not linking into `.bin` correctly, when starting from a fresh clone