### PR TITLE
fix: adjust headers type for @types/node ^24/^26 compatibility

### DIFF
--- a/packages/typescript-fetch-runtime/src/types.ts
+++ b/packages/typescript-fetch-runtime/src/types.ts
@@ -34,8 +34,11 @@ export interface AbstractFetchClientConfig {
 }
 
 // fetch HeadersInit type
+export type HeaderValue = string | readonly string[] | undefined
+
 export type HeadersInit =
   | string[][]
   | readonly (readonly [string, string])[]
-  | Record<string, string | ReadonlyArray<string>>
+  | Iterable<readonly [string, string]>
+  | Record<string, HeaderValue>
   | Headers


### PR DESCRIPTION
- solves errors like
```
Error: src/generated/client/fetch/client.ts(543,65): error TS2345: Argument of type 'import("/home/runner/work/openapi-code-generator/openapi-code-generator/node_modules/.pnpm/undici-types@7.18.2/node_modules/undici-types/fetch").HeadersInit | undefined' is not assignable to parameter of type 'import("/home/runner/work/openapi-code-generator/openapi-code-generator/packages/typescript-fetch-runtime/dist/esm/types-Dv8r_Ddi", { with: { "resolution-mode": "import" } }).n | undefined'.
  Type 'HeaderRecord' is not assignable to type 'HeadersInit | undefined'.
    Type 'HeaderRecord' is not assignable to type 'Record<string, string | readonly string[]>'.
      'string & Record<never, never>' and 'string' index signatures are incompatible.
        Type 'string | undefined' is not assignable to type 'string | readonly string[]'.
          Type 'undefined' is not assignable to type 'string | readonly string[]'.
```
- now asserted by ci, since #487 