### PR TITLE
fix: workaround esm output issues

### DIFF
--- a/packages/documentation/next.config.mjs
+++ b/packages/documentation/next.config.mjs
@@ -11,10 +11,6 @@ const nextConfig = {
   turbopack: {
     resolveAlias: {
       "next-mdx-import-source-file": "./src/mdx-components.tsx",
-      // todo: ajv validator uses `require` in esm context, causing `node:module` to be used
-      //       https://github.com/ajv-validator/ajv/issues/2598 should solve upstream
-      "@nahkies/openapi-code-generator/web":
-        "./node_modules/@nahkies/openapi-code-generator/dist/cjs/web.cjs",
     },
   },
 }

--- a/packages/openapi-code-generator/package.json
+++ b/packages/openapi-code-generator/package.json
@@ -20,7 +20,7 @@
   "bin": {
     "openapi-code-generator": "./bin/cli.mjs"
   },
-  "main": "./dist/cjs/index.cjs",
+  "main": "./dist/esm/index.mjs",
   "module": "./dist/esm/index.mjs",
   "types": "./dist/esm/index.d.mts",
   "exports": {
@@ -28,30 +28,18 @@
       "import": {
         "types": "./dist/esm/index.d.mts",
         "default": "./dist/esm/index.mjs"
-      },
-      "require": {
-        "types": "./dist/cjs/index.d.cts",
-        "default": "./dist/cjs/index.cjs"
       }
     },
     "./cli": {
       "import": {
         "types": "./dist/esm/cli.d.mts",
         "default": "./dist/esm/cli.mjs"
-      },
-      "require": {
-        "types": "./dist/cjs/cli.d.cts",
-        "default": "./dist/cjs/cli.cjs"
       }
     },
     "./web": {
       "import": {
         "types": "./dist/esm/web.d.mts",
         "default": "./dist/esm/web.mjs"
-      },
-      "require": {
-        "types": "./dist/cjs/web.d.cts",
-        "default": "./dist/cjs/web.cjs"
       }
     }
   },

--- a/packages/openapi-code-generator/src/core/schemas/openapi-3.0-specification-validator.ts
+++ b/packages/openapi-code-generator/src/core/schemas/openapi-3.0-specification-validator.ts
@@ -2013,7 +2013,7 @@ const schema33 = {
   patternProperties: {"^\\$ref$": {type: "string", format: "uri-reference"}},
 }
 const func3 = Object.prototype.hasOwnProperty
-const func0 = require("ajv/dist/runtime/equal").default
+const func0 = (await import("ajv/dist/runtime/equal")).default
 const pattern18 = new RegExp("^\\$ref$", "u")
 const schema23 = {
   type: "object",
@@ -2295,8 +2295,8 @@ const schema42 = {
   patternProperties: {"^x-": {}},
   additionalProperties: false,
 }
-const formats14 = require("ajv-formats/dist/formats").fullFormats.regex
-const formats32 = require("ajv-formats/dist/formats").fullFormats.uri
+const formats14 = (await import("ajv-formats/dist/formats")).fullFormats.regex
+const formats32 = (await import("ajv-formats/dist/formats")).fullFormats.uri
 const wrapper0 = {validate: validate21}
 function validate21(
   data,

--- a/packages/openapi-code-generator/tsdown.config.mts
+++ b/packages/openapi-code-generator/tsdown.config.mts
@@ -11,7 +11,7 @@ export default defineConfig({
   failOnWarn: true,
   logLevel: "warn",
   publint: true,
-  attw: {profile: "node16"},
+  attw: {profile: "esm-only"},
 
   deps: {
     onlyBundle: ["@nahkies/typescript-common-runtime"],
@@ -20,9 +20,6 @@ export default defineConfig({
   format: {
     esm: {
       outDir: "./dist/esm",
-    },
-    cjs: {
-      outDir: "./dist/cjs",
     },
   },
 })

--- a/scripts/generate-ajv-validator.js
+++ b/scripts/generate-ajv-validator.js
@@ -154,7 +154,15 @@ export default function validate(){
   }
 }
 
-compileOpenapi30Standalone().then((output) =>
+compileOpenapi30Standalone()
+  .then((output) => {
+    // todo: workaround https://github.com/ajv-validator/ajv/pull/2618
+    return output
+      .replace("const func0 = require(\"ajv/dist/runtime/equal\").default", "const func0 = (await import(\"ajv/dist/runtime/equal\")).default")
+      .replace("const formats14 = require(\"ajv-formats/dist/formats\").fullFormats.regex", "const formats14 = (await import(\"ajv-formats/dist/formats\")).fullFormats.regex")
+      .replace("const formats32 = require(\"ajv-formats/dist/formats\").fullFormats.uri", "const formats32 = (await import(\"ajv-formats/dist/formats\")).fullFormats.uri")
+  })
+  .then((output) =>
   writeOutput(
     path.join(outputDir, "openapi-3.0-specification-validator.ts"),
     output,

--- a/scripts/generate-ajv-validator.js
+++ b/scripts/generate-ajv-validator.js
@@ -158,16 +158,25 @@ compileOpenapi30Standalone()
   .then((output) => {
     // todo: workaround https://github.com/ajv-validator/ajv/pull/2618
     return output
-      .replace("const func0 = require(\"ajv/dist/runtime/equal\").default", "const func0 = (await import(\"ajv/dist/runtime/equal\")).default")
-      .replace("const formats14 = require(\"ajv-formats/dist/formats\").fullFormats.regex", "const formats14 = (await import(\"ajv-formats/dist/formats\")).fullFormats.regex")
-      .replace("const formats32 = require(\"ajv-formats/dist/formats\").fullFormats.uri", "const formats32 = (await import(\"ajv-formats/dist/formats\")).fullFormats.uri")
+      .replace(
+        'const func0 = require("ajv/dist/runtime/equal").default',
+        'const func0 = (await import("ajv/dist/runtime/equal")).default',
+      )
+      .replace(
+        'const formats14 = require("ajv-formats/dist/formats").fullFormats.regex',
+        'const formats14 = (await import("ajv-formats/dist/formats")).fullFormats.regex',
+      )
+      .replace(
+        'const formats32 = require("ajv-formats/dist/formats").fullFormats.uri',
+        'const formats32 = (await import("ajv-formats/dist/formats")).fullFormats.uri',
+      )
   })
   .then((output) =>
-  writeOutput(
-    path.join(outputDir, "openapi-3.0-specification-validator.ts"),
-    output,
-  ),
-)
+    writeOutput(
+      path.join(outputDir, "openapi-3.0-specification-validator.ts"),
+      output,
+    ),
+  )
 
 compileOpenapi31Standalone(true).then((output) =>
   writeOutput(


### PR DESCRIPTION
workaround until https://github.com/ajv-validator/ajv/pull/2618 is merged / released.