### PR TITLE
fix: normalize const/single-value enums to IRModelConst

### DIFF
--- a/e2e/src/generated/client/axios/schemas.ts
+++ b/e2e/src/generated/client/axios/schemas.ts
@@ -22,12 +22,15 @@ export const s_Enumerations = z.object({
     z.enum(["red", "green", "blue"]),
     z.string().transform((it) => it as typeof it & UnknownEnumStringValue),
   ]),
-  starRatings: z.union([
-    z.literal(1),
-    z.literal(2),
-    z.literal(3),
-    z.number().transform((it) => it as typeof it & UnknownEnumNumberValue),
-  ]),
+  starRatings: z.preprocess(
+    (it) => z.coerce.number().parse(it),
+    z.union([
+      z.literal(1),
+      z.literal(2),
+      z.literal(3),
+      z.number().transform((it) => it as typeof it & UnknownEnumNumberValue),
+    ]),
+  ),
 })
 
 export const s_ProductOrder = z.object({

--- a/e2e/src/generated/client/fetch/schemas.ts
+++ b/e2e/src/generated/client/fetch/schemas.ts
@@ -22,12 +22,15 @@ export const s_Enumerations = z.object({
     z.enum(["red", "green", "blue"]),
     z.string().transform((it) => it as typeof it & UnknownEnumStringValue),
   ]),
-  starRatings: z.union([
-    z.literal(1),
-    z.literal(2),
-    z.literal(3),
-    z.number().transform((it) => it as typeof it & UnknownEnumNumberValue),
-  ]),
+  starRatings: z.preprocess(
+    (it) => z.coerce.number().parse(it),
+    z.union([
+      z.literal(1),
+      z.literal(2),
+      z.literal(3),
+      z.number().transform((it) => it as typeof it & UnknownEnumNumberValue),
+    ]),
+  ),
 })
 
 export const s_ProductOrder = z.object({

--- a/e2e/src/generated/server/express/schemas.ts
+++ b/e2e/src/generated/server/express/schemas.ts
@@ -27,7 +27,10 @@ export const s_Dog = z.object({
 
 export const s_Enumerations = z.object({
   colors: z.enum(["red", "green", "blue"]),
-  starRatings: z.union([z.literal(1), z.literal(2), z.literal(3)]),
+  starRatings: z.preprocess(
+    (it) => z.coerce.number().parse(it),
+    z.union([z.literal(1), z.literal(2), z.literal(3)]),
+  ),
 })
 
 export const s_ProductOrder = z.object({

--- a/e2e/src/generated/server/koa/schemas.ts
+++ b/e2e/src/generated/server/koa/schemas.ts
@@ -27,7 +27,10 @@ export const s_Dog = z.object({
 
 export const s_Enumerations = z.object({
   colors: z.enum(["red", "green", "blue"]),
-  starRatings: z.union([z.literal(1), z.literal(2), z.literal(3)]),
+  starRatings: z.preprocess(
+    (it) => z.coerce.number().parse(it),
+    z.union([z.literal(1), z.literal(2), z.literal(3)]),
+  ),
 })
 
 export const s_ProductOrder = z.object({

--- a/integration-tests-definitions/todo-lists.yaml
+++ b/integration-tests-definitions/todo-lists.yaml
@@ -1,4 +1,4 @@
-openapi: "3.0.0"
+openapi: 3.1.1
 info:
   title: Todo Lists Example API
   version: '0.0.1'
@@ -161,6 +161,18 @@ paths:
       responses:
         204:
           description: success
+  /events:
+    get:
+      operationId: listTodoEvents
+      responses:
+        200:
+          description: success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/TodoEvent'
   /attachments:
     servers:
       - url: '{schema}://{tenant}.attachments.example.com'
@@ -251,6 +263,43 @@ components:
         enum:
           - incomplete
           - complete
+    TodoEvent:
+      type: object
+      discriminator:
+        propertyName: kind
+      oneOf:
+        - $ref: '#/components/schemas/TodoCreatedEvent'
+        - $ref: '#/components/schemas/TodoCompletedEvent'
+    TodoCreatedEvent:
+      type: object
+      required:
+        - kind
+        - id
+        - createdAt
+      properties:
+        kind:
+          const: created
+        id:
+          type: string
+          format: uuid
+        createdAt:
+          type: string
+          format: date-time
+    TodoCompletedEvent:
+      type: object
+      required:
+        - kind
+        - id
+        - completedAt
+      properties:
+        kind:
+          const: completed
+        id:
+          type: string
+          format: uuid
+        completedAt:
+          type: string
+          format: date-time
   parameters:
     listId:
       name: listId

--- a/integration-tests/typescript-angular/src/generated/api.github.com.yaml/client.service.ts
+++ b/integration-tests/typescript-angular/src/generated/api.github.com.yaml/client.service.ts
@@ -12709,6 +12709,10 @@ export class GitHubV3RestApiService {
         token_id: p["tokenId"],
       },
       {
+        sort: {
+          style: "form",
+          explode: true,
+        },
         owner: {
           style: "form",
           explode: true,
@@ -12855,6 +12859,10 @@ export class GitHubV3RestApiService {
         token_id: p["tokenId"],
       },
       {
+        sort: {
+          style: "form",
+          explode: true,
+        },
         owner: {
           style: "form",
           explode: true,
@@ -19697,17 +19705,25 @@ export class GitHubV3RestApiService {
     | HttpResponse<unknown>
   > {
     const headers = this._headers({Accept: "application/json"})
-    const params = this._query({
-      tool_name: p["toolName"],
-      tool_guid: p["toolGuid"],
-      page: p["page"],
-      per_page: p["perPage"],
-      pr: p["pr"],
-      ref: p["ref"],
-      sarif_id: p["sarifId"],
-      direction: p["direction"],
-      sort: p["sort"],
-    })
+    const params = this._query(
+      {
+        tool_name: p["toolName"],
+        tool_guid: p["toolGuid"],
+        page: p["page"],
+        per_page: p["perPage"],
+        pr: p["pr"],
+        ref: p["ref"],
+        sarif_id: p["sarifId"],
+        direction: p["direction"],
+        sort: p["sort"],
+      },
+      {
+        sort: {
+          style: "form",
+          explode: true,
+        },
+      },
+    )
 
     return this.httpClient.request<any>(
       "GET",
@@ -29300,13 +29316,21 @@ export class GitHubV3RestApiService {
     | HttpResponse<unknown>
   > {
     const headers = this._headers({Accept: "application/json"})
-    const params = this._query({
-      q: p["q"],
-      sort: p["sort"],
-      order: p["order"],
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._query(
+      {
+        q: p["q"],
+        sort: p["sort"],
+        order: p["order"],
+        per_page: p["perPage"],
+        page: p["page"],
+      },
+      {
+        sort: {
+          style: "form",
+          explode: true,
+        },
+      },
+    )
 
     return this.httpClient.request<any>(
       "GET",

--- a/integration-tests/typescript-angular/src/generated/okta.oauth.yaml/client.service.ts
+++ b/integration-tests/typescript-angular/src/generated/okta.oauth.yaml/client.service.ts
@@ -203,28 +203,36 @@ export class OktaOpenIdConnectOAuth20Service {
     (HttpResponse<t_Error> & {status: 429}) | HttpResponse<unknown>
   > {
     const headers = this._headers({Accept: "application/json"})
-    const params = this._query({
-      acr_values: p["acrValues"],
-      client_id: p["clientId"],
-      code_challenge: p["codeChallenge"],
-      code_challenge_method: p["codeChallengeMethod"],
-      display: p["display"],
-      enroll_amr_values: p["enrollAmrValues"],
-      idp_scope: p["idpScope"],
-      idp: p["idp"],
-      login_hint: p["loginHint"],
-      max_age: p["maxAge"],
-      nonce: p["nonce"],
-      prompt: p["prompt"],
-      redirect_uri: p["redirectUri"],
-      response_type: p["responseType"],
-      response_mode: p["responseMode"],
-      request_uri: p["requestUri"],
-      request: p["request"],
-      scope: p["scope"],
-      sessionToken: p["sessionToken"],
-      state: p["state"],
-    })
+    const params = this._query(
+      {
+        acr_values: p["acrValues"],
+        client_id: p["clientId"],
+        code_challenge: p["codeChallenge"],
+        code_challenge_method: p["codeChallengeMethod"],
+        display: p["display"],
+        enroll_amr_values: p["enrollAmrValues"],
+        idp_scope: p["idpScope"],
+        idp: p["idp"],
+        login_hint: p["loginHint"],
+        max_age: p["maxAge"],
+        nonce: p["nonce"],
+        prompt: p["prompt"],
+        redirect_uri: p["redirectUri"],
+        response_type: p["responseType"],
+        response_mode: p["responseMode"],
+        request_uri: p["requestUri"],
+        request: p["request"],
+        scope: p["scope"],
+        sessionToken: p["sessionToken"],
+        state: p["state"],
+      },
+      {
+        code_challenge_method: {
+          style: "form",
+          explode: true,
+        },
+      },
+    )
 
     return this.httpClient.request(
       "GET",
@@ -844,28 +852,36 @@ export class OktaOpenIdConnectOAuth20Service {
     (HttpResponse<t_Error> & {status: 429}) | HttpResponse<unknown>
   > {
     const headers = this._headers({Accept: "application/json"})
-    const params = this._query({
-      acr_values: p["acrValues"],
-      client_id: p["clientId"],
-      code_challenge: p["codeChallenge"],
-      code_challenge_method: p["codeChallengeMethod"],
-      display: p["display"],
-      enroll_amr_values: p["enrollAmrValues"],
-      idp_scope: p["idpScope"],
-      idp: p["idp"],
-      login_hint: p["loginHint"],
-      max_age: p["maxAge"],
-      nonce: p["nonce"],
-      prompt: p["prompt"],
-      redirect_uri: p["redirectUri"],
-      response_type: p["responseType"],
-      response_mode: p["responseMode"],
-      request_uri: p["requestUri"],
-      request: p["request"],
-      scope: p["scope"],
-      sessionToken: p["sessionToken"],
-      state: p["state"],
-    })
+    const params = this._query(
+      {
+        acr_values: p["acrValues"],
+        client_id: p["clientId"],
+        code_challenge: p["codeChallenge"],
+        code_challenge_method: p["codeChallengeMethod"],
+        display: p["display"],
+        enroll_amr_values: p["enrollAmrValues"],
+        idp_scope: p["idpScope"],
+        idp: p["idp"],
+        login_hint: p["loginHint"],
+        max_age: p["maxAge"],
+        nonce: p["nonce"],
+        prompt: p["prompt"],
+        redirect_uri: p["redirectUri"],
+        response_type: p["responseType"],
+        response_mode: p["responseMode"],
+        request_uri: p["requestUri"],
+        request: p["request"],
+        scope: p["scope"],
+        sessionToken: p["sessionToken"],
+        state: p["state"],
+      },
+      {
+        code_challenge_method: {
+          style: "form",
+          explode: true,
+        },
+      },
+    )
 
     return this.httpClient.request(
       "GET",

--- a/integration-tests/typescript-angular/src/generated/stripe.yaml/client.service.ts
+++ b/integration-tests/typescript-angular/src/generated/stripe.yaml/client.service.ts
@@ -2108,6 +2108,10 @@ export class StripeApiService {
         starting_after: p["startingAfter"],
       },
       {
+        alert_type: {
+          style: "form",
+          explode: true,
+        },
         expand: {
           style: "deepObject",
           explode: true,

--- a/integration-tests/typescript-angular/src/generated/todo-lists.yaml/client.service.ts
+++ b/integration-tests/typescript-angular/src/generated/todo-lists.yaml/client.service.ts
@@ -10,6 +10,7 @@ import type {
   t_CreateUpdateTodoList,
   t_Error,
   t_Statuses,
+  t_TodoEvent,
   t_TodoList,
   t_UnknownObject,
 } from "./models"
@@ -381,6 +382,22 @@ export class TodoListsExampleApiService {
       {
         headers,
         body,
+        observe: "response",
+        reportProgress: false,
+      },
+    )
+  }
+
+  listTodoEvents(): Observable<
+    (HttpResponse<t_TodoEvent[]> & {status: 200}) | HttpResponse<unknown>
+  > {
+    const headers = this._headers({Accept: "application/json"})
+
+    return this.httpClient.request<any>(
+      "GET",
+      this.config.basePath + `/events`,
+      {
+        headers,
         observe: "response",
         reportProgress: false,
       },

--- a/integration-tests/typescript-angular/src/generated/todo-lists.yaml/models.ts
+++ b/integration-tests/typescript-angular/src/generated/todo-lists.yaml/models.ts
@@ -17,6 +17,20 @@ export type t_CreateUpdateTodoList = {
 
 export type t_Statuses = ("incomplete" | "complete" | UnknownEnumStringValue)[]
 
+export type t_TodoCompletedEvent = {
+  completedAt: string
+  id: string
+  kind: "completed"
+}
+
+export type t_TodoCreatedEvent = {
+  createdAt: string
+  id: string
+  kind: "created"
+}
+
+export type t_TodoEvent = t_TodoCreatedEvent | t_TodoCompletedEvent
+
 export type t_TodoList = {
   created: string
   id: string

--- a/integration-tests/typescript-axios/src/generated/api.github.com.yaml/client.ts
+++ b/integration-tests/typescript-axios/src/generated/api.github.com.yaml/client.ts
@@ -11615,6 +11615,10 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
         token_id: p["tokenId"],
       },
       {
+        sort: {
+          style: "form",
+          explode: true,
+        },
         owner: {
           style: "form",
           explode: true,
@@ -11742,6 +11746,10 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
         token_id: p["tokenId"],
       },
       {
+        sort: {
+          style: "form",
+          explode: true,
+        },
         owner: {
           style: "form",
           explode: true,
@@ -18217,17 +18225,25 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_code_scanning_analysis[]>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/code-scanning/analyses`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
-    const query = this._query({
-      tool_name: p["toolName"],
-      tool_guid: p["toolGuid"],
-      page: p["page"],
-      per_page: p["perPage"],
-      pr: p["pr"],
-      ref: p["ref"],
-      sarif_id: p["sarifId"],
-      direction: p["direction"],
-      sort: p["sort"],
-    })
+    const query = this._query(
+      {
+        tool_name: p["toolName"],
+        tool_guid: p["toolGuid"],
+        page: p["page"],
+        per_page: p["perPage"],
+        pr: p["pr"],
+        ref: p["ref"],
+        sarif_id: p["sarifId"],
+        direction: p["direction"],
+        sort: p["sort"],
+      },
+      {
+        sort: {
+          style: "form",
+          explode: true,
+        },
+      },
+    )
 
     return this._request({
       url: url + query,
@@ -27000,13 +27016,21 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   > {
     const url = `/search/code`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
-    const query = this._query({
-      q: p["q"],
-      sort: p["sort"],
-      order: p["order"],
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const query = this._query(
+      {
+        q: p["q"],
+        sort: p["sort"],
+        order: p["order"],
+        per_page: p["perPage"],
+        page: p["page"],
+      },
+      {
+        sort: {
+          style: "form",
+          explode: true,
+        },
+      },
+    )
 
     return this._request({
       url: url + query,

--- a/integration-tests/typescript-axios/src/generated/okta.oauth.yaml/client.ts
+++ b/integration-tests/typescript-axios/src/generated/okta.oauth.yaml/client.ts
@@ -124,28 +124,36 @@ export class OktaOpenIdConnectOAuth20 extends AbstractAxiosClient {
   ): Promise<AxiosResponse<void>> {
     const url = `/oauth2/v1/authorize`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
-    const query = this._query({
-      acr_values: p["acrValues"],
-      client_id: p["clientId"],
-      code_challenge: p["codeChallenge"],
-      code_challenge_method: p["codeChallengeMethod"],
-      display: p["display"],
-      enroll_amr_values: p["enrollAmrValues"],
-      idp_scope: p["idpScope"],
-      idp: p["idp"],
-      login_hint: p["loginHint"],
-      max_age: p["maxAge"],
-      nonce: p["nonce"],
-      prompt: p["prompt"],
-      redirect_uri: p["redirectUri"],
-      response_type: p["responseType"],
-      response_mode: p["responseMode"],
-      request_uri: p["requestUri"],
-      request: p["request"],
-      scope: p["scope"],
-      sessionToken: p["sessionToken"],
-      state: p["state"],
-    })
+    const query = this._query(
+      {
+        acr_values: p["acrValues"],
+        client_id: p["clientId"],
+        code_challenge: p["codeChallenge"],
+        code_challenge_method: p["codeChallengeMethod"],
+        display: p["display"],
+        enroll_amr_values: p["enrollAmrValues"],
+        idp_scope: p["idpScope"],
+        idp: p["idp"],
+        login_hint: p["loginHint"],
+        max_age: p["maxAge"],
+        nonce: p["nonce"],
+        prompt: p["prompt"],
+        redirect_uri: p["redirectUri"],
+        response_type: p["responseType"],
+        response_mode: p["responseMode"],
+        request_uri: p["requestUri"],
+        request: p["request"],
+        scope: p["scope"],
+        sessionToken: p["sessionToken"],
+        state: p["state"],
+      },
+      {
+        code_challenge_method: {
+          style: "form",
+          explode: true,
+        },
+      },
+    )
 
     return this._request({
       url: url + query,
@@ -749,28 +757,36 @@ export class OktaOpenIdConnectOAuth20 extends AbstractAxiosClient {
   ): Promise<AxiosResponse<void>> {
     const url = `/oauth2/${p["authorizationServerId"]}/v1/authorize`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
-    const query = this._query({
-      acr_values: p["acrValues"],
-      client_id: p["clientId"],
-      code_challenge: p["codeChallenge"],
-      code_challenge_method: p["codeChallengeMethod"],
-      display: p["display"],
-      enroll_amr_values: p["enrollAmrValues"],
-      idp_scope: p["idpScope"],
-      idp: p["idp"],
-      login_hint: p["loginHint"],
-      max_age: p["maxAge"],
-      nonce: p["nonce"],
-      prompt: p["prompt"],
-      redirect_uri: p["redirectUri"],
-      response_type: p["responseType"],
-      response_mode: p["responseMode"],
-      request_uri: p["requestUri"],
-      request: p["request"],
-      scope: p["scope"],
-      sessionToken: p["sessionToken"],
-      state: p["state"],
-    })
+    const query = this._query(
+      {
+        acr_values: p["acrValues"],
+        client_id: p["clientId"],
+        code_challenge: p["codeChallenge"],
+        code_challenge_method: p["codeChallengeMethod"],
+        display: p["display"],
+        enroll_amr_values: p["enrollAmrValues"],
+        idp_scope: p["idpScope"],
+        idp: p["idp"],
+        login_hint: p["loginHint"],
+        max_age: p["maxAge"],
+        nonce: p["nonce"],
+        prompt: p["prompt"],
+        redirect_uri: p["redirectUri"],
+        response_type: p["responseType"],
+        response_mode: p["responseMode"],
+        request_uri: p["requestUri"],
+        request: p["request"],
+        scope: p["scope"],
+        sessionToken: p["sessionToken"],
+        state: p["state"],
+      },
+      {
+        code_challenge_method: {
+          style: "form",
+          explode: true,
+        },
+      },
+    )
 
     return this._request({
       url: url + query,

--- a/integration-tests/typescript-axios/src/generated/stripe.yaml/client.ts
+++ b/integration-tests/typescript-axios/src/generated/stripe.yaml/client.ts
@@ -2554,6 +2554,10 @@ export class StripeApi extends AbstractAxiosClient {
         starting_after: p["startingAfter"],
       },
       {
+        alert_type: {
+          style: "form",
+          explode: true,
+        },
         expand: {
           style: "deepObject",
           explode: true,

--- a/integration-tests/typescript-axios/src/generated/todo-lists.yaml/client.ts
+++ b/integration-tests/typescript-axios/src/generated/todo-lists.yaml/client.ts
@@ -12,6 +12,7 @@ import type {
   t_CreateTodoListItemRequestBody,
   t_CreateUpdateTodoList,
   t_Statuses,
+  t_TodoEvent,
   t_TodoList,
   t_UnknownObject,
 } from "./models"
@@ -296,6 +297,22 @@ export class TodoListsExampleApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
+      ...(timeout ? {timeout} : {}),
+      ...opts,
+      headers,
+    })
+  }
+
+  async listTodoEvents(
+    timeout?: number,
+    opts: AxiosRequestConfig = {},
+  ): Promise<AxiosResponse<t_TodoEvent[]>> {
+    const url = `/events`
+    const headers = this._headers({Accept: "application/json"}, opts.headers)
+
+    return this._request({
+      url: url,
+      method: "GET",
       ...(timeout ? {timeout} : {}),
       ...opts,
       headers,

--- a/integration-tests/typescript-axios/src/generated/todo-lists.yaml/models.ts
+++ b/integration-tests/typescript-axios/src/generated/todo-lists.yaml/models.ts
@@ -17,6 +17,20 @@ export type t_CreateUpdateTodoList = {
 
 export type t_Statuses = ("incomplete" | "complete" | UnknownEnumStringValue)[]
 
+export type t_TodoCompletedEvent = {
+  completedAt: string
+  id: string
+  kind: "completed"
+}
+
+export type t_TodoCreatedEvent = {
+  createdAt: string
+  id: string
+  kind: "created"
+}
+
+export type t_TodoEvent = t_TodoCreatedEvent | t_TodoCompletedEvent
+
 export type t_TodoList = {
   created: string
   id: string

--- a/integration-tests/typescript-express/src/generated/todo-lists.yaml/generated.ts
+++ b/integration-tests/typescript-express/src/generated/todo-lists.yaml/generated.ts
@@ -39,6 +39,7 @@ import type {
   t_GetTodoListItemsParamSchema,
   t_GetTodoListsQuerySchema,
   t_ReplaceAttachmentParamSchema,
+  t_TodoEvent,
   t_TodoList,
   t_UnknownObject,
   t_UpdateTodoListByIdParamSchema,
@@ -48,6 +49,7 @@ import {
   s_CreateUpdateTodoList,
   s_Error,
   s_Statuses,
+  s_TodoEvent,
   s_TodoList,
   s_UnknownObject,
 } from "./schemas.ts"
@@ -149,6 +151,18 @@ export type CreateTodoListItem = (
   next: NextFunction,
 ) => Promise<ExpressRuntimeResponse<unknown> | typeof SkipResponse>
 
+export type ListTodoEventsResponder = {
+  with200(): ExpressRuntimeResponse<t_TodoEvent[]>
+} & ExpressRuntimeResponder
+
+export type ListTodoEvents = (
+  params: Params<void, void, void, void>,
+  respond: ListTodoEventsResponder,
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => Promise<ExpressRuntimeResponse<unknown> | typeof SkipResponse>
+
 export type ListAttachmentsResponder = {
   with200(): ExpressRuntimeResponse<t_UnknownObject[]>
 } & ExpressRuntimeResponder
@@ -192,6 +206,7 @@ export type Implementation = {
   deleteTodoListById: DeleteTodoListById
   getTodoListItems: GetTodoListItems
   createTodoListItem: CreateTodoListItem
+  listTodoEvents: ListTodoEvents
   listAttachments: ListAttachments
   uploadAttachment: UploadAttachment
   replaceAttachment: ReplaceAttachment
@@ -524,6 +539,42 @@ export function createRouter(
           .createTodoListItem(input, responder, req, res, next)
           .catch(handleImplementationError)
           .then(handleResponse(res, createTodoListItemResponseBodyValidator))
+      } catch (error) {
+        next(error)
+      }
+    },
+  )
+
+  const listTodoEventsResponseBodyValidator = responseValidationFactory(
+    [["200", z.array(s_TodoEvent)]],
+    undefined,
+  )
+
+  // listTodoEvents
+  router.get(
+    `/events`,
+    async (req: Request, res: Response, next: NextFunction) => {
+      try {
+        const input = {
+          params: undefined,
+          query: undefined,
+          body: undefined,
+          headers: undefined,
+        }
+
+        const responder = {
+          with200() {
+            return new ExpressRuntimeResponse<t_TodoEvent[]>(200)
+          },
+          withStatus(status: StatusCode) {
+            return new ExpressRuntimeResponse(status)
+          },
+        }
+
+        await implementation
+          .listTodoEvents(input, responder, req, res, next)
+          .catch(handleImplementationError)
+          .then(handleResponse(res, listTodoEventsResponseBodyValidator))
       } catch (error) {
         next(error)
       }

--- a/integration-tests/typescript-express/src/generated/todo-lists.yaml/models.ts
+++ b/integration-tests/typescript-express/src/generated/todo-lists.yaml/models.ts
@@ -13,6 +13,20 @@ export type t_CreateUpdateTodoList = {
 
 export type t_Statuses = ("incomplete" | "complete")[]
 
+export type t_TodoCompletedEvent = {
+  completedAt: string
+  id: string
+  kind: "completed"
+}
+
+export type t_TodoCreatedEvent = {
+  createdAt: string
+  id: string
+  kind: "created"
+}
+
+export type t_TodoEvent = t_TodoCreatedEvent | t_TodoCompletedEvent
+
 export type t_TodoList = {
   created: string
   id: string

--- a/integration-tests/typescript-express/src/generated/todo-lists.yaml/schemas.ts
+++ b/integration-tests/typescript-express/src/generated/todo-lists.yaml/schemas.ts
@@ -13,6 +13,18 @@ export const s_Error = z.object({
 
 export const s_Statuses = z.array(z.enum(["incomplete", "complete"]))
 
+export const s_TodoCompletedEvent = z.object({
+  kind: z.literal("completed"),
+  id: z.string(),
+  completedAt: z.iso.datetime({offset: true}),
+})
+
+export const s_TodoCreatedEvent = z.object({
+  kind: z.literal("created"),
+  id: z.string(),
+  createdAt: z.iso.datetime({offset: true}),
+})
+
 export const s_TodoList = z.object({
   id: z.string(),
   name: z.string(),
@@ -23,6 +35,11 @@ export const s_TodoList = z.object({
 })
 
 export const s_UnknownObject = z.record(z.string(), z.unknown())
+
+export const s_TodoEvent = z.discriminatedUnion("kind", [
+  s_TodoCreatedEvent,
+  s_TodoCompletedEvent,
+])
 
 export const s_CreateTodoListItemRequestBody = z.object({
   id: z.string(),

--- a/integration-tests/typescript-fetch/src/generated/api.github.com.yaml/client.ts
+++ b/integration-tests/typescript-fetch/src/generated/api.github.com.yaml/client.ts
@@ -10925,6 +10925,10 @@ export class GitHubV3RestApi extends AbstractFetchClient {
         token_id: p["tokenId"],
       },
       {
+        sort: {
+          style: "form",
+          explode: true,
+        },
         owner: {
           style: "form",
           explode: true,
@@ -11054,6 +11058,10 @@ export class GitHubV3RestApi extends AbstractFetchClient {
         token_id: p["tokenId"],
       },
       {
+        sort: {
+          style: "form",
+          explode: true,
+        },
         owner: {
           style: "form",
           explode: true,
@@ -16898,17 +16906,25 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url =
       this.basePath + `/repos/${p["owner"]}/${p["repo"]}/code-scanning/analyses`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
-    const query = this._query({
-      tool_name: p["toolName"],
-      tool_guid: p["toolGuid"],
-      page: p["page"],
-      per_page: p["perPage"],
-      pr: p["pr"],
-      ref: p["ref"],
-      sarif_id: p["sarifId"],
-      direction: p["direction"],
-      sort: p["sort"],
-    })
+    const query = this._query(
+      {
+        tool_name: p["toolName"],
+        tool_guid: p["toolGuid"],
+        page: p["page"],
+        per_page: p["perPage"],
+        pr: p["pr"],
+        ref: p["ref"],
+        sarif_id: p["sarifId"],
+        direction: p["direction"],
+        sort: p["sort"],
+      },
+      {
+        sort: {
+          style: "form",
+          explode: true,
+        },
+      },
+    )
 
     return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
@@ -25108,13 +25124,21 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/search/code`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
-    const query = this._query({
-      q: p["q"],
-      sort: p["sort"],
-      order: p["order"],
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const query = this._query(
+      {
+        q: p["q"],
+        sort: p["sort"],
+        order: p["order"],
+        per_page: p["perPage"],
+        page: p["page"],
+      },
+      {
+        sort: {
+          style: "form",
+          explode: true,
+        },
+      },
+    )
 
     return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }

--- a/integration-tests/typescript-fetch/src/generated/okta.oauth.yaml/client.ts
+++ b/integration-tests/typescript-fetch/src/generated/okta.oauth.yaml/client.ts
@@ -121,28 +121,36 @@ export class OktaOpenIdConnectOAuth20 extends AbstractFetchClient {
   ): Promise<Res<429, t_Error>> {
     const url = this.basePath + `/oauth2/v1/authorize`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
-    const query = this._query({
-      acr_values: p["acrValues"],
-      client_id: p["clientId"],
-      code_challenge: p["codeChallenge"],
-      code_challenge_method: p["codeChallengeMethod"],
-      display: p["display"],
-      enroll_amr_values: p["enrollAmrValues"],
-      idp_scope: p["idpScope"],
-      idp: p["idp"],
-      login_hint: p["loginHint"],
-      max_age: p["maxAge"],
-      nonce: p["nonce"],
-      prompt: p["prompt"],
-      redirect_uri: p["redirectUri"],
-      response_type: p["responseType"],
-      response_mode: p["responseMode"],
-      request_uri: p["requestUri"],
-      request: p["request"],
-      scope: p["scope"],
-      sessionToken: p["sessionToken"],
-      state: p["state"],
-    })
+    const query = this._query(
+      {
+        acr_values: p["acrValues"],
+        client_id: p["clientId"],
+        code_challenge: p["codeChallenge"],
+        code_challenge_method: p["codeChallengeMethod"],
+        display: p["display"],
+        enroll_amr_values: p["enrollAmrValues"],
+        idp_scope: p["idpScope"],
+        idp: p["idp"],
+        login_hint: p["loginHint"],
+        max_age: p["maxAge"],
+        nonce: p["nonce"],
+        prompt: p["prompt"],
+        redirect_uri: p["redirectUri"],
+        response_type: p["responseType"],
+        response_mode: p["responseMode"],
+        request_uri: p["requestUri"],
+        request: p["request"],
+        scope: p["scope"],
+        sessionToken: p["sessionToken"],
+        state: p["state"],
+      },
+      {
+        code_challenge_method: {
+          style: "form",
+          explode: true,
+        },
+      },
+    )
 
     return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
@@ -661,28 +669,36 @@ export class OktaOpenIdConnectOAuth20 extends AbstractFetchClient {
     const url =
       this.basePath + `/oauth2/${p["authorizationServerId"]}/v1/authorize`
     const headers = this._headers({Accept: "application/json"}, opts.headers)
-    const query = this._query({
-      acr_values: p["acrValues"],
-      client_id: p["clientId"],
-      code_challenge: p["codeChallenge"],
-      code_challenge_method: p["codeChallengeMethod"],
-      display: p["display"],
-      enroll_amr_values: p["enrollAmrValues"],
-      idp_scope: p["idpScope"],
-      idp: p["idp"],
-      login_hint: p["loginHint"],
-      max_age: p["maxAge"],
-      nonce: p["nonce"],
-      prompt: p["prompt"],
-      redirect_uri: p["redirectUri"],
-      response_type: p["responseType"],
-      response_mode: p["responseMode"],
-      request_uri: p["requestUri"],
-      request: p["request"],
-      scope: p["scope"],
-      sessionToken: p["sessionToken"],
-      state: p["state"],
-    })
+    const query = this._query(
+      {
+        acr_values: p["acrValues"],
+        client_id: p["clientId"],
+        code_challenge: p["codeChallenge"],
+        code_challenge_method: p["codeChallengeMethod"],
+        display: p["display"],
+        enroll_amr_values: p["enrollAmrValues"],
+        idp_scope: p["idpScope"],
+        idp: p["idp"],
+        login_hint: p["loginHint"],
+        max_age: p["maxAge"],
+        nonce: p["nonce"],
+        prompt: p["prompt"],
+        redirect_uri: p["redirectUri"],
+        response_type: p["responseType"],
+        response_mode: p["responseMode"],
+        request_uri: p["requestUri"],
+        request: p["request"],
+        scope: p["scope"],
+        sessionToken: p["sessionToken"],
+        state: p["state"],
+      },
+      {
+        code_challenge_method: {
+          style: "form",
+          explode: true,
+        },
+      },
+    )
 
     return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }

--- a/integration-tests/typescript-fetch/src/generated/stripe.yaml/client.ts
+++ b/integration-tests/typescript-fetch/src/generated/stripe.yaml/client.ts
@@ -2326,6 +2326,10 @@ export class StripeApi extends AbstractFetchClient {
         starting_after: p["startingAfter"],
       },
       {
+        alert_type: {
+          style: "form",
+          explode: true,
+        },
         expand: {
           style: "deepObject",
           explode: true,

--- a/integration-tests/typescript-fetch/src/generated/todo-lists.yaml/client.ts
+++ b/integration-tests/typescript-fetch/src/generated/todo-lists.yaml/client.ts
@@ -16,6 +16,7 @@ import type {
   t_CreateUpdateTodoList,
   t_Error,
   t_Statuses,
+  t_TodoEvent,
   t_TodoList,
   t_UnknownObject,
 } from "./models.ts"
@@ -288,6 +289,16 @@ export class TodoListsExampleApi extends AbstractFetchClient {
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
+  }
+
+  async listTodoEvents(
+    timeout?: number,
+    opts: RequestInit = {},
+  ): Promise<Res<200, t_TodoEvent[]>> {
+    const url = this.basePath + `/events`
+    const headers = this._headers({Accept: "application/json"}, opts.headers)
+
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async listAttachments(

--- a/integration-tests/typescript-fetch/src/generated/todo-lists.yaml/models.ts
+++ b/integration-tests/typescript-fetch/src/generated/todo-lists.yaml/models.ts
@@ -17,6 +17,20 @@ export type t_CreateUpdateTodoList = {
 
 export type t_Statuses = ("incomplete" | "complete" | UnknownEnumStringValue)[]
 
+export type t_TodoCompletedEvent = {
+  completedAt: string
+  id: string
+  kind: "completed"
+}
+
+export type t_TodoCreatedEvent = {
+  createdAt: string
+  id: string
+  kind: "created"
+}
+
+export type t_TodoEvent = t_TodoCreatedEvent | t_TodoCompletedEvent
+
 export type t_TodoList = {
   created: string
   id: string

--- a/integration-tests/typescript-fetch/src/todo-lists.type-tests.ts
+++ b/integration-tests/typescript-fetch/src/todo-lists.type-tests.ts
@@ -1,4 +1,22 @@
 import {TodoListsExampleApiServers} from "./generated/todo-lists.yaml/client.ts"
+import type {t_TodoEvent} from "./generated/todo-lists.yaml/models.ts"
+
+// const-based discriminators must allow narrowing the union by literal type
+declare const t_event: t_TodoEvent
+if (t_event.kind === "created") {
+  const createdAt: string = t_event.createdAt
+  void createdAt
+  // @ts-expect-error `t_TodoCreatedEvent` has no `completedAt` property
+  const completedAt: string = t_event.completedAt
+  void completedAt
+}
+if (t_event.kind === "completed") {
+  const completedAt: string = t_event.completedAt
+  void completedAt
+  // @ts-expect-error `t_TodoCompletedEvent` has no `createdAt` property
+  const createdAt: string = t_event.createdAt
+  void createdAt
+}
 
 TodoListsExampleApiServers.server()
 

--- a/integration-tests/typescript-koa/src/generated/todo-lists.yaml/generated.ts
+++ b/integration-tests/typescript-koa/src/generated/todo-lists.yaml/generated.ts
@@ -35,6 +35,7 @@ import type {
   t_GetTodoListItemsParamSchema,
   t_GetTodoListsQuerySchema,
   t_ReplaceAttachmentParamSchema,
+  t_TodoEvent,
   t_TodoList,
   t_UnknownObject,
   t_UpdateTodoListByIdParamSchema,
@@ -44,6 +45,7 @@ import {
   s_CreateUpdateTodoList,
   s_Error,
   s_Statuses,
+  s_TodoEvent,
   s_TodoList,
   s_UnknownObject,
 } from "./schemas"
@@ -172,6 +174,18 @@ export type CreateTodoListItem = (
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Res<204, void> | typeof SkipResponse>
 
+export type ListTodoEventsResponder = {
+  with200(): KoaRuntimeResponse<t_TodoEvent[]>
+} & KoaRuntimeResponder
+
+export type ListTodoEvents = (
+  params: Params<void, void, void, void>,
+  respond: ListTodoEventsResponder,
+  ctx: RouterContext,
+) => Promise<
+  KoaRuntimeResponse<unknown> | Res<200, t_TodoEvent[]> | typeof SkipResponse
+>
+
 export type ListAttachmentsResponder = {
   with200(): KoaRuntimeResponse<t_UnknownObject[]>
 } & KoaRuntimeResponder
@@ -213,6 +227,7 @@ export type Implementation = {
   deleteTodoListById: DeleteTodoListById
   getTodoListItems: GetTodoListItems
   createTodoListItem: CreateTodoListItem
+  listTodoEvents: ListTodoEvents
   listAttachments: ListAttachments
   uploadAttachment: UploadAttachment
   replaceAttachment: ReplaceAttachment
@@ -501,6 +516,34 @@ export function createRouter(
       .createTodoListItem(input, responder, ctx)
       .catch(handleImplementationError)
       .then(handleResponse(ctx, createTodoListItemResponseValidator))
+  })
+
+  const listTodoEventsResponseValidator = responseValidationFactory(
+    [["200", z.array(s_TodoEvent)]],
+    undefined,
+  )
+
+  router.get("listTodoEvents", "/events", async (ctx) => {
+    const input = {
+      params: undefined,
+      query: undefined,
+      body: undefined,
+      headers: undefined,
+    }
+
+    const responder = {
+      with200() {
+        return new KoaRuntimeResponse<t_TodoEvent[]>(200)
+      },
+      withStatus(status: StatusCode) {
+        return new KoaRuntimeResponse(status)
+      },
+    }
+
+    await implementation
+      .listTodoEvents(input, responder, ctx)
+      .catch(handleImplementationError)
+      .then(handleResponse(ctx, listTodoEventsResponseValidator))
   })
 
   const listAttachmentsResponseValidator = responseValidationFactory(

--- a/integration-tests/typescript-koa/src/generated/todo-lists.yaml/models.ts
+++ b/integration-tests/typescript-koa/src/generated/todo-lists.yaml/models.ts
@@ -13,6 +13,20 @@ export type t_CreateUpdateTodoList = {
 
 export type t_Statuses = ("incomplete" | "complete")[]
 
+export type t_TodoCompletedEvent = {
+  completedAt: string
+  id: string
+  kind: "completed"
+}
+
+export type t_TodoCreatedEvent = {
+  createdAt: string
+  id: string
+  kind: "created"
+}
+
+export type t_TodoEvent = t_TodoCreatedEvent | t_TodoCompletedEvent
+
 export type t_TodoList = {
   created: string
   id: string

--- a/integration-tests/typescript-koa/src/generated/todo-lists.yaml/schemas.ts
+++ b/integration-tests/typescript-koa/src/generated/todo-lists.yaml/schemas.ts
@@ -13,6 +13,18 @@ export const s_Error = z.object({
 
 export const s_Statuses = z.array(z.enum(["incomplete", "complete"]))
 
+export const s_TodoCompletedEvent = z.object({
+  kind: z.literal("completed"),
+  id: z.string(),
+  completedAt: z.iso.datetime({offset: true}),
+})
+
+export const s_TodoCreatedEvent = z.object({
+  kind: z.literal("created"),
+  id: z.string(),
+  createdAt: z.iso.datetime({offset: true}),
+})
+
 export const s_TodoList = z.object({
   id: z.string(),
   name: z.string(),
@@ -23,6 +35,11 @@ export const s_TodoList = z.object({
 })
 
 export const s_UnknownObject = z.record(z.string(), z.unknown())
+
+export const s_TodoEvent = z.discriminatedUnion("kind", [
+  s_TodoCreatedEvent,
+  s_TodoCompletedEvent,
+])
 
 export const s_CreateTodoListItemRequestBody = z.object({
   id: z.string(),

--- a/integration-tests/typescript-koa/src/todo-lists.yaml.ts
+++ b/integration-tests/typescript-koa/src/todo-lists.yaml.ts
@@ -2,8 +2,9 @@ import {
   bootstrap,
   createRouter,
   type GetTodoLists,
+  type ListTodoEvents,
 } from "./generated/todo-lists.yaml/generated"
-import type {t_TodoList} from "./generated/todo-lists.yaml/models"
+import type {t_TodoEvent, t_TodoList} from "./generated/todo-lists.yaml/models"
 import {genericErrorMiddleware, notImplemented} from "./petstore-expanded.yaml"
 
 const getTodoLists: GetTodoLists = async ({query}, respond) => {
@@ -11,10 +12,15 @@ const getTodoLists: GetTodoLists = async ({query}, respond) => {
   return respond.with200().body([] as t_TodoList[])
 }
 
+const listTodoEvents: ListTodoEvents = async (_req, respond) => {
+  return respond.with200().body([] as t_TodoEvent[])
+}
+
 async function main() {
   const {server, address} = await bootstrap({
     router: createRouter({
       getTodoLists,
+      listTodoEvents,
       getTodoListById: notImplemented,
       updateTodoListById: notImplemented,
       deleteTodoListById: notImplemented,

--- a/packages/documentation/src/app/guides/concepts/enums/page.mdx
+++ b/packages/documentation/src/app/guides/concepts/enums/page.mdx
@@ -88,6 +88,17 @@ export type t_Fruit = "Apple"
 export const s_Fruit = z.literal("Apple")
 ```
 
+The JSON Schema `const` keyword (valid in OpenAPI 3.1) is treated identically - a single
+constant value is by definition not extensible, so it is always generated as a literal
+regardless of `--enum-extensibility`:
+
+```yaml
+type: string
+const: Apple
+```
+
+Generates the same `t_Fruit = "Apple"` / `s_Fruit = z.literal("Apple")` as above.
+
 ### Client code (open enum)
 
 For the client templates, we use a technique called "branded types" to include the `string` / `number` type in our union

--- a/packages/openapi-code-generator/src/core/normalization/schema-normalizer.spec.ts
+++ b/packages/openapi-code-generator/src/core/normalization/schema-normalizer.spec.ts
@@ -84,17 +84,12 @@ describe("core/input - SchemaNormalizer", () => {
         expect(actual).toStrictEqual(ir.string())
       })
 
-      it("defaults to closed for single element enums", () => {
+      it("normalizes single element enums to a const", () => {
         const actual = schemaNormalizer.normalize({
           type: "string",
           enum: ["a"],
         })
-        expect(actual).toStrictEqual(
-          ir.string({
-            enum: ["a"],
-            "x-enum-extensibility": "closed",
-          }),
-        )
+        expect(actual).toStrictEqual(ir.const({value: "a"}))
       })
 
       it("respects explicit open extensibility for single element enums", () => {
@@ -109,6 +104,32 @@ describe("core/input - SchemaNormalizer", () => {
             "x-enum-extensibility": "open",
           }),
         )
+      })
+
+      it("normalizes a const string to a const", () => {
+        const actual = schemaNormalizer.normalize({
+          type: "string",
+          const: "task",
+        })
+        expect(actual).toStrictEqual(ir.const({value: "task"}))
+      })
+
+      it("normalizes a nullable const string to a nullable const", () => {
+        const actual = schemaNormalizer.normalize({
+          type: "string",
+          nullable: true,
+          const: "task",
+        })
+        expect(actual).toStrictEqual(ir.const({value: "task", nullable: true}))
+      })
+
+      it("keeps a const closed even with explicit open extensibility", () => {
+        const actual = schemaNormalizer.normalize({
+          type: "string",
+          const: "task",
+          "x-enum-extensibility": "open",
+        })
+        expect(actual).toStrictEqual(ir.const({value: "task"}))
       })
 
       it("passes through string specific modifiers", () => {
@@ -153,6 +174,22 @@ describe("core/input - SchemaNormalizer", () => {
             "x-enum-extensibility": "open",
           }),
         )
+      })
+
+      it("normalizes a single element number enum to a const", () => {
+        const actual = schemaNormalizer.normalize({
+          type: "number",
+          enum: [5],
+        })
+        expect(actual).toStrictEqual(ir.const({value: 5}))
+      })
+
+      it("normalizes a const number to a const", () => {
+        const actual = schemaNormalizer.normalize({
+          type: "number",
+          const: 5,
+        })
+        expect(actual).toStrictEqual(ir.const({value: 5}))
       })
 
       it("handles an nullable enum number", () => {
@@ -278,6 +315,45 @@ describe("core/input - SchemaNormalizer", () => {
         const actual = schemaNormalizer.normalize({type: "boolean", enum: []})
         expect(actual).toStrictEqual(ir.boolean())
       })
+
+      it("normalizes a const boolean to a const", () => {
+        const actual = schemaNormalizer.normalize({
+          type: "boolean",
+          const: true,
+        })
+        expect(actual).toStrictEqual(ir.const({value: true}))
+      })
+
+      it("normalizes a single element boolean enum to a const", () => {
+        const actual = schemaNormalizer.normalize({
+          type: "boolean",
+          enum: [false],
+        })
+        expect(actual).toStrictEqual(ir.const({value: false}))
+      })
+    })
+  })
+
+  describe("const", () => {
+    it("normalizes a const with a string value", () => {
+      const actual = schemaNormalizer.normalize({
+        const: "foo",
+      })
+      expect(actual).toStrictEqual(ir.const({value: "foo"}))
+    })
+
+    it("normalizes a const with a number value", () => {
+      const actual = schemaNormalizer.normalize({
+        const: 123,
+      })
+      expect(actual).toStrictEqual(ir.const({value: 123}))
+    })
+
+    it("normalizes a const with a boolean value", () => {
+      const actual = schemaNormalizer.normalize({
+        const: true,
+      })
+      expect(actual).toStrictEqual(ir.const({value: true}))
     })
   })
 
@@ -542,18 +618,12 @@ describe("core/input - SchemaNormalizer", () => {
               schemas: [
                 ir.object({
                   properties: {
-                    type: ir.string({
-                      enum: ["foo"],
-                      "x-enum-extensibility": "closed",
-                    }),
+                    type: ir.const({value: "foo"}),
                   },
                 }),
                 ir.object({
                   properties: {
-                    type: ir.string({
-                      enum: ["bar"],
-                      "x-enum-extensibility": "closed",
-                    }),
+                    type: ir.const({value: "bar"}),
                   },
                 }),
               ],
@@ -583,18 +653,12 @@ describe("core/input - SchemaNormalizer", () => {
               schemas: [
                 ir.object({
                   properties: {
-                    type: ir.string({
-                      enum: ["foo"],
-                      "x-enum-extensibility": "closed",
-                    }),
+                    type: ir.const({value: "foo"}),
                   },
                 }),
                 ir.object({
                   properties: {
-                    type: ir.string({
-                      enum: ["bar"],
-                      "x-enum-extensibility": "closed",
-                    }),
+                    type: ir.const({value: "bar"}),
                   },
                 }),
               ],
@@ -1012,6 +1076,50 @@ describe("core/input - SchemaNormalizer", () => {
       )
     })
 
+    it("supports a const discriminator property", () => {
+      schemaProvider.registerTestRef(
+        ir.ref("/components/schemas/Foo"),
+        ir.object({
+          required: ["type"],
+          properties: {type: ir.const({value: "foo"})},
+        }),
+      )
+      schemaProvider.registerTestRef(
+        ir.ref("/components/schemas/Bar"),
+        ir.object({
+          required: ["type"],
+          properties: {type: ir.const({value: "bar"})},
+        }),
+      )
+
+      const actual = schemaNormalizer.normalize({
+        type: "object",
+        discriminator: {
+          propertyName: "type",
+        },
+        oneOf: [
+          {$ref: "#/components/schemas/Foo"},
+          {$ref: "#/components/schemas/Bar"},
+        ],
+      })
+
+      expect(actual).toStrictEqual(
+        ir.union({
+          discriminator: {
+            propertyName: "type",
+            mapping: {
+              Foo: ir.ref("/components/schemas/Foo"),
+              Bar: ir.ref("/components/schemas/Bar"),
+            },
+          },
+          schemas: [
+            ir.ref("/components/schemas/Foo"),
+            ir.ref("/components/schemas/Bar"),
+          ],
+        }),
+      )
+    })
+
     it("ignores the discriminator property when the discriminator property is not required in all alternatives", () => {
       schemaProvider.registerTestRef(
         ir.ref("/components/schemas/Foo"),
@@ -1145,15 +1253,15 @@ describe("core/input - SchemaNormalizer", () => {
       )
     })
 
-    it("detects a boolean enum", () => {
+    it("detects a boolean const", () => {
       const actual = schemaNormalizer.normalize({
         type: undefined,
         enum: [true],
       })
 
       expect(actual).toStrictEqual(
-        ir.boolean({
-          enum: ["true"],
+        ir.const({
+          value: true,
         }),
       )
     })

--- a/packages/openapi-code-generator/src/core/normalization/schema-normalizer.ts
+++ b/packages/openapi-code-generator/src/core/normalization/schema-normalizer.ts
@@ -16,6 +16,7 @@ import type {
   IRModelArray,
   IRModelBase,
   IRModelBoolean,
+  IRModelConst,
   IRModelIntersection,
   IRModelNumeric,
   IRModelObject,
@@ -45,6 +46,37 @@ export class SchemaNormalizer {
       schemaObject["x-enum-extensibility"] ??
       (enumValues.length === 1 ? "closed" : this.config.enumExtensibility)
     )
+  }
+
+  /**
+   * Determines whether a schema should be normalized to an {@link IRModelConst}.
+   *
+   * An explicit `const` always results in a constant (a constant is by definition
+   * not extensible). An enum with a single possible value also becomes a constant
+   * unless the user explicitly opts in to open extensibility.
+   */
+  private getConstValue(
+    schemaObject: {
+      enum?: (string | number | boolean | null)[] | undefined
+      const?: string | number | boolean | null | undefined
+      "x-enum-extensibility"?: "open" | "closed" | undefined
+    },
+    isScalar: (it: unknown) => it is string | number | boolean,
+    coerce: (it: string | number | boolean) => string | number | boolean,
+  ): string | number | boolean | undefined {
+    if (schemaObject.const !== undefined && isScalar(schemaObject.const)) {
+      return coerce(schemaObject.const)
+    }
+
+    if (
+      schemaObject.enum?.length === 1 &&
+      isScalar(schemaObject.enum[0]) &&
+      schemaObject["x-enum-extensibility"] !== "open"
+    ) {
+      return coerce(schemaObject.enum[0])
+    }
+
+    return undefined
   }
 
   private hasPropertiesOrComposition(schema: SchemaObject): boolean {
@@ -96,7 +128,15 @@ export class SchemaNormalizer {
 
     switch (schemaObject.type) {
       case undefined: {
-        // hack: detect missing `type` but `enum` provided, implying a `type`
+        // hack: detect missing `type` but `const`/`enum` provided, implying a `type`
+        if (typeof schemaObject.const === "string") {
+          return self.normalize({...schemaObject, type: "string"})
+        } else if (typeof schemaObject.const === "number") {
+          return self.normalize({...schemaObject, type: "number"})
+        } else if (typeof schemaObject.const === "boolean") {
+          return self.normalize({...schemaObject, type: "boolean"})
+        }
+
         if (schemaObject.enum?.length) {
           if (schemaObject.enum?.every((it) => typeof it === "number")) {
             return self.normalize({...schemaObject, type: "number"})
@@ -255,6 +295,21 @@ export class SchemaNormalizer {
           Number.isFinite(it),
         )
 
+        const constValue = this.getConstValue(
+          schemaObject,
+          (it): it is number => typeof it === "number",
+          (it) => it,
+        )
+
+        if (constValue !== undefined) {
+          return {
+            ...base,
+            nullable: nullable || base.nullable,
+            type: "const",
+            value: constValue,
+          } satisfies IRModelConst
+        }
+
         const calcMaximums = () => {
           // draft-wright-json-schema-validation-01 changed "exclusiveMaximum"/"exclusiveMinimum" from boolean modifiers
           // of "maximum"/"minimum" to independent numeric fields.
@@ -321,6 +376,21 @@ export class SchemaNormalizer {
           .filter((it) => it !== undefined && it !== null)
           .map((it) => String(it))
 
+        const constValue = this.getConstValue(
+          schemaObject,
+          (it): it is string => typeof it === "string",
+          (it) => it,
+        )
+
+        if (constValue !== undefined) {
+          return {
+            ...base,
+            nullable: nullable || base.nullable,
+            type: "const",
+            value: constValue,
+          } satisfies IRModelConst
+        }
+
         return {
           ...base,
           nullable: nullable || base.nullable,
@@ -342,6 +412,24 @@ export class SchemaNormalizer {
         const enumValues = schemaObjectEnum
           .filter((it) => it !== undefined && it !== null)
           .map((it) => String(it).toLowerCase())
+
+        const constValue = this.getConstValue(
+          schemaObject,
+          (it): it is boolean | string =>
+            typeof it === "boolean" ||
+            (typeof it === "string" &&
+              (it.toLowerCase() === "true" || it.toLowerCase() === "false")),
+          (it) => String(it).toLowerCase() === "true",
+        )
+
+        if (constValue !== undefined) {
+          return {
+            ...base,
+            nullable: nullable || base.nullable,
+            type: "const",
+            value: constValue,
+          } satisfies IRModelConst
+        }
 
         return {
           ...base,
@@ -440,9 +528,16 @@ export class SchemaNormalizer {
         ? this.schemaProvider.schema(property)
         : property
 
-      if (!normalizedProperty || !Reflect.get(normalizedProperty, "enum")) {
+      const isConstOrEnum = Boolean(
+        normalizedProperty &&
+          (Reflect.get(normalizedProperty, "enum") ||
+            Reflect.get(normalizedProperty, "const") !== undefined ||
+            Reflect.get(normalizedProperty, "type") === "const"),
+      )
+
+      if (!normalizedProperty || !isConstOrEnum) {
         logger.warn(
-          `ignoring 'discriminator' over propertyName '${discriminator.propertyName}' as it's not an enum in one or more schemas`,
+          `ignoring 'discriminator' over propertyName '${discriminator.propertyName}' as it's not an enum or const in one or more schemas`,
         )
         return undefined
       }

--- a/packages/openapi-code-generator/src/core/openapi-types-normalized.ts
+++ b/packages/openapi-code-generator/src/core/openapi-types-normalized.ts
@@ -69,6 +69,16 @@ export interface IRModelBoolean extends IRModelBase {
   enum?: string[] | undefined
 }
 
+/**
+ * A literal constant value. Produced from the `const` keyword (OpenAPI 3.1) and
+ * from enums with a single possible value. A constant is by definition not
+ * extensible, so `x-enum-extensibility` never applies.
+ */
+export interface IRModelConst extends IRModelBase {
+  type: "const"
+  value: string | number | boolean
+}
+
 export interface IRModelIntersection extends IRModelBase {
   type: "intersection"
   schemas: NonEmptyArray<MaybeIRModel>
@@ -130,6 +140,7 @@ export type IRModel =
   | IRModelNumeric
   | IRModelString
   | IRModelBoolean
+  | IRModelConst
   | IRModelObject
   | IRModelArray
   | IRModelAny

--- a/packages/openapi-code-generator/src/core/openapi-types.ts
+++ b/packages/openapi-code-generator/src/core/openapi-types.ts
@@ -247,8 +247,11 @@ export interface SchemaBase {
 
   type?: SchemaType | SchemaType[]
   enum?: (string | number | boolean | null)[] | undefined
-  // todo: Use of this keyword is functionally equivalent to an enum with a single value
-  // const?: unknown | undefined
+  /**
+   * JSON Schema `const` (OpenAPI 3.1). Functionally equivalent to an enum with
+   * a single value; always normalized to {@link IRModelConst}.
+   */
+  const?: string | number | boolean | null | undefined
 
   /**
    * OpenAPI specific keywords

--- a/packages/openapi-code-generator/src/test/ir-model.fixtures.test-utils.ts
+++ b/packages/openapi-code-generator/src/test/ir-model.fixtures.test-utils.ts
@@ -2,6 +2,7 @@ import type {
   IRModelAny,
   IRModelArray,
   IRModelBoolean,
+  IRModelConst,
   IRModelIntersection,
   IRModelNever,
   IRModelNull,
@@ -89,6 +90,13 @@ const base = {
     nullable: false,
     "x-internal-preprocess": undefined,
   } satisfies IRModelBoolean,
+  const: {
+    isIRModel: true,
+    type: "const",
+    default: undefined,
+    nullable: false,
+    "x-internal-preprocess": undefined,
+  } satisfies Omit<IRModelConst, "value">,
 }
 
 const extension = {
@@ -203,6 +211,11 @@ export const irFixture = {
   },
   boolean(partial: Partial<IRModelBoolean> = {}): IRModelBoolean {
     return {...base.boolean, ...partial}
+  },
+  const(
+    partial: Partial<IRModelConst> & Pick<IRModelConst, "value">,
+  ): IRModelConst {
+    return {...base.const, ...partial}
   },
   record(partial: Partial<IRModelRecord> = {}): IRModelRecord {
     return {...extension.record, ...partial}

--- a/packages/openapi-code-generator/src/typescript/common/schema-builders/abstract-schema-builder.ts
+++ b/packages/openapi-code-generator/src/typescript/common/schema-builders/abstract-schema-builder.ts
@@ -235,6 +235,18 @@ export abstract class AbstractSchemaBuilder<
       case "boolean":
         result = this.boolean(model)
         break
+      case "const": {
+        // number and boolean literals need to tolerate non-context-aware
+        // coercion (eg. a query param arriving as a string), so they use
+        // dedicated handlers rather than the plain string `literal`.
+        result =
+          typeof model.value === "boolean"
+            ? this.booleanLiteral(model.value)
+            : typeof model.value === "number"
+              ? this.numberLiteral(model.value)
+              : this.literal(model.value)
+        break
+      }
       case "array":
         result = this.array(model, [this.arrayItems(model.items)])
         break
@@ -395,6 +407,10 @@ export abstract class AbstractSchemaBuilder<
   protected abstract arrayItems(model: MaybeIRModel): string
 
   protected abstract literal(value: string | number | boolean): string
+
+  protected abstract numberLiteral(value: number): string
+
+  protected abstract booleanLiteral(value: boolean): string
 
   protected abstract number(model: IRModelNumeric): string
 

--- a/packages/openapi-code-generator/src/typescript/common/schema-builders/joi-schema-builder.ts
+++ b/packages/openapi-code-generator/src/typescript/common/schema-builders/joi-schema-builder.ts
@@ -278,6 +278,19 @@ export class JoiBuilder extends AbstractSchemaBuilder<
       .join(".")
   }
 
+  protected numberLiteral(value: number): string {
+    return [joi, "number()", `valid(${value})`].filter(isDefined).join(".")
+  }
+
+  protected booleanLiteral(value: boolean): string {
+    const truthy = 'truthy(1, "1")'
+    const falsy = 'falsy(0, "0")'
+
+    return [joi, "boolean()", value ? truthy : falsy, `valid(${value})`]
+      .filter(isDefined)
+      .join(".")
+  }
+
   protected number(model: IRModelNumeric) {
     const result = [joi, "number()"].filter(isDefined).join(".")
 
@@ -286,7 +299,7 @@ export class JoiBuilder extends AbstractSchemaBuilder<
         hasSingleElement(model.enum) &&
         model["x-enum-extensibility"] !== "open"
       ) {
-        return this.literal(model.enum[0])
+        return this.numberLiteral(model.enum[0])
       }
 
       if (model["x-enum-extensibility"] === "open") {

--- a/packages/openapi-code-generator/src/typescript/common/schema-builders/joi-schema-builder.unit.spec.ts
+++ b/packages/openapi-code-generator/src/typescript/common/schema-builders/joi-schema-builder.unit.spec.ts
@@ -96,7 +96,7 @@ describe("typescript/common/schema-builders/joi-schema-builder - unit tests", ()
       )
 
       expect(code).toMatchInlineSnapshot(
-        `"const x = joi.any().valid(200).required()"`,
+        `"const x = joi.number().valid(200).required()"`,
       )
 
       await expect(execute(200)).resolves.toBe(200)
@@ -634,6 +634,56 @@ describe("typescript/common/schema-builders/joi-schema-builder - unit tests", ()
       await expect(execute("false")).resolves.toBe(false)
       await expect(execute(0)).resolves.toBe(false)
       await expect(execute(true)).rejects.toThrow('"value" must be [false]')
+    })
+  })
+
+  describe("const", () => {
+    it("supports a string const", async () => {
+      const {code, execute} = await getActual(ir.const({value: "task"}))
+
+      expect(code).toMatchInlineSnapshot(
+        `"const x = joi.any().valid("task").required()"`,
+      )
+
+      await expect(execute("task")).resolves.toBe("task")
+      await expect(execute("other")).rejects.toThrow('"value" must be [task]')
+    })
+
+    it("supports a number const", async () => {
+      const {code, execute} = await getActual(ir.const({value: 5}))
+
+      expect(code).toMatchInlineSnapshot(
+        `"const x = joi.number().valid(5).required()"`,
+      )
+
+      await expect(execute(5)).resolves.toBe(5)
+      await expect(execute("5")).resolves.toBe(5)
+      await expect(execute(6)).rejects.toThrow('"value" must be [5]')
+    })
+
+    it("supports a boolean const", async () => {
+      const {code, execute} = await getActual(ir.const({value: true}))
+
+      expect(code).toMatchInlineSnapshot(
+        `"const x = joi.boolean().truthy(1, "1").valid(true).required()"`,
+      )
+
+      await expect(execute(true)).resolves.toBe(true)
+      await expect(execute("true")).resolves.toBe(true)
+      await expect(execute(false)).rejects.toThrow('"value" must be [true]')
+    })
+
+    it("supports a nullable const", async () => {
+      const {code, execute} = await getActual(
+        ir.const({value: "task", nullable: true}),
+      )
+
+      expect(code).toMatchInlineSnapshot(
+        `"const x = joi.any().valid("task").allow(null).required()"`,
+      )
+
+      await expect(execute("task")).resolves.toBe("task")
+      await expect(execute(null)).resolves.toBe(null)
     })
   })
 

--- a/packages/openapi-code-generator/src/typescript/common/schema-builders/zod-v3-schema-builder.integration.spec.ts
+++ b/packages/openapi-code-generator/src/typescript/common/schema-builders/zod-v3-schema-builder.integration.spec.ts
@@ -215,7 +215,7 @@ describe.each(testVersions)(
           str: z.enum(["foo", "bar"]).nullable().optional(),
           num: z
             .preprocess(
-              (value) => (typeof value === "number" ? value : Number(value)),
+              (it) => z.coerce.number().parse(it),
               z.union([z.literal(10), z.literal(20)]),
             )
             .nullable()

--- a/packages/openapi-code-generator/src/typescript/common/schema-builders/zod-v3-schema-builder.integration.spec.ts
+++ b/packages/openapi-code-generator/src/typescript/common/schema-builders/zod-v3-schema-builder.integration.spec.ts
@@ -214,7 +214,10 @@ describe.each(testVersions)(
         export const s_Enums = z.object({
           str: z.enum(["foo", "bar"]).nullable().optional(),
           num: z
-            .union([z.literal(10), z.literal(20)])
+            .preprocess(
+              (value) => (typeof value === "number" ? value : Number(value)),
+              z.union([z.literal(10), z.literal(20)]),
+            )
             .nullable()
             .optional(),
         })"

--- a/packages/openapi-code-generator/src/typescript/common/schema-builders/zod-v3-schema-builder.ts
+++ b/packages/openapi-code-generator/src/typescript/common/schema-builders/zod-v3-schema-builder.ts
@@ -275,13 +275,8 @@ export class ZodV3Builder extends AbstractSchemaBuilder<
     )
   }
 
-  // coerces string inputs to numbers, mirroring the `z.coerce.number()` used for
-  // plain numbers, so literals/enums also tolerate non-context-aware input.
   private coerceNumber(schema: string): string {
-    return this.preprocess(
-      schema,
-      `(value) => (typeof value === "number" ? value : Number(value))`,
-    )
+    return this.preprocess(schema, `it => z.coerce.number().parse(it)`)
   }
 
   protected number(model: IRModelNumeric) {
@@ -303,7 +298,7 @@ export class ZodV3Builder extends AbstractSchemaBuilder<
         )
         return this.coerceNumber(
           this.union([
-            ...model.enum.map((it) => [zod, `literal(${it})`].join(".")),
+            ...model.enum.map((it) => this.literal(it)),
             "z.number().transform(it => it as (typeof it & UnknownEnumNumberValue))",
           ]),
         )
@@ -311,7 +306,7 @@ export class ZodV3Builder extends AbstractSchemaBuilder<
 
       if (model["x-enum-extensibility"] === "closed") {
         return this.coerceNumber(
-          this.union(model.enum.map((it) => [zod, `literal(${it})`].join("."))),
+          this.union(model.enum.map((it) => this.literal(it))),
         )
       }
 
@@ -405,16 +400,13 @@ export class ZodV3Builder extends AbstractSchemaBuilder<
     // todo: might be nice to have an x-extension prop that lets the user define the
     //       true/false mapping in their schema.
     if (model.enum) {
-      this.addStaticSchema("PermissiveBoolean")
-
       return this.union(
         model.enum.map((it) => {
-          if (it === "true") {
-            return this.addStaticSchema("PermissiveLiteralTrue")
-          } else if (it === "false") {
-            return this.addStaticSchema("PermissiveLiteralFalse")
+          if (it !== "true" && it !== "false") {
+            throw new Error(`unsupported boolean enum value '${it}'`)
           }
-          throw new Error(`unsupported boolean enum value '${it}'`)
+
+          return this.booleanLiteral(it === "true")
         }),
       )
     }

--- a/packages/openapi-code-generator/src/typescript/common/schema-builders/zod-v3-schema-builder.ts
+++ b/packages/openapi-code-generator/src/typescript/common/schema-builders/zod-v3-schema-builder.ts
@@ -264,6 +264,26 @@ export class ZodV3Builder extends AbstractSchemaBuilder<
       .join(".")
   }
 
+  protected numberLiteral(value: number): string {
+    return this.coerceNumber(this.literal(value))
+  }
+
+  protected booleanLiteral(value: boolean): string {
+    this.addStaticSchema("PermissiveBoolean")
+    return this.addStaticSchema(
+      value ? "PermissiveLiteralTrue" : "PermissiveLiteralFalse",
+    )
+  }
+
+  // coerces string inputs to numbers, mirroring the `z.coerce.number()` used for
+  // plain numbers, so literals/enums also tolerate non-context-aware input.
+  private coerceNumber(schema: string): string {
+    return this.preprocess(
+      schema,
+      `(value) => (typeof value === "number" ? value : Number(value))`,
+    )
+  }
+
   protected number(model: IRModelNumeric) {
     if (model.enum) {
       // TODO: replace with enum after https://github.com/colinhacks/zod/issues/2686
@@ -272,7 +292,7 @@ export class ZodV3Builder extends AbstractSchemaBuilder<
         hasSingleElement(model.enum) &&
         model["x-enum-extensibility"] !== "open"
       ) {
-        return this.literal(model.enum[0])
+        return this.numberLiteral(model.enum[0])
       }
 
       if (model["x-enum-extensibility"] === "open") {
@@ -281,22 +301,18 @@ export class ZodV3Builder extends AbstractSchemaBuilder<
           this.typeBuilder.filename,
           true,
         )
-        return [
+        return this.coerceNumber(
           this.union([
             ...model.enum.map((it) => [zod, `literal(${it})`].join(".")),
             "z.number().transform(it => it as (typeof it & UnknownEnumNumberValue))",
           ]),
-        ]
-          .filter(isDefined)
-          .join(".")
+        )
       }
 
       if (model["x-enum-extensibility"] === "closed") {
-        return [
+        return this.coerceNumber(
           this.union(model.enum.map((it) => [zod, `literal(${it})`].join("."))),
-        ]
-          .filter(isDefined)
-          .join(".")
+        )
       }
 
       throw new Error(

--- a/packages/openapi-code-generator/src/typescript/common/schema-builders/zod-v3-schema-builder.unit.spec.ts
+++ b/packages/openapi-code-generator/src/typescript/common/schema-builders/zod-v3-schema-builder.unit.spec.ts
@@ -60,7 +60,12 @@ describe("typescript/common/schema-builders/zod-v3-schema-builder - unit tests",
       )
 
       expect(code).toMatchInlineSnapshot(
-        '"const x = z.union([z.literal(200), z.literal(301), z.literal(404)])"',
+        `
+        "const x = z.preprocess(
+          (value) => (typeof value === "number" ? value : Number(value)),
+          z.union([z.literal(200), z.literal(301), z.literal(404)]),
+        )"
+      `,
       )
 
       await expect(execute(123)).rejects.toThrow(
@@ -78,19 +83,22 @@ describe("typescript/common/schema-builders/zod-v3-schema-builder - unit tests",
       )
 
       expect(code).toMatchInlineSnapshot(`
-          "const x = z.union([
+        "const x = z.preprocess(
+          (value) => (typeof value === "number" ? value : Number(value)),
+          z.union([
             z.literal(200),
             z.literal(301),
             z.literal(404),
             z.number().transform((it) => it as typeof it & UnknownEnumNumberValue),
-          ])"
-        `)
+          ]),
+        )"
+      `)
 
       await expect(execute(123)).resolves.toBe(123)
       await expect(execute(404)).resolves.toBe(404)
-      await expect(execute("not a number")).rejects.toThrow(
-        "Expected number, received string",
-      )
+      // string numbers are coerced, so they're accepted too
+      await expect(execute("404")).resolves.toBe(404)
+      await expect(execute("not a number")).rejects.toThrow()
     })
 
     it("supports single element closed numeric enums as literal", async () => {
@@ -103,9 +111,15 @@ describe("typescript/common/schema-builders/zod-v3-schema-builder - unit tests",
         }),
       )
 
-      expect(code).toMatchInlineSnapshot(`"const x = z.literal(200)"`)
+      expect(code).toMatchInlineSnapshot(`
+        "const x = z.preprocess(
+          (value) => (typeof value === "number" ? value : Number(value)),
+          z.literal(200),
+        )"
+      `)
 
       await expect(execute(200)).resolves.toBe(200)
+      await expect(execute("200")).resolves.toBe(200)
 
       await expect(execute(404)).rejects.toThrow(/200/)
     })
@@ -121,10 +135,13 @@ describe("typescript/common/schema-builders/zod-v3-schema-builder - unit tests",
       )
 
       expect(code).toMatchInlineSnapshot(`
-        "const x = z.union([
-          z.literal(200),
-          z.number().transform((it) => it as typeof it & UnknownEnumNumberValue),
-        ])"
+        "const x = z.preprocess(
+          (value) => (typeof value === "number" ? value : Number(value)),
+          z.union([
+            z.literal(200),
+            z.number().transform((it) => it as typeof it & UnknownEnumNumberValue),
+          ]),
+        )"
       `)
 
       await expect(execute(200)).resolves.toBe(200)
@@ -725,6 +742,39 @@ describe("typescript/common/schema-builders/zod-v3-schema-builder - unit tests",
       )
     })
 
+    it("supports a boolean const using the permissive literal", async () => {
+      const {code} = await getActual(ir.const({value: true}))
+
+      const codeWithoutImport = inlineStaticSchemas(code)
+
+      expect(codeWithoutImport).toMatchInlineSnapshot(`
+        "const PermissiveBoolean = z.preprocess((value) => {
+                  if(typeof value === "string" && (value === "true" || value === "false")) {
+                    return value === "true"
+                  } else if(typeof value === "number" && (value === 1 || value === 0)) {
+                    return value === 1
+                  }
+                  return value
+                }, z.boolean())
+        const PermissiveLiteralTrue = z.preprocess((value) => {
+                  return PermissiveBoolean.parse(value)
+                }, z.literal(true))
+
+        const x = PermissiveLiteralTrue"
+      `)
+
+      await expect(executeBooleanTest(codeWithoutImport, true)).resolves.toBe(
+        true,
+      )
+      await expect(executeBooleanTest(codeWithoutImport, "true")).resolves.toBe(
+        true,
+      )
+      await expect(executeBooleanTest(codeWithoutImport, 1)).resolves.toBe(true)
+      await expect(
+        executeBooleanTest(codeWithoutImport, false),
+      ).rejects.toThrow("Invalid literal value, expected true")
+    })
+
     it("PermissiveBoolean works as expected", async () => {
       const code = `
         const x = ${staticSchemas.PermissiveBoolean}
@@ -751,6 +801,45 @@ describe("typescript/common/schema-builders/zod-v3-schema-builder - unit tests",
       await expect(executeBooleanTest(code, {})).rejects.toThrow(
         "Expected boolean, received object",
       )
+    })
+  })
+
+  describe("const", () => {
+    it("supports a string const", async () => {
+      const {code, execute} = await getActual(ir.const({value: "task"}))
+
+      expect(code).toMatchInlineSnapshot(`"const x = z.literal("task")"`)
+
+      await expect(execute("task")).resolves.toBe("task")
+      await expect(execute("other")).rejects.toThrow(/task/)
+    })
+
+    it("supports a number const", async () => {
+      const {code, execute} = await getActual(ir.const({value: 5}))
+
+      expect(code).toMatchInlineSnapshot(`
+        "const x = z.preprocess(
+          (value) => (typeof value === "number" ? value : Number(value)),
+          z.literal(5),
+        )"
+      `)
+
+      await expect(execute(5)).resolves.toBe(5)
+      await expect(execute("5")).resolves.toBe(5)
+      await expect(execute(6)).rejects.toThrow(/5/)
+    })
+
+    it("supports a nullable const", async () => {
+      const {code, execute} = await getActual(
+        ir.const({value: "task", nullable: true}),
+      )
+
+      expect(code).toMatchInlineSnapshot(
+        `"const x = z.literal("task").nullable()"`,
+      )
+
+      await expect(execute("task")).resolves.toBe("task")
+      await expect(execute(null)).resolves.toBe(null)
     })
   })
 

--- a/packages/openapi-code-generator/src/typescript/common/schema-builders/zod-v3-schema-builder.unit.spec.ts
+++ b/packages/openapi-code-generator/src/typescript/common/schema-builders/zod-v3-schema-builder.unit.spec.ts
@@ -62,7 +62,7 @@ describe("typescript/common/schema-builders/zod-v3-schema-builder - unit tests",
       expect(code).toMatchInlineSnapshot(
         `
         "const x = z.preprocess(
-          (value) => (typeof value === "number" ? value : Number(value)),
+          (it) => z.coerce.number().parse(it),
           z.union([z.literal(200), z.literal(301), z.literal(404)]),
         )"
       `,
@@ -84,7 +84,7 @@ describe("typescript/common/schema-builders/zod-v3-schema-builder - unit tests",
 
       expect(code).toMatchInlineSnapshot(`
         "const x = z.preprocess(
-          (value) => (typeof value === "number" ? value : Number(value)),
+          (it) => z.coerce.number().parse(it),
           z.union([
             z.literal(200),
             z.literal(301),
@@ -111,12 +111,9 @@ describe("typescript/common/schema-builders/zod-v3-schema-builder - unit tests",
         }),
       )
 
-      expect(code).toMatchInlineSnapshot(`
-        "const x = z.preprocess(
-          (value) => (typeof value === "number" ? value : Number(value)),
-          z.literal(200),
-        )"
-      `)
+      expect(code).toMatchInlineSnapshot(
+        `"const x = z.preprocess((it) => z.coerce.number().parse(it), z.literal(200))"`,
+      )
 
       await expect(execute(200)).resolves.toBe(200)
       await expect(execute("200")).resolves.toBe(200)
@@ -136,7 +133,7 @@ describe("typescript/common/schema-builders/zod-v3-schema-builder - unit tests",
 
       expect(code).toMatchInlineSnapshot(`
         "const x = z.preprocess(
-          (value) => (typeof value === "number" ? value : Number(value)),
+          (it) => z.coerce.number().parse(it),
           z.union([
             z.literal(200),
             z.number().transform((it) => it as typeof it & UnknownEnumNumberValue),
@@ -817,12 +814,9 @@ describe("typescript/common/schema-builders/zod-v3-schema-builder - unit tests",
     it("supports a number const", async () => {
       const {code, execute} = await getActual(ir.const({value: 5}))
 
-      expect(code).toMatchInlineSnapshot(`
-        "const x = z.preprocess(
-          (value) => (typeof value === "number" ? value : Number(value)),
-          z.literal(5),
-        )"
-      `)
+      expect(code).toMatchInlineSnapshot(
+        `"const x = z.preprocess((it) => z.coerce.number().parse(it), z.literal(5))"`,
+      )
 
       await expect(execute(5)).resolves.toBe(5)
       await expect(execute("5")).resolves.toBe(5)

--- a/packages/openapi-code-generator/src/typescript/common/schema-builders/zod-v4-schema-builder.integration.spec.ts
+++ b/packages/openapi-code-generator/src/typescript/common/schema-builders/zod-v4-schema-builder.integration.spec.ts
@@ -211,7 +211,10 @@ describe.each(testVersions)(
         export const s_Enums = z.object({
           str: z.enum(["foo", "bar"]).nullable().optional(),
           num: z
-            .union([z.literal(10), z.literal(20)])
+            .preprocess(
+              (it) => z.coerce.number().parse(it),
+              z.union([z.literal(10), z.literal(20)]),
+            )
             .nullable()
             .optional(),
         })"

--- a/packages/openapi-code-generator/src/typescript/common/schema-builders/zod-v4-schema-builder.ts
+++ b/packages/openapi-code-generator/src/typescript/common/schema-builders/zod-v4-schema-builder.ts
@@ -290,13 +290,30 @@ export class ZodV4Builder extends AbstractSchemaBuilder<
       .join(".")
   }
 
+  protected numberLiteral(value: number): string {
+    return this.coerceNumber(this.literal(value))
+  }
+
+  protected booleanLiteral(value: boolean): string {
+    this.addStaticSchema("PermissiveBoolean")
+    return this.addStaticSchema(
+      value ? "PermissiveLiteralTrue" : "PermissiveLiteralFalse",
+    )
+  }
+
+  // coerces string inputs to numbers, mirroring the `z.coerce.number()` used for
+  // plain numbers, so literals/enums also tolerate non-context-aware input.
+  private coerceNumber(schema: string): string {
+    return this.preprocess(schema, `it => z.coerce.number().parse(it)`)
+  }
+
   protected number(model: IRModelNumeric) {
     if (model.enum) {
       if (
         hasSingleElement(model.enum) &&
         model["x-enum-extensibility"] !== "open"
       ) {
-        return this.literal(model.enum[0])
+        return this.numberLiteral(model.enum[0])
       }
 
       if (model["x-enum-extensibility"] === "open") {
@@ -305,22 +322,18 @@ export class ZodV4Builder extends AbstractSchemaBuilder<
           this.typeBuilder.filename,
           true,
         )
-        return [
+        return this.coerceNumber(
           this.union([
-            ...model.enum.map((it) => [zod, `literal(${it})`].join(".")),
+            ...model.enum.map((it) => this.literal(it)),
             "z.number().transform(it => it as (typeof it & UnknownEnumNumberValue))",
           ]),
-        ]
-          .filter(isDefined)
-          .join(".")
+        )
       }
 
       if (model["x-enum-extensibility"] === "closed") {
-        return [
-          this.union(model.enum.map((it) => [zod, `literal(${it})`].join("."))),
-        ]
-          .filter(isDefined)
-          .join(".")
+        return this.coerceNumber(
+          this.union(model.enum.map((it) => this.literal(it))),
+        )
       }
 
       throw new Error(
@@ -420,16 +433,13 @@ export class ZodV4Builder extends AbstractSchemaBuilder<
     //       true/false mapping in their schema.
 
     if (model.enum) {
-      this.addStaticSchema("PermissiveBoolean")
-
       return this.union(
         model.enum.map((it) => {
-          if (it === "true") {
-            return this.addStaticSchema("PermissiveLiteralTrue")
-          } else if (it === "false") {
-            return this.addStaticSchema("PermissiveLiteralFalse")
+          if (it !== "true" && it !== "false") {
+            throw new Error(`unsupported boolean enum value '${it}'`)
           }
-          throw new Error(`unsupported boolean enum value '${it}'`)
+
+          return this.booleanLiteral(it === "true")
         }),
       )
     }

--- a/packages/openapi-code-generator/src/typescript/common/schema-builders/zod-v4-schema-builder.ts
+++ b/packages/openapi-code-generator/src/typescript/common/schema-builders/zod-v4-schema-builder.ts
@@ -301,8 +301,6 @@ export class ZodV4Builder extends AbstractSchemaBuilder<
     )
   }
 
-  // coerces string inputs to numbers, mirroring the `z.coerce.number()` used for
-  // plain numbers, so literals/enums also tolerate non-context-aware input.
   private coerceNumber(schema: string): string {
     return this.preprocess(schema, `it => z.coerce.number().parse(it)`)
   }

--- a/packages/openapi-code-generator/src/typescript/common/schema-builders/zod-v4-schema-builder.unit.spec.ts
+++ b/packages/openapi-code-generator/src/typescript/common/schema-builders/zod-v4-schema-builder.unit.spec.ts
@@ -90,7 +90,12 @@ describe("typescript/common/schema-builders/zod-v4-schema-builder - unit tests",
       )
 
       expect(code).toMatchInlineSnapshot(
-        '"const x = z.union([z.literal(200), z.literal(301), z.literal(404)])"',
+        `
+        "const x = z.preprocess(
+          (it) => z.coerce.number().parse(it),
+          z.union([z.literal(200), z.literal(301), z.literal(404)]),
+        )"
+      `,
       )
 
       await expect(execute(123)).rejects.toThrow("Invalid input: expected 404")
@@ -106,19 +111,22 @@ describe("typescript/common/schema-builders/zod-v4-schema-builder - unit tests",
       )
 
       expect(code).toMatchInlineSnapshot(`
-          "const x = z.union([
+        "const x = z.preprocess(
+          (it) => z.coerce.number().parse(it),
+          z.union([
             z.literal(200),
             z.literal(301),
             z.literal(404),
             z.number().transform((it) => it as typeof it & UnknownEnumNumberValue),
-          ])"
-        `)
+          ]),
+        )"
+      `)
 
       await expect(execute(123)).resolves.toBe(123)
       await expect(execute(404)).resolves.toBe(404)
-      await expect(execute("not a number")).rejects.toThrow(
-        "Invalid input: expected number, received string",
-      )
+      // string numbers are coerced, so they're accepted too
+      await expect(execute("404")).resolves.toBe(404)
+      await expect(execute("not a number")).rejects.toThrow()
     })
 
     it("supports single element closed numeric enums as literal", async () => {
@@ -131,9 +139,12 @@ describe("typescript/common/schema-builders/zod-v4-schema-builder - unit tests",
         }),
       )
 
-      expect(code).toMatchInlineSnapshot(`"const x = z.literal(200)"`)
+      expect(code).toMatchInlineSnapshot(
+        `"const x = z.preprocess((it) => z.coerce.number().parse(it), z.literal(200))"`,
+      )
 
       await expect(execute(200)).resolves.toBe(200)
+      await expect(execute("200")).resolves.toBe(200)
 
       await expect(execute(404)).rejects.toThrow(/200/)
     })
@@ -149,10 +160,13 @@ describe("typescript/common/schema-builders/zod-v4-schema-builder - unit tests",
       )
 
       expect(code).toMatchInlineSnapshot(`
-        "const x = z.union([
-          z.literal(200),
-          z.number().transform((it) => it as typeof it & UnknownEnumNumberValue),
-        ])"
+        "const x = z.preprocess(
+          (it) => z.coerce.number().parse(it),
+          z.union([
+            z.literal(200),
+            z.number().transform((it) => it as typeof it & UnknownEnumNumberValue),
+          ]),
+        )"
       `)
 
       await expect(execute(200)).resolves.toBe(200)
@@ -783,6 +797,39 @@ describe("typescript/common/schema-builders/zod-v4-schema-builder - unit tests",
       )
     })
 
+    it("supports a boolean const using the permissive literal", async () => {
+      const {code} = await getActual(ir.const({value: true}))
+
+      const codeWithoutImport = inlineStaticSchemas(code)
+
+      expect(codeWithoutImport).toMatchInlineSnapshot(`
+        "const PermissiveBoolean = z.preprocess((value) => {
+                  if(typeof value === "string" && (value === "true" || value === "false")) {
+                    return value === "true"
+                  } else if(typeof value === "number" && (value === 1 || value === 0)) {
+                    return value === 1
+                  }
+                  return value
+                }, z.boolean())
+        const PermissiveLiteralTrue = z.preprocess((value) => {
+                  return PermissiveBoolean.parse(value)
+                }, z.literal(true))
+
+        const x = PermissiveLiteralTrue"
+      `)
+
+      await expect(executeBooleanTest(codeWithoutImport, true)).resolves.toBe(
+        true,
+      )
+      await expect(executeBooleanTest(codeWithoutImport, "true")).resolves.toBe(
+        true,
+      )
+      await expect(executeBooleanTest(codeWithoutImport, 1)).resolves.toBe(true)
+      await expect(
+        executeBooleanTest(codeWithoutImport, false),
+      ).rejects.toThrow("Invalid input: expected true")
+    })
+
     it("PermissiveBoolean works as expected", async () => {
       const code = `
         const x = ${staticSchemas.PermissiveBoolean}
@@ -809,6 +856,42 @@ describe("typescript/common/schema-builders/zod-v4-schema-builder - unit tests",
       await expect(executeBooleanTest(code, {})).rejects.toThrow(
         "Invalid input: expected boolean, received Object",
       )
+    })
+  })
+
+  describe("const", () => {
+    it("supports a string const", async () => {
+      const {code, execute} = await getActual(ir.const({value: "task"}))
+
+      expect(code).toMatchInlineSnapshot(`"const x = z.literal("task")"`)
+
+      await expect(execute("task")).resolves.toBe("task")
+      await expect(execute("other")).rejects.toThrow(/task/)
+    })
+
+    it("supports a number const", async () => {
+      const {code, execute} = await getActual(ir.const({value: 5}))
+
+      expect(code).toMatchInlineSnapshot(
+        `"const x = z.preprocess((it) => z.coerce.number().parse(it), z.literal(5))"`,
+      )
+
+      await expect(execute(5)).resolves.toBe(5)
+      await expect(execute("5")).resolves.toBe(5)
+      await expect(execute(6)).rejects.toThrow(/5/)
+    })
+
+    it("supports a nullable const", async () => {
+      const {code, execute} = await getActual(
+        ir.const({value: "task", nullable: true}),
+      )
+
+      expect(code).toMatchInlineSnapshot(
+        `"const x = z.literal("task").nullable()"`,
+      )
+
+      await expect(execute("task")).resolves.toBe("task")
+      await expect(execute(null)).resolves.toBe(null)
     })
   })
 

--- a/packages/openapi-code-generator/src/typescript/common/type-builder/type-builder.ts
+++ b/packages/openapi-code-generator/src/typescript/common/type-builder/type-builder.ts
@@ -265,6 +265,15 @@ export class TypeBuilder implements ICompilable {
         break
       }
 
+      case "const": {
+        result.push(
+          typeof schemaObject.value === "string"
+            ? quotedStringLiteral(schemaObject.value)
+            : String(schemaObject.value),
+        )
+        break
+      }
+
       case "number": {
         // todo: support bigint as string, https://github.com/mnahkies/openapi-code-generator/issues/51
 

--- a/packages/openapi-code-generator/src/typescript/common/type-builder/type-builder.unit.spec.ts
+++ b/packages/openapi-code-generator/src/typescript/common/type-builder/type-builder.unit.spec.ts
@@ -104,6 +104,28 @@ describe("typescript/common/type-builder - unit tests", () => {
     })
   })
 
+  describe("const", () => {
+    it("handles a string const", async () => {
+      const {code} = await getActual(ir.const({value: "task"}))
+      expect(code).toMatchInlineSnapshot(`"declare const x: "task""`)
+    })
+
+    it("handles a number const", async () => {
+      const {code} = await getActual(ir.const({value: 5}))
+      expect(code).toMatchInlineSnapshot(`"declare const x: 5"`)
+    })
+
+    it("handles a boolean const", async () => {
+      const {code} = await getActual(ir.const({value: true}))
+      expect(code).toMatchInlineSnapshot(`"declare const x: true"`)
+    })
+
+    it("handles a nullable const", async () => {
+      const {code} = await getActual(ir.const({value: "task", nullable: true}))
+      expect(code).toMatchInlineSnapshot(`"declare const x: "task" | null"`)
+    })
+  })
+
   describe("numbers", () => {
     it("handles a basic number", async () => {
       const {code} = await getActual(ir.number())

--- a/packages/openapi-code-generator/src/typescript/server/server-operation-builder.ts
+++ b/packages/openapi-code-generator/src/typescript/server/server-operation-builder.ts
@@ -250,6 +250,16 @@ export class ServerOperationBuilder {
         }
       }
 
+      case "const": {
+        const type =
+          typeof schema.value === "number"
+            ? "number"
+            : typeof schema.value === "boolean"
+              ? "boolean"
+              : "string"
+        return {type}
+      }
+
       case "intersection": {
         // todo: figure out if this can be done better
         logger.error(


### PR DESCRIPTION
The JSON Schema `const` keyword (OpenAPI 3.1) was parsed away silently, widening literal types to their base type and breaking discriminated unions. Introduce an IRModelConst abstraction used for both `const` and single-value `enum` (which default to closed), so enum extensibility never applies to a constant. 

Update type/schema builders and the discriminator check, and add a const-based discriminated union to the todo-lists integration spec.

Also addresses a few discrepancies where literals would've failed at runtime if used in a query string setting. Now coerced to `number` / `boolean` correctly.

closes #529